### PR TITLE
Fix interface duplicate definition.

### DIFF
--- a/pkg/service/interfaces.go
+++ b/pkg/service/interfaces.go
@@ -35,7 +35,6 @@ type RoomManager interface {
 	RoomStore
 
 	GetRoom(ctx context.Context, roomName string) *rtc.Room
-	DeleteRoom(ctx context.Context, roomName string) error
 	StartSession(ctx context.Context, roomName string, pi routing.ParticipantInit, requestSource routing.MessageSource, responseSink routing.MessageSink)
 	CleanupRooms() error
 	CloseIdleRooms()


### PR DESCRIPTION
Got the following error on a fresh install
```
wire: /root/ws/livekit-server/pkg/service/interfaces.go:35:2: DeleteRoom redeclared
wire: /root/ws/livekit-server/pkg/service/interfaces.go:38:2: 	other declaration of DeleteRoom
wire: generate failed
Error: exit status 1
```
Probably something from the latest `wire` version.

After consulting David, removing the duplicate.

Testing:
--------
- Server builds and runs. Client is able to connect.