### PR TITLE
Add pprof endpoint when running in dev mode

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -87,16 +87,12 @@ func main() {
 			},
 			// debugging flags
 			&cli.StringFlag{
-				Name:  "cpuprofile",
-				Usage: "write cpu profile to `file`",
-			},
-			&cli.StringFlag{
 				Name:  "memprofile",
 				Usage: "write memory profile to `file`",
 			},
 			&cli.BoolFlag{
 				Name:  "dev",
-				Usage: "sets log-level to debug, and console formatter",
+				Usage: "sets log-level to debug, console formatter, and /debug/pprof",
 			},
 		},
 		Action: startServer,
@@ -159,7 +155,6 @@ func getConfig(c *cli.Context) (*config.Config, error) {
 func startServer(c *cli.Context) error {
 	rand.Seed(time.Now().UnixNano())
 
-	cpuProfile := c.String("cpuprofile")
 	memProfile := c.String("memprofile")
 
 	conf, err := getConfig(c)
@@ -168,18 +163,6 @@ func startServer(c *cli.Context) error {
 	}
 
 	serverlogger.InitFromConfig(conf.Logging)
-
-	if cpuProfile != "" {
-		if f, err := os.Create(cpuProfile); err != nil {
-			return err
-		} else {
-			defer f.Close()
-			if err := pprof.StartCPUProfile(f); err != nil {
-				return err
-			}
-			defer pprof.StopCPUProfile()
-		}
-	}
 
 	if memProfile != "" {
 		if f, err := os.Create(memProfile); err != nil {

--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -24,6 +24,10 @@ import (
 	"os"
 )
 
+import (
+	_ "net/http/pprof"
+)
+
 // Injectors from wire.go:
 
 func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*LivekitServer, error) {

--- a/test/integration_helpers.go
+++ b/test/integration_helpers.go
@@ -140,7 +140,6 @@ func createSingleNodeServer(configUpdater func(*config.Config)) *service.Livekit
 	if err != nil {
 		panic(fmt.Sprintf("could not create config: %v", err))
 	}
-	conf.Development = true
 	conf.Keys = map[string]string{testApiKey: testApiSecret}
 	if configUpdater != nil {
 		configUpdater(conf)
@@ -171,7 +170,6 @@ func createMultiNodeServer(nodeID string, port uint32) *service.LivekitServer {
 	conf.RTC.UDPPort = port + 1
 	conf.RTC.TCPPort = port + 2
 	conf.Redis.Address = "localhost:6379"
-	conf.Development = true
 	conf.Keys = map[string]string{testApiKey: testApiSecret}
 
 	currentNode, err := routing.NewLocalNode(conf)

--- a/test/webhook_test.go
+++ b/test/webhook_test.go
@@ -111,7 +111,6 @@ func setupServerWithWebhook() (server *service.LivekitServer, testServer *webhoo
 	}
 	conf.WebHook.URLs = []string{"http://localhost:7890"}
 	conf.WebHook.APIKey = testApiKey
-	conf.Development = true
 	conf.Keys = map[string]string{testApiKey: testApiSecret}
 
 	testServer = newTestServer(":7890")


### PR DESCRIPTION
The previous --cpuprofile flag is fairly useless as it only captures the profile during shutdown. Removing that option in favor of a pprof endpoint.