### PR TITLE
Use a go routine to clean up stats workers.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1837,8 +1837,11 @@ func (p *ParticipantImpl) handleTrackPublished(track types.MediaTrack) {
 		p.SetMigrateState(types.MigrateStateComplete)
 	}
 
-	if p.onTrackPublished != nil {
-		p.onTrackPublished(p, track)
+	p.lock.RLock()
+	onTrackPublished := p.onTrackPublished
+	p.lock.RUnlock()
+	if onTrackPublished != nil {
+		onTrackPublished(p, track)
 	}
 }
 

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -53,10 +53,16 @@ func NewTelemetryService(notifier webhook.Notifier, analytics AnalyticsService) 
 func (t *telemetryService) run() {
 	ticker := time.NewTicker(config.StatsUpdateInterval)
 	defer ticker.Stop()
+
+	cleanupTicker := time.NewTicker(time.Minute)
+	defer cleanupTicker.Stop()
+
 	for {
 		select {
 		case <-ticker.C:
 			t.internalService.SendAnalytics()
+		case <-cleanupTicker.C:
+			t.internalService.CleanupWorkers()
 		case op := <-t.jobsChan:
 			op()
 		}

--- a/pkg/telemetry/telemetryserviceinternal.go
+++ b/pkg/telemetry/telemetryserviceinternal.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gammazero/workerpool"
 
 	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/webhook"
 
 	"github.com/livekit/livekit-server/pkg/telemetry/prometheus"
@@ -121,6 +122,7 @@ func (t *telemetryServiceInternal) CleanupWorkers() {
 		closedAt := worker.ClosedAt()
 		if !closedAt.IsZero() && time.Since(closedAt) > workerCleanupWait {
 			pID := worker.ParticipantID()
+			logger.Infow("reaping analytics worker for participant", "pID", pID)
 			t.workersMu.Lock()
 			if idx, ok := t.workersIdx[pID]; ok {
 				delete(t.workersIdx, pID)

--- a/pkg/telemetry/telemetryserviceinternal.go
+++ b/pkg/telemetry/telemetryserviceinternal.go
@@ -122,7 +122,7 @@ func (t *telemetryServiceInternal) CleanupWorkers() {
 		closedAt := worker.ClosedAt()
 		if !closedAt.IsZero() && time.Since(closedAt) > workerCleanupWait {
 			pID := worker.ParticipantID()
-			logger.Infow("reaping analytics worker for participant", "pID", pID)
+			logger.Debugw("reaping analytics worker for participant", "pID", pID)
 			t.workersMu.Lock()
 			if idx, ok := t.workersIdx[pID]; ok {
 				delete(t.workersIdx, pID)

--- a/pkg/telemetry/telemetryserviceinternalevents.go
+++ b/pkg/telemetry/telemetryserviceinternalevents.go
@@ -119,13 +119,6 @@ func (t *telemetryServiceInternal) ParticipantLeft(ctx context.Context, room *li
 		w.Close()
 	}
 
-	t.workersMu.Lock()
-	if idx, ok := t.workersIdx[livekit.ParticipantID(participant.Sid)]; ok {
-		delete(t.workersIdx, livekit.ParticipantID(participant.Sid))
-		t.workers[idx] = nil
-	}
-	t.workersMu.Unlock()
-
 	prometheus.SubParticipant()
 
 	t.notifyEvent(ctx, &livekit.WebhookEvent{


### PR DESCRIPTION
It is possible that certain events (like TrackUnpublished) can
happen after the participant is closed. For webhooks pertaining
to those events, need details like room name/id. So,reap stats
workers a little while after the participant left event happens.