### PR TITLE
Room sid for room specific message in `RoomService`

### DIFF
--- a/pkg/routing/interfaces.go
+++ b/pkg/routing/interfaces.go
@@ -66,9 +66,9 @@ type Router interface {
 
 	ListNodes() ([]*livekit.Node, error)
 
-	GetNodeForRoom(ctx context.Context, roomName livekit.RoomName) (*livekit.Node, error)
-	SetNodeForRoom(ctx context.Context, roomName livekit.RoomName, nodeId livekit.NodeID) error
-	ClearRoomState(ctx context.Context, roomName livekit.RoomName) error
+	GetNodeForRoom(ctx context.Context, roomName livekit.RoomName, roomID livekit.RoomID) (*livekit.Node, error)
+	SetNodeForRoom(ctx context.Context, roomName livekit.RoomName, roomID livekit.RoomID, nodeId livekit.NodeID) error
+	ClearRoomState(ctx context.Context, roomName livekit.RoomName, roomID livekit.RoomID) error
 
 	GetRegion() string
 
@@ -89,7 +89,7 @@ type MessageRouter interface {
 
 	// Write a message to a participant or room
 	WriteParticipantRTC(ctx context.Context, roomName livekit.RoomName, identity livekit.ParticipantIdentity, msg *livekit.RTCNodeMessage) error
-	WriteRoomRTC(ctx context.Context, roomName livekit.RoomName, msg *livekit.RTCNodeMessage) error
+	WriteRoomRTC(ctx context.Context, roomName livekit.RoomName, roomID livekit.RoomID, msg *livekit.RTCNodeMessage) error
 }
 
 func CreateRouter(rc *redis.Client, node LocalNode) Router {

--- a/pkg/routing/localrouter.go
+++ b/pkg/routing/localrouter.go
@@ -39,18 +39,18 @@ func NewLocalRouter(currentNode LocalNode) *LocalRouter {
 	}
 }
 
-func (r *LocalRouter) GetNodeForRoom(_ context.Context, _ livekit.RoomName) (*livekit.Node, error) {
+func (r *LocalRouter) GetNodeForRoom(_ context.Context, _ livekit.RoomName, _ livekit.RoomID) (*livekit.Node, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	node := proto.Clone((*livekit.Node)(r.currentNode)).(*livekit.Node)
 	return node, nil
 }
 
-func (r *LocalRouter) SetNodeForRoom(_ context.Context, _ livekit.RoomName, _ livekit.NodeID) error {
+func (r *LocalRouter) SetNodeForRoom(_ context.Context, _ livekit.RoomName, _ livekit.RoomID, _ livekit.NodeID) error {
 	return nil
 }
 
-func (r *LocalRouter) ClearRoomState(_ context.Context, _ livekit.RoomName) error {
+func (r *LocalRouter) ClearRoomState(_ context.Context, _ livekit.RoomName, _ livekit.RoomID) error {
 	// do nothing
 	return nil
 }
@@ -133,7 +133,7 @@ func (r *LocalRouter) WriteParticipantRTC(_ context.Context, roomName livekit.Ro
 	return r.writeRTCMessage(r.rtcMessageChan, msg)
 }
 
-func (r *LocalRouter) WriteRoomRTC(ctx context.Context, roomName livekit.RoomName, msg *livekit.RTCNodeMessage) error {
+func (r *LocalRouter) WriteRoomRTC(ctx context.Context, roomName livekit.RoomName, _roomID livekit.RoomID, msg *livekit.RTCNodeMessage) error {
 	msg.ParticipantKey = string(participantKey(roomName, ""))
 	return r.WriteNodeRTC(ctx, r.currentNode.Id, msg)
 }

--- a/pkg/routing/redis.go
+++ b/pkg/routing/redis.go
@@ -16,6 +16,9 @@ const (
 
 	// hash of room_name => node_id
 	NodeRoomKey = "room_node_map"
+
+	// hash of room_sid => node_id
+	NodeRoomSidKey = "room_sid_node_map"
 )
 
 var redisCtx = context.Background()

--- a/pkg/routing/routingfakes/fake_router.go
+++ b/pkg/routing/routingfakes/fake_router.go
@@ -165,12 +165,13 @@ type FakeRouter struct {
 	writeParticipantRTCReturnsOnCall map[int]struct {
 		result1 error
 	}
-	WriteRoomRTCStub        func(context.Context, livekit.RoomName, *livekit.RTCNodeMessage) error
+	WriteRoomRTCStub        func(context.Context, livekit.RoomName, livekit.RoomID, *livekit.RTCNodeMessage) error
 	writeRoomRTCMutex       sync.RWMutex
 	writeRoomRTCArgsForCall []struct {
 		arg1 context.Context
 		arg2 livekit.RoomName
-		arg3 *livekit.RTCNodeMessage
+		arg3 livekit.RoomID
+		arg4 *livekit.RTCNodeMessage
 	}
 	writeRoomRTCReturns struct {
 		result1 error
@@ -944,20 +945,21 @@ func (fake *FakeRouter) WriteParticipantRTCReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeRouter) WriteRoomRTC(arg1 context.Context, arg2 livekit.RoomName, arg3 *livekit.RTCNodeMessage) error {
+func (fake *FakeRouter) WriteRoomRTC(arg1 context.Context, arg2 livekit.RoomName, arg3 livekit.RoomID, arg4 *livekit.RTCNodeMessage) error {
 	fake.writeRoomRTCMutex.Lock()
 	ret, specificReturn := fake.writeRoomRTCReturnsOnCall[len(fake.writeRoomRTCArgsForCall)]
 	fake.writeRoomRTCArgsForCall = append(fake.writeRoomRTCArgsForCall, struct {
 		arg1 context.Context
 		arg2 livekit.RoomName
-		arg3 *livekit.RTCNodeMessage
-	}{arg1, arg2, arg3})
+		arg3 livekit.RoomID
+		arg4 *livekit.RTCNodeMessage
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.WriteRoomRTCStub
 	fakeReturns := fake.writeRoomRTCReturns
-	fake.recordInvocation("WriteRoomRTC", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("WriteRoomRTC", []interface{}{arg1, arg2, arg3, arg4})
 	fake.writeRoomRTCMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
@@ -971,17 +973,17 @@ func (fake *FakeRouter) WriteRoomRTCCallCount() int {
 	return len(fake.writeRoomRTCArgsForCall)
 }
 
-func (fake *FakeRouter) WriteRoomRTCCalls(stub func(context.Context, livekit.RoomName, *livekit.RTCNodeMessage) error) {
+func (fake *FakeRouter) WriteRoomRTCCalls(stub func(context.Context, livekit.RoomName, livekit.RoomID, *livekit.RTCNodeMessage) error) {
 	fake.writeRoomRTCMutex.Lock()
 	defer fake.writeRoomRTCMutex.Unlock()
 	fake.WriteRoomRTCStub = stub
 }
 
-func (fake *FakeRouter) WriteRoomRTCArgsForCall(i int) (context.Context, livekit.RoomName, *livekit.RTCNodeMessage) {
+func (fake *FakeRouter) WriteRoomRTCArgsForCall(i int) (context.Context, livekit.RoomName, livekit.RoomID, *livekit.RTCNodeMessage) {
 	fake.writeRoomRTCMutex.RLock()
 	defer fake.writeRoomRTCMutex.RUnlock()
 	argsForCall := fake.writeRoomRTCArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeRouter) WriteRoomRTCReturns(result1 error) {

--- a/pkg/routing/routingfakes/fake_router.go
+++ b/pkg/routing/routingfakes/fake_router.go
@@ -10,11 +10,12 @@ import (
 )
 
 type FakeRouter struct {
-	ClearRoomStateStub        func(context.Context, livekit.RoomName) error
+	ClearRoomStateStub        func(context.Context, livekit.RoomName, livekit.RoomID) error
 	clearRoomStateMutex       sync.RWMutex
 	clearRoomStateArgsForCall []struct {
 		arg1 context.Context
 		arg2 livekit.RoomName
+		arg3 livekit.RoomID
 	}
 	clearRoomStateReturns struct {
 		result1 error
@@ -26,11 +27,12 @@ type FakeRouter struct {
 	drainMutex       sync.RWMutex
 	drainArgsForCall []struct {
 	}
-	GetNodeForRoomStub        func(context.Context, livekit.RoomName) (*livekit.Node, error)
+	GetNodeForRoomStub        func(context.Context, livekit.RoomName, livekit.RoomID) (*livekit.Node, error)
 	getNodeForRoomMutex       sync.RWMutex
 	getNodeForRoomArgsForCall []struct {
 		arg1 context.Context
 		arg2 livekit.RoomName
+		arg3 livekit.RoomID
 	}
 	getNodeForRoomReturns struct {
 		result1 *livekit.Node
@@ -92,12 +94,13 @@ type FakeRouter struct {
 	removeDeadNodesReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SetNodeForRoomStub        func(context.Context, livekit.RoomName, livekit.NodeID) error
+	SetNodeForRoomStub        func(context.Context, livekit.RoomName, livekit.RoomID, livekit.NodeID) error
 	setNodeForRoomMutex       sync.RWMutex
 	setNodeForRoomArgsForCall []struct {
 		arg1 context.Context
 		arg2 livekit.RoomName
-		arg3 livekit.NodeID
+		arg3 livekit.RoomID
+		arg4 livekit.NodeID
 	}
 	setNodeForRoomReturns struct {
 		result1 error
@@ -179,19 +182,20 @@ type FakeRouter struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeRouter) ClearRoomState(arg1 context.Context, arg2 livekit.RoomName) error {
+func (fake *FakeRouter) ClearRoomState(arg1 context.Context, arg2 livekit.RoomName, arg3 livekit.RoomID) error {
 	fake.clearRoomStateMutex.Lock()
 	ret, specificReturn := fake.clearRoomStateReturnsOnCall[len(fake.clearRoomStateArgsForCall)]
 	fake.clearRoomStateArgsForCall = append(fake.clearRoomStateArgsForCall, struct {
 		arg1 context.Context
 		arg2 livekit.RoomName
-	}{arg1, arg2})
+		arg3 livekit.RoomID
+	}{arg1, arg2, arg3})
 	stub := fake.ClearRoomStateStub
 	fakeReturns := fake.clearRoomStateReturns
-	fake.recordInvocation("ClearRoomState", []interface{}{arg1, arg2})
+	fake.recordInvocation("ClearRoomState", []interface{}{arg1, arg2, arg3})
 	fake.clearRoomStateMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -205,17 +209,17 @@ func (fake *FakeRouter) ClearRoomStateCallCount() int {
 	return len(fake.clearRoomStateArgsForCall)
 }
 
-func (fake *FakeRouter) ClearRoomStateCalls(stub func(context.Context, livekit.RoomName) error) {
+func (fake *FakeRouter) ClearRoomStateCalls(stub func(context.Context, livekit.RoomName, livekit.RoomID) error) {
 	fake.clearRoomStateMutex.Lock()
 	defer fake.clearRoomStateMutex.Unlock()
 	fake.ClearRoomStateStub = stub
 }
 
-func (fake *FakeRouter) ClearRoomStateArgsForCall(i int) (context.Context, livekit.RoomName) {
+func (fake *FakeRouter) ClearRoomStateArgsForCall(i int) (context.Context, livekit.RoomName, livekit.RoomID) {
 	fake.clearRoomStateMutex.RLock()
 	defer fake.clearRoomStateMutex.RUnlock()
 	argsForCall := fake.clearRoomStateArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeRouter) ClearRoomStateReturns(result1 error) {
@@ -265,19 +269,20 @@ func (fake *FakeRouter) DrainCalls(stub func()) {
 	fake.DrainStub = stub
 }
 
-func (fake *FakeRouter) GetNodeForRoom(arg1 context.Context, arg2 livekit.RoomName) (*livekit.Node, error) {
+func (fake *FakeRouter) GetNodeForRoom(arg1 context.Context, arg2 livekit.RoomName, arg3 livekit.RoomID) (*livekit.Node, error) {
 	fake.getNodeForRoomMutex.Lock()
 	ret, specificReturn := fake.getNodeForRoomReturnsOnCall[len(fake.getNodeForRoomArgsForCall)]
 	fake.getNodeForRoomArgsForCall = append(fake.getNodeForRoomArgsForCall, struct {
 		arg1 context.Context
 		arg2 livekit.RoomName
-	}{arg1, arg2})
+		arg3 livekit.RoomID
+	}{arg1, arg2, arg3})
 	stub := fake.GetNodeForRoomStub
 	fakeReturns := fake.getNodeForRoomReturns
-	fake.recordInvocation("GetNodeForRoom", []interface{}{arg1, arg2})
+	fake.recordInvocation("GetNodeForRoom", []interface{}{arg1, arg2, arg3})
 	fake.getNodeForRoomMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -291,17 +296,17 @@ func (fake *FakeRouter) GetNodeForRoomCallCount() int {
 	return len(fake.getNodeForRoomArgsForCall)
 }
 
-func (fake *FakeRouter) GetNodeForRoomCalls(stub func(context.Context, livekit.RoomName) (*livekit.Node, error)) {
+func (fake *FakeRouter) GetNodeForRoomCalls(stub func(context.Context, livekit.RoomName, livekit.RoomID) (*livekit.Node, error)) {
 	fake.getNodeForRoomMutex.Lock()
 	defer fake.getNodeForRoomMutex.Unlock()
 	fake.GetNodeForRoomStub = stub
 }
 
-func (fake *FakeRouter) GetNodeForRoomArgsForCall(i int) (context.Context, livekit.RoomName) {
+func (fake *FakeRouter) GetNodeForRoomArgsForCall(i int) (context.Context, livekit.RoomName, livekit.RoomID) {
 	fake.getNodeForRoomMutex.RLock()
 	defer fake.getNodeForRoomMutex.RUnlock()
 	argsForCall := fake.getNodeForRoomArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeRouter) GetNodeForRoomReturns(result1 *livekit.Node, result2 error) {
@@ -609,20 +614,21 @@ func (fake *FakeRouter) RemoveDeadNodesReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeRouter) SetNodeForRoom(arg1 context.Context, arg2 livekit.RoomName, arg3 livekit.NodeID) error {
+func (fake *FakeRouter) SetNodeForRoom(arg1 context.Context, arg2 livekit.RoomName, arg3 livekit.RoomID, arg4 livekit.NodeID) error {
 	fake.setNodeForRoomMutex.Lock()
 	ret, specificReturn := fake.setNodeForRoomReturnsOnCall[len(fake.setNodeForRoomArgsForCall)]
 	fake.setNodeForRoomArgsForCall = append(fake.setNodeForRoomArgsForCall, struct {
 		arg1 context.Context
 		arg2 livekit.RoomName
-		arg3 livekit.NodeID
-	}{arg1, arg2, arg3})
+		arg3 livekit.RoomID
+		arg4 livekit.NodeID
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.SetNodeForRoomStub
 	fakeReturns := fake.setNodeForRoomReturns
-	fake.recordInvocation("SetNodeForRoom", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("SetNodeForRoom", []interface{}{arg1, arg2, arg3, arg4})
 	fake.setNodeForRoomMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
@@ -636,17 +642,17 @@ func (fake *FakeRouter) SetNodeForRoomCallCount() int {
 	return len(fake.setNodeForRoomArgsForCall)
 }
 
-func (fake *FakeRouter) SetNodeForRoomCalls(stub func(context.Context, livekit.RoomName, livekit.NodeID) error) {
+func (fake *FakeRouter) SetNodeForRoomCalls(stub func(context.Context, livekit.RoomName, livekit.RoomID, livekit.NodeID) error) {
 	fake.setNodeForRoomMutex.Lock()
 	defer fake.setNodeForRoomMutex.Unlock()
 	fake.SetNodeForRoomStub = stub
 }
 
-func (fake *FakeRouter) SetNodeForRoomArgsForCall(i int) (context.Context, livekit.RoomName, livekit.NodeID) {
+func (fake *FakeRouter) SetNodeForRoomArgsForCall(i int) (context.Context, livekit.RoomName, livekit.RoomID, livekit.NodeID) {
 	fake.setNodeForRoomMutex.RLock()
 	defer fake.setNodeForRoomMutex.RUnlock()
 	argsForCall := fake.setNodeForRoomArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeRouter) SetNodeForRoomReturns(result1 error) {

--- a/pkg/service/egress.go
+++ b/pkg/service/egress.go
@@ -80,7 +80,7 @@ func (s *EgressService) StartEgress(ctx context.Context, roomName livekit.RoomNa
 		return nil, ErrEgressNotConnected
 	}
 
-	room, err := s.store.LoadRoom(ctx, roomName)
+	room, err := s.store.LoadRoom(ctx, roomName, "")
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (s *EgressService) ListEgress(ctx context.Context, req *livekit.ListEgressR
 
 	var roomID livekit.RoomID
 	if req.RoomName != "" {
-		room, err := s.store.LoadRoom(ctx, livekit.RoomName(req.RoomName))
+		room, err := s.store.LoadRoom(ctx, livekit.RoomName(req.RoomName), "")
 		if err != nil {
 			if err == ErrRoomNotFound {
 				return &livekit.ListEgressResponse{}, nil

--- a/pkg/service/interfaces.go
+++ b/pkg/service/interfaces.go
@@ -20,7 +20,7 @@ type ObjectStore interface {
 	UnlockRoom(ctx context.Context, name livekit.RoomName, uid string) error
 
 	StoreRoom(ctx context.Context, room *livekit.Room) error
-	DeleteRoom(ctx context.Context, name livekit.RoomName) error
+	DeleteRoom(ctx context.Context, name livekit.RoomName, roomID livekit.RoomID) error
 
 	StoreParticipant(ctx context.Context, roomName livekit.RoomName, participant *livekit.ParticipantInfo) error
 	DeleteParticipant(ctx context.Context, roomName livekit.RoomName, identity livekit.ParticipantIdentity) error
@@ -28,7 +28,7 @@ type ObjectStore interface {
 
 //counterfeiter:generate . ServiceStore
 type ServiceStore interface {
-	LoadRoom(ctx context.Context, name livekit.RoomName) (*livekit.Room, error)
+	LoadRoom(ctx context.Context, name livekit.RoomName, roomID livekit.RoomID) (*livekit.Room, error)
 	// ListRooms returns currently active rooms. if names and/or sids is not nil, it'll filter and return
 	// only rooms that match
 	ListRooms(ctx context.Context, names []livekit.RoomName, sids []livekit.RoomID) ([]*livekit.Room, error)

--- a/pkg/service/redisstore.go
+++ b/pkg/service/redisstore.go
@@ -118,6 +118,7 @@ func (s *RedisStore) DeleteRoom(ctx context.Context, name livekit.RoomName, room
 
 	pp := s.rc.Pipeline()
 	pp.HDel(s.ctx, RoomsKey, string(name))
+	pp.HDel(s.ctx, RoomSidsKey, string(roomID))
 	pp.Del(s.ctx, RoomParticipantsPrefix+string(name))
 
 	_, err = pp.Exec(s.ctx)

--- a/pkg/service/redisstore_test.go
+++ b/pkg/service/redisstore_test.go
@@ -19,7 +19,7 @@ func TestParticipantPersistence(t *testing.T) {
 	rs := service.NewRedisStore(redisClient())
 
 	roomName := livekit.RoomName("room1")
-	_ = rs.DeleteRoom(ctx, roomName)
+	_ = rs.DeleteRoom(ctx, roomName, "")
 
 	p := &livekit.ParticipantInfo{
 		Sid:      "PA_test",

--- a/pkg/service/roomallocator.go
+++ b/pkg/service/roomallocator.go
@@ -46,7 +46,7 @@ func (r *StandardRoomAllocator) CreateRoom(ctx context.Context, req *livekit.Cre
 	}()
 
 	// find existing room and update it
-	rm, err := r.roomStore.LoadRoom(ctx, livekit.RoomName(req.Name))
+	rm, err := r.roomStore.LoadRoom(ctx, livekit.RoomName(req.Name), "")
 	if err == ErrRoomNotFound {
 		rm = &livekit.Room{
 			Sid:          utils.NewGuid(utils.RoomPrefix),
@@ -73,7 +73,7 @@ func (r *StandardRoomAllocator) CreateRoom(ctx context.Context, req *livekit.Cre
 	}
 
 	// check if room already assigned
-	existing, err := r.router.GetNodeForRoom(ctx, livekit.RoomName(rm.Name))
+	existing, err := r.router.GetNodeForRoom(ctx, livekit.RoomName(rm.Name), "")
 	if err != routing.ErrNotFound && err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (r *StandardRoomAllocator) CreateRoom(ctx context.Context, req *livekit.Cre
 	}
 
 	logger.Debugw("selected node for room", "room", rm.Name, "roomID", rm.Sid, "nodeID", nodeID)
-	err = r.router.SetNodeForRoom(ctx, livekit.RoomName(rm.Name), nodeID)
+	err = r.router.SetNodeForRoom(ctx, livekit.RoomName(rm.Name), livekit.RoomID(rm.Sid), nodeID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/rtcservice.go
+++ b/pkg/service/rtcservice.go
@@ -111,7 +111,7 @@ func (s *RTCService) validate(r *http.Request) (livekit.RoomName, routing.Partic
 	region := ""
 	if router, ok := s.router.(routing.Router); ok {
 		region = router.GetRegion()
-		if foundNode, err := router.GetNodeForRoom(r.Context(), roomName); err == nil {
+		if foundNode, err := router.GetNodeForRoom(r.Context(), roomName, ""); err == nil {
 			if selector.LimitsReached(s.limits, foundNode.Stats) {
 				return "", routing.ParticipantInit{}, http.StatusServiceUnavailable, rtc.ErrLimitExceeded
 			}
@@ -154,7 +154,7 @@ func (s *RTCService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// when auto create is disabled, we'll check to ensure it's already created
 	if !s.config.Room.AutoCreate {
-		_, err := s.store.LoadRoom(context.Background(), roomName)
+		_, err := s.store.LoadRoom(context.Background(), roomName, "")
 		if err == ErrRoomNotFound {
 			handleError(w, 404, err.Error())
 			return

--- a/pkg/service/servicefakes/fake_object_store.go
+++ b/pkg/service/servicefakes/fake_object_store.go
@@ -36,11 +36,12 @@ type FakeObjectStore struct {
 	deleteParticipantReturnsOnCall map[int]struct {
 		result1 error
 	}
-	DeleteRoomStub        func(context.Context, livekit.RoomName) error
+	DeleteRoomStub        func(context.Context, livekit.RoomName, livekit.RoomID) error
 	deleteRoomMutex       sync.RWMutex
 	deleteRoomArgsForCall []struct {
 		arg1 context.Context
 		arg2 livekit.RoomName
+		arg3 livekit.RoomID
 	}
 	deleteRoomReturns struct {
 		result1 error
@@ -120,11 +121,12 @@ type FakeObjectStore struct {
 		result1 *livekit.ParticipantInfo
 		result2 error
 	}
-	LoadRoomStub        func(context.Context, livekit.RoomName) (*livekit.Room, error)
+	LoadRoomStub        func(context.Context, livekit.RoomName, livekit.RoomID) (*livekit.Room, error)
 	loadRoomMutex       sync.RWMutex
 	loadRoomArgsForCall []struct {
 		arg1 context.Context
 		arg2 livekit.RoomName
+		arg3 livekit.RoomID
 	}
 	loadRoomReturns struct {
 		result1 *livekit.Room
@@ -340,19 +342,20 @@ func (fake *FakeObjectStore) DeleteParticipantReturnsOnCall(i int, result1 error
 	}{result1}
 }
 
-func (fake *FakeObjectStore) DeleteRoom(arg1 context.Context, arg2 livekit.RoomName) error {
+func (fake *FakeObjectStore) DeleteRoom(arg1 context.Context, arg2 livekit.RoomName, arg3 livekit.RoomID) error {
 	fake.deleteRoomMutex.Lock()
 	ret, specificReturn := fake.deleteRoomReturnsOnCall[len(fake.deleteRoomArgsForCall)]
 	fake.deleteRoomArgsForCall = append(fake.deleteRoomArgsForCall, struct {
 		arg1 context.Context
 		arg2 livekit.RoomName
-	}{arg1, arg2})
+		arg3 livekit.RoomID
+	}{arg1, arg2, arg3})
 	stub := fake.DeleteRoomStub
 	fakeReturns := fake.deleteRoomReturns
-	fake.recordInvocation("DeleteRoom", []interface{}{arg1, arg2})
+	fake.recordInvocation("DeleteRoom", []interface{}{arg1, arg2, arg3})
 	fake.deleteRoomMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -366,17 +369,17 @@ func (fake *FakeObjectStore) DeleteRoomCallCount() int {
 	return len(fake.deleteRoomArgsForCall)
 }
 
-func (fake *FakeObjectStore) DeleteRoomCalls(stub func(context.Context, livekit.RoomName) error) {
+func (fake *FakeObjectStore) DeleteRoomCalls(stub func(context.Context, livekit.RoomName, livekit.RoomID) error) {
 	fake.deleteRoomMutex.Lock()
 	defer fake.deleteRoomMutex.Unlock()
 	fake.DeleteRoomStub = stub
 }
 
-func (fake *FakeObjectStore) DeleteRoomArgsForCall(i int) (context.Context, livekit.RoomName) {
+func (fake *FakeObjectStore) DeleteRoomArgsForCall(i int) (context.Context, livekit.RoomName, livekit.RoomID) {
 	fake.deleteRoomMutex.RLock()
 	defer fake.deleteRoomMutex.RUnlock()
 	argsForCall := fake.deleteRoomArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeObjectStore) DeleteRoomReturns(result1 error) {
@@ -739,19 +742,20 @@ func (fake *FakeObjectStore) LoadParticipantReturnsOnCall(i int, result1 *liveki
 	}{result1, result2}
 }
 
-func (fake *FakeObjectStore) LoadRoom(arg1 context.Context, arg2 livekit.RoomName) (*livekit.Room, error) {
+func (fake *FakeObjectStore) LoadRoom(arg1 context.Context, arg2 livekit.RoomName, arg3 livekit.RoomID) (*livekit.Room, error) {
 	fake.loadRoomMutex.Lock()
 	ret, specificReturn := fake.loadRoomReturnsOnCall[len(fake.loadRoomArgsForCall)]
 	fake.loadRoomArgsForCall = append(fake.loadRoomArgsForCall, struct {
 		arg1 context.Context
 		arg2 livekit.RoomName
-	}{arg1, arg2})
+		arg3 livekit.RoomID
+	}{arg1, arg2, arg3})
 	stub := fake.LoadRoomStub
 	fakeReturns := fake.loadRoomReturns
-	fake.recordInvocation("LoadRoom", []interface{}{arg1, arg2})
+	fake.recordInvocation("LoadRoom", []interface{}{arg1, arg2, arg3})
 	fake.loadRoomMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -765,17 +769,17 @@ func (fake *FakeObjectStore) LoadRoomCallCount() int {
 	return len(fake.loadRoomArgsForCall)
 }
 
-func (fake *FakeObjectStore) LoadRoomCalls(stub func(context.Context, livekit.RoomName) (*livekit.Room, error)) {
+func (fake *FakeObjectStore) LoadRoomCalls(stub func(context.Context, livekit.RoomName, livekit.RoomID) (*livekit.Room, error)) {
 	fake.loadRoomMutex.Lock()
 	defer fake.loadRoomMutex.Unlock()
 	fake.LoadRoomStub = stub
 }
 
-func (fake *FakeObjectStore) LoadRoomArgsForCall(i int) (context.Context, livekit.RoomName) {
+func (fake *FakeObjectStore) LoadRoomArgsForCall(i int) (context.Context, livekit.RoomName, livekit.RoomID) {
 	fake.loadRoomMutex.RLock()
 	defer fake.loadRoomMutex.RUnlock()
 	argsForCall := fake.loadRoomArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeObjectStore) LoadRoomReturns(result1 *livekit.Room, result2 error) {

--- a/pkg/service/servicefakes/fake_service_store.go
+++ b/pkg/service/servicefakes/fake_service_store.go
@@ -94,11 +94,12 @@ type FakeServiceStore struct {
 		result1 *livekit.ParticipantInfo
 		result2 error
 	}
-	LoadRoomStub        func(context.Context, livekit.RoomName) (*livekit.Room, error)
+	LoadRoomStub        func(context.Context, livekit.RoomName, livekit.RoomID) (*livekit.Room, error)
 	loadRoomMutex       sync.RWMutex
 	loadRoomArgsForCall []struct {
 		arg1 context.Context
 		arg2 livekit.RoomName
+		arg3 livekit.RoomID
 	}
 	loadRoomReturns struct {
 		result1 *livekit.Room
@@ -535,19 +536,20 @@ func (fake *FakeServiceStore) LoadParticipantReturnsOnCall(i int, result1 *livek
 	}{result1, result2}
 }
 
-func (fake *FakeServiceStore) LoadRoom(arg1 context.Context, arg2 livekit.RoomName) (*livekit.Room, error) {
+func (fake *FakeServiceStore) LoadRoom(arg1 context.Context, arg2 livekit.RoomName, arg3 livekit.RoomID) (*livekit.Room, error) {
 	fake.loadRoomMutex.Lock()
 	ret, specificReturn := fake.loadRoomReturnsOnCall[len(fake.loadRoomArgsForCall)]
 	fake.loadRoomArgsForCall = append(fake.loadRoomArgsForCall, struct {
 		arg1 context.Context
 		arg2 livekit.RoomName
-	}{arg1, arg2})
+		arg3 livekit.RoomID
+	}{arg1, arg2, arg3})
 	stub := fake.LoadRoomStub
 	fakeReturns := fake.loadRoomReturns
-	fake.recordInvocation("LoadRoom", []interface{}{arg1, arg2})
+	fake.recordInvocation("LoadRoom", []interface{}{arg1, arg2, arg3})
 	fake.loadRoomMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -561,17 +563,17 @@ func (fake *FakeServiceStore) LoadRoomCallCount() int {
 	return len(fake.loadRoomArgsForCall)
 }
 
-func (fake *FakeServiceStore) LoadRoomCalls(stub func(context.Context, livekit.RoomName) (*livekit.Room, error)) {
+func (fake *FakeServiceStore) LoadRoomCalls(stub func(context.Context, livekit.RoomName, livekit.RoomID) (*livekit.Room, error)) {
 	fake.loadRoomMutex.Lock()
 	defer fake.loadRoomMutex.Unlock()
 	fake.LoadRoomStub = stub
 }
 
-func (fake *FakeServiceStore) LoadRoomArgsForCall(i int) (context.Context, livekit.RoomName) {
+func (fake *FakeServiceStore) LoadRoomArgsForCall(i int) (context.Context, livekit.RoomName, livekit.RoomID) {
 	fake.loadRoomMutex.RLock()
 	defer fake.loadRoomMutex.RUnlock()
 	argsForCall := fake.loadRoomArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeServiceStore) LoadRoomReturns(result1 *livekit.Room, result2 error) {

--- a/pkg/service/turn.go
+++ b/pkg/service/turn.go
@@ -116,7 +116,7 @@ func NewTurnServer(conf *config.Config, authHandler turn.AuthHandler) (*turn.Ser
 func newTurnAuthHandler(roomStore ObjectStore) turn.AuthHandler {
 	return func(username, realm string, srcAddr net.Addr) (key []byte, ok bool) {
 		// room id should be the username, create a hashed room id
-		rm, err := roomStore.LoadRoom(context.Background(), livekit.RoomName(username))
+		rm, err := roomStore.LoadRoom(context.Background(), livekit.RoomName(username), "")
 		if err != nil {
 			return nil, false
 		}


### PR DESCRIPTION
@davidzhao @cnderrauber Please consider this a draft PR for requesting feedback. I still need to enhance/add tests if this direction is okay.

Things get a wee bit unwieldy with both name and sid. We have to maintain maps by both in stores and ensure we operate on them. Not bad, but was just wondering if there is a better option. This would get more unwieldy when I start handling requests which take both room and participant info. Will have to check 4 combinations of room name + participant identity, room name + participant sid, room sid + participant identity, room sid + participant sid. Again, may not be too bad. But, wanted to check if there is a more elegant way to handle these.