### PR TITLE
disable ice lite by default

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -35,8 +35,8 @@ rtc:
   # this is useful for cloud environments such as AWS & Google where hosts have an internal IP
   # that maps to an external one
   use_external_ip: true
-  # when set to true, pion will use a lite ice agent, that will speed up ice connection, but 
-  # might cause connect issue if server running behind nats.
+  # when set to true, server will use a lite ice agent, that will speed up ice connection, but 
+  # might cause connect issue if server running behind NAT.
   # use_ice_lite: true
   # when set, LiveKit will attempt to use a UDP mux so all UDP traffic goes through
   # a single port. This simplifies deployment, but mux will become an overhead for

--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -35,6 +35,9 @@ rtc:
   # this is useful for cloud environments such as AWS & Google where hosts have an internal IP
   # that maps to an external one
   use_external_ip: true
+  # when set to true, pion will use a lite ice agent, that will speed up ice connection, but 
+  # might cause connect issue if server running behind nats.
+  # use_ice_lite: true
   # when set, LiveKit will attempt to use a UDP mux so all UDP traffic goes through
   # a single port. This simplifies deployment, but mux will become an overhead for
   # highly trafficked deployments.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -195,7 +195,6 @@ func NewConfig(confString string, c *cli.Context) (*Config, error) {
 		Port: 7880,
 		RTC: RTCConfig{
 			UseExternalIP:     false,
-			UseICELite:        true,
 			TCPPort:           7881,
 			UDPPort:           0,
 			ICEPortRangeStart: 0,

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -123,7 +123,7 @@ func (t *MediaTrackReceiver) SetupReceiver(receiver sfu.TrackReceiver, priority 
 	var upgradeReceiver bool
 	for _, r := range t.receivers {
 		if strings.EqualFold(r.Codec().MimeType, receiver.Codec().MimeType) {
-			if d, ok := r.TrackReceiver.(*DumbReceiver); ok {
+			if d, ok := r.TrackReceiver.(*DummyReceiver); ok {
 				d.Upgrade(receiver)
 				upgradeReceiver = true
 				break
@@ -181,7 +181,7 @@ func (t *MediaTrackReceiver) SetPotentialCodecs(codecs []webrtc.RTPCodecParamete
 		}
 		if !exist {
 			t.receivers = append(t.receivers, &simulcastReceiver{
-				TrackReceiver: NewDumbReceiver(livekit.TrackID(t.trackInfo.Sid), string(t.PublisherID()), c, headers),
+				TrackReceiver: NewDummyReceiver(livekit.TrackID(t.trackInfo.Sid), string(t.PublisherID()), c, headers),
 				priority:      i,
 			})
 		}
@@ -622,7 +622,7 @@ func (t *MediaTrackReceiver) PrimaryReceiver() sfu.TrackReceiver {
 	if len(t.receiversShadow) == 0 {
 		return nil
 	}
-	if dr, ok := t.receiversShadow[0].TrackReceiver.(*DumbReceiver); ok {
+	if dr, ok := t.receiversShadow[0].TrackReceiver.(*DummyReceiver); ok {
 		return dr.Receiver()
 	}
 	return t.receiversShadow[0].TrackReceiver
@@ -634,7 +634,7 @@ func (t *MediaTrackReceiver) Receiver(mime string) sfu.TrackReceiver {
 
 	for _, r := range t.receiversShadow {
 		if strings.EqualFold(r.Codec().MimeType, mime) {
-			if dr, ok := r.TrackReceiver.(*DumbReceiver); ok {
+			if dr, ok := r.TrackReceiver.(*DummyReceiver); ok {
 				return dr.Receiver()
 			}
 			return r.TrackReceiver

--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -61,7 +61,7 @@ func (r *WrappedReceiver) Codecs() []webrtc.RTPCodecParameters {
 	return codecs
 }
 
-type DumbReceiver struct {
+type DummyReceiver struct {
 	receiver         atomic.Value
 	trackID          livekit.TrackID
 	streamId         string
@@ -71,8 +71,8 @@ type DumbReceiver struct {
 	downtracks       map[livekit.ParticipantID]sfu.TrackSender
 }
 
-func NewDumbReceiver(trackID livekit.TrackID, streamId string, codec webrtc.RTPCodecParameters, headerExtensions []webrtc.RTPHeaderExtensionParameter) *DumbReceiver {
-	return &DumbReceiver{
+func NewDummyReceiver(trackID livekit.TrackID, streamId string, codec webrtc.RTPCodecParameters, headerExtensions []webrtc.RTPHeaderExtensionParameter) *DummyReceiver {
+	return &DummyReceiver{
 		trackID:          trackID,
 		streamId:         streamId,
 		codec:            codec,
@@ -81,12 +81,12 @@ func NewDumbReceiver(trackID livekit.TrackID, streamId string, codec webrtc.RTPC
 	}
 }
 
-func (d *DumbReceiver) Receiver() sfu.TrackReceiver {
+func (d *DummyReceiver) Receiver() sfu.TrackReceiver {
 	r, _ := d.receiver.Load().(sfu.TrackReceiver)
 	return r
 }
 
-func (d *DumbReceiver) Upgrade(receiver sfu.TrackReceiver) {
+func (d *DummyReceiver) Upgrade(receiver sfu.TrackReceiver) {
 	d.downtrackLock.Lock()
 	defer d.downtrackLock.Unlock()
 	d.receiver.CompareAndSwap(nil, receiver)
@@ -96,68 +96,68 @@ func (d *DumbReceiver) Upgrade(receiver sfu.TrackReceiver) {
 	d.downtracks = make(map[livekit.ParticipantID]sfu.TrackSender)
 }
 
-func (d *DumbReceiver) TrackID() livekit.TrackID {
+func (d *DummyReceiver) TrackID() livekit.TrackID {
 	return d.trackID
 }
 
-func (d *DumbReceiver) StreamID() string {
+func (d *DummyReceiver) StreamID() string {
 	return d.streamId
 }
 
-func (d *DumbReceiver) Codec() webrtc.RTPCodecParameters {
+func (d *DummyReceiver) Codec() webrtc.RTPCodecParameters {
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.Codec()
 	}
 	return d.codec
 }
 
-func (d *DumbReceiver) HeaderExtensions() []webrtc.RTPHeaderExtensionParameter {
+func (d *DummyReceiver) HeaderExtensions() []webrtc.RTPHeaderExtensionParameter {
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.HeaderExtensions()
 	}
 	return d.headerExtensions
 }
 
-func (d *DumbReceiver) ReadRTP(buf []byte, layer uint8, sn uint16) (int, error) {
+func (d *DummyReceiver) ReadRTP(buf []byte, layer uint8, sn uint16) (int, error) {
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.ReadRTP(buf, layer, sn)
 	}
 	return 0, errors.New("no receiver")
 }
 
-func (d *DumbReceiver) GetBitrateTemporalCumulative() sfu.Bitrates {
+func (d *DummyReceiver) GetBitrateTemporalCumulative() sfu.Bitrates {
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.GetBitrateTemporalCumulative()
 	}
 	return sfu.Bitrates{}
 }
 
-func (d *DumbReceiver) GetAudioLevel() (float64, bool) {
+func (d *DummyReceiver) GetAudioLevel() (float64, bool) {
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.GetAudioLevel()
 	}
 	return 0, false
 }
 
-func (d *DumbReceiver) SendPLI(layer int32, force bool) {
+func (d *DummyReceiver) SendPLI(layer int32, force bool) {
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		r.SendPLI(layer, force)
 	}
 }
 
-func (d *DumbReceiver) SetUpTrackPaused(paused bool) {
+func (d *DummyReceiver) SetUpTrackPaused(paused bool) {
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		r.SetUpTrackPaused(paused)
 	}
 }
 
-func (d *DumbReceiver) SetMaxExpectedSpatialLayer(layer int32) {
+func (d *DummyReceiver) SetMaxExpectedSpatialLayer(layer int32) {
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		r.SetMaxExpectedSpatialLayer(layer)
 	}
 }
 
-func (d *DumbReceiver) AddDownTrack(track sfu.TrackSender) error {
+func (d *DummyReceiver) AddDownTrack(track sfu.TrackSender) error {
 	d.downtrackLock.Lock()
 	defer d.downtrackLock.Unlock()
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
@@ -168,7 +168,7 @@ func (d *DumbReceiver) AddDownTrack(track sfu.TrackSender) error {
 	return nil
 }
 
-func (d *DumbReceiver) DeleteDownTrack(participantID livekit.ParticipantID) {
+func (d *DummyReceiver) DeleteDownTrack(participantID livekit.ParticipantID) {
 	d.downtrackLock.Lock()
 	defer d.downtrackLock.Unlock()
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
@@ -178,28 +178,28 @@ func (d *DumbReceiver) DeleteDownTrack(participantID livekit.ParticipantID) {
 	}
 }
 
-func (d *DumbReceiver) DebugInfo() map[string]interface{} {
+func (d *DummyReceiver) DebugInfo() map[string]interface{} {
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.DebugInfo()
 	}
 	return nil
 }
 
-func (d *DumbReceiver) GetLayerDimension(quality int32) (uint32, uint32) {
+func (d *DummyReceiver) GetLayerDimension(quality int32) (uint32, uint32) {
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.GetLayerDimension(quality)
 	}
 	return 0, 0
 }
 
-func (d *DumbReceiver) IsDtxDisabled() bool {
+func (d *DummyReceiver) IsDtxDisabled() bool {
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.IsDtxDisabled()
 	}
 	return false
 }
 
-func (d *DumbReceiver) TrackSource() livekit.TrackSource {
+func (d *DummyReceiver) TrackSource() livekit.TrackSource {
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.TrackSource()
 	}


### PR DESCRIPTION
enable ice-lite can speed up ice connection but cause problem for user running server without public address, they should either disable ice-lite manually or enable user_external_ip if host behind 1to1 nats. That’s hard for people who are not familiar with ice negotiation