### PR TITLE
Supervisor tweaks

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1564,7 +1564,7 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 		} else {
 			p.pendingTracks[req.Cid].trackInfos = append(p.pendingTracks[req.Cid].trackInfos, ti)
 		}
-		p.params.Logger.Debugw("pending track queued", "track", ti.String(), "request", req.String())
+		p.params.Logger.Debugw("pending track queued", "trackID", ti.Sid, "track", ti.String(), "request", req.String())
 		return nil
 	}
 
@@ -1572,7 +1572,7 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 	p.supervisor.SetPublicationMute(livekit.TrackID(ti.Sid), ti.Muted)
 
 	p.pendingTracks[req.Cid] = &pendingTrackInfo{trackInfos: []*livekit.TrackInfo{ti}}
-	p.params.Logger.Debugw("pending track added", "track", ti.String(), "request", req.String())
+	p.params.Logger.Debugw("pending track added", "trackID", ti.Sid, "track", ti.String(), "request", req.String())
 	return ti
 }
 

--- a/pkg/rtc/supervisor/publication_monitor.go
+++ b/pkg/rtc/supervisor/publication_monitor.go
@@ -83,8 +83,6 @@ func (p *PublicationMonitor) setMute(isMuted bool) {
 	p.isMuted = isMuted
 	if !p.isMuted {
 		p.unmutedAt = time.Now()
-	} else {
-		p.unmutedAt = time.Time{}
 	}
 	p.lock.Unlock()
 }

--- a/pkg/rtc/supervisor/publication_monitor.go
+++ b/pkg/rtc/supervisor/publication_monitor.go
@@ -83,6 +83,8 @@ func (p *PublicationMonitor) setMute(isMuted bool) {
 	p.isMuted = isMuted
 	if !p.isMuted {
 		p.unmutedAt = time.Now()
+	} else {
+		p.unmutedAt = time.Time{}
 	}
 	p.lock.Unlock()
 }

--- a/pkg/rtc/supervisor/publication_monitor.go
+++ b/pkg/rtc/supervisor/publication_monitor.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	publishWaitDuration = 10 * time.Second
+	publishWaitDuration = 30 * time.Second
 )
 
 var (

--- a/pkg/rtc/supervisor/publication_monitor.go
+++ b/pkg/rtc/supervisor/publication_monitor.go
@@ -37,6 +37,8 @@ type PublicationMonitor struct {
 	publishedTrack types.LocalMediaTrack
 	isMuted        bool
 	unmutedAt      time.Time
+
+	lastError error
 }
 
 func NewPublicationMonitor(params PublicationMonitorParams) *PublicationMonitor {
@@ -108,6 +110,12 @@ func (p *PublicationMonitor) clearPublishedTrack(pubTrack types.LocalMediaTrack)
 
 func (p *PublicationMonitor) Check() error {
 	p.lock.RLock()
+	if p.lastError != nil {
+		p.lock.RUnlock()
+		// return an error only once
+		return nil
+	}
+
 	var pub *publish
 	if p.desiredPublishes.Len() > 0 {
 		pub = p.desiredPublishes.Front().(*publish)
@@ -123,6 +131,10 @@ func (p *PublicationMonitor) Check() error {
 
 	if pub.isStart && !isMuted && !unmutedAt.IsZero() && time.Since(unmutedAt) > publishWaitDuration {
 		// timed out waiting for publish
+		p.lock.Lock()
+		p.lastError = errPublishTimeout
+		p.lock.Unlock()
+
 		return errPublishTimeout
 	}
 
@@ -154,5 +166,7 @@ func (p *PublicationMonitor) update() {
 			p.desiredPublishes.PushFront(pub)
 			return
 		}
+
+		p.lastError = nil
 	}
 }


### PR DESCRIPTION
Saw some publication timing out. Took 19 seconds to publish.
Possibly have to tweak time outs. UPDATE: Setting publication timeout to 30 seconds to see if some sessions hit that.

Some minor tweaks for error type so it is clearer. Also, do not keep returning the same error again and again. Spams the logs. Cache the error and return it only once. The error is cleared on a successful operation.

Also, adding `trackID` to pending track logs for easier search.