### PR TITLE
remove close check in downtrack.bind

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -275,8 +275,14 @@ func (d *DownTrack) Bind(t webrtc.TrackLocalContext) (webrtc.RTPCodecParameters,
 	if codec.MimeType == "" {
 		return webrtc.RTPCodecParameters{}, webrtc.ErrUnsupportedCodec
 	}
-	d.logger.Debugw("DownTrack.Bind", "codecs", d.upstreamCodecs, "matchCodec", codec)
 
+	// if a downtrack is closed before bind, it already unsubscribed from client, don't do subsequent operation and return here.
+	if d.IsClosed() {
+		d.logger.Debugw("DownTrack closed before bind")
+		return codec, nil
+	}
+
+	d.logger.Debugw("DownTrack.Bind", "codecs", d.upstreamCodecs, "matchCodec", codec)
 	d.ssrc = uint32(t.SSRC())
 	d.payloadType = uint8(codec.PayloadType)
 	d.writeStream = t.WriteStream()

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -260,9 +260,6 @@ func NewDownTrack(
 // This asserts that the code requested is supported by the remote peer.
 // If so it sets up all the state (SSRC and PayloadType) to have a call
 func (d *DownTrack) Bind(t webrtc.TrackLocalContext) (webrtc.RTPCodecParameters, error) {
-	if d.IsClosed() {
-		return webrtc.RTPCodecParameters{}, ErrDownTrackClosed
-	}
 	if d.bound.Load() {
 		return webrtc.RTPCodecParameters{}, ErrDownTrackAlreadyBound
 	}


### PR DESCRIPTION
when a downtrack close before it's bind be called, will cause bind failed, then the signal state will stick to have local sdp, will not recover unless client reconnect. the event sequence is:
1. user subscribe , downtrack added, sent offer to client
2. unsubscribe, downtrack close, negotiation enqueue
3. receiver client answer, set remote sdp failed because downtrack.bind return error (closed)
4. signal state stuck at negotiationRetry

since this is caused by the downtrack unsubscribe (close) before it has been bind,  I think don't check close in bind will not cause problem, the downtrack will not  start work.