### PR TITLE
Batch subscriber updates to reduce noise

### DIFF
--- a/pkg/rtc/helper_test.go
+++ b/pkg/rtc/helper_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/livekit/livekit-server/pkg/rtc/types/typesfakes"
 )
 
-func newMockParticipant(identity livekit.ParticipantIdentity, protocol types.ProtocolVersion, hidden bool) *typesfakes.FakeLocalParticipant {
+func newMockParticipant(identity livekit.ParticipantIdentity, protocol types.ProtocolVersion, hidden bool, publisher bool) *typesfakes.FakeLocalParticipant {
 	p := &typesfakes.FakeLocalParticipant{}
 	sid := utils.NewGuid(utils.ParticipantPrefix)
 	p.IDReturns(livekit.ParticipantID(sid))
@@ -20,9 +20,10 @@ func newMockParticipant(identity livekit.ParticipantIdentity, protocol types.Pro
 	p.CanPublishDataReturns(!hidden)
 	p.HiddenReturns(hidden)
 	p.ToProtoReturns(&livekit.ParticipantInfo{
-		Sid:      sid,
-		Identity: string(identity),
-		State:    livekit.ParticipantInfo_JOINED,
+		Sid:         sid,
+		Identity:    string(identity),
+		State:       livekit.ParticipantInfo_JOINED,
+		IsPublisher: publisher,
 	})
 
 	p.SetMetadataStub = func(m string) {

--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -328,6 +328,7 @@ func TestSubscriberAsPrimary(t *testing.T) {
 type participantOpts struct {
 	permissions     *livekit.ParticipantPermission
 	protocolVersion types.ProtocolVersion
+	publisher       bool
 }
 
 func newParticipantForTestWithOpts(identity livekit.ParticipantIdentity, opts *participantOpts) *ParticipantImpl {
@@ -362,6 +363,8 @@ func newParticipantForTestWithOpts(identity livekit.ParticipantIdentity, opts *p
 		PLIThrottleConfig: conf.RTC.PLIThrottle,
 		Grants:            grants,
 	})
+	p.isPublisher.Store(opts.publisher)
+
 	return p
 }
 

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -734,16 +734,15 @@ func (r *Room) broadcastParticipantState(p types.LocalParticipant, opts broadcas
 	pi := p.ToProto()
 	updates := []*livekit.ParticipantInfo{pi}
 
-	if !opts.skipSource {
-		// send update only to hidden participant
-		err := p.SendParticipantUpdate(updates)
-		if err != nil {
-			r.Logger.Errorw("could not send update to participant", err,
-				"participant", p.Identity(), "pID", p.ID())
-		}
-	}
-
 	if p.Hidden() {
+		if !opts.skipSource {
+			// send update only to hidden participant
+			err := p.SendParticipantUpdate(updates)
+			if err != nil {
+				r.Logger.Errorw("could not send update to participant", err,
+					"participant", p.Identity(), "pID", p.ID())
+			}
+		}
 		return
 	}
 


### PR DESCRIPTION
Improve scalability by batching subscriber updates on an interval.
When lots of subscribers join, the server ends up spending 20% CPU
sending each state change to everyone. There's a non-trivial amount of
overhead with each send operation.

For publishers, updates are sent right away.