### PR TITLE
Move reset of set local description sent to later

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -1045,10 +1045,6 @@ func (t *PCTransport) CreateAndSendOffer(options *webrtc.OfferOptions) error {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	if options != nil && options.ICERestart {
-		t.clearLocalDescriptionSentLocked()
-	}
-
 	return t.createAndSendOffer(options)
 }
 
@@ -1124,6 +1120,10 @@ func (t *PCTransport) createAndSendOffer(options *webrtc.OfferOptions) error {
 	if t.restartAtNextOffer {
 		t.restartAtNextOffer = false
 		options = ensureICERestart(options)
+	}
+
+	if options != nil && options.ICERestart {
+		t.clearLocalDescriptionSentLocked()
 	}
 
 	offer, err := t.pc.CreateOffer(options)


### PR DESCRIPTION
There is a path of restart after next offer.
So, reset has to happen in that path also.
Move it to just before creating offer.

Also, thinking about making more of a state machine
of this in the hopes of making it easier to follow.