### PR TITLE
Use go map for subscribedTo.

### DIFF
--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -675,3 +675,14 @@ func (t *MediaTrackReceiver) OnSubscribedMaxQualityChange(f func(trackID livekit
 }
 
 // ---------------------------
+
+func VideoQualityToRID(q livekit.VideoQuality) string {
+	switch q {
+	case livekit.VideoQuality_HIGH:
+		return sfu.FullResolution
+	case livekit.VideoQuality_MEDIUM:
+		return sfu.HalfResolution
+	default:
+		return sfu.QuarterResolution
+	}
+}


### PR DESCRIPTION
Range over a sync.Map could produce unexpected results if
there are concurrent changes (change in value or delete).
While we do not change value (the value is a place holder in this map),
just moving to go map to avoid hard to find concurrency issues.
The lock scoping is well defined for the map. So, making the change
to be more defensive.