### PR TITLE
Record dynacast requirement of a subscriber synchronously.

### DIFF
--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -301,7 +301,7 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 	})
 
 	downTrack.OnMaxLayerChanged(func(dt *sfu.DownTrack, layer int32) {
-		go t.notifySubscriberMaxQuality(subscriberID, dt.Codec(), utils.QualityForSpatialLayer(layer))
+		t.notifySubscriberMaxQuality(subscriberID, dt.Codec(), utils.QualityForSpatialLayer(layer))
 	})
 
 	downTrack.OnRttUpdate(func(_ *sfu.DownTrack, rtt uint32) {
@@ -517,7 +517,7 @@ func (t *MediaTrackSubscriptions) notifySubscriberMaxQuality(subscriberID liveki
 	}
 	t.maxQualityLock.Unlock()
 
-	t.UpdateQualityChange(false)
+	go t.UpdateQualityChange(false)
 }
 
 func (t *MediaTrackSubscriptions) NotifySubscriberNodeMaxQuality(nodeID livekit.NodeID, qualities []types.SubscribedCodecQuality) {
@@ -563,7 +563,7 @@ func (t *MediaTrackSubscriptions) NotifySubscriberNodeMaxQuality(nodeID livekit.
 	}
 	t.maxQualityLock.Unlock()
 
-	t.UpdateQualityChange(false)
+	go t.UpdateQualityChange(false)
 }
 
 func (t *MediaTrackSubscriptions) UpdateQualityChange(force bool) {

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -973,9 +973,10 @@ func (p *ParticipantImpl) UpdateSubscribedTrackSettings(trackID livekit.TrackID,
 
 	subTrack := p.subscribedTracks[trackID]
 	if subTrack == nil {
+		// will get set when subscribed track is added
 		p.lock.Unlock()
-		p.params.Logger.Warnw("could not find subscribed track", nil, "trackID", trackID)
-		return errors.New("could not find subscribed track")
+		p.params.Logger.Infow("could not find subscribed track", nil, "trackID", trackID)
+		return nil
 	}
 	p.lock.Unlock()
 
@@ -1969,6 +1970,7 @@ func (p *ParticipantImpl) rtcpSendWorker() {
 	// read from rtcpChan
 	for pkts := range p.rtcpCh {
 		if pkts == nil {
+			p.params.Logger.Infow("exiting RTCP send worker")
 			return
 		}
 

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -259,10 +259,6 @@ func (r *RTPStats) Update(rtph *rtp.Header, payloadSize int, paddingSize int, pa
 		r.highestSN = rtph.SequenceNumber
 		r.highestTS = rtph.Timestamp
 		r.highestTime = packetTime
-
-		if rtph.Marker {
-			r.frames++
-		}
 	}
 
 	if !isDuplicate {
@@ -271,6 +267,10 @@ func (r *RTPStats) Update(rtph *rtp.Header, payloadSize int, paddingSize int, pa
 			r.bytesPadding += pktSize
 		} else {
 			r.bytes += pktSize
+
+			if rtph.Marker {
+				r.frames++
+			}
 		}
 
 		r.updateJitter(rtph, packetTime)


### PR DESCRIPTION
With rapid changes to subscription settings, use of a goroutine
could end up processing dynacast needs for that subscriber in
a different order. So, record the susbcription needs of a subscriber
in the callback and process the data in a go routine.