### PR TITLE
Separate calls to Telemetry vs Prometheus room lifecycle

### DIFF
--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/livekit/livekit-server/pkg/telemetry/prometheus"
 	"github.com/livekit/livekit-server/version"
 	"github.com/livekit/protocol/auth"
 	"github.com/livekit/protocol/livekit"
@@ -379,7 +380,9 @@ func (r *RoomManager) getOrCreateRoom(ctx context.Context, roomName livekit.Room
 	newRoom := rtc.NewRoom(ri, *r.rtcConfig, &r.config.Audio, r.serverInfo, r.telemetry)
 
 	newRoom.OnClose(func() {
-		r.telemetry.RoomEnded(ctx, newRoom.ToProto())
+		roomInfo := newRoom.ToProto()
+		r.telemetry.RoomEnded(ctx, roomInfo)
+		prometheus.RoomEnded(time.Unix(roomInfo.CreationTime, 0))
 		if err := r.DeleteRoom(ctx, roomName); err != nil {
 			newRoom.Logger.Errorw("could not delete room", err)
 		}
@@ -408,6 +411,7 @@ func (r *RoomManager) getOrCreateRoom(ctx context.Context, roomName livekit.Room
 	newRoom.Hold()
 
 	r.telemetry.RoomStarted(ctx, newRoom.ToProto())
+	prometheus.RoomStarted()
 
 	return newRoom, nil
 }

--- a/pkg/telemetry/prometheus/rooms.go
+++ b/pkg/telemetry/prometheus/rooms.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
-
-	"github.com/livekit/protocol/logger"
 )
 
 var (

--- a/pkg/telemetry/prometheus/rooms.go
+++ b/pkg/telemetry/prometheus/rooms.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
+
+	"github.com/livekit/protocol/logger"
 )
 
 var (

--- a/pkg/telemetry/telemetryserviceinternalevents.go
+++ b/pkg/telemetry/telemetryserviceinternalevents.go
@@ -15,8 +15,6 @@ import (
 )
 
 func (t *telemetryServiceInternal) RoomStarted(ctx context.Context, room *livekit.Room) {
-	prometheus.RoomStarted()
-
 	t.notifyEvent(ctx, &livekit.WebhookEvent{
 		Event: webhook.EventRoomStarted,
 		Room:  room,
@@ -30,8 +28,6 @@ func (t *telemetryServiceInternal) RoomStarted(ctx context.Context, room *liveki
 }
 
 func (t *telemetryServiceInternal) RoomEnded(ctx context.Context, room *livekit.Room) {
-	prometheus.RoomEnded(time.Unix(room.CreationTime, 0))
-
 	t.notifyEvent(ctx, &livekit.WebhookEvent{
 		Event: webhook.EventRoomFinished,
 		Room:  room,
@@ -53,6 +49,7 @@ func (t *telemetryServiceInternal) ParticipantJoined(
 	clientMeta *livekit.AnalyticsClientMeta,
 ) {
 	prometheus.IncrementParticipantJoin(1)
+	prometheus.AddParticipant()
 
 	newWorker := newStatsWorker(
 		ctx,
@@ -80,8 +77,6 @@ func (t *telemetryServiceInternal) ParticipantJoined(
 		t.workers = append(t.workers, newWorker)
 	}
 	t.workersMu.Unlock()
-
-	prometheus.AddParticipant()
 
 	t.analytics.SendEvent(ctx, &livekit.AnalyticsEvent{
 		Type:          livekit.AnalyticsEventType_PARTICIPANT_JOINED,


### PR DESCRIPTION
Prometheus counter represents rooms on the current node. Where as Telemetry stats tracks overall room lifecycle. Separating the two things.