### PR TITLE
queue restart ice offer while publisher pc gathering ice

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -255,6 +255,7 @@ func NewParticipant(params ParticipantParams) (*ParticipantImpl, error) {
 		}
 		p.sendIceCandidate(c, livekit.SignalTarget_PUBLISHER)
 	})
+	p.publisher.OnRemoteDescripitonSettled(p.createPublsiherAnswerAndSend)
 	p.subscriber.pc.OnICECandidate(func(c *webrtc.ICECandidate) {
 		if c == nil || p.State() == livekit.ParticipantInfo_DISCONNECTED || p.MigrateState() == types.MigrateStateInit {
 			return
@@ -552,7 +553,6 @@ func (p *ParticipantImpl) HandleOffer(sdp webrtc.SessionDescription) (answer web
 		p.lock.Unlock()
 		return
 	}
-	onParticipantUpdate := p.onParticipantUpdate
 	p.lock.Unlock()
 	p.params.Logger.Debugw("answering pub offer",
 		"state", p.State().String(),
@@ -564,21 +564,26 @@ func (p *ParticipantImpl) HandleOffer(sdp webrtc.SessionDescription) (answer web
 		return
 	}
 
+	return
+}
+
+func (p *ParticipantImpl) createPublsiherAnswerAndSend() error {
+	p.lock.RLock()
+	onParticipantUpdate := p.onParticipantUpdate
+	p.lock.RUnlock()
 	p.configureReceiverDTX()
 
-	answer, err = p.publisher.pc.CreateAnswer(nil)
+	answer, err := p.publisher.pc.CreateAnswer(nil)
 	if err != nil {
 		prometheus.ServiceOperationCounter.WithLabelValues("answer", "error", "create").Add(1)
-		err = errors.Wrap(err, "could not create answer")
-		return
+		return errors.Wrap(err, "could not create answer")
 	}
 
 	answer = p.publisher.FilterCandidates(answer)
 
 	if err = p.publisher.pc.SetLocalDescription(answer); err != nil {
 		prometheus.ServiceOperationCounter.WithLabelValues("answer", "error", "local_description").Add(1)
-		err = errors.Wrap(err, "could not set local description")
-		return
+		return errors.Wrap(err, "could not set local description")
 	}
 
 	p.params.Logger.Debugw("sending answer to client")
@@ -590,7 +595,7 @@ func (p *ParticipantImpl) HandleOffer(sdp webrtc.SessionDescription) (answer web
 	})
 	if err != nil {
 		prometheus.ServiceOperationCounter.WithLabelValues("answer", "error", "write_message").Add(1)
-		return
+		return err
 	}
 
 	if p.isPublisher.Load() != p.CanPublish() {
@@ -607,7 +612,7 @@ func (p *ParticipantImpl) HandleOffer(sdp webrtc.SessionDescription) (answer web
 		go p.handleMigrateMutedTrack()
 	}
 
-	return
+	return nil
 }
 
 func (p *ParticipantImpl) handleMigrateMutedTrack() {

--- a/pkg/rtc/signalhandler.go
+++ b/pkg/rtc/signalhandler.go
@@ -10,7 +10,7 @@ import (
 func HandleParticipantSignal(room types.Room, participant types.LocalParticipant, req *livekit.SignalRequest, pLogger logger.Logger) error {
 	switch msg := req.Message.(type) {
 	case *livekit.SignalRequest_Offer:
-		_, err := participant.HandleOffer(FromProtoSessionDescription(msg.Offer))
+		err := participant.HandleOffer(FromProtoSessionDescription(msg.Offer))
 		if err != nil {
 			pLogger.Errorw("could not handle offer", err)
 			return err

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -229,7 +229,7 @@ type LocalParticipant interface {
 
 	AddICECandidate(candidate webrtc.ICECandidateInit, target livekit.SignalTarget) error
 
-	HandleOffer(sdp webrtc.SessionDescription) (answer webrtc.SessionDescription, err error)
+	HandleOffer(sdp webrtc.SessionDescription) error
 
 	AddTrack(req *livekit.AddTrackRequest)
 	SetTrackMuted(trackID livekit.TrackID, muted bool, fromAdmin bool)

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -270,18 +270,16 @@ type FakeLocalParticipant struct {
 	handleAnswerReturnsOnCall map[int]struct {
 		result1 error
 	}
-	HandleOfferStub        func(webrtc.SessionDescription) (webrtc.SessionDescription, error)
+	HandleOfferStub        func(webrtc.SessionDescription) error
 	handleOfferMutex       sync.RWMutex
 	handleOfferArgsForCall []struct {
 		arg1 webrtc.SessionDescription
 	}
 	handleOfferReturns struct {
-		result1 webrtc.SessionDescription
-		result2 error
+		result1 error
 	}
 	handleOfferReturnsOnCall map[int]struct {
-		result1 webrtc.SessionDescription
-		result2 error
+		result1 error
 	}
 	HiddenStub        func() bool
 	hiddenMutex       sync.RWMutex
@@ -2087,7 +2085,7 @@ func (fake *FakeLocalParticipant) HandleAnswerReturnsOnCall(i int, result1 error
 	}{result1}
 }
 
-func (fake *FakeLocalParticipant) HandleOffer(arg1 webrtc.SessionDescription) (webrtc.SessionDescription, error) {
+func (fake *FakeLocalParticipant) HandleOffer(arg1 webrtc.SessionDescription) error {
 	fake.handleOfferMutex.Lock()
 	ret, specificReturn := fake.handleOfferReturnsOnCall[len(fake.handleOfferArgsForCall)]
 	fake.handleOfferArgsForCall = append(fake.handleOfferArgsForCall, struct {
@@ -2101,9 +2099,9 @@ func (fake *FakeLocalParticipant) HandleOffer(arg1 webrtc.SessionDescription) (w
 		return stub(arg1)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1
 }
 
 func (fake *FakeLocalParticipant) HandleOfferCallCount() int {
@@ -2112,7 +2110,7 @@ func (fake *FakeLocalParticipant) HandleOfferCallCount() int {
 	return len(fake.handleOfferArgsForCall)
 }
 
-func (fake *FakeLocalParticipant) HandleOfferCalls(stub func(webrtc.SessionDescription) (webrtc.SessionDescription, error)) {
+func (fake *FakeLocalParticipant) HandleOfferCalls(stub func(webrtc.SessionDescription) error) {
 	fake.handleOfferMutex.Lock()
 	defer fake.handleOfferMutex.Unlock()
 	fake.HandleOfferStub = stub
@@ -2125,30 +2123,27 @@ func (fake *FakeLocalParticipant) HandleOfferArgsForCall(i int) webrtc.SessionDe
 	return argsForCall.arg1
 }
 
-func (fake *FakeLocalParticipant) HandleOfferReturns(result1 webrtc.SessionDescription, result2 error) {
+func (fake *FakeLocalParticipant) HandleOfferReturns(result1 error) {
 	fake.handleOfferMutex.Lock()
 	defer fake.handleOfferMutex.Unlock()
 	fake.HandleOfferStub = nil
 	fake.handleOfferReturns = struct {
-		result1 webrtc.SessionDescription
-		result2 error
-	}{result1, result2}
+		result1 error
+	}{result1}
 }
 
-func (fake *FakeLocalParticipant) HandleOfferReturnsOnCall(i int, result1 webrtc.SessionDescription, result2 error) {
+func (fake *FakeLocalParticipant) HandleOfferReturnsOnCall(i int, result1 error) {
 	fake.handleOfferMutex.Lock()
 	defer fake.handleOfferMutex.Unlock()
 	fake.HandleOfferStub = nil
 	if fake.handleOfferReturnsOnCall == nil {
 		fake.handleOfferReturnsOnCall = make(map[int]struct {
-			result1 webrtc.SessionDescription
-			result2 error
+			result1 error
 		})
 	}
 	fake.handleOfferReturnsOnCall[i] = struct {
-		result1 webrtc.SessionDescription
-		result2 error
-	}{result1, result2}
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeLocalParticipant) Hidden() bool {


### PR DESCRIPTION
If client send a offer to restart publisher pc ice while it is gathering ice candidate, queue the offer before gather complete.