### PR TITLE
Fixed unclean DownTrack close when removed before bound.

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -154,7 +154,6 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.Tra
 		newWR := sfu.NewWebRTCReceiver(
 			receiver,
 			track,
-			t.PublisherID(),
 			t.params.TrackInfo,
 			LoggerWithCodecMime(t.params.Logger, mime),
 			twcc,

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -144,6 +144,7 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 		codecs,
 		wr,
 		t.params.BufferFactory,
+		sub.Identity(),
 		subscriberID,
 		t.params.ReceiverConfig.PacketBufferSize,
 		LoggerWithTrack(sub.GetLogger(), trackID),
@@ -309,6 +310,10 @@ func (t *MediaTrackSubscriptions) RevokeDisallowedSubscribers(allowedSubscriberI
 		}
 
 		if !found {
+			t.params.Logger.Infow("revoking subscription",
+				"subscriber", subTrack.SubscriberIdentity(),
+				"subscriberID", subTrack.SubscriberID(),
+			)
 			go subTrack.DownTrack().Close()
 			revokedSubscriberIdentities = append(revokedSubscriberIdentities, subTrack.SubscriberIdentity())
 		}

--- a/pkg/rtc/signalhandler.go
+++ b/pkg/rtc/signalhandler.go
@@ -38,7 +38,8 @@ func HandleParticipantSignal(room types.Room, participant types.LocalParticipant
 		participant.SetTrackMuted(livekit.TrackID(msg.Mute.Sid), msg.Mute.Muted, false)
 	case *livekit.SignalRequest_Subscription:
 		var err error
-		if participant.CanSubscribe() {
+		// always allow unsubscribe
+		if participant.CanSubscribe() || !msg.Subscription.Subscribe {
 			updateErr := room.UpdateSubscriptions(
 				participant,
 				livekit.StringsAsTrackIDs(msg.Subscription.TrackSids),

--- a/pkg/rtc/uptrackmanager.go
+++ b/pkg/rtc/uptrackmanager.go
@@ -198,21 +198,21 @@ func (u *UpTrackManager) UpdateSubscriptionPermission(
 	u.lock.Lock()
 	defer u.lock.Unlock()
 
-	// store as is for use when migrating
-	u.subscriptionPermission = subscriptionPermission
 	if subscriptionPermission == nil {
+		// store as is for use when migrating
+		u.subscriptionPermission = subscriptionPermission
 		// possible to get a nil when migrating
 		return nil
 	}
 
 	if err := u.parseSubscriptionPermissions(subscriptionPermission, resolverBySid); err != nil {
-		// do not accept permissions if parse fails
-		u.subscriptionPermission = nil
+		// when failed, do not override previous permissions
 		return err
 	}
 
+	// store as is for use when migrating
+	u.subscriptionPermission = subscriptionPermission
 	u.processPendingSubscriptions(resolverByIdentity)
-
 	u.maybeRevokeSubscriptions(resolverByIdentity)
 
 	return nil
@@ -322,19 +322,15 @@ func (u *UpTrackManager) parseSubscriptionPermissions(
 	}
 
 	// per participant permissions
-	u.subscriberPermissions = make(map[livekit.ParticipantIdentity]*livekit.TrackPermission)
+	subscriberPermissions := make(map[livekit.ParticipantIdentity]*livekit.TrackPermission)
 	for _, trackPerms := range subscriptionPermission.TrackPermissions {
 		subscriberIdentity := livekit.ParticipantIdentity(trackPerms.ParticipantIdentity)
 		if subscriberIdentity == "" {
 			if trackPerms.ParticipantSid == "" {
-				u.subscriberPermissions = nil
 				return ErrSubscriptionPermissionNeedsId
 			}
 
-			var sub types.LocalParticipant
-			if resolver != nil {
-				sub = resolver(livekit.ParticipantID(trackPerms.ParticipantSid))
-			}
+			sub := resolver(livekit.ParticipantID(trackPerms.ParticipantSid))
 			if sub == nil {
 				u.params.Logger.Warnw("could not find subscriber for permissions update", nil, "subscriberID", trackPerms.ParticipantSid)
 				continue
@@ -353,8 +349,10 @@ func (u *UpTrackManager) parseSubscriptionPermissions(
 			}
 		}
 
-		u.subscriberPermissions[subscriberIdentity] = trackPerms
+		subscriberPermissions[subscriberIdentity] = trackPerms
 	}
+
+	u.subscriberPermissions = subscriberPermissions
 
 	return nil
 }
@@ -437,11 +435,13 @@ func (u *UpTrackManager) maybeRemovePendingSubscription(trackID livekit.TrackID,
 	}
 }
 
+// creates subscriptions for tracks if permissions have been granted
 func (u *UpTrackManager) processPendingSubscriptions(resolver func(participantIdentity livekit.ParticipantIdentity) types.LocalParticipant) {
 	updatedPendingSubscriptions := make(map[livekit.TrackID][]livekit.ParticipantIdentity)
 	for trackID, pending := range u.pendingSubscriptions {
 		track := u.getPublishedTrack(trackID)
 		if track == nil {
+			// published track is gone
 			continue
 		}
 
@@ -488,11 +488,9 @@ func (u *UpTrackManager) maybeRevokeSubscriptions(resolver func(participantIdent
 
 		revokedSubscribers := track.RevokeDisallowedSubscribers(allowed)
 		for _, subIdentity := range revokedSubscribers {
-			var sub types.LocalParticipant
-			if resolver != nil {
-				sub = resolver(subIdentity)
-			}
+			sub := resolver(subIdentity)
 			if sub == nil {
+				// participant may have disconnected
 				continue
 			}
 

--- a/pkg/rtc/utils.go
+++ b/pkg/rtc/utils.go
@@ -35,12 +35,12 @@ func PackDataTrackLabel(participantID livekit.ParticipantID, trackID livekit.Tra
 	return string(participantID) + trackIdSeparator + string(trackID) + trackIdSeparator + label
 }
 
-func UnpackDataTrackLabel(packed string) (peerID livekit.ParticipantID, trackID livekit.TrackID, label string) {
+func UnpackDataTrackLabel(packed string) (participantID livekit.ParticipantID, trackID livekit.TrackID, label string) {
 	parts := strings.Split(packed, trackIdSeparator)
 	if len(parts) != 3 {
 		return "", livekit.TrackID(packed), ""
 	}
-	peerID = livekit.ParticipantID(parts[0])
+	participantID = livekit.ParticipantID(parts[0])
 	trackID = livekit.TrackID(parts[1])
 	label = parts[2]
 	return

--- a/pkg/sfu/downtrackspreader.go
+++ b/pkg/sfu/downtrackspreader.go
@@ -61,7 +61,7 @@ func (d *DownTrackSpreader) Store(ts TrackSender) {
 	d.downTrackMu.Lock()
 	defer d.downTrackMu.Unlock()
 
-	d.downTracks[ts.PeerID()] = ts
+	d.downTracks[ts.SubscriberID()] = ts
 	d.shadowDownTracks()
 }
 

--- a/pkg/sfu/downtrackspreader.go
+++ b/pkg/sfu/downtrackspreader.go
@@ -65,19 +65,19 @@ func (d *DownTrackSpreader) Store(ts TrackSender) {
 	d.shadowDownTracks()
 }
 
-func (d *DownTrackSpreader) Free(peerID livekit.ParticipantID) {
+func (d *DownTrackSpreader) Free(subscriberID livekit.ParticipantID) {
 	d.downTrackMu.Lock()
 	defer d.downTrackMu.Unlock()
 
-	delete(d.downTracks, peerID)
+	delete(d.downTracks, subscriberID)
 	d.shadowDownTracks()
 }
 
-func (d *DownTrackSpreader) HasDownTrack(peerID livekit.ParticipantID) bool {
+func (d *DownTrackSpreader) HasDownTrack(subscriberID livekit.ParticipantID) bool {
 	d.downTrackMu.RLock()
 	defer d.downTrackMu.RUnlock()
 
-	_, ok := d.downTracks[peerID]
+	_, ok := d.downTracks[subscriberID]
 	return ok
 }
 

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -49,7 +49,7 @@ type TrackReceiver interface {
 	SetMaxExpectedSpatialLayer(layer int32)
 
 	AddDownTrack(track TrackSender) error
-	DeleteDownTrack(peerID livekit.ParticipantID)
+	DeleteDownTrack(participantID livekit.ParticipantID)
 
 	DebugInfo() map[string]interface{}
 
@@ -63,7 +63,6 @@ type WebRTCReceiver struct {
 	pliThrottleConfig config.PLIThrottleConfig
 	audioConfig       config.AudioConfig
 
-	peerID         livekit.ParticipantID
 	trackID        livekit.TrackID
 	streamID       string
 	kind           webrtc.RTPCodecType
@@ -163,7 +162,6 @@ func WithLoadBalanceThreshold(downTracks int) ReceiverOpts {
 func NewWebRTCReceiver(
 	receiver *webrtc.RTPReceiver,
 	track *webrtc.TrackRemote,
-	pid livekit.ParticipantID,
 	trackInfo *livekit.TrackInfo,
 	logger logger.Logger,
 	twcc *twcc.Responder,
@@ -171,7 +169,6 @@ func NewWebRTCReceiver(
 ) *WebRTCReceiver {
 	w := &WebRTCReceiver{
 		logger:   logger,
-		peerID:   pid,
 		receiver: receiver,
 		trackID:  livekit.TrackID(track.ID()),
 		streamID: track.StreamID(),
@@ -423,12 +420,12 @@ func (w *WebRTCReceiver) OnCloseHandler(fn func()) {
 }
 
 // DeleteDownTrack removes a DownTrack from a Receiver
-func (w *WebRTCReceiver) DeleteDownTrack(peerID livekit.ParticipantID) {
+func (w *WebRTCReceiver) DeleteDownTrack(subscriberID livekit.ParticipantID) {
 	if w.closed.Load() {
 		return
 	}
 
-	w.downTrackSpreader.Free(peerID)
+	w.downTrackSpreader.Free(subscriberID)
 }
 
 func (w *WebRTCReceiver) sendRTCP(packets []rtcp.Packet) {

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -381,7 +381,7 @@ func (w *WebRTCReceiver) AddDownTrack(track TrackSender) error {
 		return ErrReceiverClosed
 	}
 
-	if w.downTrackSpreader.HasDownTrack(track.PeerID()) {
+	if w.downTrackSpreader.HasDownTrack(track.SubscriberID()) {
 		return ErrDownTrackAlreadyExist
 	}
 


### PR DESCRIPTION
When a DownTrack is closed before it had a chance to be bound to a
transceiver, we'd skip close and leave it hanging. This is unlikely in
normal operations. However, it can be seen with permissions and
subscription APIs.