### PR TITLE
Keep track of pending subscriber operations.

### DIFF
--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -93,11 +93,8 @@ func (t *MediaTrackSubscriptions) Restart() {
 }
 
 func (t *MediaTrackSubscriptions) Stop() {
-	t.stopMaxQualityTimer()
-}
-
-func (t *MediaTrackSubscriptions) Close() {
 	t.qualityNotifyOpQueue.Stop()
+	t.stopMaxQualityTimer()
 }
 
 func (t *MediaTrackSubscriptions) OnDownTrackCreated(f func(downTrack *sfu.DownTrack)) {
@@ -700,6 +697,11 @@ func (t *MediaTrackSubscriptions) startMaxQualityTimer(force bool) {
 
 	if t.params.MediaTrack.Kind() != livekit.TrackType_VIDEO {
 		return
+	}
+
+	if t.maxQualityTimer != nil {
+		t.maxQualityTimer.Stop()
+		t.maxQualityTimer = nil
 	}
 
 	t.maxQualityTimer = time.AfterFunc(initialQualityUpdateWait, func() {

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2163,20 +2163,20 @@ func (p *ParticipantImpl) ProcessSubscriptionRequestsQueue(trackID livekit.Track
 			}
 
 			// process pending request even if adding errors out
-			go p.ClearInProgressAndProcessSubscriptionRequestsQueue(trackID)
+			p.ClearInProgressAndProcessSubscriptionRequestsQueue(trackID)
 		}
 
 	case SubscribeRequestTypeRemove:
 		err := request.removeCb(p.ID(), request.willBeResumed)
 		if err != nil {
-			go p.ClearInProgressAndProcessSubscriptionRequestsQueue(trackID)
+			p.ClearInProgressAndProcessSubscriptionRequestsQueue(trackID)
 		}
 
 	default:
 		p.params.Logger.Warnw("unknown request type", nil)
 
 		// let the queue move forward
-		go p.ClearInProgressAndProcessSubscriptionRequestsQueue(trackID)
+		p.ClearInProgressAndProcessSubscriptionRequestsQueue(trackID)
 	}
 }
 
@@ -2185,5 +2185,5 @@ func (p *ParticipantImpl) ClearInProgressAndProcessSubscriptionRequestsQueue(tra
 	delete(p.subscriptionInProgress, trackID)
 	p.lock.Unlock()
 
-	p.ProcessSubscriptionRequestsQueue(trackID)
+	go p.ProcessSubscriptionRequestsQueue(trackID)
 }

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2112,7 +2112,7 @@ func (p *ParticipantImpl) handleNegotiationFailed() {
 }
 
 func (p *ParticipantImpl) EnqueueSubscribeTrack(trackID livekit.TrackID, f func(sub types.LocalParticipant) error) {
-	p.params.Logger.Infow("queueing subscribe", "trackID", trackID)
+	p.params.Logger.Infow("queuing subscribe", "trackID", trackID)
 
 	p.lock.Lock()
 	p.subscriptionRequestsQueue[trackID] = append(p.subscriptionRequestsQueue[trackID], SubscribeRequest{
@@ -2125,7 +2125,7 @@ func (p *ParticipantImpl) EnqueueSubscribeTrack(trackID livekit.TrackID, f func(
 }
 
 func (p *ParticipantImpl) EnqueueUnsubscribeTrack(trackID livekit.TrackID, willBeResumed bool, f func(subscriberID livekit.ParticipantID, willBeResumed bool) error) {
-	p.params.Logger.Infow("queueing unsubscribe", "trackID", trackID)
+	p.params.Logger.Infow("queuing unsubscribe", "trackID", trackID)
 
 	p.lock.Lock()
 	p.subscriptionRequestsQueue[trackID] = append(p.subscriptionRequestsQueue[trackID], SubscribeRequest{


### PR DESCRIPTION
This is required to determine if a receiver does not have
any subscription.