### PR TITLE
Handle exempted layers

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -95,14 +95,15 @@ type VideoAllocation struct {
 	bandwidthRequested int64
 	bandwidthDelta     int64
 	availableLayers    []int32
+	exemptedLayers     []int32
 	bitrates           Bitrates
 	targetLayers       VideoLayers
 	distanceToDesired  int32
 }
 
 func (v VideoAllocation) String() string {
-	return fmt.Sprintf("VideoAllocation{state: %s, change: %s, bw: %d, del: %d, avail: %+v, rates: %+v, target: %s}",
-		v.state, v.change, v.bandwidthRequested, v.bandwidthDelta, v.availableLayers, v.bitrates, v.targetLayers)
+	return fmt.Sprintf("VideoAllocation{state: %s, change: %s, bw: %d, del: %d, avail: %+v, exmpt: %+v, rates: %+v, target: %s}",
+		v.state, v.change, v.bandwidthRequested, v.bandwidthDelta, v.availableLayers, v.exemptedLayers, v.bitrates, v.targetLayers)
 }
 
 var (
@@ -114,11 +115,13 @@ var (
 // -------------------------------------------------------------------
 
 type VideoAllocationProvisional struct {
-	layers          VideoLayers
 	muted           bool
 	bitrates        Bitrates
 	availableLayers []int32
+	exemptedLayers  []int32
 	maxLayers       VideoLayers
+
+	allocatedLayers VideoLayers
 }
 
 // -------------------------------------------------------------------
@@ -192,6 +195,7 @@ type Forwarder struct {
 	lastAllocation VideoAllocation
 
 	availableLayers []int32
+	exemptedLayers  []int32
 
 	rtpMunger *RTPMunger
 	vp8Munger *VP8Munger
@@ -390,7 +394,7 @@ func (f *Forwarder) IsReducedQuality() (int32, bool) {
 	return distance, f.lastAllocation.state == VideoAllocationStateDeficient
 }
 
-func (f *Forwarder) UpTrackLayersChange(availableLayers []int32) {
+func (f *Forwarder) UpTrackLayersChange(availableLayers []int32, exemptedLayers []int32) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -399,6 +403,13 @@ func (f *Forwarder) UpTrackLayersChange(availableLayers []int32) {
 		copy(f.availableLayers, availableLayers)
 	} else {
 		f.availableLayers = nil
+	}
+
+	if len(exemptedLayers) > 0 {
+		f.exemptedLayers = make([]int32, len(exemptedLayers))
+		copy(f.exemptedLayers, exemptedLayers)
+	} else {
+		f.exemptedLayers = nil
 	}
 }
 
@@ -418,22 +429,40 @@ func (f *Forwarder) getOptimalBandwidthNeeded(brs Bitrates) int64 {
 
 func (f *Forwarder) bitrateAvailable(brs Bitrates) bool {
 	neededLayers := 0
-	var bitrateAvailableLayers []int32
+	bitrateAvailableLayers := 0
 	for _, layer := range f.availableLayers {
 		if layer > f.maxLayers.Spatial {
+			continue
+		}
+
+		//
+		// Layers could be exempted from stream tracker.
+		// If such a layer actually stops, it will not
+		// be removed from available layers as it is exempt.
+		// But, it could have zero bit rate as it actually stopped.
+		// So, do not take exempt layers into bitrate availability condition.
+		//
+		exempt := false
+		for _, el := range f.exemptedLayers {
+			if layer == el {
+				exempt = true
+				break
+			}
+		}
+		if exempt {
 			continue
 		}
 
 		neededLayers++
 		for t := f.maxLayers.Temporal; t >= 0; t-- {
 			if brs[layer][t] != 0 {
-				bitrateAvailableLayers = append(bitrateAvailableLayers, layer)
+				bitrateAvailableLayers++
 				break
 			}
 		}
 	}
 
-	return len(bitrateAvailableLayers) == neededLayers
+	return bitrateAvailableLayers == neededLayers
 }
 
 func (f *Forwarder) getDistanceToDesired(brs Bitrates, targetLayers VideoLayers) int32 {
@@ -441,9 +470,9 @@ func (f *Forwarder) getDistanceToDesired(brs Bitrates, targetLayers VideoLayers)
 		return 0
 	}
 
+	found := false
 	distance := int32(0)
 	for s := f.maxLayers.Spatial; s >= 0; s-- {
-		found := false
 		for t := f.maxLayers.Temporal; t >= 0; t-- {
 			if brs[s][t] == 0 {
 				continue
@@ -458,6 +487,19 @@ func (f *Forwarder) getDistanceToDesired(brs Bitrates, targetLayers VideoLayers)
 
 		if found {
 			break
+		}
+	}
+
+	// maybe overshooting
+	if !found && targetLayers.IsValid() {
+		distance = 0
+		for s := targetLayers.Spatial; s > f.maxLayers.Spatial; s-- {
+			for t := DefaultMaxLayerTemporal; t >= f.maxLayers.Temporal; t-- {
+				if brs[s][t] == 0 {
+					continue
+				}
+				distance--
+			}
 		}
 	}
 
@@ -489,7 +531,7 @@ func (f *Forwarder) DistanceToDesired() int32 {
 	return f.lastAllocation.distanceToDesired
 }
 
-func (f *Forwarder) AllocateOptimal(brs Bitrates) VideoAllocation {
+func (f *Forwarder) AllocateOptimal(brs Bitrates, allowOvershoot bool) VideoAllocation {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -537,10 +579,6 @@ func (f *Forwarder) AllocateOptimal(brs Bitrates) VideoAllocation {
 
 				bandwidthRequested = brs[s][t]
 				state = VideoAllocationStateOptimal
-
-				if f.targetLayers == InvalidLayers {
-					change = VideoStreamingChangeResuming
-				}
 				break
 			}
 
@@ -549,15 +587,15 @@ func (f *Forwarder) AllocateOptimal(brs Bitrates) VideoAllocation {
 			}
 		}
 
-		if bandwidthRequested == 0 && f.maxLayers.IsValid() {
+		if bandwidthRequested == 0 && f.maxLayers.IsValid() && allowOvershoot {
 			// if we cannot allocate anything below max layer,
 			// look for a layer above. It is okay to overshoot
 			// in optimal allocation (i.e. no bandwidth restrictions).
 			// It is possible that clients send only a higher layer.
 			// To accommodate cases like that, try finding a layer
 			// above the requested maximum to ensure streaming
-			for s := DefaultMaxLayerSpatial; s >= 0; s-- {
-				for t := DefaultMaxLayerTemporal; t >= 0; t-- {
+			for s := f.maxLayers.Spatial + 1; s <= DefaultMaxLayerSpatial; s++ {
+				for t := int32(0); t <= DefaultMaxLayerTemporal; t++ {
 					if brs[s][t] == 0 {
 						continue
 					}
@@ -569,10 +607,6 @@ func (f *Forwarder) AllocateOptimal(brs Bitrates) VideoAllocation {
 
 					bandwidthRequested = brs[s][t]
 					state = VideoAllocationStateOptimal
-
-					if f.targetLayers == InvalidLayers {
-						change = VideoStreamingChangeResuming
-					}
 					f.logger.Infow("allowing overshoot", "maxLayer", f.maxLayers, "targetLayers", targetLayers)
 					break
 				}
@@ -581,6 +615,35 @@ func (f *Forwarder) AllocateOptimal(brs Bitrates) VideoAllocation {
 					break
 				}
 			}
+		}
+
+		if bandwidthRequested == 0 && f.maxLayers.IsValid() {
+			// if overshoot was allowed and it did not also find a layer,
+			// keep target at exempted layer (if available) and the current layer is at that level.
+			// i. e. exempted layer may really have stopped, so a layer switch to an exempted layer should
+			// not happen as layer switch will send PLI requests. Just letting it continue at the current
+			// layer if the current is exempted will protect against any stream tracker misdetects
+			// OR latch on to the layer quicker when it restarts
+			if f.currentLayers.IsValid() {
+				for _, s := range f.exemptedLayers {
+					if s <= f.maxLayers.Spatial && f.currentLayers.Spatial == s {
+						targetLayers = f.currentLayers
+						bandwidthRequested = brs[targetLayers.Spatial][targetLayers.Temporal]
+						state = VideoAllocationStateDeficient
+						break
+					}
+				}
+			}
+		}
+
+		if f.targetLayers == InvalidLayers && targetLayers.IsValid() {
+			change = VideoStreamingChangeResuming
+		} else if f.targetLayers != InvalidLayers && !targetLayers.IsValid() {
+			change = VideoStreamingChangePausing
+		}
+
+		if !targetLayers.IsValid() && f.maxLayers.IsValid() {
+			state = VideoAllocationStateDeficient
 		}
 	}
 
@@ -600,6 +663,10 @@ func (f *Forwarder) AllocateOptimal(brs Bitrates) VideoAllocation {
 		f.lastAllocation.availableLayers = make([]int32, len(f.availableLayers))
 		copy(f.lastAllocation.availableLayers, f.availableLayers)
 	}
+	if len(f.exemptedLayers) > 0 {
+		f.lastAllocation.exemptedLayers = make([]int32, len(f.exemptedLayers))
+		copy(f.lastAllocation.exemptedLayers, f.exemptedLayers)
+	}
 
 	f.setTargetLayers(f.lastAllocation.targetLayers)
 	if f.targetLayers == InvalidLayers {
@@ -614,50 +681,73 @@ func (f *Forwarder) ProvisionalAllocatePrepare(bitrates Bitrates) {
 	defer f.lock.Unlock()
 
 	f.provisional = &VideoAllocationProvisional{
-		layers:    InvalidLayers,
-		muted:     f.muted,
-		bitrates:  bitrates,
-		maxLayers: f.maxLayers,
+		allocatedLayers: InvalidLayers,
+		muted:           f.muted,
+		bitrates:        bitrates,
+		maxLayers:       f.maxLayers,
 	}
 	if len(f.availableLayers) > 0 {
 		f.provisional.availableLayers = make([]int32, len(f.availableLayers))
 		copy(f.provisional.availableLayers, f.availableLayers)
 	}
+	if len(f.exemptedLayers) > 0 {
+		f.provisional.exemptedLayers = make([]int32, len(f.exemptedLayers))
+		copy(f.provisional.exemptedLayers, f.exemptedLayers)
+	}
 }
 
-func (f *Forwarder) ProvisionalAllocate(availableChannelCapacity int64, layers VideoLayers, allowPause bool) int64 {
+func (f *Forwarder) ProvisionalAllocate(availableChannelCapacity int64, layers VideoLayers, allowPause bool, allowOvershoot bool) int64 {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	if f.provisional.muted || !f.provisional.maxLayers.IsValid() || layers.GreaterThan(f.provisional.maxLayers) {
+	if f.provisional.muted || !f.provisional.maxLayers.IsValid() || (!allowOvershoot && layers.GreaterThan(f.provisional.maxLayers)) {
 		return 0
+	}
+
+	maybeAdoptExempt := func() int64 {
+		br := int64(0)
+		if f.currentLayers.IsValid() {
+			for _, s := range f.provisional.exemptedLayers {
+				if s <= f.provisional.maxLayers.Spatial && f.currentLayers.Spatial == s {
+					f.provisional.allocatedLayers = f.currentLayers
+					br = f.provisional.bitrates[f.provisional.allocatedLayers.Spatial][f.provisional.allocatedLayers.Temporal]
+					break
+				}
+			}
+		}
+		return br
 	}
 
 	requiredBitrate := f.provisional.bitrates[layers.Spatial][layers.Temporal]
 	if requiredBitrate == 0 {
-		return 0
+		return maybeAdoptExempt()
 	}
 
 	alreadyAllocatedBitrate := int64(0)
-	if f.provisional.layers != InvalidLayers {
-		alreadyAllocatedBitrate = f.provisional.bitrates[f.provisional.layers.Spatial][f.provisional.layers.Temporal]
+	if f.provisional.allocatedLayers != InvalidLayers {
+		alreadyAllocatedBitrate = f.provisional.bitrates[f.provisional.allocatedLayers.Spatial][f.provisional.allocatedLayers.Temporal]
 	}
 
-	if requiredBitrate <= (availableChannelCapacity + alreadyAllocatedBitrate) {
-		f.provisional.layers = layers
+	// a layer under maximum fits, take it
+	if !layers.GreaterThan(f.provisional.maxLayers) && requiredBitrate <= (availableChannelCapacity+alreadyAllocatedBitrate) {
+		f.provisional.allocatedLayers = layers
 		return requiredBitrate - alreadyAllocatedBitrate
 	}
 
-	// when pause is disallowed, pick the layer if none allocated already or something lower is available
-	if !allowPause && (f.provisional.layers == InvalidLayers || !layers.GreaterThan(f.provisional.layers)) {
-		f.provisional.layers = layers
+	//
+	// Given layer does not fit.
+	// Could be a layer below maximum that does not fit OR it could be a layer above maximum which may or may not fit.
+	// In any of those cases, take the lowest possible layer if pause is not allowed
+	//
+	if !allowPause && (f.provisional.allocatedLayers == InvalidLayers || !layers.GreaterThan(f.provisional.allocatedLayers)) {
+		f.provisional.allocatedLayers = layers
 		return requiredBitrate - alreadyAllocatedBitrate
 	}
 
-	return 0
+	return maybeAdoptExempt()
 }
 
-func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition() VideoTransition {
+func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition(allowOvershoot bool) VideoTransition {
 	//
 	// This is called when a track needs a change (could be mute/unmute, subscribed layers changed, published layers changed)
 	// when channel is congested.
@@ -681,7 +771,7 @@ func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition() VideoTransitio
 	defer f.lock.Unlock()
 
 	if f.provisional.muted {
-		f.provisional.layers = InvalidLayers
+		f.provisional.allocatedLayers = InvalidLayers
 		return VideoTransition{
 			from:           f.targetLayers,
 			to:             InvalidLayers,
@@ -710,9 +800,9 @@ func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition() VideoTransitio
 		}
 
 		if maximalLayers != InvalidLayers {
-			if !f.targetLayers.GreaterThan(maximalLayers) && (f.provisional.bitrates[f.targetLayers.Spatial][f.targetLayers.Temporal] != 0) {
+			if !f.targetLayers.GreaterThan(maximalLayers) && f.provisional.bitrates[f.targetLayers.Spatial][f.targetLayers.Temporal] != 0 {
 				// currently streaming and wanting an upgrade, just preserve current target in the cooperative scheme of things
-				f.provisional.layers = f.targetLayers
+				f.provisional.allocatedLayers = f.targetLayers
 				return VideoTransition{
 					from:           f.targetLayers,
 					to:             f.targetLayers,
@@ -722,7 +812,7 @@ func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition() VideoTransitio
 
 			if f.targetLayers.GreaterThan(maximalLayers) {
 				// maximalLayers <= f.targetLayers, make the down move
-				f.provisional.layers = maximalLayers
+				f.provisional.allocatedLayers = maximalLayers
 				return VideoTransition{
 					from:           f.targetLayers,
 					to:             maximalLayers,
@@ -732,31 +822,66 @@ func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition() VideoTransitio
 		}
 	}
 
-	// currently not streaming, find minimal
-	// NOTE: a layer in feed could have paused and there could be other options than going back to minimal,
-	// but the cooperative scheme knocks things back to minimal
-	minimalLayers := InvalidLayers
-	bandwidthRequired := int64(0)
-	for s := int32(0); s <= f.provisional.maxLayers.Spatial; s++ {
-		for t := int32(0); t <= f.provisional.maxLayers.Temporal; t++ {
-			if f.provisional.bitrates[s][t] != 0 {
-				minimalLayers = VideoLayers{Spatial: s, Temporal: t}
-				bandwidthRequired = f.provisional.bitrates[s][t]
+	findNextLayer := func(
+		minSpatial, maxSpatial int32,
+		minTemporal, maxTemporal int32,
+	) (VideoLayers, int64) {
+		layers := InvalidLayers
+		bw := int64(0)
+		for s := minSpatial; s <= maxSpatial; s++ {
+			for t := minTemporal; t <= maxTemporal; t++ {
+				if f.provisional.bitrates[s][t] != 0 {
+					layers = VideoLayers{Spatial: s, Temporal: t}
+					bw = f.provisional.bitrates[s][t]
+					break
+				}
+			}
+
+			if bw != 0 {
 				break
 			}
 		}
 
-		if bandwidthRequired != 0 {
-			break
-		}
+		return layers, bw
 	}
 
 	targetLayers := f.targetLayers
-	if targetLayers == InvalidLayers || targetLayers.GreaterThan(minimalLayers) || (f.provisional.bitrates[targetLayers.Spatial][targetLayers.Temporal] == 0) {
-		targetLayers = minimalLayers
+	bandwidthRequired := int64(0)
+	if targetLayers == InvalidLayers {
+		// currently not streaming, find minimal
+		// NOTE: a layer in feed could have paused and there could be other options than going back to minimal,
+		// but the cooperative scheme knocks things back to minimal
+		targetLayers, bandwidthRequired = findNextLayer(
+			0, f.provisional.maxLayers.Spatial,
+			0, f.provisional.maxLayers.Temporal,
+		)
 	}
 
-	f.provisional.layers = targetLayers
+	// could not find a minimal layer, overshoot if allowed
+	if bandwidthRequired == 0 && f.provisional.maxLayers.IsValid() && allowOvershoot {
+		targetLayers, bandwidthRequired = findNextLayer(
+			f.provisional.maxLayers.Spatial+1, DefaultMaxLayerSpatial,
+			0, DefaultMaxLayerTemporal,
+		)
+	}
+
+	// adopt exempted layer if current is at one of the exempted layers below maximum
+	if bandwidthRequired == 0 && f.provisional.maxLayers.IsValid() && f.currentLayers.IsValid() {
+		for _, s := range f.provisional.exemptedLayers {
+			if s <= f.provisional.maxLayers.Spatial && f.currentLayers.Spatial == s {
+				targetLayers = f.currentLayers
+				bandwidthRequired = f.provisional.bitrates[targetLayers.Spatial][targetLayers.Temporal]
+				break
+			}
+		}
+	}
+
+	// turn off if nothing found, not even an exempted layer to continue with
+	if bandwidthRequired == 0 && (!f.currentLayers.IsValid() || f.currentLayers != targetLayers) {
+		targetLayers = InvalidLayers
+	}
+
+	f.provisional.allocatedLayers = targetLayers
 	return VideoTransition{
 		from:           f.targetLayers,
 		to:             targetLayers,
@@ -783,7 +908,7 @@ func (f *Forwarder) ProvisionalAllocateGetBestWeightedTransition() VideoTransiti
 	defer f.lock.Unlock()
 
 	if f.provisional.muted {
-		f.provisional.layers = InvalidLayers
+		f.provisional.allocatedLayers = InvalidLayers
 		return VideoTransition{
 			from:           f.targetLayers,
 			to:             InvalidLayers,
@@ -805,9 +930,11 @@ func (f *Forwarder) ProvisionalAllocateGetBestWeightedTransition() VideoTransiti
 		}
 	}
 
+	// RAJA-TODO: need to exempted layers maybe?
+
 	if maxReachableLayerTemporal == InvalidLayerTemporal {
 		// feed has gone dry,
-		f.provisional.layers = InvalidLayers
+		f.provisional.allocatedLayers = InvalidLayers
 		return VideoTransition{
 			from:           f.targetLayers,
 			to:             InvalidLayers,
@@ -848,7 +975,7 @@ func (f *Forwarder) ProvisionalAllocateGetBestWeightedTransition() VideoTransiti
 		}
 	}
 
-	f.provisional.layers = bestLayers
+	f.provisional.allocatedLayers = bestLayers
 	return VideoTransition{
 		from:           f.targetLayers,
 		to:             bestLayers,
@@ -870,17 +997,23 @@ func (f *Forwarder) ProvisionalAllocateCommit() VideoAllocation {
 	case len(f.provisional.availableLayers) == 0:
 		// feed is dry
 		state = VideoAllocationStateFeedDry
-	case f.provisional.layers == InvalidLayers:
+	case f.provisional.allocatedLayers == InvalidLayers:
 		state = VideoAllocationStateDeficient
 
 		if f.targetLayers != InvalidLayers {
 			change = VideoStreamingChangePausing
 		}
 	default:
-		bandwidthRequested = f.provisional.bitrates[f.provisional.layers.Spatial][f.provisional.layers.Temporal]
-		if bandwidthRequested == f.getOptimalBandwidthNeeded(f.provisional.bitrates) {
+		optimalBandwidthNeeded := f.getOptimalBandwidthNeeded(f.provisional.bitrates)
+		bandwidthRequested = f.provisional.bitrates[f.provisional.allocatedLayers.Spatial][f.provisional.allocatedLayers.Temporal]
+		if optimalBandwidthNeeded > 0 && bandwidthRequested >= optimalBandwidthNeeded {
+			// could be greater than optimal if overshooting
 			state = VideoAllocationStateOptimal
 		} else {
+			//
+			// Optimal bandwidth could be 0 if using exempted layer.
+			// Exempted layer is still treated as deficient.
+			//
 			state = VideoAllocationStateDeficient
 		}
 
@@ -895,12 +1028,16 @@ func (f *Forwarder) ProvisionalAllocateCommit() VideoAllocation {
 		bandwidthRequested: bandwidthRequested,
 		bandwidthDelta:     bandwidthRequested - f.lastAllocation.bandwidthRequested,
 		bitrates:           f.provisional.bitrates,
-		targetLayers:       f.provisional.layers,
-		distanceToDesired:  f.getDistanceToDesired(f.provisional.bitrates, f.provisional.layers),
+		targetLayers:       f.provisional.allocatedLayers,
+		distanceToDesired:  f.getDistanceToDesired(f.provisional.bitrates, f.provisional.allocatedLayers),
 	}
 	if len(f.availableLayers) > 0 {
 		f.lastAllocation.availableLayers = make([]int32, len(f.availableLayers))
 		copy(f.lastAllocation.availableLayers, f.provisional.availableLayers)
+	}
+	if len(f.exemptedLayers) > 0 {
+		f.lastAllocation.exemptedLayers = make([]int32, len(f.exemptedLayers))
+		copy(f.lastAllocation.exemptedLayers, f.provisional.exemptedLayers)
 	}
 
 	f.setTargetLayers(f.lastAllocation.targetLayers)
@@ -911,7 +1048,7 @@ func (f *Forwarder) ProvisionalAllocateCommit() VideoAllocation {
 	return f.lastAllocation
 }
 
-func (f *Forwarder) AllocateNextHigher(availableChannelCapacity int64, brs Bitrates) (VideoAllocation, bool) {
+func (f *Forwarder) AllocateNextHigher(availableChannelCapacity int64, brs Bitrates, allowOvershoot bool) (VideoAllocation, bool) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -939,86 +1076,91 @@ func (f *Forwarder) AllocateNextHigher(availableChannelCapacity int64, brs Bitra
 		alreadyAllocated = brs[f.targetLayers.Spatial][f.targetLayers.Temporal]
 	}
 
+	doAllocation := func(
+		minSpatial, maxSpatial int32,
+		minTemporal, maxTemporal int32,
+	) (bool, VideoAllocation, bool) {
+		for s := minSpatial; s <= maxSpatial; s++ {
+			for t := minTemporal; t <= maxTemporal; t++ {
+				bandwidthRequested := brs[s][t]
+				if bandwidthRequested == 0 {
+					continue
+				}
+
+				if bandwidthRequested-alreadyAllocated > availableChannelCapacity {
+					// next higher available layer does not fit, return
+					f.lastAllocation.change = VideoStreamingChangeNone
+					return true, f.lastAllocation, false
+				}
+
+				state := VideoAllocationStateDeficient
+				if optimalBandwidthNeeded > 0 && bandwidthRequested >= optimalBandwidthNeeded {
+					state = VideoAllocationStateOptimal
+				}
+
+				change := VideoStreamingChangeNone
+				if f.targetLayers == InvalidLayers {
+					change = VideoStreamingChangeResuming
+				}
+
+				targetLayers := VideoLayers{Spatial: s, Temporal: t}
+				f.lastAllocation = VideoAllocation{
+					state:              state,
+					change:             change,
+					bandwidthRequested: bandwidthRequested,
+					bandwidthDelta:     bandwidthRequested - alreadyAllocated,
+					bitrates:           brs,
+					targetLayers:       targetLayers,
+					distanceToDesired:  f.getDistanceToDesired(brs, targetLayers),
+				}
+				if len(f.availableLayers) > 0 {
+					f.lastAllocation.availableLayers = make([]int32, len(f.availableLayers))
+					copy(f.lastAllocation.availableLayers, f.availableLayers)
+				}
+				if len(f.exemptedLayers) > 0 {
+					f.lastAllocation.exemptedLayers = make([]int32, len(f.exemptedLayers))
+					copy(f.lastAllocation.exemptedLayers, f.exemptedLayers)
+				}
+
+				f.setTargetLayers(f.lastAllocation.targetLayers)
+				return true, f.lastAllocation, true
+			}
+		}
+
+		return false, VideoAllocation{}, false
+	}
+
+	done := false
+	var allocation VideoAllocation
+	boosted := false
+
 	// try moving temporal layer up in currently streaming spatial layer
 	if f.targetLayers != InvalidLayers {
-		for t := f.targetLayers.Temporal + 1; t <= f.maxLayers.Temporal; t++ {
-			bandwidthRequested := brs[f.targetLayers.Spatial][t]
-			if bandwidthRequested == 0 {
-				continue
-			}
-
-			if bandwidthRequested-alreadyAllocated > availableChannelCapacity {
-				// next higher available layer does not fit, return
-				f.lastAllocation.change = VideoStreamingChangeNone
-				return f.lastAllocation, false
-			}
-
-			state := VideoAllocationStateOptimal
-			if bandwidthRequested != optimalBandwidthNeeded {
-				state = VideoAllocationStateDeficient
-			}
-
-			targetLayers := VideoLayers{Spatial: f.targetLayers.Spatial, Temporal: t}
-			f.lastAllocation = VideoAllocation{
-				state:              state,
-				change:             VideoStreamingChangeNone,
-				bandwidthRequested: bandwidthRequested,
-				bandwidthDelta:     bandwidthRequested - alreadyAllocated,
-				bitrates:           brs,
-				targetLayers:       targetLayers,
-				distanceToDesired:  f.getDistanceToDesired(brs, targetLayers),
-			}
-			if len(f.availableLayers) > 0 {
-				f.lastAllocation.availableLayers = make([]int32, len(f.availableLayers))
-				copy(f.lastAllocation.availableLayers, f.availableLayers)
-			}
-
-			f.setTargetLayers(f.lastAllocation.targetLayers)
-			return f.lastAllocation, true
+		done, allocation, boosted = doAllocation(
+			f.targetLayers.Spatial, f.targetLayers.Spatial,
+			f.targetLayers.Temporal+1, f.maxLayers.Temporal,
+		)
+		if done {
+			return allocation, boosted
 		}
 	}
 
 	// try moving spatial layer up if temporal layer move up is not available
-	for s := f.targetLayers.Spatial + 1; s <= f.maxLayers.Spatial; s++ {
-		for t := int32(0); t <= f.maxLayers.Temporal; t++ {
-			bandwidthRequested := brs[s][t]
-			if bandwidthRequested == 0 {
-				continue
-			}
+	done, allocation, boosted = doAllocation(
+		f.targetLayers.Spatial+1, f.maxLayers.Spatial,
+		0, f.maxLayers.Temporal,
+	)
+	if done {
+		return allocation, boosted
+	}
 
-			if bandwidthRequested-alreadyAllocated > availableChannelCapacity {
-				// next higher available layer does not fit, return
-				f.lastAllocation.change = VideoStreamingChangeNone
-				return f.lastAllocation, false
-			}
-
-			state := VideoAllocationStateOptimal
-			if bandwidthRequested != optimalBandwidthNeeded {
-				state = VideoAllocationStateDeficient
-			}
-
-			change := VideoStreamingChangeNone
-			if f.targetLayers == InvalidLayers {
-				change = VideoStreamingChangeResuming
-			}
-
-			targetLayers := VideoLayers{Spatial: s, Temporal: t}
-			f.lastAllocation = VideoAllocation{
-				state:              state,
-				change:             change,
-				bandwidthRequested: bandwidthRequested,
-				bandwidthDelta:     bandwidthRequested - alreadyAllocated,
-				bitrates:           brs,
-				targetLayers:       targetLayers,
-				distanceToDesired:  f.getDistanceToDesired(brs, targetLayers),
-			}
-			if len(f.availableLayers) > 0 {
-				f.lastAllocation.availableLayers = make([]int32, len(f.availableLayers))
-				copy(f.lastAllocation.availableLayers, f.availableLayers)
-			}
-
-			f.setTargetLayers(f.lastAllocation.targetLayers)
-			return f.lastAllocation, true
+	if allowOvershoot && f.maxLayers.IsValid() {
+		done, allocation, boosted = doAllocation(
+			f.maxLayers.Spatial+1, DefaultMaxLayerSpatial,
+			0, DefaultMaxLayerTemporal,
+		)
+		if done {
+			return allocation, boosted
 		}
 	}
 
@@ -1026,7 +1168,7 @@ func (f *Forwarder) AllocateNextHigher(availableChannelCapacity int64, brs Bitra
 	return f.lastAllocation, false
 }
 
-func (f *Forwarder) GetNextHigherTransition(brs Bitrates) (VideoTransition, bool) {
+func (f *Forwarder) GetNextHigherTransition(brs Bitrates, allowOvershoot bool) (VideoTransition, bool) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -1049,39 +1191,61 @@ func (f *Forwarder) GetNextHigherTransition(brs Bitrates) (VideoTransition, bool
 		alreadyAllocated = brs[f.targetLayers.Spatial][f.targetLayers.Temporal]
 	}
 
+	findNextHigher := func(
+		minSpatial, maxSpatial int32,
+		minTemporal, maxTemporal int32,
+	) (bool, VideoTransition, bool) {
+		for s := minSpatial; s <= maxSpatial; s++ {
+			for t := minTemporal; t <= maxTemporal; t++ {
+				bandwidthRequested := brs[s][t]
+				if bandwidthRequested == 0 {
+					continue
+				}
+
+				transition := VideoTransition{
+					from:           f.targetLayers,
+					to:             VideoLayers{Spatial: s, Temporal: t},
+					bandwidthDelta: bandwidthRequested - alreadyAllocated,
+				}
+
+				return true, transition, true
+			}
+		}
+
+		return false, VideoTransition{}, false
+	}
+
+	done := false
+	var transition VideoTransition
+	isAvailable := false
+
 	// try moving temporal layer up in currently streaming spatial layer
 	if f.targetLayers != InvalidLayers {
-		for t := f.targetLayers.Temporal + 1; t <= f.maxLayers.Temporal; t++ {
-			bandwidthRequested := brs[f.targetLayers.Spatial][t]
-			if bandwidthRequested == 0 {
-				continue
-			}
-
-			transition := VideoTransition{
-				from:           f.targetLayers,
-				to:             VideoLayers{Spatial: f.targetLayers.Spatial, Temporal: t},
-				bandwidthDelta: bandwidthRequested - alreadyAllocated,
-			}
-
-			return transition, true
+		done, transition, isAvailable = findNextHigher(
+			f.targetLayers.Spatial, f.targetLayers.Spatial,
+			f.targetLayers.Temporal+1, f.maxLayers.Temporal,
+		)
+		if done {
+			return transition, isAvailable
 		}
 	}
 
 	// try moving spatial layer up if temporal layer move up is not available
-	for s := f.targetLayers.Spatial + 1; s <= f.maxLayers.Spatial; s++ {
-		for t := int32(0); t <= f.maxLayers.Temporal; t++ {
-			bandwidthRequested := brs[s][t]
-			if bandwidthRequested == 0 {
-				continue
-			}
+	done, transition, isAvailable = findNextHigher(
+		f.targetLayers.Spatial+1, f.maxLayers.Spatial,
+		0, f.maxLayers.Temporal,
+	)
+	if done {
+		return transition, isAvailable
+	}
 
-			transition := VideoTransition{
-				from:           f.targetLayers,
-				to:             VideoLayers{Spatial: s, Temporal: t},
-				bandwidthDelta: bandwidthRequested - alreadyAllocated,
-			}
-
-			return transition, true
+	if allowOvershoot && f.maxLayers.IsValid() {
+		done, transition, isAvailable = findNextHigher(
+			f.maxLayers.Spatial+1, DefaultMaxLayerSpatial,
+			0, DefaultMaxLayerTemporal,
+		)
+		if done {
+			return transition, isAvailable
 		}
 	}
 
@@ -1122,6 +1286,10 @@ func (f *Forwarder) Pause(brs Bitrates) VideoAllocation {
 	if len(f.availableLayers) > 0 {
 		f.lastAllocation.availableLayers = make([]int32, len(f.availableLayers))
 		copy(f.lastAllocation.availableLayers, f.availableLayers)
+	}
+	if len(f.exemptedLayers) > 0 {
+		f.lastAllocation.exemptedLayers = make([]int32, len(f.exemptedLayers))
+		copy(f.lastAllocation.exemptedLayers, f.exemptedLayers)
 	}
 
 	f.setTargetLayers(f.lastAllocation.targetLayers)

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -1,7 +1,6 @@
 package sfu
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -1066,7 +1065,6 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 	require.False(t, boosted)
 
 	// test allowOvershoot
-	fmt.Printf("test start\n") // REMOVE
 	f.SetMaxSpatialLayer(0)
 
 	bitrates = Bitrates{

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -121,7 +121,7 @@ func TestForwarderGetForwardingStatus(t *testing.T) {
 
 	// with available layers, should be off
 	availableLayers := []int32{0, 1, 2}
-	f.UpTrackLayersChange(availableLayers)
+	f.UpTrackLayersChange(availableLayers, []int32{})
 	require.Equal(t, ForwardingStatusOff, f.GetForwardingStatus())
 
 	// when muted, should be optimal
@@ -139,7 +139,7 @@ func TestForwarderGetForwardingStatus(t *testing.T) {
 
 	// when available layers are lower than max subscribed, optimal as long as target is at max available
 	availableLayers = []int32{0, 1}
-	f.UpTrackLayersChange(availableLayers)
+	f.UpTrackLayersChange(availableLayers, []int32{})
 	require.Equal(t, ForwardingStatusOptimal, f.GetForwardingStatus())
 }
 
@@ -149,19 +149,24 @@ func TestForwarderUpTrackLayersChange(t *testing.T) {
 	require.Nil(t, f.availableLayers)
 
 	availableLayers := []int32{0, 1, 2}
-	f.UpTrackLayersChange(availableLayers)
+	exemptedLayers := []int32{0}
+	f.UpTrackLayersChange(availableLayers, exemptedLayers)
 	require.Equal(t, availableLayers, f.availableLayers)
+	require.Equal(t, exemptedLayers, f.exemptedLayers)
 
 	availableLayers = []int32{0, 2}
-	f.UpTrackLayersChange(availableLayers)
+	f.UpTrackLayersChange(availableLayers, []int32{})
 	require.Equal(t, availableLayers, f.availableLayers)
+	require.Nil(t, f.exemptedLayers)
 
 	availableLayers = []int32{}
-	f.UpTrackLayersChange(availableLayers)
+	exemptedLayers = []int32{}
+	f.UpTrackLayersChange(availableLayers, exemptedLayers)
 	require.Nil(t, f.availableLayers)
+	require.Nil(t, f.exemptedLayers)
 }
 
-func TestForwarderAllocate(t *testing.T) {
+func TestForwarderAllocateOptimal(t *testing.T) {
 	f := newForwarder(testutils.TestVP8Codec, webrtc.RTPCodecTypeVideo)
 	f.SetMaxSpatialLayer(DefaultMaxLayerSpatial)
 	f.SetMaxTemporalLayer(DefaultMaxLayerTemporal)
@@ -186,7 +191,7 @@ func TestForwarderAllocate(t *testing.T) {
 		targetLayers:       InvalidLayers,
 		distanceToDesired:  0,
 	}
-	result := f.AllocateOptimal(bitrates)
+	result := f.AllocateOptimal(bitrates, true)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 
@@ -204,14 +209,14 @@ func TestForwarderAllocate(t *testing.T) {
 		targetLayers:       InvalidLayers,
 		distanceToDesired:  0,
 	}
-	result = f.AllocateOptimal(emptyBitrates)
+	result = f.AllocateOptimal(emptyBitrates, true)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 
 	// awaiting measurement, i.e. bitrates are not available, but layers available
 	f.lastAllocation.state = VideoAllocationStateNone
 	disable(f)
-	f.UpTrackLayersChange([]int32{0})
+	f.UpTrackLayersChange([]int32{0}, []int32{})
 	expectedTargetLayers := VideoLayers{
 		Spatial:  0,
 		Temporal: DefaultMaxLayerTemporal,
@@ -226,14 +231,58 @@ func TestForwarderAllocate(t *testing.T) {
 		targetLayers:       expectedTargetLayers,
 		distanceToDesired:  0,
 	}
-	result = f.AllocateOptimal(emptyBitrates)
+	result = f.AllocateOptimal(emptyBitrates, true)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 	require.Equal(t, expectedTargetLayers, f.TargetLayers())
 	require.Equal(t, InvalidLayers, f.CurrentLayers())
 
+	// layers are available, but all layers under max are exempted
+	f.SetMaxSpatialLayer(0)
+	f.currentLayers = VideoLayers{Spatial: 0, Temporal: 0}
+	f.UpTrackLayersChange([]int32{0, 1, 2}, []int32{0})
+	expectedTargetLayers = VideoLayers{
+		Spatial:  0,
+		Temporal: 0,
+	}
+	expectedResult = VideoAllocation{
+		state:              VideoAllocationStateDeficient,
+		change:             VideoStreamingChangeNone,
+		bandwidthRequested: 0,
+		bandwidthDelta:     0,
+		availableLayers:    []int32{0, 1, 2},
+		exemptedLayers:     []int32{0},
+		bitrates:           emptyBitrates,
+		targetLayers:       expectedTargetLayers,
+		distanceToDesired:  0,
+	}
+	result = f.AllocateOptimal(emptyBitrates, true)
+	require.Equal(t, expectedResult, result)
+	require.Equal(t, expectedResult, f.lastAllocation)
+	require.Equal(t, expectedTargetLayers, f.TargetLayers())
+
+	// if current is not exempt, should not choose that
+	f.currentLayers = VideoLayers{Spatial: 1, Temporal: 0}
+	expectedResult = VideoAllocation{
+		state:              VideoAllocationStateDeficient,
+		change:             VideoStreamingChangeNone,
+		bandwidthRequested: 0,
+		bandwidthDelta:     0,
+		availableLayers:    []int32{0, 1, 2},
+		exemptedLayers:     []int32{0},
+		bitrates:           emptyBitrates,
+		targetLayers:       InvalidLayers,
+		distanceToDesired:  0,
+	}
+	result = f.AllocateOptimal(emptyBitrates, true)
+	require.Equal(t, expectedResult, result)
+	require.Equal(t, expectedResult, f.lastAllocation)
+	require.Equal(t, InvalidLayers, f.TargetLayers())
+
 	// allocate using bitrates, allocation should choose optimal
-	f.UpTrackLayersChange([]int32{0, 1, 2})
+	f.currentLayers = InvalidLayers
+	f.SetMaxSpatialLayer(DefaultMaxLayerSpatial)
+	f.UpTrackLayersChange([]int32{0, 1, 2}, []int32{})
 	f.maxLayers = VideoLayers{Spatial: 1, Temporal: 3}
 	expectedTargetLayers = VideoLayers{
 		Spatial:  1,
@@ -241,7 +290,7 @@ func TestForwarderAllocate(t *testing.T) {
 	}
 	expectedResult = VideoAllocation{
 		state:              VideoAllocationStateOptimal,
-		change:             VideoStreamingChangeNone,
+		change:             VideoStreamingChangeResuming,
 		bandwidthRequested: bitrates[1][3],
 		bandwidthDelta:     bitrates[1][3],
 		availableLayers:    []int32{0, 1, 2},
@@ -249,14 +298,14 @@ func TestForwarderAllocate(t *testing.T) {
 		targetLayers:       expectedTargetLayers,
 		distanceToDesired:  0,
 	}
-	result = f.AllocateOptimal(bitrates)
+	result = f.AllocateOptimal(bitrates, true)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 	require.Equal(t, InvalidLayers, f.CurrentLayers())
 	require.Equal(t, expectedTargetLayers, f.TargetLayers())
 
-	// allocate using bitrates above maximum layer
-	f.UpTrackLayersChange([]int32{2})
+	// allocate using bitrates above maximum layer, allowing overshoot
+	f.UpTrackLayersChange([]int32{2}, []int32{})
 	sparseBitrates := Bitrates{
 		{0, 0, 0, 0},
 		{0, 0, 0, 0},
@@ -276,11 +325,28 @@ func TestForwarderAllocate(t *testing.T) {
 		targetLayers:       expectedTargetLayers,
 		distanceToDesired:  0,
 	}
-	result = f.AllocateOptimal(sparseBitrates)
+	result = f.AllocateOptimal(sparseBitrates, true)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 	require.Equal(t, InvalidLayers, f.CurrentLayers())
 	require.Equal(t, expectedTargetLayers, f.TargetLayers())
+
+	// when not allowing overshoot, should not be able to find a layer
+	expectedResult = VideoAllocation{
+		state:              VideoAllocationStateDeficient,
+		change:             VideoStreamingChangeNone,
+		bandwidthRequested: 0,
+		bandwidthDelta:     -sparseBitrates[2][1],
+		availableLayers:    []int32{2},
+		bitrates:           sparseBitrates,
+		targetLayers:       InvalidLayers,
+		distanceToDesired:  0,
+	}
+	result = f.AllocateOptimal(sparseBitrates, false)
+	require.Equal(t, expectedResult, result)
+	require.Equal(t, expectedResult, f.lastAllocation)
+	require.Equal(t, InvalidLayers, f.CurrentLayers())
+	require.Equal(t, InvalidLayers, f.TargetLayers())
 }
 
 func TestForwarderProvisionalAllocate(t *testing.T) {
@@ -298,20 +364,20 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 	f.availableLayers = availableLayers
 	f.ProvisionalAllocatePrepare(bitrates)
 
-	usedBitrate := f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 0}, true)
+	usedBitrate := f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 0}, true, false)
 	require.Equal(t, bitrates[0][0], usedBitrate)
 
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 2, Temporal: 3}, true)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 2, Temporal: 3}, true, false)
 	require.Equal(t, bitrates[2][3]-bitrates[0][0], usedBitrate)
 
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 3}, true)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 3}, true, false)
 	require.Equal(t, bitrates[0][3]-bitrates[2][3], usedBitrate)
 
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 1, Temporal: 2}, true)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 1, Temporal: 2}, true, false)
 	require.Equal(t, bitrates[1][2]-bitrates[0][3], usedBitrate)
 
 	// available not enough to reach (2, 2), allocating at (2, 2) should not succeed
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][2]-bitrates[1][2]-1, VideoLayers{Spatial: 2, Temporal: 2}, true)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][2]-bitrates[1][2]-1, VideoLayers{Spatial: 2, Temporal: 2}, true, false)
 	require.Equal(t, int64(0), usedBitrate)
 
 	// committing should set target to (1, 2)
@@ -337,7 +403,7 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 	// when nothing fits and pausing disallowed, should allocate (0, 0)
 	f.targetLayers = InvalidLayers
 	f.ProvisionalAllocatePrepare(bitrates)
-	usedBitrate = f.ProvisionalAllocate(0, VideoLayers{Spatial: 0, Temporal: 0}, false)
+	usedBitrate = f.ProvisionalAllocate(0, VideoLayers{Spatial: 0, Temporal: 0}, false, false)
 	require.Equal(t, int64(1), usedBitrate)
 
 	// committing should set target to (0, 0)
@@ -359,6 +425,9 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 	require.Equal(t, expectedTargetLayers, f.TargetLayers())
+
+	// RAJA-TODO - test allowOvershoot
+	// RAJA-TODO - test exempted layer choice (when current layer matches and current layer does not match)
 }
 
 func TestForwarderProvisionalAllocateMute(t *testing.T) {
@@ -373,10 +442,10 @@ func TestForwarderProvisionalAllocateMute(t *testing.T) {
 	f.Mute(true)
 	f.ProvisionalAllocatePrepare(bitrates)
 
-	usedBitrate := f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 0}, true)
+	usedBitrate := f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 0}, true, false)
 	require.Equal(t, int64(0), usedBitrate)
 
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 1, Temporal: 2}, true)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 1, Temporal: 2}, true, true)
 	require.Equal(t, int64(0), usedBitrate)
 
 	// committing should set target to InvalidLayers as track is muted
@@ -417,7 +486,7 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 		to:             VideoLayers{Spatial: 0, Temporal: 0},
 		bandwidthDelta: 1,
 	}
-	transition := f.ProvisionalAllocateGetCooperativeTransition()
+	transition := f.ProvisionalAllocateGetCooperativeTransition(false)
 	require.Equal(t, expectedTransition, transition)
 
 	// committing should set target to (0, 0)
@@ -446,7 +515,7 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 		to:             targetLayers,
 		bandwidthDelta: 0,
 	}
-	transition = f.ProvisionalAllocateGetCooperativeTransition()
+	transition = f.ProvisionalAllocateGetCooperativeTransition(false)
 	require.Equal(t, expectedTransition, transition)
 
 	// committing should set target to (2, 1)
@@ -474,7 +543,7 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 		to:             VideoLayers{Spatial: 2, Temporal: 1},
 		bandwidthDelta: 0,
 	}
-	transition = f.ProvisionalAllocateGetCooperativeTransition()
+	transition = f.ProvisionalAllocateGetCooperativeTransition(false)
 	require.Equal(t, expectedTransition, transition)
 
 	f.ProvisionalAllocateCommit()
@@ -489,8 +558,10 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 		to:             InvalidLayers,
 		bandwidthDelta: -10,
 	}
-	transition = f.ProvisionalAllocateGetCooperativeTransition()
+	transition = f.ProvisionalAllocateGetCooperativeTransition(false)
 	require.Equal(t, expectedTransition, transition)
+
+	// RAJA-TODO - test allowOvershoot and exempted layers
 }
 
 func TestForwarderProvisionalAllocateGetBestWeightedTransition(t *testing.T) {
@@ -741,7 +812,7 @@ func TestForwarderPause(t *testing.T) {
 
 	f.availableLayers = availableLayers
 	f.ProvisionalAllocatePrepare(bitrates)
-	f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 0}, true)
+	f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 0}, true, false)
 	// should have set target at (0, 0)
 	f.ProvisionalAllocateCommit()
 
@@ -775,7 +846,7 @@ func TestForwarderPauseMute(t *testing.T) {
 
 	f.availableLayers = availableLayers
 	f.ProvisionalAllocatePrepare(bitrates)
-	f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 0}, true)
+	f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 0}, true, true)
 	// should have set target at (0, 0)
 	f.ProvisionalAllocateCommit()
 

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -381,10 +381,8 @@ func (w *WebRTCReceiver) AddDownTrack(track TrackSender) error {
 
 	if w.Kind() == webrtc.RTPCodecTypeVideo {
 		// notify added down track of available layers
-		layers := w.streamTrackerManager.GetAvailableLayers()
-		if len(layers) != 0 {
-			track.UpTrackLayersChange(layers)
-		}
+		availableLayers, exemptedLayers := w.streamTrackerManager.GetAvailableLayers()
+		track.UpTrackLayersChange(availableLayers, exemptedLayers)
 	}
 	track.TrackInfoAvailable()
 
@@ -396,9 +394,9 @@ func (w *WebRTCReceiver) SetMaxExpectedSpatialLayer(layer int32) {
 	w.streamTrackerManager.SetMaxExpectedSpatialLayer(layer)
 }
 
-func (w *WebRTCReceiver) downTrackLayerChange(layers []int32) {
+func (w *WebRTCReceiver) downTrackLayerChange(availableLayers []int32, exemptedLayers []int32) {
 	for _, dt := range w.downTrackSpreader.GetDownTracks() {
-		dt.UpTrackLayersChange(layers)
+		dt.UpTrackLayersChange(availableLayers, exemptedLayers)
 	}
 }
 


### PR DESCRIPTION
A few changes to handle exempted layers and more configurable overshoot
- Setting exempted layer only for screen share
- Notify downtrack/forwarder about exempted layers to ensure zero bitrate on a exempted layer does not trip allocator.
- When allocating, if no layer is available and if the current layers are at an exempted layer, let it continue. This is to handle cases where any stream tracker misses on exempted layer is not disruptive or an exempted layer restarting allows faster catch up.
- Exempted layer is treated as `DEFICIENT`. Rationale being that exempted layer may or may not have stopped. Treat it as `DEFICIENT` (in case the layer has actually stopped) and allow probing to catch up.
- Allow overshoot flag wherever applicable. These can possibly become configuration parameters. For now, they are flags in stream allocator. The current default
   - Allow overshoot when `OPTIMAL`.
   - Allow overshoot when trying to find a higher layer to start a probe when `DEFICIENT` and trying to catch up to `OPTIMAL`
   - Do not allow overshoot while allocating in `DEFICIENT` state. Note there is already an `AllowPause` config which is applied in `DEFICIENT` state to stop streams from completely stopping. If over shoot is allowed along with disallowing pause, a layer more than max. could be chosen to be streamed.
   
 Have done sanity checks and e2e checks. Have also added a bunch more unit tests. But, the number of combinations are high. Will be watching carefully for any unexplained/undesired behaviour.
 
 This effort was triggered by Firefox stopping the lowest layer of camera when screen sharing was enabled. That went through the path where the allocator thinks it was waiting for bitrate measurement and hence allocated the highest available layer up to the subscribed maximum. Turns out that was layer 0 and the layer 0 had actually stopped. But, because of exemption, it was still declared available.