### PR TITLE
Look for stable mex expected layer before calculating score.

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -21,7 +21,6 @@ import (
 	"github.com/livekit/livekit-server/pkg/sfu/buffer"
 	"github.com/livekit/livekit-server/pkg/sfu/connectionquality"
 	dd "github.com/livekit/livekit-server/pkg/sfu/dependencydescriptor"
-	"github.com/livekit/livekit-server/pkg/utils"
 )
 
 // TrackSender defines an interface send media to remote peer
@@ -228,10 +227,10 @@ func NewDownTrack(
 		GetDeltaStats:     d.getDeltaStats,
 		IsDtxDisabled:     d.receiver.IsDtxDisabled,
 		GetLayerDimension: d.receiver.GetLayerDimension,
-		GetMaxExpectedLayer: func() *livekit.VideoLayer {
+		GetMaxExpectedLayer: func() (int32, uint32, uint32) {
 			maxLayer := d.forwarder.MaxLayers().Spatial
 			width, height := d.receiver.GetLayerDimension(maxLayer)
-			return &livekit.VideoLayer{Quality: utils.QualityForSpatialLayer(maxLayer), Width: width, Height: height}
+			return maxLayer, width, height
 		},
 		GetCurrentLayerSpatial: func() int32 {
 			return d.forwarder.CurrentLayers().Spatial

--- a/pkg/sfu/streamtrackermanager.go
+++ b/pkg/sfu/streamtrackermanager.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/livekit/livekit-server/pkg/utils"
 	"github.com/livekit/protocol/livekit"
@@ -276,7 +275,7 @@ func (s *StreamTrackerManager) GetLayerDimension(layer int32) (uint32, uint32) {
 	return width, height
 }
 
-func (s *StreamTrackerManager) GetMaxExpectedLayer() *livekit.VideoLayer {
+func (s *StreamTrackerManager) GetMaxExpectedLayer() (layer int32, width uint32, height uint32) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
@@ -287,11 +286,11 @@ func (s *StreamTrackerManager) GetMaxExpectedLayer() *livekit.VideoLayer {
 	}
 	for _, layer := range s.trackInfo.Layers {
 		if maxExpectedLayer == utils.SpatialLayerForQuality(layer.Quality) {
-			return proto.Clone(layer).(*livekit.VideoLayer)
+			return maxExpectedLayer, layer.Width, layer.Height
 		}
 	}
 
-	return nil
+	return maxExpectedLayer, 0, 0
 }
 
 func (s *StreamTrackerManager) GetBitrateTemporalCumulative() Bitrates {


### PR DESCRIPTION
For muxed track (like down track), adaptive streaming could change
maximum layer. So, calculation windows could contain data from
other layers. Using them against a changed expected layer could
yield lower score whereas in reality, it is expected change.

Ideally, it would be good to track every expected layer change
and keep track of stats. But, that could get unnecessarily complex.
A sub-optimal solution is to maintain previous score in windows
where the expected layer changes. As calculation windows are short,
this is a reasonable compromise.