### PR TITLE
A few misc changes

### DIFF
--- a/pkg/rtc/dynacastmanager.go
+++ b/pkg/rtc/dynacastmanager.go
@@ -174,6 +174,12 @@ func (d *DynacastManager) updateMaxQualityForMime(mime string, maxQuality liveki
 func (d *DynacastManager) update(force bool) {
 	d.lock.Lock()
 
+	if len(d.maxSubscribedQuality) == 0 {
+		// no mime has been added, nothing to update
+		d.lock.Unlock()
+		return
+	}
+
 	// add or remove of a mime triggers an update
 	changed := len(d.maxSubscribedQuality) != len(d.committedMaxSubscribedQuality)
 	downgradesOnly := !changed

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -294,9 +294,10 @@ func (r *RTPStats) Update(rtph *rtp.Header, payloadSize int, paddingSize int, pa
 			if rtph.Marker {
 				r.frames++
 			}
+
+			r.updateJitter(rtph, packetTime)
 		}
 
-		r.updateJitter(rtph, packetTime)
 	}
 
 	return

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -298,9 +298,6 @@ func (d *DownTrack) Bind(t webrtc.TrackLocalContext) (webrtc.RTPCodecParameters,
 	d.bound.Store(true)
 	d.bindLock.Unlock()
 
-	if d.onMaxLayerChanged != nil {
-		d.onMaxLayerChanged(d, d.MaxLayers().Spatial)
-	}
 	d.connectionStats.Start(d.receiver.TrackInfo())
 	d.logger.Debugw("downtrack bound")
 


### PR DESCRIPTION
- Do not update jitter on padding only packet.
Padding only packet may not have proper timestamp.
If it does, it probably has the time stamp of the
last packet with payload. That will also affect
jitter calculation, i. e. wall clock time is moving,
but RTP time is the same.
- Do not send `onMaxLayer` changed on bind.
It was probably racing with update when max layer
is updated when adaptive stream is off. There is
no need to send that update as the default would
be OFF. It will be enabled when adaptive stream
subscription turns it on or when max layer is
set when down track bind happens and adaptive stream
is off.