### PR TITLE
Separate close and stop on MediaTrackSubscriptions.

### DIFF
--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -280,7 +280,7 @@ func (t *MediaTrackReceiver) Close() {
 	onclose := t.onClose
 	t.lock.RUnlock()
 
-	t.MediaTrackSubscriptions.Stop()
+	t.MediaTrackSubscriptions.Close()
 	for _, f := range onclose {
 		f()
 	}

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -93,6 +93,10 @@ func (t *MediaTrackSubscriptions) Restart() {
 }
 
 func (t *MediaTrackSubscriptions) Stop() {
+	t.stopMaxQualityTimer()
+}
+
+func (t *MediaTrackSubscriptions) Close() {
 	t.qualityNotifyOpQueue.Stop()
 	t.stopMaxQualityTimer()
 }

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1674,7 +1674,7 @@ func (p *ParticipantImpl) mediaTrackReceived(track *webrtc.TrackRemote, rtpRecei
 	p.pendingTracksLock.Lock()
 	newTrack := false
 
-	p.params.Logger.Debugw("media track received", "track", track.ID(), "kind", track.Kind())
+	p.params.Logger.Debugw("media track received", "trackID", track.ID(), "kind", track.Kind())
 	var mid string
 	for _, tr := range p.publisher.pc.GetTransceivers() {
 		if tr.Receiver() == rtpReceiver {


### PR DESCRIPTION
Used to be this way till I merged it. As ops queue is stopped,
should happen only on close. Just added the stop quality timer
to close also which was not there before.