### PR TITLE
Use a shadow for receivers for safe range

### DIFF
--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -43,6 +43,7 @@ type MediaTrackReceiver struct {
 
 	lock            sync.RWMutex
 	receivers       []*simulcastReceiver
+	receiversShadow []*simulcastReceiver
 	trackInfo       *livekit.TrackInfo
 	layerDimensions map[livekit.VideoQuality]*livekit.VideoLayer
 
@@ -102,7 +103,7 @@ func NewMediaTrackReceiver(params MediaTrackReceiverParams) *MediaTrackReceiver 
 
 func (t *MediaTrackReceiver) Restart() {
 	t.lock.Lock()
-	receivers := t.receivers
+	receivers := t.receiversShadow
 	t.lock.Unlock()
 
 	for _, receiver := range receivers {
@@ -138,8 +139,12 @@ func (t *MediaTrackReceiver) SetupReceiver(receiver sfu.TrackReceiver, priority 
 		}
 	}
 
+	t.receiversShadow = make([]*simulcastReceiver, len(t.receivers))
+	copy(t.receiversShadow, t.receivers)
+
+	t.params.Logger.Debugw("setup receiver", "mime", receiver.Codec().MimeType, "priority", priority, "receivers", t.receiversShadow)
 	t.lock.Unlock()
-	t.params.Logger.Debugw("setup receiver", "mime", receiver.Codec().MimeType, "priority", priority, "receivers", t.receivers)
+
 	t.MediaTrackSubscriptions.AddCodec(receiver.Codec().MimeType)
 
 	t.MediaTrackSubscriptions.Start()
@@ -150,7 +155,7 @@ func (t *MediaTrackReceiver) SetLayerSsrc(mime string, rid string, ssrc uint32) 
 	defer t.lock.Unlock()
 
 	layer := sfu.RidToLayer(rid)
-	for _, receiver := range t.receivers {
+	for _, receiver := range t.receiversShadow {
 		if strings.EqualFold(receiver.Codec().MimeType, mime) && int(layer) < len(receiver.layerSSRCs) {
 			receiver.layerSSRCs[layer] = ssrc
 			return
@@ -167,7 +172,11 @@ func (t *MediaTrackReceiver) ClearReceiver(mime string) {
 			break
 		}
 	}
-	closeSubscription := len(t.receivers) == 0
+
+	t.receiversShadow = make([]*simulcastReceiver, len(t.receivers))
+	copy(t.receiversShadow, t.receivers)
+
+	closeSubscription := len(t.receiversShadow) == 0
 	t.lock.Unlock()
 
 	if closeSubscription {
@@ -178,6 +187,7 @@ func (t *MediaTrackReceiver) ClearReceiver(mime string) {
 func (t *MediaTrackReceiver) ClearAllReceivers() {
 	t.lock.Lock()
 	t.receivers = t.receivers[:0]
+	t.receiversShadow = nil
 	t.lock.Unlock()
 	t.MediaTrackSubscriptions.Close()
 }
@@ -192,7 +202,7 @@ func (t *MediaTrackReceiver) OnVideoLayerUpdate(f func(layers []*livekit.VideoLa
 
 func (t *MediaTrackReceiver) TryClose() bool {
 	t.lock.Lock()
-	if len(t.receivers) > 0 {
+	if len(t.receiversShadow) > 0 {
 		t.lock.Unlock()
 		return false
 	}
@@ -259,7 +269,7 @@ func (t *MediaTrackReceiver) SetMuted(muted bool) {
 	t.muted.Store(muted)
 
 	t.lock.RLock()
-	for _, receiver := range t.receivers {
+	for _, receiver := range t.receiversShadow {
 		receiver.SetUpTrackPaused(muted)
 	}
 	t.lock.RUnlock()
@@ -280,7 +290,7 @@ func (t *MediaTrackReceiver) AddOnClose(f func()) {
 // AddSubscriber subscribes sub to current mediaTrack
 func (t *MediaTrackReceiver) AddSubscriber(sub types.LocalParticipant) error {
 	t.lock.RLock()
-	receivers := t.receivers
+	receivers := t.receiversShadow
 	t.lock.RUnlock()
 
 	if len(receivers) == 0 {
@@ -324,6 +334,7 @@ func (t *MediaTrackReceiver) UpdateTrackInfo(ti *livekit.TrackInfo) {
 func (t *MediaTrackReceiver) TrackInfo(generateLayer bool) *livekit.TrackInfo {
 	t.lock.RLock()
 	ti := proto.Clone(t.trackInfo).(*livekit.TrackInfo)
+	receivers := t.receiversShadow
 	t.lock.RUnlock()
 	if !generateLayer {
 		return ti
@@ -332,7 +343,7 @@ func (t *MediaTrackReceiver) TrackInfo(generateLayer bool) *livekit.TrackInfo {
 
 	// set video layer ssrc info
 	for i, ci := range ti.Codecs {
-		for _, receiver := range t.receivers {
+		for _, receiver := range receivers {
 			if receiver.priority == i {
 				originLayers := ci.Layers
 				ci.Layers = []*livekit.VideoLayer{}
@@ -356,8 +367,8 @@ func (t *MediaTrackReceiver) TrackInfo(generateLayer bool) *livekit.TrackInfo {
 	}
 
 	// for client don't use simulcast codecs (old client version or single codec)
-	if len(ti.Codecs) == 0 && len(t.receivers) > 0 {
-		receiver := t.receivers[0]
+	if len(ti.Codecs) == 0 && len(receivers) > 0 {
+		receiver := receivers[0]
 		originLayers := ti.Layers
 		ti.Layers = []*livekit.VideoLayer{}
 		for layerIdx, layer := range layers {
@@ -515,7 +526,7 @@ func (t *MediaTrackReceiver) DebugInfo() map[string]interface{} {
 	info["DownTracks"] = t.MediaTrackSubscriptions.DebugInfo()
 
 	t.lock.RLock()
-	for _, receiver := range t.receivers {
+	for _, receiver := range t.receiversShadow {
 		info[receiver.Codec().MimeType] = receiver.DebugInfo()
 	}
 	t.lock.RUnlock()
@@ -526,17 +537,17 @@ func (t *MediaTrackReceiver) PrimaryReceiver() sfu.TrackReceiver {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 
-	if len(t.receivers) == 0 {
+	if len(t.receiversShadow) == 0 {
 		return nil
 	}
-	return t.receivers[0].TrackReceiver
+	return t.receiversShadow[0].TrackReceiver
 }
 
 func (t *MediaTrackReceiver) Receiver(mime string) sfu.TrackReceiver {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 
-	for _, r := range t.receivers {
+	for _, r := range t.receiversShadow {
 		if strings.EqualFold(r.Codec().MimeType, mime) {
 			return r.TrackReceiver
 		}
@@ -548,8 +559,8 @@ func (t *MediaTrackReceiver) Receivers() []sfu.TrackReceiver {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 
-	receivers := make([]sfu.TrackReceiver, 0, len(t.receivers))
-	for _, r := range t.receivers {
+	receivers := make([]sfu.TrackReceiver, 0, len(t.receiversShadow))
+	for _, r := range t.receiversShadow {
 		receivers = append(receivers, r.TrackReceiver)
 	}
 	return receivers
@@ -559,7 +570,7 @@ func (t *MediaTrackReceiver) SetRTT(rtt uint32) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	for _, r := range t.receivers {
+	for _, r := range t.receiversShadow {
 		r.TrackReceiver.(*sfu.WebRTCReceiver).SetRTT(rtt)
 	}
 }

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -333,11 +333,13 @@ func (t *MediaTrackReceiver) UpdateTrackInfo(ti *livekit.TrackInfo) {
 
 func (t *MediaTrackReceiver) TrackInfo(generateLayer bool) *livekit.TrackInfo {
 	t.lock.RLock()
+	defer t.lock.RUnlock()
+
 	ti := proto.Clone(t.trackInfo).(*livekit.TrackInfo)
 	if !generateLayer {
-		t.lock.RUnlock()
 		return ti
 	}
+
 	layers := t.getVideoLayersLocked()
 
 	// set video layer ssrc info
@@ -381,7 +383,6 @@ func (t *MediaTrackReceiver) TrackInfo(generateLayer bool) *livekit.TrackInfo {
 			}
 		}
 	}
-	t.lock.RUnlock()
 
 	return ti
 }

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -502,6 +502,7 @@ func (t *MediaTrackSubscriptions) UpdateQualityChange(force bool) {
 		return
 	}
 
+	t.maxQualityLock.Lock()
 	t.params.Logger.Debugw("updating quality change",
 		"force", force,
 		"maxSubscriberQuality", t.maxSubscriberQuality,
@@ -510,7 +511,6 @@ func (t *MediaTrackSubscriptions) UpdateQualityChange(force bool) {
 
 	maxSubscribedQuality := make(map[string]livekit.VideoQuality, len(t.maxSubscribedQuality))
 	var changed bool
-	t.maxQualityLock.Lock()
 	// reset maxSubscribedQuality
 	for mime := range t.maxSubscribedQuality {
 		maxSubscribedQuality[mime] = livekit.VideoQuality_OFF

--- a/pkg/sfu/buffer/datastats.go
+++ b/pkg/sfu/buffer/datastats.go
@@ -62,7 +62,6 @@ func (s *DataStats) ToProtoActive() *livekit.RTPStats {
 		Bytes:     uint64(s.windowBytes),
 		Bitrate:   float64(s.windowBytes) * 8 / float64(duration) / 1e9,
 	}
-
 }
 
 func (s *DataStats) Stop() {

--- a/pkg/sfu/buffer/datastats_test.go
+++ b/pkg/sfu/buffer/datastats_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/livekit/protocol/livekit"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestDataStats(t *testing.T) {
@@ -18,7 +20,7 @@ func TestDataStats(t *testing.T) {
 	r.StartTime = nil
 	r.EndTime = nil
 	r.Duration = 0
-	require.Zero(t, *r)
+	require.True(t, proto.Equal(r, &livekit.RTPStats{}))
 
 	stats.Update(100, time.Now().UnixNano())
 	r = stats.ToProtoActive()
@@ -28,7 +30,7 @@ func TestDataStats(t *testing.T) {
 	// wait for window duration
 	time.Sleep(time.Second)
 	r = stats.ToProtoActive()
-	require.Zero(t, *r)
+	require.True(t, proto.Equal(r, &livekit.RTPStats{}))
 	stats.Stop()
 	r = stats.ToProtoAggregateOnly()
 	require.EqualValues(t, 100, r.Bytes)


### PR DESCRIPTION
Got a race with access to `layerSSRCs`. Addressing that (holding lock across `ToProto`, maybe each `simulcastReceiver` can have an internal lock, but decided to hold the higher level lock for now as it should be short).

Using `receiversShadow` to have safe range and also not holding lock when doing things like calling RTT or mute on all the receivers.

Also, CI reported a race with max subscribed quality logging.