### PR TITLE
Fix filtering candidates 

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	Video          VideoConfig        `yaml:"video,omitempty"`
 	Room           RoomConfig         `yaml:"room,omitempty"`
 	TURN           TURNConfig         `yaml:"turn,omitempty"`
-	Ingress        IngressConfig      `yaml:ingress,omitempty"`
+	Ingress        IngressConfig      `yaml:"ingress,omitempty"`
 	WebHook        WebHookConfig      `yaml:"webhook,omitempty"`
 	NodeSelector   NodeSelectorConfig `yaml:"node_selector,omitempty"`
 	KeyFile        string             `yaml:"key_file,omitempty"`
@@ -74,6 +74,9 @@ type RTCConfig struct {
 
 	// for testing, disable UDP
 	ForceTCP bool `yaml:"force_tcp,omitempty"`
+
+	// allow TCP fallback
+	AllowTCPFallback bool `yaml:"allow_tcp_fallback,omitempty"`
 }
 
 type TURNServer struct {

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -582,6 +582,12 @@ func (p *ParticipantImpl) createPublsiherAnswerAndSend() error {
 		return errors.Wrap(err, "could not set local description")
 	}
 
+	//
+	// Filter after setting local description as pion expects the answer
+	// to match between CreateAnswer and SetLocalDescription.
+	// Filtered answer is sent to remote so that remote does not
+	// see filtered candidates.
+	//
 	answer = p.publisher.FilterCandidates(answer)
 	p.publisher.Logger().Infow("local answer (filtered)", "sdp", answer.SDP)
 	err = p.writeMessage(&livekit.SignalResponse{

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -84,6 +84,7 @@ type ParticipantParams struct {
 	Region                  string
 	Migration               bool
 	AdaptiveStream          bool
+	AllowTCPFallback        bool
 }
 
 type ParticipantImpl struct {
@@ -1370,11 +1371,13 @@ func (p *ParticipantImpl) handleConnectionFailed(isPrimary bool) {
 		} else {
 			pcTransport.Logger().Infow("short ICE connection", "pair", pair, "duration", duration)
 		}
-		pcTransport.Logger().Infow("restricting transport to TCP on both peer connections")
-		p.SetICEConfig(types.IceConfig{
-			PreferPubTcp: true,
-			PreferSubTcp: true,
-		})
+		if p.params.AllowTCPFallback {
+			pcTransport.Logger().Infow("restricting transport to TCP on both peer connections")
+			p.SetICEConfig(types.IceConfig{
+				PreferPubTcp: true,
+				PreferSubTcp: true,
+			})
+		}
 	}
 }
 

--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -183,20 +183,22 @@ func (p *ParticipantImpl) SendRefreshToken(token string) error {
 
 func (p *ParticipantImpl) sendIceCandidate(c *webrtc.ICECandidate, target livekit.SignalTarget) {
 	var filterOut bool
+	var pcTransport *PCTransport
 	p.lock.RLock()
 	if target == livekit.SignalTarget_SUBSCRIBER {
 		if p.iceConfig.PreferSubTcp && c.Protocol != webrtc.ICEProtocolTCP {
 			filterOut = true
-			p.subscriber.Logger().Infow("filtering out candidate", "candidate", c)
+			pcTransport = p.subscriber
 		}
 	} else if target == livekit.SignalTarget_PUBLISHER {
 		if p.iceConfig.PreferPubTcp && c.Protocol != webrtc.ICEProtocolTCP {
 			filterOut = true
-			p.publisher.Logger().Infow("filtering out candidate", "candidate", c)
+			pcTransport = p.publisher
 		}
 	}
 	p.lock.RUnlock()
 	if filterOut {
+		pcTransport.Logger().Infow("filtering out local candidate", "candidate", c)
 		return
 	}
 

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -229,6 +229,10 @@ func (t *PCTransport) Logger() logger.Logger {
 func (t *PCTransport) SetICEConnectedAt(at time.Time) {
 	t.lock.Lock()
 	if t.iceConnectedAt.IsZero() {
+		//
+		// Record initial connection time.
+		// This prevents reset of connected at time if ICE goes `Connected` -> `Disconnected` -> `Connected`.
+		//
 		t.iceConnectedAt = at
 	}
 	t.lock.Unlock()

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -569,7 +569,9 @@ func (t *PCTransport) createAndSendOffer(options *webrtc.OfferOptions) error {
 		return err
 	}
 
-	t.params.Logger.Infow("local offer (unfiltered)", "sdp", offer.SDP)
+	if t.preferTCP {
+		t.params.Logger.Infow("local offer (unfiltered)", "sdp", offer.SDP)
+	}
 	err = t.pc.SetLocalDescription(offer)
 	if err != nil {
 		prometheus.ServiceOperationCounter.WithLabelValues("offer", "error", "local_description").Add(1)
@@ -584,7 +586,9 @@ func (t *PCTransport) createAndSendOffer(options *webrtc.OfferOptions) error {
 	// see filtered candidates.
 	//
 	offer = t.filterCandidates(offer)
-	t.params.Logger.Infow("local offer (filtered)", "sdp", offer.SDP)
+	if t.preferTCP {
+		t.params.Logger.Infow("local offer (filtered)", "sdp", offer.SDP)
+	}
 
 	// indicate waiting for client
 	t.negotiationState = negotiationStateClient

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -37,7 +37,7 @@ const (
 	iceFailedTimeout       = 25 * time.Second // pion's default
 	iceKeepaliveInterval   = 2 * time.Second  // pion's default
 
-	shortConnectionThreshold = 2 * time.Minute
+	shortConnectionThreshold = 90 * time.Second
 )
 
 var (
@@ -228,7 +228,9 @@ func (t *PCTransport) Logger() logger.Logger {
 
 func (t *PCTransport) SetICEConnectedAt(at time.Time) {
 	t.lock.Lock()
-	t.iceConnectedAt = at
+	if t.iceConnectedAt.IsZero() {
+		t.iceConnectedAt = at
+	}
 	t.lock.Unlock()
 }
 

--- a/pkg/rtc/transport_test.go
+++ b/pkg/rtc/transport_test.go
@@ -1,21 +1,17 @@
 package rtc
 
 import (
-	"net"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/pion/ice/v2"
 	"github.com/pion/sdp/v3"
 	"github.com/pion/webrtc/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/livekit/protocol/livekit"
-	"github.com/livekit/protocol/logger"
 
-	logging "github.com/livekit/livekit-server/pkg/logger"
 	"github.com/livekit/livekit-server/pkg/testutils"
 )
 
@@ -394,81 +390,6 @@ func TestFilteringCandidates(t *testing.T) {
 	require.Equal(t, 2, tcp)
 }
 
-func TestTCPFallback(t *testing.T) {
-	seA := setupTCPMux(t, 10000)
-	paramsA := TransportParams{
-		ParticipantID:       "idA",
-		ParticipantIdentity: "identityA",
-		Target:              livekit.SignalTarget_PUBLISHER,
-		Config: &WebRTCConfig{
-			SettingEngine: *seA,
-		},
-	}
-	transportA, err := NewPCTransport(paramsA)
-	require.NoError(t, err)
-	_, err = transportA.pc.CreateDataChannel("test", nil)
-	require.NoError(t, err)
-
-	seB := setupTCPMux(t, 10001)
-	paramsB := TransportParams{
-		ParticipantID:       "idB",
-		ParticipantIdentity: "identityB",
-		Target:              livekit.SignalTarget_PUBLISHER,
-		Config: &WebRTCConfig{
-			SettingEngine: *seB,
-		},
-	}
-	transportB, err := NewPCTransport(paramsB)
-	require.NoError(t, err)
-
-	// exchange ICE
-	handleTCPOnlyICEExchange(t, transportA, transportB)
-
-	// set offer/answer
-	handleOffer := handleOfferFunc(t, transportA, transportB)
-	transportA.OnOffer(handleOffer)
-
-	// first establish connection
-	require.NoError(t, transportA.CreateAndSendOffer(nil))
-
-	// ensure we are connected the first time
-	testutils.WithTimeout(t, func() string {
-		if transportA.pc.ICEConnectionState() != webrtc.ICEConnectionStateConnected {
-			return "transportA did not become connected"
-		}
-
-		if transportB.pc.ICEConnectionState() != webrtc.ICEConnectionStateConnected {
-			return "transportB did not become connected"
-		}
-		return ""
-	})
-	require.Equal(t, webrtc.ICEConnectionStateConnected, transportA.pc.ICEConnectionState())
-	require.Equal(t, webrtc.ICEConnectionStateConnected, transportB.pc.ICEConnectionState())
-
-	// offer again, but missed
-	transportA.OnOffer(func(sd webrtc.SessionDescription) {})
-	require.NoError(t, transportA.CreateAndSendOffer(nil))
-	require.Equal(t, webrtc.SignalingStateHaveLocalOffer, transportA.pc.SignalingState())
-	require.Equal(t, negotiationStateClient, transportA.negotiationState)
-
-	// now restart ICE
-	t.Logf("creating offer with ICE restart")
-	transportA.OnOffer(handleOffer)
-	require.NoError(t, transportA.CreateAndSendOffer(&webrtc.OfferOptions{
-		ICERestart: true,
-	}))
-
-	testutils.WithTimeout(t, func() string {
-		if transportA.pc.ICEConnectionState() != webrtc.ICEConnectionStateConnected {
-			return "transportA did not reconnect after ICE restart"
-		}
-		if transportB.pc.ICEConnectionState() != webrtc.ICEConnectionStateConnected {
-			return "transportB did not reconnect after ICE restart"
-		}
-		return ""
-	})
-}
-
 func handleOfferFunc(t *testing.T, current, other *PCTransport) func(sd webrtc.SessionDescription) {
 	return func(sd webrtc.SessionDescription) {
 		t.Logf("handling offer")
@@ -496,59 +417,6 @@ func handleICEExchange(t *testing.T, a, b *PCTransport) {
 			return
 		}
 		t.Logf("got ICE candidate from B: %v", candidate)
-		require.NoError(t, a.AddICECandidate(candidate.ToJSON()))
-	})
-}
-
-func setupTCPMux(t *testing.T, port int) *webrtc.SettingEngine {
-	se := &webrtc.SettingEngine{
-		LoggerFactory: logging.NewLoggerFactory(logger.GetLogger()),
-	}
-	tcpListener, err := net.ListenTCP("tcp", &net.TCPAddr{
-		Port: int(port),
-	})
-	require.NoError(t, err)
-	require.NotNil(t, tcpListener)
-
-	tcpMux := ice.NewTCPMuxDefault(ice.TCPMuxParams{
-		Logger:          se.LoggerFactory.NewLogger("tcp_mux"),
-		Listener:        tcpListener,
-		ReadBufferSize:  50,
-		WriteBufferSize: 4 * 1024 * 1024,
-	})
-
-	se.SetICETCPMux(tcpMux)
-	se.SetNetworkTypes([]webrtc.NetworkType{
-		webrtc.NetworkTypeUDP4,
-		webrtc.NetworkTypeUDP6,
-		webrtc.NetworkTypeTCP4,
-		webrtc.NetworkTypeTCP6,
-	})
-
-	return se
-}
-
-func handleTCPOnlyICEExchange(t *testing.T, a, b *PCTransport) {
-	a.pc.OnICECandidate(func(candidate *webrtc.ICECandidate) {
-		if candidate == nil {
-			return
-		}
-		t.Logf("got ICE candidate from A: %v", candidate)
-		if candidate.Protocol != webrtc.ICEProtocolTCP {
-			t.Logf("filtering out ICE candidate from A: %v", candidate)
-			return
-		}
-		require.NoError(t, b.AddICECandidate(candidate.ToJSON()))
-	})
-	b.pc.OnICECandidate(func(candidate *webrtc.ICECandidate) {
-		if candidate == nil {
-			return
-		}
-		t.Logf("got ICE candidate from B: %v", candidate)
-		if candidate.Protocol != webrtc.ICEProtocolTCP {
-			t.Logf("filtering out ICE candidate from B: %v", candidate)
-			return
-		}
 		require.NoError(t, a.AddICECandidate(candidate.ToJSON()))
 	})
 }

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -25,7 +25,7 @@ const (
 	roomPurgeSeconds     = 24 * 60 * 60
 	tokenRefreshInterval = 5 * time.Minute
 	tokenDefaultTTL      = 10 * time.Minute
-	iceConfigTTL         = 60 * time.Minute
+	iceConfigTTL         = 5 * time.Minute
 )
 
 type iceConfigCacheEntry struct {

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -270,6 +270,7 @@ func (r *RoomManager) StartSession(
 		ClientConf:              clientConf,
 		Region:                  pi.Region,
 		AdaptiveStream:          pi.AdaptiveStream,
+		AllowTCPFallback:        r.config.RTC.AllowTCPFallback,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
- For offer/answer from remote, do filtering before setting remote
  description so that Pion does not see filtered candidates
- For offer/answer originating from server, do filtering after setting
  local description (comments in code) so that remote side does not
  see filtered candidates.
- Make logging a little consistent and use right context.

Testing:
--------
- Force TCP and ensure all selected ICE candidate pairs are only TCP based.