### PR TITLE
Use LocalNode ID in Prometheus metrics

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	serverlogger "github.com/livekit/livekit-server/pkg/logger"
+	"github.com/livekit/livekit-server/pkg/telemetry/prometheus"
 	"github.com/livekit/protocol/logger"
 
 	"github.com/livekit/livekit-server/pkg/config"
@@ -215,6 +216,8 @@ func startServer(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	prometheus.Init(currentNode.Id)
 
 	server, err := service.InitializeServer(conf, currentNode)
 	if err != nil {

--- a/pkg/rtc/helper_test.go
+++ b/pkg/rtc/helper_test.go
@@ -6,7 +6,12 @@ import (
 
 	"github.com/livekit/livekit-server/pkg/rtc/types"
 	"github.com/livekit/livekit-server/pkg/rtc/types/typesfakes"
+	"github.com/livekit/livekit-server/pkg/telemetry/prometheus"
 )
+
+func init() {
+	prometheus.Init("test")
+}
 
 func newMockParticipant(identity livekit.ParticipantIdentity, protocol types.ProtocolVersion, hidden bool, publisher bool) *typesfakes.FakeLocalParticipant {
 	p := &typesfakes.FakeLocalParticipant{}

--- a/pkg/telemetry/prometheus/node.go
+++ b/pkg/telemetry/prometheus/node.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/mackerelio/go-osstat/loadavg"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/atomic"
 
 	"github.com/livekit/livekit-server/pkg/config"
 	"github.com/livekit/protocol/livekit"
-	"github.com/livekit/protocol/utils"
 )
 
 const (
@@ -16,6 +16,8 @@ const (
 )
 
 var (
+	initialized atomic.Bool
+
 	MessageCounter          *prometheus.CounterVec
 	ServiceOperationCounter *prometheus.CounterVec
 
@@ -25,8 +27,11 @@ var (
 	promSysDroppedPacketPctGauge prometheus.Gauge
 )
 
-func init() {
-	nodeID, _ := utils.LocalNodeID()
+func Init(nodeID string) {
+	if initialized.Swap(true) {
+		return
+	}
+
 	MessageCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace:   livekitNamespace,

--- a/pkg/telemetry/test/telemetry_service_test.go
+++ b/pkg/telemetry/test/telemetry_service_test.go
@@ -9,8 +9,13 @@ import (
 	"github.com/livekit/protocol/livekit"
 
 	"github.com/livekit/livekit-server/pkg/telemetry"
+	"github.com/livekit/livekit-server/pkg/telemetry/prometheus"
 	"github.com/livekit/livekit-server/pkg/telemetry/telemetryfakes"
 )
+
+func init() {
+	prometheus.Init("test")
+}
 
 type telemetryServiceFixture struct {
 	sut       telemetry.TelemetryServiceInternal

--- a/test/integration_helpers.go
+++ b/test/integration_helpers.go
@@ -20,6 +20,7 @@ import (
 	serverlogger "github.com/livekit/livekit-server/pkg/logger"
 	"github.com/livekit/livekit-server/pkg/routing"
 	"github.com/livekit/livekit-server/pkg/service"
+	"github.com/livekit/livekit-server/pkg/telemetry/prometheus"
 	"github.com/livekit/livekit-server/pkg/testutils"
 	testclient "github.com/livekit/livekit-server/test/client"
 )
@@ -39,14 +40,14 @@ const (
 	// connectTimeout = 5000 * time.Second
 )
 
-var (
-	roomClient livekit.RoomService
-)
+var roomClient livekit.RoomService
 
 func init() {
 	serverlogger.InitFromConfig(config.LoggingConfig{
 		Config: logger.Config{Level: "debug"},
 	})
+
+	prometheus.Init("test")
 }
 
 func setupSingleNodeTest(name string) (*service.LivekitServer, func()) {
@@ -222,6 +223,7 @@ func createRTCClientWithToken(token string, port int, opts *testclient.Options) 
 
 	return c
 }
+
 func redisClient() *redis.Client {
 	return redis.NewClient(&redis.Options{
 		Addr: "localhost:6379",


### PR DESCRIPTION
Instead of regenerating `node_id` used in prometheus metrics, get the actual `nodeID` from current `LocalNode`.