### PR TITLE
set DownTrack's initial codec to first codec of potential codecs

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -216,6 +216,7 @@ func NewDownTrack(
 		receiver:       r,
 		upstreamCodecs: codecs,
 		kind:           kind,
+		codec:          codecs[0],
 	}
 	d.forwarder = NewForwarder(d.kind, d.logger)
 


### PR DESCRIPTION
Client send updated subscribed track settings immediately after setting answer, that might cause server side receive `SignalRequest_TrackSetting` before setting answer to peerconnection, at this time, DownTrack's codec is empty since it is not bound yet and update subscribed track setting might failed.
This commit set DownTrack's initial codec to first codec of potential codecs.