### PR TITLE
Use a queue for add/remove subscribe operations.

### DIFF
--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -91,6 +91,7 @@ func NewMediaTrackReceiver(params MediaTrackReceiverParams) *MediaTrackReceiver 
 		Telemetry:        params.Telemetry,
 		Logger:           params.Logger,
 	})
+	t.MediaTrackSubscriptions.OnDownTrackCreated(t.onDownTrackCreated)
 
 	if t.trackInfo.Muted {
 		t.SetMuted(true)

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -381,17 +381,11 @@ func (t *MediaTrackReceiver) AddSubscriber(sub types.LocalParticipant) error {
 		streamId = PackStreamID(t.PublisherID(), t.ID())
 	}
 
-	downTrack, err := t.MediaTrackSubscriptions.AddSubscriber(sub, NewWrappedReceiver(receivers, t.ID(), streamId, potentialCodecs))
+	err := t.MediaTrackSubscriptions.AddSubscriber(sub, NewWrappedReceiver(receivers, t.ID(), streamId, potentialCodecs))
 	if err != nil {
 		return err
 	}
 
-	if downTrack != nil {
-		if t.Kind() == livekit.TrackType_AUDIO {
-			downTrack.AddReceiverReportListener(t.handleMaxLossFeedback)
-		}
-
-	}
 	return nil
 }
 
@@ -548,6 +542,12 @@ func (t *MediaTrackReceiver) GetAudioLevel() (float64, bool) {
 	}
 
 	return receiver.GetAudioLevel()
+}
+
+func (t *MediaTrackReceiver) onDownTrackCreated(downTrack *sfu.DownTrack) {
+	if t.Kind() == livekit.TrackType_AUDIO {
+		downTrack.AddReceiverReportListener(t.handleMaxLossFeedback)
+	}
 }
 
 // handles max loss for audio streams

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -180,6 +180,9 @@ func (t *MediaTrackSubscriptions) processRequestsQueue(subscriberID livekit.Part
 
 	default:
 		t.params.Logger.Warnw("unknown request type", nil)
+
+		// let the queue move forward
+		go t.clearInProgressAndProcessRequestsQueue(subscriberID)
 	}
 }
 

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -29,6 +29,8 @@ const (
 
 var (
 	errAlreadySubscribed = errors.New("already subscribed")
+	errNoTransceiver     = errors.New("cannot subscribe without a transceiver in place")
+	errNoSender          = errors.New("cannot subscribe without a sender in place")
 )
 
 type SubscribeRequestType int
@@ -332,11 +334,11 @@ func (t *MediaTrackSubscriptions) addSubscriber(sub types.LocalParticipant, wr *
 	}
 	if transceiver == nil {
 		// cannot add, no transceiver
-		return errors.New("cannot subscribe without a transceiver in place")
+		return errNoTransceiver
 	}
 	if sender == nil {
 		// cannot add, no sender
-		return errors.New("cannot subscribe without a sender in place")
+		return errNoSender
 	}
 
 	// wthether re-using or stopping remove transceiver from cache

--- a/pkg/rtc/uptrackmanager.go
+++ b/pkg/rtc/uptrackmanager.go
@@ -124,7 +124,7 @@ func (u *UpTrackManager) AddSubscriber(sub types.LocalParticipant, params types.
 	for _, track := range tracks {
 		trackIDs = append(trackIDs, track.ID())
 	}
-	u.params.Logger.Debugw("subscribing new participant to tracks",
+	u.params.Logger.Debugw("subscribing participant to tracks",
 		"subscriber", sub.Identity(),
 		"subscriberID", sub.ID(),
 		"trackIDs", trackIDs)


### PR DESCRIPTION
If subscribe/unsubscribe happens very quickly, the subscription
state gets mixed up as things are keyed off of subscriberID.

Use a queue of subscribe operations and process it serially.