### PR TITLE
Run connection quality worker every 5 seconds.

### DIFF
--- a/pkg/sfu/connectionquality/connectionstats.go
+++ b/pkg/sfu/connectionquality/connectionstats.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	UpdateInterval           = 2 * time.Second
+	UpdateInterval           = 5 * time.Second
 	audioPacketRateThreshold = float64(25.0)
 )
 


### PR DESCRIPTION
With a small window, the quality is volatile even on small disturbances.
For example losing 2 audio packets in a 2 second window could
drop the quality metric.