### PR TITLE
fix resume/restart with single node mode

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -576,12 +576,12 @@ func (p *ParticipantImpl) Start() {
 }
 
 func (p *ParticipantImpl) Close(sendLeave bool, reason types.ParticipantCloseReason) error {
+	p.params.Logger.Infow("try close participant", "sendLeave", sendLeave, "reason", reason.String())
 	if p.isClosed.Swap(true) {
 		// already closed
 		return nil
 	}
 
-	p.params.Logger.Infow("closing participant", "sendLeave", sendLeave, "reason", reason.String())
 	// send leave message
 	if sendLeave {
 		_ = p.writeMessage(&livekit.SignalResponse{

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -415,8 +415,6 @@ func (r *RoomManager) getOrCreateRoom(ctx context.Context, roomName livekit.Room
 // manages an RTC session for a participant, runs on the RTC node
 func (r *RoomManager) rtcSessionWorker(room *rtc.Room, participant types.LocalParticipant, requestSource routing.MessageSource) {
 	defer func() {
-		// give time for the participant to be closed with a proper reason.
-		// if participant is closed from here, we would be obscuring the real reason the participant is closed.
 		logger.Infow("RTC session finishing",
 			"participant", participant.Identity(),
 			"pID", participant.ID(),

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -417,7 +417,6 @@ func (r *RoomManager) rtcSessionWorker(room *rtc.Room, participant types.LocalPa
 	defer func() {
 		// give time for the participant to be closed with a proper reason.
 		// if participant is closed from here, we would be obscuring the real reason the participant is closed.
-		time.Sleep(2 * time.Second)
 		logger.Infow("RTC session finishing",
 			"participant", participant.Identity(),
 			"pID", participant.ID(),


### PR DESCRIPTION
The delay close makes client resume connection happen with single node mode, then after 2s, server closed participant with `CanReconnect: false`, so client will disconnect and has no chance to auto reconnect.

This PR remove the delay close to fix the issue, for `obscuring the real reason the participant is closed`, move the close log to beginning of `Close`, so we can log the real reason.