### PR TITLE
As "remote" is a logging context key already, use a different name.

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -298,10 +298,10 @@ func (t *PCTransport) logICECandidates() {
 	t.lock.RLock()
 	t.params.Logger.Infow(
 		"ice candidates",
-		"local", t.allowedLocalCandidates,
-		"remote", t.allowedRemoteCandidates,
-		"local (filtered)", t.filteredLocalCandidates,
-		"remote (filtered)", t.filteredRemoteCandidates,
+		"lc", t.allowedLocalCandidates,
+		"rc", t.allowedRemoteCandidates,
+		"lc (filtered)", t.filteredLocalCandidates,
+		"rc (filtered)", t.filteredRemoteCandidates,
 	)
 	t.lock.RUnlock()
 }


### PR DESCRIPTION
Open to better suggestions. Could not think of anything better.