### PR TITLE
Bump up stream allocator event queue size

### DIFF
--- a/pkg/sfu/streamallocator.go
+++ b/pkg/sfu/streamallocator.go
@@ -184,7 +184,7 @@ func NewStreamAllocator(params StreamAllocatorParams) *StreamAllocator {
 			Logger: params.Logger,
 		}),
 		videoTracks: make(map[livekit.TrackID]*Track),
-		eventCh:     make(chan Event, 20),
+		eventCh:     make(chan Event, 200),
 	}
 
 	s.resetState()


### PR DESCRIPTION
This probably needs more work
- Maybe some events should not be queued
- Reduce number of events

Bump up the size any way so that the queue does not overflow
when subscribing to a lot of tracks.