### PR TITLE
Fix some test races and other things found with go test -race

### DIFF
--- a/pkg/sfu/prober.go
+++ b/pkg/sfu/prober.go
@@ -210,8 +210,8 @@ func (p *Prober) ProbeSent(size int) {
 }
 
 func (p *Prober) getFrontCluster() *Cluster {
-	p.clustersMu.RLock()
-	defer p.clustersMu.RUnlock()
+	p.clustersMu.Lock()
+	defer p.clustersMu.Unlock()
 
 	if p.activeCluster != nil {
 		return p.activeCluster

--- a/pkg/sfu/streamtracker_test.go
+++ b/pkg/sfu/streamtracker_test.go
@@ -2,6 +2,7 @@ package sfu
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -54,18 +55,26 @@ func TestStreamTracker(t *testing.T) {
 		tracker.Start()
 		require.Equal(t, StreamStatusStopped, tracker.Status())
 
-		tracker.Observe(1, 0, 20, 10)
-		testutils.WithTimeout(t, func() string {
-			if tracker.Status() == StreamStatusActive {
-				return ""
-			} else {
-				return "first packet did not activate stream"
-			}
+		callbackStatusMu := sync.RWMutex{}
+		callbackStatusMu.Lock()
+		callbackStatus := StreamStatusStopped
+		callbackStatusMu.Unlock()
+		tracker.OnStatusChanged(func(status StreamStatus) {
+			callbackStatusMu.Lock()
+			callbackStatus = status
+			callbackStatusMu.Unlock()
 		})
 
-		callbackCalled := atomic.NewBool(false)
-		tracker.OnStatusChanged(func(status StreamStatus) {
-			callbackCalled.Store(true)
+		tracker.Observe(1, 0, 20, 10)
+		testutils.WithTimeout(t, func() string {
+			callbackStatusMu.RLock()
+			defer callbackStatusMu.RUnlock()
+
+			if callbackStatus == StreamStatusActive {
+				return ""
+			}
+
+			return "first packet did not activate stream"
 		})
 		require.Equal(t, StreamStatusActive, tracker.Status())
 
@@ -73,14 +82,17 @@ func TestStreamTracker(t *testing.T) {
 		tracker.detectChanges()
 
 		testutils.WithTimeout(t, func() string {
-			if callbackCalled.Load() {
+			callbackStatusMu.RLock()
+			defer callbackStatusMu.RUnlock()
+
+			if callbackStatus == StreamStatusStopped {
 				return ""
-			} else {
-				return "inactive cycle did not declare stream stopped"
 			}
+
+			return "inactive cycle did not declare stream stopped"
 		})
 		require.Equal(t, StreamStatusStopped, tracker.Status())
-		require.True(t, callbackCalled.Load())
+		require.Equal(t, StreamStatusStopped, callbackStatus)
 
 		tracker.Stop()
 	})

--- a/pkg/telemetry/prometheus/node_linux.go
+++ b/pkg/telemetry/prometheus/node_linux.go
@@ -4,9 +4,12 @@
 package prometheus
 
 import (
+	"sync"
+
 	"github.com/mackerelio/go-osstat/cpu"
 )
 
+var cpuStatsLock sync.RWMutex
 var lastCPUTotal, lastCPUIdle uint64
 
 func getCPUStats() (cpuLoad float32, numCPUs uint32, err error) {
@@ -15,12 +18,14 @@ func getCPUStats() (cpuLoad float32, numCPUs uint32, err error) {
 		return
 	}
 
+	cpuStatsLock.Lock()
 	if lastCPUTotal > 0 && lastCPUTotal < cpuInfo.Total {
 		cpuLoad = 1 - float32(cpuInfo.Idle-lastCPUIdle)/float32(cpuInfo.Total-lastCPUTotal)
 	}
 
 	lastCPUTotal = cpuInfo.Total
 	lastCPUIdle = cpuInfo.Idle // + cpu.Iowait
+	cpuStatsLock.Unlock()
 
 	numCPUs = uint32(cpuInfo.CPUCount)
 

--- a/pkg/telemetry/prometheus/node_nonlinux.go
+++ b/pkg/telemetry/prometheus/node_nonlinux.go
@@ -5,10 +5,12 @@ package prometheus
 
 import (
 	"runtime"
+	"sync"
 
 	"github.com/mackerelio/go-osstat/cpu"
 )
 
+var cpuStatsLock sync.RWMutex
 var lastCPUTotal, lastCPUIdle uint64
 
 func getCPUStats() (cpuLoad float32, numCPUs uint32, err error) {
@@ -17,12 +19,14 @@ func getCPUStats() (cpuLoad float32, numCPUs uint32, err error) {
 		return
 	}
 
+	cpuStatsLock.Lock()
 	if lastCPUTotal > 0 && lastCPUTotal < cpuInfo.Total {
 		cpuLoad = 1 - float32(cpuInfo.Idle-lastCPUIdle)/float32(cpuInfo.Total-lastCPUTotal)
 	}
 
 	lastCPUTotal = cpuInfo.Total
 	lastCPUIdle = cpuInfo.Idle
+	cpuStatsLock.Unlock()
 
 	numCPUs = uint32(runtime.NumCPU())
 


### PR DESCRIPTION
Some of these are just adding locks around test, but good to have a clean run with `go test -race`.

- One case of having to use `Lock` instead of `RLock` in prober.
- Case of `getCPUStats` racing (could not quite understand why there were two goroutines running that - maybe due to simulating multi node in tests? - anyhow a simple lock to ensure it can pass with `-race`)

There are a few more when running `-race`, but want to catch a few at a time. It is a bit of a chase.