### PR TITLE
enable nack for audio track

### DIFF
--- a/pkg/rtc/config.go
+++ b/pkg/rtc/config.go
@@ -171,6 +171,9 @@ func NewWebRTCConfig(conf *config.Config, externalIP string) (*WebRTCConfig, err
 				{Type: webrtc.TypeRTCPFBNACK},
 				{Type: webrtc.TypeRTCPFBNACK, Parameter: "pli"},
 			},
+			Audio: []webrtc.RTCPFeedback{
+				{Type: webrtc.TypeRTCPFBNACK},
+			},
 		},
 	}
 	if rtcConf.CongestionControl.UseSendSideBWE {

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -179,13 +179,13 @@ func (b *Buffer) Bind(params webrtc.RTPParameters, codec webrtc.RTPCodecCapabili
 		}
 	}
 
-	if b.codecType == webrtc.RTPCodecTypeVideo {
-		for _, fb := range codec.RTCPFeedback {
-			switch fb.Type {
-			case webrtc.TypeRTCPFBGoogREMB:
-				b.logger.Debugw("Setting feedback", "type", webrtc.TypeRTCPFBGoogREMB)
-				b.logger.Warnw("REMB not supported, RTCP feedback will not be generated", nil)
-			case webrtc.TypeRTCPFBTransportCC:
+	for _, fb := range codec.RTCPFeedback {
+		switch fb.Type {
+		case webrtc.TypeRTCPFBGoogREMB:
+			b.logger.Debugw("Setting feedback", "type", webrtc.TypeRTCPFBGoogREMB)
+			b.logger.Warnw("REMB not supported, RTCP feedback will not be generated", nil)
+		case webrtc.TypeRTCPFBTransportCC:
+			if b.codecType == webrtc.RTPCodecTypeVideo {
 				b.logger.Debugw("Setting feedback", "type", webrtc.TypeRTCPFBTransportCC)
 				for _, ext := range params.HeaderExtensions {
 					if ext.URI == sdp.TransportCCURI {
@@ -193,11 +193,11 @@ func (b *Buffer) Bind(params webrtc.RTPParameters, codec webrtc.RTPCodecCapabili
 						break
 					}
 				}
-			case webrtc.TypeRTCPFBNACK:
-				b.logger.Debugw("Setting feedback", "type", webrtc.TypeRTCPFBNACK)
-				b.nacker = NewNACKQueue()
-				b.nacker.SetRTT(70) // default till it is updated
 			}
+		case webrtc.TypeRTCPFBNACK:
+			b.logger.Debugw("Setting feedback", "type", webrtc.TypeRTCPFBNACK)
+			b.nacker = NewNACKQueue()
+			b.nacker.SetRTT(70) // default till it is updated
 		}
 	}
 

--- a/pkg/sfu/buffer/factory.go
+++ b/pkg/sfu/buffer/factory.go
@@ -25,7 +25,7 @@ func NewBufferFactory(trackingPackets int) *Factory {
 		},
 		audioPool: &sync.Pool{
 			New: func() interface{} {
-				b := make([]byte, maxPktSize*25)
+				b := make([]byte, maxPktSize*200)
 				return &b
 			},
 		},

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -292,9 +292,7 @@ func (d *DownTrack) Bind(t webrtc.TrackLocalContext) (webrtc.RTPCodecParameters,
 			d.handleRTCP(pkt)
 		})
 	}
-	if strings.HasPrefix(codec.MimeType, "video/") {
-		d.sequencer = newSequencer(d.maxTrack, d.logger)
-	}
+	d.sequencer = newSequencer(d.maxTrack, d.logger)
 	d.codec = codec.RTPCodecCapability
 	d.forwarder.DetermineCodec(d.codec)
 	if d.onBind != nil {


### PR DESCRIPTION
Now we don't have nack for audio, in some case have a high loss rate, in-band fec and plc can't provide high audio quality, nack can improve when rtt is not very high.  
A 10% loss rate test, subscriber get <0.1% loss rate after nack

`{"trackID": "TR_AMgNZLzXuFSLgf", "stats": "t: Wed Jul 13 07:18:58 UTC 2022|Wed Jul 13 07:21:47 UTC 2022|169.07s sn: 5997|14140, ep: 8144|48.17/s, p: 8144|48.17/s, l: 50|0.3/s|0.61%, b: 469762|22228.0bps, f: 70|0.4/s / 0|Mon Jan  1 00:00:00 UTC 0001, d: 1213|7.17/s, bd: 70472|3334.6bps, pp: 0|0.00/s, bp: 0|0.0bps, o: 1335, c: 48000, j: 947(19729.2us)|3264(68000.0us), gh:[4:1, 2:12, 3:3, 5:1, 1:80], n:1621|1213|0|68, pli:0|Mon Jan  1 00:00:00 UTC 0001 / 0|Mon Jan  1 00:00:00 UTC 0001, fir:0|Mon Jan  1 00:00:00 UTC 0001, rtt(ms):76|133"}`

```
[codec]	opus (111, minptime=10;useinbandfec=1)
mediaType	audio
jitter	0.004
packetsLost	47
packetsDiscarded	59
packetsReceived	7328
nackCount	1103
