### PR TITLE
Set SSRC for RTCP

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -3,7 +3,6 @@ package buffer
 import (
 	"encoding/binary"
 	"io"
-	"math/rand"
 	"strings"
 	"sync"
 	"time"
@@ -324,7 +323,7 @@ func (b *Buffer) SendPLI(force bool) {
 
 	b.logger.Debugw("send pli", "ssrc", b.mediaSSRC, "force", force)
 	pli := []rtcp.Packet{
-		&rtcp.PictureLossIndication{SenderSSRC: rand.Uint32(), MediaSSRC: b.mediaSSRC},
+		&rtcp.PictureLossIndication{SenderSSRC: b.mediaSSRC, MediaSSRC: b.mediaSSRC},
 	}
 
 	if b.onRtcpFeedback != nil {
@@ -529,8 +528,9 @@ func (b *Buffer) buildNACKPacket() ([]rtcp.Packet, int) {
 		var pkts []rtcp.Packet
 		if len(nacks) > 0 {
 			pkts = []rtcp.Packet{&rtcp.TransportLayerNack{
-				MediaSSRC: b.mediaSSRC,
-				Nacks:     nacks,
+				SenderSSRC: b.mediaSSRC,
+				MediaSSRC:  b.mediaSSRC,
+				Nacks:      nacks,
 			}}
 		}
 
@@ -571,6 +571,7 @@ func (b *Buffer) getRTCP() []rtcp.Packet {
 	rr := b.buildReceptionReport()
 	if rr != nil {
 		pkts = append(pkts, &rtcp.ReceiverReport{
+			SSRC:    b.mediaSSRC,
 			Reports: []rtcp.ReceptionReport{*rr},
 		})
 	}

--- a/pkg/sfu/streamtrackermanager.go
+++ b/pkg/sfu/streamtrackermanager.go
@@ -25,13 +25,13 @@ var (
 		},
 		{
 			SamplesRequired:       5,
-			CyclesRequired:        60,
+			CyclesRequired:        20,
 			CycleDuration:         500 * time.Millisecond,
 			BitrateReportInterval: 1 * time.Second,
 		},
 		{
 			SamplesRequired:       5,
-			CyclesRequired:        60,
+			CyclesRequired:        20,
 			CycleDuration:         500 * time.Millisecond,
 			BitrateReportInterval: 1 * time.Second,
 		},


### PR DESCRIPTION
- SenderSSRC was not set for NACK, RTCP_RR - so SRTP context
was using SSRC = 0 which is not bad, but let us set the SSRC properly.
- PLI was using a random SSRC on every PLI. So, that would have
created a new SRTP stream (not bad as that stream context is small)
on every PLI. It is wasteful. So, set the SenderSSRC to the mediaSSRC.
- Reduce re-start of higher layers to 10 seconds. That is long enough
to declare that a stream layer has restarted.