### PR TITLE
Switch release CI to build on Linux

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Fetch all tags

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,17 +3,6 @@ before:
     - go mod tidy
     - go generate ./...
 builds:
-  # darwin build requires CGO, declaring it separately
-  - id: darwin
-    env:
-      - CGO_ENABLED=1
-    main: ./cmd/server
-    binary: livekit-server
-    goarch:
-      - amd64
-      - arm64
-    goos:
-      - darwin
   - id: livekit
     env:
       - CGO_ENABLED=0
@@ -32,24 +21,8 @@ archives:
   - format_overrides:
       - goos: windows
         format: zip
-    replacements:
-      darwin: mac
     files:
       - LICENSE
-nfpms:
-  - package_name: livekit
-    vendor: LiveKit
-    homepage: https://livekit.io
-    description: |-
-      LiveKit is a high-performance WebRTC server. It provides software components for building multi-user, real-time, media applications.
-    license: Apache 2.0
-
-    formats:
-      - deb
-      - rpm
-
-    recommends:
-      - redis-server
 release:
   github:
     owner: livekit


### PR DESCRIPTION
Also disabled Mac builds and .deb generation.
* Mac build - they are unsigned and will not be able to run when downloaded
* .deb - it doesn't add much value in addition to the binaries