### PR TITLE
Logging some connection quality stuff to get some data.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -876,6 +876,7 @@ func (p *ParticipantImpl) GetConnectionQuality() *livekit.ConnectionQualityInfo 
 	if avgScore < 4.5 {
 		p.params.Logger.Infow(
 			"low connection quality score",
+			"avgScore", avgScore,
 			"publisherScores", publisherScores,
 			"subscriberScores", subscriberScores,
 		)

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -873,6 +873,14 @@ func (p *ParticipantImpl) GetConnectionQuality() *livekit.ConnectionQualityInfo 
 		avgScore = totalScore / float32(numTracks)
 	}
 
+	if avgScore < 4.5 {
+		p.params.Logger.Infow(
+			"low connection quality score",
+			"publisherScores", publisherScores,
+			"subscriberScores", subscriberScores,
+		)
+	}
+
 	rating := connectionquality.Score2Rating(avgScore)
 
 	return &livekit.ConnectionQualityInfo{


### PR DESCRIPTION
Setting it at 4.5 as normalised scores are higher.

We need more improvements to this. The normalisation is probably not penalising disruptions. Also, video score is not conditioned on loss. We should also add expected frame rate for video and expected bit rate for audio to the protocol which can be used in scoring.

Also moved the low score logging for both media types.