### PR TITLE
Process as many events as possible in update.

### DIFF
--- a/pkg/rtc/supervisor/publication_monitor.go
+++ b/pkg/rtc/supervisor/publication_monitor.go
@@ -139,23 +139,20 @@ func (p *PublicationMonitor) IsIdle() bool {
 }
 
 func (p *PublicationMonitor) update() {
-	var pub *publish
-	if p.desiredPublishes.Len() > 0 {
-		pub = p.desiredPublishes.PopFront().(*publish)
-	}
+	for {
+		var pub *publish
+		if p.desiredPublishes.Len() > 0 {
+			pub = p.desiredPublishes.PopFront().(*publish)
+		}
 
-	if pub == nil {
-		return
-	}
+		if pub == nil {
+			return
+		}
 
-	switch {
-	case pub.isStart && p.publishedTrack != nil:
-		return
-	case !pub.isStart && p.publishedTrack == nil:
-		return
-	default:
-		// put it back as the condition is not satisfied
-		p.desiredPublishes.PushFront(pub)
-		return
+		if (pub.isStart && p.publishedTrack == nil) || (!pub.isStart && p.publishedTrack != nil) {
+			// put it back as the condition is not satisfied
+			p.desiredPublishes.PushFront(pub)
+			return
+		}
 	}
 }

--- a/pkg/rtc/supervisor/subscription_monitor.go
+++ b/pkg/rtc/supervisor/subscription_monitor.go
@@ -117,23 +117,20 @@ func (s *SubscriptionMonitor) IsIdle() bool {
 }
 
 func (s *SubscriptionMonitor) update() {
-	var tx *transition
-	if s.desiredTransitions.Len() > 0 {
-		tx = s.desiredTransitions.PopFront().(*transition)
-	}
+	for {
+		var tx *transition
+		if s.desiredTransitions.Len() > 0 {
+			tx = s.desiredTransitions.PopFront().(*transition)
+		}
 
-	if tx == nil {
-		return
-	}
+		if tx == nil {
+			return
+		}
 
-	switch {
-	case tx.isSubscribed && s.subscribedTrack != nil:
-		return
-	case !tx.isSubscribed && s.subscribedTrack == nil:
-		return
-	default:
-		// put it back as the condition is not satisfied
-		s.desiredTransitions.PushFront(tx)
-		return
+		if (tx.isSubscribed && s.subscribedTrack == nil) || (!tx.isSubscribed && s.subscribedTrack != nil) {
+			// put it back as the condition is not satisfied
+			s.desiredTransitions.PushFront(tx)
+			return
+		}
 	}
 }


### PR DESCRIPTION
With removal of subscription, it could happen twice. When the subscriber actually unusbscribes and the publisher removing all subscribers. The second unsubscribe was never removed from the event list and eventually timed out. So, process events as long as condition is satisfied.