### PR TITLE
Reuse transceivers

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -166,30 +166,46 @@ func (t *MediaTrack) AddSubscriber(sub types.Participant) error {
 	}
 	subTrack := NewSubscribedTrack(downTrack)
 
-	//
-	// AddTrack will create a new transceiver or re-use an unused one
-	// if the attributes match. This prevents SDP from bloating
-	// because of dormant transceivers buidling up.
-	//
-	sender, err := sub.SubscriberPC().AddTrack(downTrack)
-	if err != nil {
-		return err
-	}
+	var transceiver *webrtc.RTPTransceiver
+	var sender *webrtc.RTPSender
+	if sub.ProtocolVersion().SupportsTransceiverReuse() {
+		//
+		// AddTrack will create a new transceiver or re-use an unused one
+		// if the attributes match. This prevents SDP from bloating
+		// because of dormant transceivers buidling up.
+		//
+		sender, err = sub.SubscriberPC().AddTrack(downTrack)
+		if err != nil {
+			return err
+		}
 
-	// as there is no way to get transceiver from sender, search
-	var matchedTransceiver *webrtc.RTPTransceiver
-	for _, transceiver := range sub.SubscriberPC().GetTransceivers() {
-		if transceiver.Sender() == sender {
-			matchedTransceiver = transceiver
-			break
+		// as there is no way to get transceiver from sender, search
+		for _, tr := range sub.SubscriberPC().GetTransceivers() {
+			if tr.Sender() == sender {
+				transceiver = tr
+				break
+			}
+		}
+		if transceiver == nil {
+			// cannot add, no transceiver
+			return errors.New("cannot subscribe without a transceiver in place")
+		}
+	} else {
+		transceiver, err = sub.SubscriberPC().AddTransceiverFromTrack(downTrack, webrtc.RTPTransceiverInit{
+			Direction: webrtc.RTPTransceiverDirectionSendonly,
+		})
+		if err != nil {
+			return err
+		}
+
+		sender = transceiver.Sender()
+		if sender == nil {
+			// cannot add, no sender
+			return errors.New("cannot subscribe without a sender in place")
 		}
 	}
-	if matchedTransceiver == nil {
-		// cannot add, no transceiver
-		return errors.New("cannot subscribe without a transceiver in place")
-	}
 
-	downTrack.SetTransceiver(matchedTransceiver)
+	downTrack.SetTransceiver(transceiver)
 	// when outtrack is bound, start loop to send reports
 	downTrack.OnBind(func() {
 		go t.sendDownTrackBindingReports(sub)
@@ -210,6 +226,9 @@ func (t *MediaTrack) AddSubscriber(sub types.Participant) error {
 
 			// if the source has been terminated, we'll need to terminate all of the subscribedtracks
 			// however, if the dest sub has disconnected, then we can skip
+			if sender == nil {
+				return
+			}
 			logger.Debugw("removing peerconnection track",
 				"track", t.params.TrackID,
 				"pIDs", []string{t.params.ParticipantID, sub.ID()},

--- a/pkg/rtc/types/protocol_version.go
+++ b/pkg/rtc/types/protocol_version.go
@@ -25,3 +25,8 @@ func (v ProtocolVersion) SubscriberAsPrimary() bool {
 func (v ProtocolVersion) SupportsSpeakerChanged() bool {
 	return v > 2
 }
+
+// SupportsTransceiverReuse - if transceiver reuse is supported, optimizes SDP size
+func (v ProtocolVersion) SupportsTransceiverReuse() bool {
+	return v > 3
+}


### PR DESCRIPTION
LK-22 (https://linear.app/livekit/issue/LK-22/feature-pooled-transceivers-to-avoid-re-negotiation)

- Introducing reuse of transceivers in protocol version 4 (clients need to understand it, so protocol bump)
- Use `AddTrack` method of peer connection to let the peer connection add or re-use a transceiver (more comments in code).

## Testing
- Testing notes about new protocol in this PR commit notes https://github.com/livekit/client-sdk-js/pull/51
- Ensure that old protocol client also works using the same testing method as above. The only difference is that the subscriber SDP keeps growing.