### PR TITLE
RemoveSubscriber while revoking.

### DIFF
--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -385,7 +385,7 @@ func (t *MediaTrackSubscriptions) RevokeDisallowedSubscribers(allowedSubscriberI
 				"subscriber", subTrack.SubscriberIdentity(),
 				"subscriberID", subTrack.SubscriberID(),
 			)
-			go subTrack.DownTrack().Close()
+			t.RemoveSubscriber(subTrack.SubscriberID(), false)
 			revokedSubscriberIdentities = append(revokedSubscriberIdentities, subTrack.SubscriberIdentity())
 		}
 	}


### PR DESCRIPTION
Else, a quick turn around of permissions tries to subscribe
again and the subscriber is already in the subscribed list.