### PR TITLE
we need to consider SPS presence as keyframe indicator for simple NALU

### DIFF
--- a/pkg/sfu/buffer/helpers.go
+++ b/pkg/sfu/buffer/helpers.go
@@ -223,7 +223,7 @@ func IsH264Keyframe(payload []byte) bool {
 		return false
 	} else if nalu <= 23 {
 		// simple NALU
-		return nalu == 5
+		return nalu == 7
 	} else if nalu == 24 || nalu == 25 || nalu == 26 || nalu == 27 {
 		// STAP-A, STAP-B, MTAP16 or MTAP24
 		i := 1


### PR DESCRIPTION
We need to use SPS indicator in NALU as Keyframe. This is handled in the case of Fragmented unit NALU but not for simple NALU.

This fixes some of the issues with gstreamer encoders not working with livekit.

from RFC https://www.rfc-editor.org/rfc/rfc6184.html
```

For NAL units having nal_unit_type equal to 7 or 8 (indicating
         a sequence parameter set or a picture parameter set,
         respectively), an H.264 encoder SHOULD set the value of NRI to
         11 (in binary format).  For coded slice NAL units of a primary
         coded picture having nal_unit_type equal to 5 (indicating a
         coded slice belonging to an IDR picture), an H.264 encoder
         SHOULD set the value of NRI to 11 (in binary format).
```