### PR TITLE
Clear disconnect timer on ICERestart

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1189,13 +1189,9 @@ func (p *ParticipantImpl) clearDisconnectTimer() {
 	p.lock.Unlock()
 }
 
-func (p *ParticipantImpl) onAnyTransportFailed() {
-	// clients support resuming of connections when websocket becomes disconnected
-	p.closeSignalConnection()
-
+func (p *ParticipantImpl) setupDisconnectTimer() {
 	p.clearDisconnectTimer()
 
-	// detect when participant has actually left.
 	p.lock.Lock()
 	p.disconnectTimer = time.AfterFunc(disconnectCleanupDuration, func() {
 		p.clearDisconnectTimer()
@@ -1207,6 +1203,14 @@ func (p *ParticipantImpl) onAnyTransportFailed() {
 		_ = p.Close(true, types.ParticipantCloseReasonPeerConnectionDisconnected)
 	})
 	p.lock.Unlock()
+}
+
+func (p *ParticipantImpl) onAnyTransportFailed() {
+	// clients support resuming of connections when websocket becomes disconnected
+	p.closeSignalConnection()
+
+	// detect when participant has actually left.
+	p.setupDisconnectTimer()
 }
 
 // subscriberRTCPWorker sends SenderReports periodically when the participant is subscribed to

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -672,6 +672,8 @@ func (p *ParticipantImpl) MigrateState() types.MigrateState {
 
 // ICERestart restarts subscriber ICE connections
 func (p *ParticipantImpl) ICERestart(iceConfig *types.IceConfig) error {
+	p.clearDisconnectTimer()
+
 	for _, t := range p.GetPublishedTracks() {
 		t.(types.LocalMediaTrack).Restart()
 	}
@@ -1178,21 +1180,25 @@ func (p *ParticipantImpl) onPrimaryTransportFullyEstablished() {
 	p.updateState(livekit.ParticipantInfo_ACTIVE)
 }
 
-func (p *ParticipantImpl) onAnyTransportFailed() {
-	// clients support resuming of connections when websocket becomes disconnected
-	p.closeSignalConnection()
-
-	// detect when participant has actually left.
+func (p *ParticipantImpl) clearDisconnectTimer() {
 	p.lock.Lock()
 	if p.disconnectTimer != nil {
 		p.disconnectTimer.Stop()
 		p.disconnectTimer = nil
 	}
+	p.lock.Unlock()
+}
+
+func (p *ParticipantImpl) onAnyTransportFailed() {
+	// clients support resuming of connections when websocket becomes disconnected
+	p.closeSignalConnection()
+
+	p.clearDisconnectTimer()
+
+	// detect when participant has actually left.
+	p.lock.Lock()
 	p.disconnectTimer = time.AfterFunc(disconnectCleanupDuration, func() {
-		p.lock.Lock()
-		p.disconnectTimer.Stop()
-		p.disconnectTimer = nil
-		p.lock.Unlock()
+		p.clearDisconnectTimer()
 
 		if p.isClosed.Load() || p.State() == livekit.ParticipantInfo_DISCONNECTED {
 			return

--- a/pkg/rtc/transportmanager.go
+++ b/pkg/rtc/transportmanager.go
@@ -53,7 +53,6 @@ type TransportManager struct {
 	onSubscriberInitialConnected       func()
 	onPrimaryTransportInitialConnected func()
 	onAnyTransportFailed               func()
-	onAllTransportConnected            func()
 
 	onICEConfigChanged func(iceConfig types.IceConfig)
 }
@@ -250,10 +249,6 @@ func (t *TransportManager) OnPrimaryTransportFullyEstablished(f func()) {
 
 func (t *TransportManager) OnAnyTransportFailed(f func()) {
 	t.onAnyTransportFailed = f
-}
-
-func (t *TransportManager) OnAllTransportConnected(f func()) {
-	t.onAllTransportConnected = f
 }
 
 func (t *TransportManager) AddSubscribedTrack(subTrack types.SubscribedTrack) {

--- a/pkg/rtc/transportmanager.go
+++ b/pkg/rtc/transportmanager.go
@@ -53,6 +53,7 @@ type TransportManager struct {
 	onSubscriberInitialConnected       func()
 	onPrimaryTransportInitialConnected func()
 	onAnyTransportFailed               func()
+	onAllTransportConnected            func()
 
 	onICEConfigChanged func(iceConfig types.IceConfig)
 }
@@ -249,6 +250,10 @@ func (t *TransportManager) OnPrimaryTransportFullyEstablished(f func()) {
 
 func (t *TransportManager) OnAnyTransportFailed(f func()) {
 	t.onAnyTransportFailed = f
+}
+
+func (t *TransportManager) OnAllTransportConnected(f func()) {
+	t.onAllTransportConnected = f
 }
 
 func (t *TransportManager) AddSubscribedTrack(subTrack types.SubscribedTrack) {


### PR DESCRIPTION
Disconnect timer is set up when a transport fails.
But, it is possible that the connection is resumed.
So, clear disconnect timer on resume.