### PR TITLE
Do not hold lock while invoking resolver.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1558,7 +1558,7 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 	}
 
 	if req.Sid != "" {
-		track := p.getPublishedTrack(livekit.TrackID(req.Sid))
+		track := p.GetPublishedTrack(livekit.TrackID(req.Sid))
 		if track == nil {
 			p.params.Logger.Infow("track not found for new codec publish", "trackID", req.Sid)
 			return nil

--- a/pkg/rtc/uptrackmanager_test.go
+++ b/pkg/rtc/uptrackmanager_test.go
@@ -191,16 +191,16 @@ func TestSubscriptionPermission(t *testing.T) {
 			AllParticipants: true,
 		}
 		um.UpdateSubscriptionPermission(subscriptionPermission, nil, nil)
-		require.True(t, um.hasPermission("audio", "p1"))
-		require.True(t, um.hasPermission("audio", "p2"))
+		require.True(t, um.hasPermissionLocked("audio", "p1"))
+		require.True(t, um.hasPermissionLocked("audio", "p2"))
 
 		// nobody is allowed to subscribe
 		subscriptionPermission = &livekit.SubscriptionPermission{
 			TrackPermissions: []*livekit.TrackPermission{},
 		}
 		um.UpdateSubscriptionPermission(subscriptionPermission, nil, nil)
-		require.False(t, um.hasPermission("audio", "p1"))
-		require.False(t, um.hasPermission("audio", "p2"))
+		require.False(t, um.hasPermissionLocked("audio", "p1"))
+		require.False(t, um.hasPermissionLocked("audio", "p2"))
 
 		// allow all tracks for participants
 		subscriptionPermission = &livekit.SubscriptionPermission{
@@ -216,22 +216,22 @@ func TestSubscriptionPermission(t *testing.T) {
 			},
 		}
 		um.UpdateSubscriptionPermission(subscriptionPermission, nil, nil)
-		require.True(t, um.hasPermission("audio", "p1"))
-		require.True(t, um.hasPermission("video", "p1"))
-		require.True(t, um.hasPermission("audio", "p2"))
-		require.True(t, um.hasPermission("video", "p2"))
+		require.True(t, um.hasPermissionLocked("audio", "p1"))
+		require.True(t, um.hasPermissionLocked("video", "p1"))
+		require.True(t, um.hasPermissionLocked("audio", "p2"))
+		require.True(t, um.hasPermissionLocked("video", "p2"))
 
 		// add a new track after permissions are set
 		trs := &typesfakes.FakeMediaTrack{}
 		trs.IDReturns("screen")
 		um.publishedTracks["screen"] = trs
 
-		require.True(t, um.hasPermission("audio", "p1"))
-		require.True(t, um.hasPermission("video", "p1"))
-		require.True(t, um.hasPermission("screen", "p1"))
-		require.True(t, um.hasPermission("audio", "p2"))
-		require.True(t, um.hasPermission("video", "p2"))
-		require.True(t, um.hasPermission("screen", "p2"))
+		require.True(t, um.hasPermissionLocked("audio", "p1"))
+		require.True(t, um.hasPermissionLocked("video", "p1"))
+		require.True(t, um.hasPermissionLocked("screen", "p1"))
+		require.True(t, um.hasPermissionLocked("audio", "p2"))
+		require.True(t, um.hasPermissionLocked("video", "p2"))
+		require.True(t, um.hasPermissionLocked("screen", "p2"))
 
 		// allow all tracks for some and restrictive for others
 		subscriptionPermission = &livekit.SubscriptionPermission{
@@ -251,36 +251,36 @@ func TestSubscriptionPermission(t *testing.T) {
 			},
 		}
 		um.UpdateSubscriptionPermission(subscriptionPermission, nil, nil)
-		require.True(t, um.hasPermission("audio", "p1"))
-		require.True(t, um.hasPermission("video", "p1"))
-		require.True(t, um.hasPermission("screen", "p1"))
+		require.True(t, um.hasPermissionLocked("audio", "p1"))
+		require.True(t, um.hasPermissionLocked("video", "p1"))
+		require.True(t, um.hasPermissionLocked("screen", "p1"))
 
-		require.True(t, um.hasPermission("audio", "p2"))
-		require.False(t, um.hasPermission("video", "p2"))
-		require.False(t, um.hasPermission("screen", "p2"))
+		require.True(t, um.hasPermissionLocked("audio", "p2"))
+		require.False(t, um.hasPermissionLocked("video", "p2"))
+		require.False(t, um.hasPermissionLocked("screen", "p2"))
 
-		require.False(t, um.hasPermission("audio", "p3"))
-		require.True(t, um.hasPermission("video", "p3"))
-		require.False(t, um.hasPermission("screen", "p3"))
+		require.False(t, um.hasPermissionLocked("audio", "p3"))
+		require.True(t, um.hasPermissionLocked("video", "p3"))
+		require.False(t, um.hasPermissionLocked("screen", "p3"))
 
 		// add a new track after restrictive permissions are set
 		trw := &typesfakes.FakeMediaTrack{}
 		trw.IDReturns("watch")
 		um.publishedTracks["watch"] = trw
 
-		require.True(t, um.hasPermission("audio", "p1"))
-		require.True(t, um.hasPermission("video", "p1"))
-		require.True(t, um.hasPermission("screen", "p1"))
-		require.True(t, um.hasPermission("watch", "p1"))
+		require.True(t, um.hasPermissionLocked("audio", "p1"))
+		require.True(t, um.hasPermissionLocked("video", "p1"))
+		require.True(t, um.hasPermissionLocked("screen", "p1"))
+		require.True(t, um.hasPermissionLocked("watch", "p1"))
 
-		require.True(t, um.hasPermission("audio", "p2"))
-		require.False(t, um.hasPermission("video", "p2"))
-		require.False(t, um.hasPermission("screen", "p2"))
-		require.False(t, um.hasPermission("watch", "p2"))
+		require.True(t, um.hasPermissionLocked("audio", "p2"))
+		require.False(t, um.hasPermissionLocked("video", "p2"))
+		require.False(t, um.hasPermissionLocked("screen", "p2"))
+		require.False(t, um.hasPermissionLocked("watch", "p2"))
 
-		require.False(t, um.hasPermission("audio", "p3"))
-		require.True(t, um.hasPermission("video", "p3"))
-		require.False(t, um.hasPermission("screen", "p3"))
-		require.False(t, um.hasPermission("watch", "p3"))
+		require.False(t, um.hasPermissionLocked("audio", "p3"))
+		require.True(t, um.hasPermissionLocked("video", "p3"))
+		require.False(t, um.hasPermissionLocked("screen", "p3"))
+		require.False(t, um.hasPermissionLocked("watch", "p3"))
 	})
 }


### PR DESCRIPTION
Resolver is in room and it will grab its lock.
It is called from participant when checking permissions.
Permissions processing uses the participant lock.
So, not a good idea to call a room function with
participant lock held. Avoid that.

Also, use a full lock in the add/remove subscription
path. This is to ensure that permissions path and
subscription path (like subscribing to new participant's
tracks) do not race. As subscriptions are queued now
on the subscriber side, this should be fine.