### PR TITLE
Re-use transceiver (via ReplaceTrack) if a down track is going to be resumed.

### DIFF
--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -161,72 +161,115 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 		return nil, err
 	}
 
+	t.params.Logger.Debugw("RAJA add new subscribed track") // REMOVE
 	subTrack := NewSubscribedTrack(SubscribedTrackParams{
-		PublisherID:        t.params.MediaTrack.PublisherID(),
-		PublisherIdentity:  t.params.MediaTrack.PublisherIdentity(),
+		PublisherID:       t.params.MediaTrack.PublisherID(),
+		PublisherIdentity: t.params.MediaTrack.PublisherIdentity(),
+		/* RAJA-REMOVE
 		SubscriberID:       subscriberID,
 		SubscriberIdentity: sub.Identity(),
-		MediaTrack:         t.params.MediaTrack,
-		DownTrack:          downTrack,
-		AdaptiveStream:     sub.GetAdaptiveStream(),
+		*/
+		Subscriber:     sub,
+		MediaTrack:     t.params.MediaTrack,
+		DownTrack:      downTrack,
+		AdaptiveStream: sub.GetAdaptiveStream(),
+	})
+
+	// Bind callback can happen from replaceTrack, so set it up early
+	downTrack.OnBind(func() {
+		t.params.Logger.Debugw("RAJA onBind happend", "codec", downTrack.Codec()) // REMOVE
+		wr.DetermineReceiver(downTrack.Codec())
+		if err = wr.AddDownTrack(downTrack); err != nil {
+			t.params.Logger.Errorw("could not add down track", err, "participant", sub.Identity(), "pID", sub.ID())
+		}
+
+		go subTrack.Bound()
+
+		// when down track is bound, start loop to send reports
+		go t.sendDownTrackBindingReports(sub)
+
+		// initialize to default layer
+		t.notifySubscriberMaxQuality(subscriberID, downTrack.Codec(), livekit.VideoQuality_HIGH)
+		subTrack.SetPublisherMuted(t.params.MediaTrack.IsMuted())
 	})
 
 	var transceiver *webrtc.RTPTransceiver
 	var sender *webrtc.RTPSender
-	if sub.ProtocolVersion().SupportsTransceiverReuse() {
-		//
-		// AddTrack will create a new transceiver or re-use an unused one
-		// if the attributes match. This prevents SDP from bloating
-		// because of dormant transceivers building up.
-		//
-		sender, err = sub.SubscriberPC().AddTrack(downTrack)
-		if err != nil {
-			return nil, err
-		}
 
-		// as there is no way to get transceiver from sender, search
-		for _, tr := range sub.SubscriberPC().GetTransceivers() {
-			if tr.Sender() == sender {
-				transceiver = tr
-				break
+	// try cached RTP senders for a chance to replace track
+	replacedTrack := false
+	existingTransceiver := sub.GetCachedRTPTransceiver(trackID)
+	if existingTransceiver != nil {
+		rtpSender := existingTransceiver.Sender()
+		if rtpSender != nil {
+			err := rtpSender.ReplaceTrack(downTrack)
+			if err == nil {
+				sender = rtpSender
+				transceiver = existingTransceiver
+				replacedTrack = true
 			}
 		}
-		if transceiver == nil {
-			// cannot add, no transceiver
-			return nil, errors.New("cannot subscribe without a transceiver in place")
-		}
-	} else {
-		transceiver, err = sub.SubscriberPC().AddTransceiverFromTrack(downTrack, webrtc.RTPTransceiverInit{
-			Direction: webrtc.RTPTransceiverDirectionSendonly,
-		})
-		if err != nil {
-			return nil, err
-		}
 
-		sender = transceiver.Sender()
-		if sender == nil {
-			// cannot add, no sender
-			return nil, errors.New("cannot subscribe without a sender in place")
+		if !replacedTrack {
+			// Could not re-use cached transceiver for this track.
+			// Stop the transceiver so that it is at least not active.
+			// It is not usable once stopped,
+			//
+			// Adding down track will create a new transceiver (or re-use
+			// an inactive existing one). In either case, a renegotiation
+			// will happen and that will notify remote of this stopped
+			// transceiver
+			existingTransceiver.Stop()
 		}
+	}
+	// wthether re-using or stopping, remove transceiver from cache
+	sub.UncacheRTPTransceiver(trackID)
+
+	// if cannot replace, find an unused transceiver or add new one
+	if transceiver == nil {
+		if sub.ProtocolVersion().SupportsTransceiverReuse() {
+			//
+			// AddTrack will create a new transceiver or re-use an unused one
+			// if the attributes match. This prevents SDP from bloating
+			// because of dormant transceivers building up.
+			//
+			t.params.Logger.Debugw("RAJA adding track") // REMOVE
+			sender, err = sub.SubscriberPC().AddTrack(downTrack)
+			if err != nil {
+				return nil, err
+			}
+
+			// as there is no way to get transceiver from sender, search
+			for _, tr := range sub.SubscriberPC().GetTransceivers() {
+				if tr.Sender() == sender {
+					transceiver = tr
+					break
+				}
+			}
+		} else {
+			transceiver, err = sub.SubscriberPC().AddTransceiverFromTrack(downTrack, webrtc.RTPTransceiverInit{
+				Direction: webrtc.RTPTransceiverDirectionSendonly,
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			sender = transceiver.Sender()
+		}
+	}
+	if transceiver == nil {
+		// cannot add, no transceiver
+		return nil, errors.New("cannot subscribe without a transceiver in place")
+	}
+	if sender == nil {
+		// cannot add, no sender
+		return nil, errors.New("cannot subscribe without a sender in place")
 	}
 
 	sendParameters := sender.GetParameters()
 	downTrack.SetRTPHeaderExtensions(sendParameters.HeaderExtensions)
 
 	downTrack.SetTransceiver(transceiver)
-
-	// when out track is bound, start loop to send reports
-	downTrack.OnBind(func() {
-		wr.DetermineReceiver(downTrack.Codec())
-		if err = wr.AddDownTrack(downTrack); err != nil {
-			logger.Errorw("could not add down track", err, "participant", sub.Identity(), "pID", sub.ID())
-		}
-		go subTrack.Bound()
-		go t.sendDownTrackBindingReports(sub)
-		// initialize to default layer
-		t.notifySubscriberMaxQuality(subscriberID, downTrack.Codec(), livekit.VideoQuality_HIGH)
-		subTrack.SetPublisherMuted(t.params.MediaTrack.IsMuted())
-	})
 
 	downTrack.OnStatsUpdate(func(_ *sfu.DownTrack, stat *livekit.AnalyticsStat) {
 		t.params.Telemetry.TrackStats(livekit.StreamType_DOWNSTREAM, subscriberID, trackID, stat)
@@ -251,7 +294,12 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 	// since sub will lock, run it in a goroutine to avoid deadlocks
 	go func() {
 		sub.AddSubscribedTrack(subTrack)
-		sub.Negotiate(false)
+		if !replacedTrack {
+			t.params.Logger.Debugw("RAJA re-neg sub") // REMOVE
+			sub.Negotiate(false)
+		} else {
+			t.params.Logger.Debugw("RAJA skipping re-neg sub because of replaced track") // REMOVE
+		}
 	}()
 
 	t.params.Telemetry.TrackSubscribed(context.Background(), subscriberID, t.params.MediaTrack.ToProto(),
@@ -272,7 +320,18 @@ func (t *MediaTrackSubscriptions) RemoveSubscriber(participantID livekit.Partici
 	t.subscribedTracksMu.Unlock()
 
 	if subTrack != nil {
-		subTrack.DownTrack().CloseWithFlush(!willBeResumed)
+		dt := subTrack.DownTrack()
+		if dt != nil {
+			if willBeResumed {
+				tr := dt.GetTransceiver()
+				if tr != nil {
+					sub := subTrack.Subscriber()
+					sub.CacheRTPTransceiver(subTrack.ID(), tr)
+				}
+			}
+
+			dt.CloseWithFlush(!willBeResumed)
+		}
 	}
 }
 
@@ -289,7 +348,18 @@ func (t *MediaTrackSubscriptions) RemoveAllSubscribers(willBeResumed bool) {
 	t.subscribedTracksMu.Unlock()
 
 	for _, subTrack := range subscribedTracks {
-		subTrack.DownTrack().CloseWithFlush(!willBeResumed)
+		dt := subTrack.DownTrack()
+		if dt != nil {
+			if willBeResumed {
+				tr := dt.GetTransceiver()
+				if tr != nil {
+					sub := subTrack.Subscriber()
+					sub.CacheRTPTransceiver(subTrack.ID(), tr)
+				}
+			}
+
+			dt.CloseWithFlush(!willBeResumed)
+		}
 	}
 }
 
@@ -681,6 +751,7 @@ func (t *MediaTrackSubscriptions) downTrackClosed(
 	willBeResumed bool,
 	sender *webrtc.RTPSender,
 ) {
+	t.params.Logger.Debugw("RAJA DT closed", "willBeResumed", willBeResumed) // REMOVE
 	subscriberID := sub.ID()
 	t.subscribedTracksMu.Lock()
 	delete(t.subscribedTracks, subscriberID)
@@ -726,6 +797,9 @@ func (t *MediaTrackSubscriptions) downTrackClosed(
 
 	sub.RemoveSubscribedTrack(subTrack)
 	if !willBeResumed {
+		t.params.Logger.Debugw("RAJA re-neg on track removal") // REMOVE
 		sub.Negotiate(false)
+	} else {
+		t.params.Logger.Debugw("RAJA skipping re-neg on track removal") // REMOVE
 	}
 }

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -161,23 +161,17 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 		return nil, err
 	}
 
-	t.params.Logger.Debugw("RAJA add new subscribed track") // REMOVE
 	subTrack := NewSubscribedTrack(SubscribedTrackParams{
 		PublisherID:       t.params.MediaTrack.PublisherID(),
 		PublisherIdentity: t.params.MediaTrack.PublisherIdentity(),
-		/* RAJA-REMOVE
-		SubscriberID:       subscriberID,
-		SubscriberIdentity: sub.Identity(),
-		*/
-		Subscriber:     sub,
-		MediaTrack:     t.params.MediaTrack,
-		DownTrack:      downTrack,
-		AdaptiveStream: sub.GetAdaptiveStream(),
+		Subscriber:        sub,
+		MediaTrack:        t.params.MediaTrack,
+		DownTrack:         downTrack,
+		AdaptiveStream:    sub.GetAdaptiveStream(),
 	})
 
 	// Bind callback can happen from replaceTrack, so set it up early
 	downTrack.OnBind(func() {
-		t.params.Logger.Debugw("RAJA onBind happend", "codec", downTrack.Codec()) // REMOVE
 		wr.DetermineReceiver(downTrack.Codec())
 		if err = wr.AddDownTrack(downTrack); err != nil {
 			t.params.Logger.Errorw("could not add down track", err, "participant", sub.Identity(), "pID", sub.ID())
@@ -233,7 +227,6 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 			// if the attributes match. This prevents SDP from bloating
 			// because of dormant transceivers building up.
 			//
-			t.params.Logger.Debugw("RAJA adding track") // REMOVE
 			sender, err = sub.SubscriberPC().AddTrack(downTrack)
 			if err != nil {
 				return nil, err
@@ -295,10 +288,7 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 	go func() {
 		sub.AddSubscribedTrack(subTrack)
 		if !replacedTrack {
-			t.params.Logger.Debugw("RAJA re-neg sub") // REMOVE
 			sub.Negotiate(false)
-		} else {
-			t.params.Logger.Debugw("RAJA skipping re-neg sub because of replaced track") // REMOVE
 		}
 	}()
 
@@ -751,7 +741,6 @@ func (t *MediaTrackSubscriptions) downTrackClosed(
 	willBeResumed bool,
 	sender *webrtc.RTPSender,
 ) {
-	t.params.Logger.Debugw("RAJA DT closed", "willBeResumed", willBeResumed) // REMOVE
 	subscriberID := sub.ID()
 	t.subscribedTracksMu.Lock()
 	delete(t.subscribedTracks, subscriberID)
@@ -797,9 +786,6 @@ func (t *MediaTrackSubscriptions) downTrackClosed(
 
 	sub.RemoveSubscribedTrack(subTrack)
 	if !willBeResumed {
-		t.params.Logger.Debugw("RAJA re-neg on track removal") // REMOVE
 		sub.Negotiate(false)
-	} else {
-		t.params.Logger.Debugw("RAJA skipping re-neg on track removal") // REMOVE
 	}
 }

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -137,6 +137,8 @@ type ParticipantImpl struct {
 	activeCounter  atomic.Int32
 	firstConnected atomic.Bool
 	iceConfig      types.IceConfig
+
+	cachedRTPTransceivers map[livekit.TrackID]*webrtc.RTPTransceiver
 }
 
 func NewParticipant(params ParticipantParams) (*ParticipantImpl, error) {
@@ -159,6 +161,7 @@ func NewParticipant(params ParticipantParams) (*ParticipantImpl, error) {
 		subscribedTo:             make(map[livekit.ParticipantID]struct{}),
 		connectedAt:              time.Now(),
 		rttUpdatedAt:             time.Now(),
+		cachedRTPTransceivers:    make(map[livekit.TrackID]*webrtc.RTPTransceiver),
 	}
 	p.version.Store(params.InitialVersion)
 	p.migrateState.Store(types.MigrateStateInit)
@@ -1907,4 +1910,26 @@ func (p *ParticipantImpl) setDowntracksConnected() {
 			dt.SetConnected()
 		}
 	}
+}
+
+func (p *ParticipantImpl) CacheRTPTransceiver(trackID livekit.TrackID, rtpTransceiver *webrtc.RTPTransceiver) {
+	p.lock.Lock()
+	if existing := p.cachedRTPTransceivers[trackID]; existing != nil && existing != rtpTransceiver {
+		p.params.Logger.Infow("cached transceiver change", "trackID", trackID)
+	}
+	p.cachedRTPTransceivers[trackID] = rtpTransceiver
+	p.lock.Unlock()
+}
+
+func (p *ParticipantImpl) UncacheRTPTransceiver(trackID livekit.TrackID) {
+	p.lock.Lock()
+	delete(p.cachedRTPTransceivers, trackID)
+	p.lock.Unlock()
+}
+
+func (p *ParticipantImpl) GetCachedRTPTransceiver(trackID livekit.TrackID) *webrtc.RTPTransceiver {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return p.cachedRTPTransceivers[trackID]
 }

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1921,9 +1921,14 @@ func (p *ParticipantImpl) CacheRTPTransceiver(trackID livekit.TrackID, rtpTransc
 	p.lock.Unlock()
 }
 
-func (p *ParticipantImpl) UncacheRTPTransceiver(trackID livekit.TrackID) {
+func (p *ParticipantImpl) UncacheRTPTransceiver(rtpTransceiver *webrtc.RTPTransceiver) {
 	p.lock.Lock()
-	delete(p.cachedRTPTransceivers, trackID)
+	for trackID, tr := range p.cachedRTPTransceivers {
+		if tr == rtpTransceiver {
+			delete(p.cachedRTPTransceivers, trackID)
+			break
+		}
+	}
 	p.lock.Unlock()
 }
 

--- a/pkg/rtc/subscribedtrack.go
+++ b/pkg/rtc/subscribedtrack.go
@@ -64,7 +64,7 @@ func (t *SubscribedTrack) Bound() {
 
 func (t *SubscribedTrack) maybeOnBind() {
 	if onBind := t.onBind.Load(); onBind != nil && t.bound.Load() {
-		onBind.(func())()
+		go onBind.(func())()
 	}
 }
 

--- a/pkg/rtc/subscribedtrack.go
+++ b/pkg/rtc/subscribedtrack.go
@@ -19,13 +19,16 @@ const (
 )
 
 type SubscribedTrackParams struct {
-	PublisherID        livekit.ParticipantID
-	PublisherIdentity  livekit.ParticipantIdentity
-	SubscriberID       livekit.ParticipantID
-	SubscriberIdentity livekit.ParticipantIdentity
-	MediaTrack         types.MediaTrack
-	DownTrack          *sfu.DownTrack
-	AdaptiveStream     bool
+	PublisherID       livekit.ParticipantID
+	PublisherIdentity livekit.ParticipantIdentity
+	/*
+		SubscriberID       livekit.ParticipantID
+		SubscriberIdentity livekit.ParticipantIdentity
+	*/
+	Subscriber     types.LocalParticipant
+	MediaTrack     types.MediaTrack
+	DownTrack      *sfu.DownTrack
+	AdaptiveStream bool
 }
 
 type SubscribedTrack struct {
@@ -34,7 +37,8 @@ type SubscribedTrack struct {
 	pubMuted atomic.Bool
 	settings atomic.Value // *livekit.UpdateTrackSettings
 
-	onBind func()
+	onBind atomic.Value // fucn()
+	bound  atomic.Bool
 
 	debouncer func(func())
 }
@@ -49,15 +53,22 @@ func NewSubscribedTrack(params SubscribedTrackParams) *SubscribedTrack {
 }
 
 func (t *SubscribedTrack) OnBind(f func()) {
-	t.onBind = f
+	t.onBind.Store(f)
+
+	t.maybeOnBind()
 }
 
 func (t *SubscribedTrack) Bound() {
+	t.bound.Store(true)
 	if !t.params.AdaptiveStream {
 		t.params.DownTrack.SetMaxSpatialLayer(utils.SpatialLayerForQuality(livekit.VideoQuality_HIGH))
 	}
-	if t.onBind != nil {
-		t.onBind()
+	t.maybeOnBind()
+}
+
+func (t *SubscribedTrack) maybeOnBind() {
+	if onBind := t.onBind.Load(); onBind != nil && t.bound.Load() {
+		onBind.(func())()
 	}
 }
 
@@ -74,11 +85,15 @@ func (t *SubscribedTrack) PublisherIdentity() livekit.ParticipantIdentity {
 }
 
 func (t *SubscribedTrack) SubscriberID() livekit.ParticipantID {
-	return t.params.SubscriberID
+	return t.params.Subscriber.ID()
 }
 
 func (t *SubscribedTrack) SubscriberIdentity() livekit.ParticipantIdentity {
-	return t.params.SubscriberIdentity
+	return t.params.Subscriber.Identity()
+}
+
+func (t *SubscribedTrack) Subscriber() types.LocalParticipant {
+	return t.params.Subscriber
 }
 
 func (t *SubscribedTrack) DownTrack() *sfu.DownTrack {

--- a/pkg/rtc/subscribedtrack.go
+++ b/pkg/rtc/subscribedtrack.go
@@ -33,7 +33,7 @@ type SubscribedTrack struct {
 	pubMuted atomic.Bool
 	settings atomic.Value // *livekit.UpdateTrackSettings
 
-	onBind atomic.Value // fucn()
+	onBind atomic.Value // func()
 	bound  atomic.Bool
 
 	debouncer func(func())

--- a/pkg/rtc/subscribedtrack.go
+++ b/pkg/rtc/subscribedtrack.go
@@ -21,14 +21,10 @@ const (
 type SubscribedTrackParams struct {
 	PublisherID       livekit.ParticipantID
 	PublisherIdentity livekit.ParticipantIdentity
-	/*
-		SubscriberID       livekit.ParticipantID
-		SubscriberIdentity livekit.ParticipantIdentity
-	*/
-	Subscriber     types.LocalParticipant
-	MediaTrack     types.MediaTrack
-	DownTrack      *sfu.DownTrack
-	AdaptiveStream bool
+	Subscriber        types.LocalParticipant
+	MediaTrack        types.MediaTrack
+	DownTrack         *sfu.DownTrack
+	AdaptiveStream    bool
 }
 
 type SubscribedTrack struct {

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -246,6 +246,10 @@ type LocalParticipant interface {
 	SetMigrateInfo(previousAnswer *webrtc.SessionDescription, mediaTracks []*livekit.TrackPublishedResponse, dataChannels []*livekit.DataChannelInfo)
 
 	UpdateRTT(rtt uint32)
+
+	CacheRTPTransceiver(trackID livekit.TrackID, rtpTransceiver *webrtc.RTPTransceiver)
+	UncacheRTPTransceiver(trackID livekit.TrackID)
+	GetCachedRTPTransceiver(trackID livekit.TrackID) *webrtc.RTPTransceiver
 }
 
 // Room is a container of participants, and can provide room-level actions
@@ -325,6 +329,7 @@ type SubscribedTrack interface {
 	PublisherIdentity() livekit.ParticipantIdentity
 	SubscriberID() livekit.ParticipantID
 	SubscriberIdentity() livekit.ParticipantIdentity
+	Subscriber() LocalParticipant
 	DownTrack() *sfu.DownTrack
 	MediaTrack() MediaTrack
 	IsMuted() bool

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -248,7 +248,7 @@ type LocalParticipant interface {
 	UpdateRTT(rtt uint32)
 
 	CacheRTPTransceiver(trackID livekit.TrackID, rtpTransceiver *webrtc.RTPTransceiver)
-	UncacheRTPTransceiver(trackID livekit.TrackID)
+	UncacheRTPTransceiver(rtpTransceiver *webrtc.RTPTransceiver)
 	GetCachedRTPTransceiver(trackID livekit.TrackID) *webrtc.RTPTransceiver
 }
 

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -50,10 +50,11 @@ type FakeLocalParticipant struct {
 	addTrackArgsForCall []struct {
 		arg1 *livekit.AddTrackRequest
 	}
-	CacheRTPTransceiverStub        func(*webrtc.RTPTransceiver)
+	CacheRTPTransceiverStub        func(livekit.TrackID, *webrtc.RTPTransceiver)
 	cacheRTPTransceiverMutex       sync.RWMutex
 	cacheRTPTransceiverArgsForCall []struct {
-		arg1 *webrtc.RTPTransceiver
+		arg1 livekit.TrackID
+		arg2 *webrtc.RTPTransceiver
 	}
 	CanPublishStub        func() bool
 	canPublishMutex       sync.RWMutex
@@ -149,15 +150,16 @@ type FakeLocalParticipant struct {
 		result1 float64
 		result2 bool
 	}
-	GetCachedRTPTransceiversStub        func() []*webrtc.RTPTransceiver
-	getCachedRTPTransceiversMutex       sync.RWMutex
-	getCachedRTPTransceiversArgsForCall []struct {
+	GetCachedRTPTransceiverStub        func(livekit.TrackID) *webrtc.RTPTransceiver
+	getCachedRTPTransceiverMutex       sync.RWMutex
+	getCachedRTPTransceiverArgsForCall []struct {
+		arg1 livekit.TrackID
 	}
-	getCachedRTPTransceiversReturns struct {
-		result1 []*webrtc.RTPTransceiver
+	getCachedRTPTransceiverReturns struct {
+		result1 *webrtc.RTPTransceiver
 	}
-	getCachedRTPTransceiversReturnsOnCall map[int]struct {
-		result1 []*webrtc.RTPTransceiver
+	getCachedRTPTransceiverReturnsOnCall map[int]struct {
+		result1 *webrtc.RTPTransceiver
 	}
 	GetConnectionQualityStub        func() *livekit.ConnectionQualityInfo
 	getConnectionQualityMutex       sync.RWMutex
@@ -604,10 +606,10 @@ type FakeLocalParticipant struct {
 	toProtoReturnsOnCall map[int]struct {
 		result1 *livekit.ParticipantInfo
 	}
-	UncacheRTPTransceiverStub        func(*webrtc.RTPTransceiver)
+	UncacheRTPTransceiverStub        func(livekit.TrackID)
 	uncacheRTPTransceiverMutex       sync.RWMutex
 	uncacheRTPTransceiverArgsForCall []struct {
-		arg1 *webrtc.RTPTransceiver
+		arg1 livekit.TrackID
 	}
 	UpdateMediaLossStub        func(livekit.NodeID, livekit.TrackID, uint32) error
 	updateMediaLossMutex       sync.RWMutex
@@ -871,16 +873,17 @@ func (fake *FakeLocalParticipant) AddTrackArgsForCall(i int) *livekit.AddTrackRe
 	return argsForCall.arg1
 }
 
-func (fake *FakeLocalParticipant) CacheRTPTransceiver(arg1 *webrtc.RTPTransceiver) {
+func (fake *FakeLocalParticipant) CacheRTPTransceiver(arg1 livekit.TrackID, arg2 *webrtc.RTPTransceiver) {
 	fake.cacheRTPTransceiverMutex.Lock()
 	fake.cacheRTPTransceiverArgsForCall = append(fake.cacheRTPTransceiverArgsForCall, struct {
-		arg1 *webrtc.RTPTransceiver
-	}{arg1})
+		arg1 livekit.TrackID
+		arg2 *webrtc.RTPTransceiver
+	}{arg1, arg2})
 	stub := fake.CacheRTPTransceiverStub
-	fake.recordInvocation("CacheRTPTransceiver", []interface{}{arg1})
+	fake.recordInvocation("CacheRTPTransceiver", []interface{}{arg1, arg2})
 	fake.cacheRTPTransceiverMutex.Unlock()
 	if stub != nil {
-		fake.CacheRTPTransceiverStub(arg1)
+		fake.CacheRTPTransceiverStub(arg1, arg2)
 	}
 }
 
@@ -890,17 +893,17 @@ func (fake *FakeLocalParticipant) CacheRTPTransceiverCallCount() int {
 	return len(fake.cacheRTPTransceiverArgsForCall)
 }
 
-func (fake *FakeLocalParticipant) CacheRTPTransceiverCalls(stub func(*webrtc.RTPTransceiver)) {
+func (fake *FakeLocalParticipant) CacheRTPTransceiverCalls(stub func(livekit.TrackID, *webrtc.RTPTransceiver)) {
 	fake.cacheRTPTransceiverMutex.Lock()
 	defer fake.cacheRTPTransceiverMutex.Unlock()
 	fake.CacheRTPTransceiverStub = stub
 }
 
-func (fake *FakeLocalParticipant) CacheRTPTransceiverArgsForCall(i int) *webrtc.RTPTransceiver {
+func (fake *FakeLocalParticipant) CacheRTPTransceiverArgsForCall(i int) (livekit.TrackID, *webrtc.RTPTransceiver) {
 	fake.cacheRTPTransceiverMutex.RLock()
 	defer fake.cacheRTPTransceiverMutex.RUnlock()
 	argsForCall := fake.cacheRTPTransceiverArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeLocalParticipant) CanPublish() bool {
@@ -1392,17 +1395,18 @@ func (fake *FakeLocalParticipant) GetAudioLevelReturnsOnCall(i int, result1 floa
 	}{result1, result2}
 }
 
-func (fake *FakeLocalParticipant) GetCachedRTPTransceivers() []*webrtc.RTPTransceiver {
-	fake.getCachedRTPTransceiversMutex.Lock()
-	ret, specificReturn := fake.getCachedRTPTransceiversReturnsOnCall[len(fake.getCachedRTPTransceiversArgsForCall)]
-	fake.getCachedRTPTransceiversArgsForCall = append(fake.getCachedRTPTransceiversArgsForCall, struct {
-	}{})
-	stub := fake.GetCachedRTPTransceiversStub
-	fakeReturns := fake.getCachedRTPTransceiversReturns
-	fake.recordInvocation("GetCachedRTPTransceivers", []interface{}{})
-	fake.getCachedRTPTransceiversMutex.Unlock()
+func (fake *FakeLocalParticipant) GetCachedRTPTransceiver(arg1 livekit.TrackID) *webrtc.RTPTransceiver {
+	fake.getCachedRTPTransceiverMutex.Lock()
+	ret, specificReturn := fake.getCachedRTPTransceiverReturnsOnCall[len(fake.getCachedRTPTransceiverArgsForCall)]
+	fake.getCachedRTPTransceiverArgsForCall = append(fake.getCachedRTPTransceiverArgsForCall, struct {
+		arg1 livekit.TrackID
+	}{arg1})
+	stub := fake.GetCachedRTPTransceiverStub
+	fakeReturns := fake.getCachedRTPTransceiverReturns
+	fake.recordInvocation("GetCachedRTPTransceiver", []interface{}{arg1})
+	fake.getCachedRTPTransceiverMutex.Unlock()
 	if stub != nil {
-		return stub()
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
@@ -1410,38 +1414,45 @@ func (fake *FakeLocalParticipant) GetCachedRTPTransceivers() []*webrtc.RTPTransc
 	return fakeReturns.result1
 }
 
-func (fake *FakeLocalParticipant) GetCachedRTPTransceiversCallCount() int {
-	fake.getCachedRTPTransceiversMutex.RLock()
-	defer fake.getCachedRTPTransceiversMutex.RUnlock()
-	return len(fake.getCachedRTPTransceiversArgsForCall)
+func (fake *FakeLocalParticipant) GetCachedRTPTransceiverCallCount() int {
+	fake.getCachedRTPTransceiverMutex.RLock()
+	defer fake.getCachedRTPTransceiverMutex.RUnlock()
+	return len(fake.getCachedRTPTransceiverArgsForCall)
 }
 
-func (fake *FakeLocalParticipant) GetCachedRTPTransceiversCalls(stub func() []*webrtc.RTPTransceiver) {
-	fake.getCachedRTPTransceiversMutex.Lock()
-	defer fake.getCachedRTPTransceiversMutex.Unlock()
-	fake.GetCachedRTPTransceiversStub = stub
+func (fake *FakeLocalParticipant) GetCachedRTPTransceiverCalls(stub func(livekit.TrackID) *webrtc.RTPTransceiver) {
+	fake.getCachedRTPTransceiverMutex.Lock()
+	defer fake.getCachedRTPTransceiverMutex.Unlock()
+	fake.GetCachedRTPTransceiverStub = stub
 }
 
-func (fake *FakeLocalParticipant) GetCachedRTPTransceiversReturns(result1 []*webrtc.RTPTransceiver) {
-	fake.getCachedRTPTransceiversMutex.Lock()
-	defer fake.getCachedRTPTransceiversMutex.Unlock()
-	fake.GetCachedRTPTransceiversStub = nil
-	fake.getCachedRTPTransceiversReturns = struct {
-		result1 []*webrtc.RTPTransceiver
+func (fake *FakeLocalParticipant) GetCachedRTPTransceiverArgsForCall(i int) livekit.TrackID {
+	fake.getCachedRTPTransceiverMutex.RLock()
+	defer fake.getCachedRTPTransceiverMutex.RUnlock()
+	argsForCall := fake.getCachedRTPTransceiverArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeLocalParticipant) GetCachedRTPTransceiverReturns(result1 *webrtc.RTPTransceiver) {
+	fake.getCachedRTPTransceiverMutex.Lock()
+	defer fake.getCachedRTPTransceiverMutex.Unlock()
+	fake.GetCachedRTPTransceiverStub = nil
+	fake.getCachedRTPTransceiverReturns = struct {
+		result1 *webrtc.RTPTransceiver
 	}{result1}
 }
 
-func (fake *FakeLocalParticipant) GetCachedRTPTransceiversReturnsOnCall(i int, result1 []*webrtc.RTPTransceiver) {
-	fake.getCachedRTPTransceiversMutex.Lock()
-	defer fake.getCachedRTPTransceiversMutex.Unlock()
-	fake.GetCachedRTPTransceiversStub = nil
-	if fake.getCachedRTPTransceiversReturnsOnCall == nil {
-		fake.getCachedRTPTransceiversReturnsOnCall = make(map[int]struct {
-			result1 []*webrtc.RTPTransceiver
+func (fake *FakeLocalParticipant) GetCachedRTPTransceiverReturnsOnCall(i int, result1 *webrtc.RTPTransceiver) {
+	fake.getCachedRTPTransceiverMutex.Lock()
+	defer fake.getCachedRTPTransceiverMutex.Unlock()
+	fake.GetCachedRTPTransceiverStub = nil
+	if fake.getCachedRTPTransceiverReturnsOnCall == nil {
+		fake.getCachedRTPTransceiverReturnsOnCall = make(map[int]struct {
+			result1 *webrtc.RTPTransceiver
 		})
 	}
-	fake.getCachedRTPTransceiversReturnsOnCall[i] = struct {
-		result1 []*webrtc.RTPTransceiver
+	fake.getCachedRTPTransceiverReturnsOnCall[i] = struct {
+		result1 *webrtc.RTPTransceiver
 	}{result1}
 }
 
@@ -3910,10 +3921,10 @@ func (fake *FakeLocalParticipant) ToProtoReturnsOnCall(i int, result1 *livekit.P
 	}{result1}
 }
 
-func (fake *FakeLocalParticipant) UncacheRTPTransceiver(arg1 *webrtc.RTPTransceiver) {
+func (fake *FakeLocalParticipant) UncacheRTPTransceiver(arg1 livekit.TrackID) {
 	fake.uncacheRTPTransceiverMutex.Lock()
 	fake.uncacheRTPTransceiverArgsForCall = append(fake.uncacheRTPTransceiverArgsForCall, struct {
-		arg1 *webrtc.RTPTransceiver
+		arg1 livekit.TrackID
 	}{arg1})
 	stub := fake.UncacheRTPTransceiverStub
 	fake.recordInvocation("UncacheRTPTransceiver", []interface{}{arg1})
@@ -3929,13 +3940,13 @@ func (fake *FakeLocalParticipant) UncacheRTPTransceiverCallCount() int {
 	return len(fake.uncacheRTPTransceiverArgsForCall)
 }
 
-func (fake *FakeLocalParticipant) UncacheRTPTransceiverCalls(stub func(*webrtc.RTPTransceiver)) {
+func (fake *FakeLocalParticipant) UncacheRTPTransceiverCalls(stub func(livekit.TrackID)) {
 	fake.uncacheRTPTransceiverMutex.Lock()
 	defer fake.uncacheRTPTransceiverMutex.Unlock()
 	fake.UncacheRTPTransceiverStub = stub
 }
 
-func (fake *FakeLocalParticipant) UncacheRTPTransceiverArgsForCall(i int) *webrtc.RTPTransceiver {
+func (fake *FakeLocalParticipant) UncacheRTPTransceiverArgsForCall(i int) livekit.TrackID {
 	fake.uncacheRTPTransceiverMutex.RLock()
 	defer fake.uncacheRTPTransceiverMutex.RUnlock()
 	argsForCall := fake.uncacheRTPTransceiverArgsForCall[i]
@@ -4322,8 +4333,8 @@ func (fake *FakeLocalParticipant) Invocations() map[string][][]interface{} {
 	defer fake.getAdaptiveStreamMutex.RUnlock()
 	fake.getAudioLevelMutex.RLock()
 	defer fake.getAudioLevelMutex.RUnlock()
-	fake.getCachedRTPTransceiversMutex.RLock()
-	defer fake.getCachedRTPTransceiversMutex.RUnlock()
+	fake.getCachedRTPTransceiverMutex.RLock()
+	defer fake.getCachedRTPTransceiverMutex.RUnlock()
 	fake.getConnectionQualityMutex.RLock()
 	defer fake.getConnectionQualityMutex.RUnlock()
 	fake.getLoggerMutex.RLock()

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -606,10 +606,10 @@ type FakeLocalParticipant struct {
 	toProtoReturnsOnCall map[int]struct {
 		result1 *livekit.ParticipantInfo
 	}
-	UncacheRTPTransceiverStub        func(livekit.TrackID)
+	UncacheRTPTransceiverStub        func(*webrtc.RTPTransceiver)
 	uncacheRTPTransceiverMutex       sync.RWMutex
 	uncacheRTPTransceiverArgsForCall []struct {
-		arg1 livekit.TrackID
+		arg1 *webrtc.RTPTransceiver
 	}
 	UpdateMediaLossStub        func(livekit.NodeID, livekit.TrackID, uint32) error
 	updateMediaLossMutex       sync.RWMutex
@@ -3921,10 +3921,10 @@ func (fake *FakeLocalParticipant) ToProtoReturnsOnCall(i int, result1 *livekit.P
 	}{result1}
 }
 
-func (fake *FakeLocalParticipant) UncacheRTPTransceiver(arg1 livekit.TrackID) {
+func (fake *FakeLocalParticipant) UncacheRTPTransceiver(arg1 *webrtc.RTPTransceiver) {
 	fake.uncacheRTPTransceiverMutex.Lock()
 	fake.uncacheRTPTransceiverArgsForCall = append(fake.uncacheRTPTransceiverArgsForCall, struct {
-		arg1 livekit.TrackID
+		arg1 *webrtc.RTPTransceiver
 	}{arg1})
 	stub := fake.UncacheRTPTransceiverStub
 	fake.recordInvocation("UncacheRTPTransceiver", []interface{}{arg1})
@@ -3940,13 +3940,13 @@ func (fake *FakeLocalParticipant) UncacheRTPTransceiverCallCount() int {
 	return len(fake.uncacheRTPTransceiverArgsForCall)
 }
 
-func (fake *FakeLocalParticipant) UncacheRTPTransceiverCalls(stub func(livekit.TrackID)) {
+func (fake *FakeLocalParticipant) UncacheRTPTransceiverCalls(stub func(*webrtc.RTPTransceiver)) {
 	fake.uncacheRTPTransceiverMutex.Lock()
 	defer fake.uncacheRTPTransceiverMutex.Unlock()
 	fake.UncacheRTPTransceiverStub = stub
 }
 
-func (fake *FakeLocalParticipant) UncacheRTPTransceiverArgsForCall(i int) livekit.TrackID {
+func (fake *FakeLocalParticipant) UncacheRTPTransceiverArgsForCall(i int) *webrtc.RTPTransceiver {
 	fake.uncacheRTPTransceiverMutex.RLock()
 	defer fake.uncacheRTPTransceiverMutex.RUnlock()
 	argsForCall := fake.uncacheRTPTransceiverArgsForCall[i]

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -50,6 +50,11 @@ type FakeLocalParticipant struct {
 	addTrackArgsForCall []struct {
 		arg1 *livekit.AddTrackRequest
 	}
+	CacheRTPTransceiverStub        func(*webrtc.RTPTransceiver)
+	cacheRTPTransceiverMutex       sync.RWMutex
+	cacheRTPTransceiverArgsForCall []struct {
+		arg1 *webrtc.RTPTransceiver
+	}
 	CanPublishStub        func() bool
 	canPublishMutex       sync.RWMutex
 	canPublishArgsForCall []struct {
@@ -143,6 +148,16 @@ type FakeLocalParticipant struct {
 	getAudioLevelReturnsOnCall map[int]struct {
 		result1 float64
 		result2 bool
+	}
+	GetCachedRTPTransceiversStub        func() []*webrtc.RTPTransceiver
+	getCachedRTPTransceiversMutex       sync.RWMutex
+	getCachedRTPTransceiversArgsForCall []struct {
+	}
+	getCachedRTPTransceiversReturns struct {
+		result1 []*webrtc.RTPTransceiver
+	}
+	getCachedRTPTransceiversReturnsOnCall map[int]struct {
+		result1 []*webrtc.RTPTransceiver
 	}
 	GetConnectionQualityStub        func() *livekit.ConnectionQualityInfo
 	getConnectionQualityMutex       sync.RWMutex
@@ -589,6 +604,11 @@ type FakeLocalParticipant struct {
 	toProtoReturnsOnCall map[int]struct {
 		result1 *livekit.ParticipantInfo
 	}
+	UncacheRTPTransceiverStub        func(*webrtc.RTPTransceiver)
+	uncacheRTPTransceiverMutex       sync.RWMutex
+	uncacheRTPTransceiverArgsForCall []struct {
+		arg1 *webrtc.RTPTransceiver
+	}
 	UpdateMediaLossStub        func(livekit.NodeID, livekit.TrackID, uint32) error
 	updateMediaLossMutex       sync.RWMutex
 	updateMediaLossArgsForCall []struct {
@@ -848,6 +868,38 @@ func (fake *FakeLocalParticipant) AddTrackArgsForCall(i int) *livekit.AddTrackRe
 	fake.addTrackMutex.RLock()
 	defer fake.addTrackMutex.RUnlock()
 	argsForCall := fake.addTrackArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeLocalParticipant) CacheRTPTransceiver(arg1 *webrtc.RTPTransceiver) {
+	fake.cacheRTPTransceiverMutex.Lock()
+	fake.cacheRTPTransceiverArgsForCall = append(fake.cacheRTPTransceiverArgsForCall, struct {
+		arg1 *webrtc.RTPTransceiver
+	}{arg1})
+	stub := fake.CacheRTPTransceiverStub
+	fake.recordInvocation("CacheRTPTransceiver", []interface{}{arg1})
+	fake.cacheRTPTransceiverMutex.Unlock()
+	if stub != nil {
+		fake.CacheRTPTransceiverStub(arg1)
+	}
+}
+
+func (fake *FakeLocalParticipant) CacheRTPTransceiverCallCount() int {
+	fake.cacheRTPTransceiverMutex.RLock()
+	defer fake.cacheRTPTransceiverMutex.RUnlock()
+	return len(fake.cacheRTPTransceiverArgsForCall)
+}
+
+func (fake *FakeLocalParticipant) CacheRTPTransceiverCalls(stub func(*webrtc.RTPTransceiver)) {
+	fake.cacheRTPTransceiverMutex.Lock()
+	defer fake.cacheRTPTransceiverMutex.Unlock()
+	fake.CacheRTPTransceiverStub = stub
+}
+
+func (fake *FakeLocalParticipant) CacheRTPTransceiverArgsForCall(i int) *webrtc.RTPTransceiver {
+	fake.cacheRTPTransceiverMutex.RLock()
+	defer fake.cacheRTPTransceiverMutex.RUnlock()
+	argsForCall := fake.cacheRTPTransceiverArgsForCall[i]
 	return argsForCall.arg1
 }
 
@@ -1338,6 +1390,59 @@ func (fake *FakeLocalParticipant) GetAudioLevelReturnsOnCall(i int, result1 floa
 		result1 float64
 		result2 bool
 	}{result1, result2}
+}
+
+func (fake *FakeLocalParticipant) GetCachedRTPTransceivers() []*webrtc.RTPTransceiver {
+	fake.getCachedRTPTransceiversMutex.Lock()
+	ret, specificReturn := fake.getCachedRTPTransceiversReturnsOnCall[len(fake.getCachedRTPTransceiversArgsForCall)]
+	fake.getCachedRTPTransceiversArgsForCall = append(fake.getCachedRTPTransceiversArgsForCall, struct {
+	}{})
+	stub := fake.GetCachedRTPTransceiversStub
+	fakeReturns := fake.getCachedRTPTransceiversReturns
+	fake.recordInvocation("GetCachedRTPTransceivers", []interface{}{})
+	fake.getCachedRTPTransceiversMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLocalParticipant) GetCachedRTPTransceiversCallCount() int {
+	fake.getCachedRTPTransceiversMutex.RLock()
+	defer fake.getCachedRTPTransceiversMutex.RUnlock()
+	return len(fake.getCachedRTPTransceiversArgsForCall)
+}
+
+func (fake *FakeLocalParticipant) GetCachedRTPTransceiversCalls(stub func() []*webrtc.RTPTransceiver) {
+	fake.getCachedRTPTransceiversMutex.Lock()
+	defer fake.getCachedRTPTransceiversMutex.Unlock()
+	fake.GetCachedRTPTransceiversStub = stub
+}
+
+func (fake *FakeLocalParticipant) GetCachedRTPTransceiversReturns(result1 []*webrtc.RTPTransceiver) {
+	fake.getCachedRTPTransceiversMutex.Lock()
+	defer fake.getCachedRTPTransceiversMutex.Unlock()
+	fake.GetCachedRTPTransceiversStub = nil
+	fake.getCachedRTPTransceiversReturns = struct {
+		result1 []*webrtc.RTPTransceiver
+	}{result1}
+}
+
+func (fake *FakeLocalParticipant) GetCachedRTPTransceiversReturnsOnCall(i int, result1 []*webrtc.RTPTransceiver) {
+	fake.getCachedRTPTransceiversMutex.Lock()
+	defer fake.getCachedRTPTransceiversMutex.Unlock()
+	fake.GetCachedRTPTransceiversStub = nil
+	if fake.getCachedRTPTransceiversReturnsOnCall == nil {
+		fake.getCachedRTPTransceiversReturnsOnCall = make(map[int]struct {
+			result1 []*webrtc.RTPTransceiver
+		})
+	}
+	fake.getCachedRTPTransceiversReturnsOnCall[i] = struct {
+		result1 []*webrtc.RTPTransceiver
+	}{result1}
 }
 
 func (fake *FakeLocalParticipant) GetConnectionQuality() *livekit.ConnectionQualityInfo {
@@ -3805,6 +3910,38 @@ func (fake *FakeLocalParticipant) ToProtoReturnsOnCall(i int, result1 *livekit.P
 	}{result1}
 }
 
+func (fake *FakeLocalParticipant) UncacheRTPTransceiver(arg1 *webrtc.RTPTransceiver) {
+	fake.uncacheRTPTransceiverMutex.Lock()
+	fake.uncacheRTPTransceiverArgsForCall = append(fake.uncacheRTPTransceiverArgsForCall, struct {
+		arg1 *webrtc.RTPTransceiver
+	}{arg1})
+	stub := fake.UncacheRTPTransceiverStub
+	fake.recordInvocation("UncacheRTPTransceiver", []interface{}{arg1})
+	fake.uncacheRTPTransceiverMutex.Unlock()
+	if stub != nil {
+		fake.UncacheRTPTransceiverStub(arg1)
+	}
+}
+
+func (fake *FakeLocalParticipant) UncacheRTPTransceiverCallCount() int {
+	fake.uncacheRTPTransceiverMutex.RLock()
+	defer fake.uncacheRTPTransceiverMutex.RUnlock()
+	return len(fake.uncacheRTPTransceiverArgsForCall)
+}
+
+func (fake *FakeLocalParticipant) UncacheRTPTransceiverCalls(stub func(*webrtc.RTPTransceiver)) {
+	fake.uncacheRTPTransceiverMutex.Lock()
+	defer fake.uncacheRTPTransceiverMutex.Unlock()
+	fake.UncacheRTPTransceiverStub = stub
+}
+
+func (fake *FakeLocalParticipant) UncacheRTPTransceiverArgsForCall(i int) *webrtc.RTPTransceiver {
+	fake.uncacheRTPTransceiverMutex.RLock()
+	defer fake.uncacheRTPTransceiverMutex.RUnlock()
+	argsForCall := fake.uncacheRTPTransceiverArgsForCall[i]
+	return argsForCall.arg1
+}
+
 func (fake *FakeLocalParticipant) UpdateMediaLoss(arg1 livekit.NodeID, arg2 livekit.TrackID, arg3 uint32) error {
 	fake.updateMediaLossMutex.Lock()
 	ret, specificReturn := fake.updateMediaLossReturnsOnCall[len(fake.updateMediaLossArgsForCall)]
@@ -4165,6 +4302,8 @@ func (fake *FakeLocalParticipant) Invocations() map[string][][]interface{} {
 	defer fake.addSubscriberMutex.RUnlock()
 	fake.addTrackMutex.RLock()
 	defer fake.addTrackMutex.RUnlock()
+	fake.cacheRTPTransceiverMutex.RLock()
+	defer fake.cacheRTPTransceiverMutex.RUnlock()
 	fake.canPublishMutex.RLock()
 	defer fake.canPublishMutex.RUnlock()
 	fake.canPublishDataMutex.RLock()
@@ -4183,6 +4322,8 @@ func (fake *FakeLocalParticipant) Invocations() map[string][][]interface{} {
 	defer fake.getAdaptiveStreamMutex.RUnlock()
 	fake.getAudioLevelMutex.RLock()
 	defer fake.getAudioLevelMutex.RUnlock()
+	fake.getCachedRTPTransceiversMutex.RLock()
+	defer fake.getCachedRTPTransceiversMutex.RUnlock()
 	fake.getConnectionQualityMutex.RLock()
 	defer fake.getConnectionQualityMutex.RUnlock()
 	fake.getLoggerMutex.RLock()
@@ -4285,6 +4426,8 @@ func (fake *FakeLocalParticipant) Invocations() map[string][][]interface{} {
 	defer fake.subscriptionPermissionUpdateMutex.RUnlock()
 	fake.toProtoMutex.RLock()
 	defer fake.toProtoMutex.RUnlock()
+	fake.uncacheRTPTransceiverMutex.RLock()
+	defer fake.uncacheRTPTransceiverMutex.RUnlock()
 	fake.updateMediaLossMutex.RLock()
 	defer fake.updateMediaLossMutex.RUnlock()
 	fake.updateRTTMutex.RLock()

--- a/pkg/rtc/types/typesfakes/fake_subscribed_track.go
+++ b/pkg/rtc/types/typesfakes/fake_subscribed_track.go
@@ -80,6 +80,16 @@ type FakeSubscribedTrack struct {
 	setPublisherMutedArgsForCall []struct {
 		arg1 bool
 	}
+	SubscriberStub        func() types.LocalParticipant
+	subscriberMutex       sync.RWMutex
+	subscriberArgsForCall []struct {
+	}
+	subscriberReturns struct {
+		result1 types.LocalParticipant
+	}
+	subscriberReturnsOnCall map[int]struct {
+		result1 types.LocalParticipant
+	}
 	SubscriberIDStub        func() livekit.ParticipantID
 	subscriberIDMutex       sync.RWMutex
 	subscriberIDArgsForCall []struct {
@@ -495,6 +505,59 @@ func (fake *FakeSubscribedTrack) SetPublisherMutedArgsForCall(i int) bool {
 	return argsForCall.arg1
 }
 
+func (fake *FakeSubscribedTrack) Subscriber() types.LocalParticipant {
+	fake.subscriberMutex.Lock()
+	ret, specificReturn := fake.subscriberReturnsOnCall[len(fake.subscriberArgsForCall)]
+	fake.subscriberArgsForCall = append(fake.subscriberArgsForCall, struct {
+	}{})
+	stub := fake.SubscriberStub
+	fakeReturns := fake.subscriberReturns
+	fake.recordInvocation("Subscriber", []interface{}{})
+	fake.subscriberMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeSubscribedTrack) SubscriberCallCount() int {
+	fake.subscriberMutex.RLock()
+	defer fake.subscriberMutex.RUnlock()
+	return len(fake.subscriberArgsForCall)
+}
+
+func (fake *FakeSubscribedTrack) SubscriberCalls(stub func() types.LocalParticipant) {
+	fake.subscriberMutex.Lock()
+	defer fake.subscriberMutex.Unlock()
+	fake.SubscriberStub = stub
+}
+
+func (fake *FakeSubscribedTrack) SubscriberReturns(result1 types.LocalParticipant) {
+	fake.subscriberMutex.Lock()
+	defer fake.subscriberMutex.Unlock()
+	fake.SubscriberStub = nil
+	fake.subscriberReturns = struct {
+		result1 types.LocalParticipant
+	}{result1}
+}
+
+func (fake *FakeSubscribedTrack) SubscriberReturnsOnCall(i int, result1 types.LocalParticipant) {
+	fake.subscriberMutex.Lock()
+	defer fake.subscriberMutex.Unlock()
+	fake.SubscriberStub = nil
+	if fake.subscriberReturnsOnCall == nil {
+		fake.subscriberReturnsOnCall = make(map[int]struct {
+			result1 types.LocalParticipant
+		})
+	}
+	fake.subscriberReturnsOnCall[i] = struct {
+		result1 types.LocalParticipant
+	}{result1}
+}
+
 func (fake *FakeSubscribedTrack) SubscriberID() livekit.ParticipantID {
 	fake.subscriberIDMutex.Lock()
 	ret, specificReturn := fake.subscriberIDReturnsOnCall[len(fake.subscriberIDArgsForCall)]
@@ -676,6 +739,8 @@ func (fake *FakeSubscribedTrack) Invocations() map[string][][]interface{} {
 	defer fake.publisherIdentityMutex.RUnlock()
 	fake.setPublisherMutedMutex.RLock()
 	defer fake.setPublisherMutedMutex.RUnlock()
+	fake.subscriberMutex.RLock()
+	defer fake.subscriberMutex.RUnlock()
 	fake.subscriberIDMutex.RLock()
 	defer fake.subscriberIDMutex.RUnlock()
 	fake.subscriberIdentityMutex.RLock()

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -364,6 +364,10 @@ func (d *DownTrack) SetTransceiver(transceiver *webrtc.RTPTransceiver) {
 	d.transceiver = transceiver
 }
 
+func (d *DownTrack) GetTransceiver() *webrtc.RTPTransceiver {
+	return d.transceiver
+}
+
 func (d *DownTrack) maybeStartKeyFrameRequester() {
 	//
 	// Always move to next generation to abandon any running key frame requester
@@ -411,6 +415,7 @@ func (d *DownTrack) keyFrameRequester(generation uint32, layer int32) {
 
 // WriteRTP writes an RTP Packet to the DownTrack
 func (d *DownTrack) WriteRTP(extPkt *buffer.ExtPacket, layer int32) error {
+	//d.logger.Debugw("RAJA writing", "layer", layer) // REMOVE
 	var pool *[]byte
 	defer func() {
 		if pool != nil {

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -415,7 +415,6 @@ func (d *DownTrack) keyFrameRequester(generation uint32, layer int32) {
 
 // WriteRTP writes an RTP Packet to the DownTrack
 func (d *DownTrack) WriteRTP(extPkt *buffer.ExtPacket, layer int32) error {
-	//d.logger.Debugw("RAJA writing", "layer", layer) // REMOVE
 	var pool *[]byte
 	defer func() {
 		if pool != nil {

--- a/pkg/sfu/streamallocator.go
+++ b/pkg/sfu/streamallocator.go
@@ -219,6 +219,7 @@ func (s *StreamAllocator) AddTrack(downTrack *DownTrack, params AddTrackParams) 
 	if downTrack.Kind() != webrtc.RTPCodecTypeVideo {
 		return
 	}
+	s.params.Logger.Debugw("RAJA adding track", "id", downTrack.ID()) // REMOVE
 
 	track := newTrack(downTrack, params.Source, params.IsSimulcast, params.PublisherID, s.params.Logger)
 	track.SetPriority(params.Priority)
@@ -239,8 +240,11 @@ func (s *StreamAllocator) AddTrack(downTrack *DownTrack, params AddTrackParams) 
 }
 
 func (s *StreamAllocator) RemoveTrack(downTrack *DownTrack) {
+	s.params.Logger.Debugw("RAJA deleting track", "id", downTrack.ID()) // REMOVE
 	s.videoTracksMu.Lock()
-	delete(s.videoTracks, livekit.TrackID(downTrack.ID()))
+	if existing := s.videoTracks[livekit.TrackID(downTrack.ID())]; existing != nil && existing.DownTrack() == downTrack {
+		delete(s.videoTracks, livekit.TrackID(downTrack.ID()))
+	}
 	s.videoTracksMu.Unlock()
 
 	// LK-TODO: use any saved bandwidth to re-distribute

--- a/pkg/sfu/streamallocator.go
+++ b/pkg/sfu/streamallocator.go
@@ -219,7 +219,6 @@ func (s *StreamAllocator) AddTrack(downTrack *DownTrack, params AddTrackParams) 
 	if downTrack.Kind() != webrtc.RTPCodecTypeVideo {
 		return
 	}
-	s.params.Logger.Debugw("RAJA adding track", "id", downTrack.ID()) // REMOVE
 
 	track := newTrack(downTrack, params.Source, params.IsSimulcast, params.PublisherID, s.params.Logger)
 	track.SetPriority(params.Priority)
@@ -240,7 +239,6 @@ func (s *StreamAllocator) AddTrack(downTrack *DownTrack, params AddTrackParams) 
 }
 
 func (s *StreamAllocator) RemoveTrack(downTrack *DownTrack) {
-	s.params.Logger.Debugw("RAJA deleting track", "id", downTrack.ID()) // REMOVE
 	s.videoTracksMu.Lock()
 	if existing := s.videoTracks[livekit.TrackID(downTrack.ID())]; existing != nil && existing.DownTrack() == downTrack {
 		delete(s.videoTracks, livekit.TrackID(downTrack.ID()))


### PR DESCRIPTION
- Cache transceiver when closing a down track if that down track is expected to be resumed
- When creating a new down track, check for cached transceiver that can be re-used.
- If possible, re-use.
- If not, stop the transceiver to ensure that there is no transceiver in active state if not used.