### PR TITLE
Store pure padding packets also in SnOffsets cache.

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -439,8 +439,8 @@ func (b *Buffer) getExtPacket(rawPacket []byte, rtpPacket *rtp.Packet, arrivalTi
 		Arrival:   arrivalTime,
 		RawPacket: rawPacket,
 		VideoLayer: VideoLayer{
-			Spatial:  -1,
-			Temporal: -1,
+			Spatial:  InvalidLayerSpatial,
+			Temporal: InvalidLayerTemporal,
 		},
 	}
 
@@ -472,7 +472,7 @@ func (b *Buffer) getExtPacket(rawPacket []byte, rtpPacket *rtp.Packet, arrivalTi
 		} else {
 			// vp8 with DependencyDescriptor enabled, use the TID from the descriptor
 			vp8Packet.TID = uint8(ep.Temporal)
-			ep.Spatial = -1 // vp8 don't have spatial scalability, reset to -1
+			ep.Spatial = InvalidLayerSpatial // vp8 don't have spatial scalability, reset to -1
 		}
 	case "video/h264":
 		ep.KeyFrame = IsH264Keyframe(rtpPacket.Payload)


### PR DESCRIPTION
Otherwise, it is possible to return an incorrect offset.

There is a sequence number offset cache in forwarder that is used to look up sequence number offset while munging RTP header of an out-of-order packet. This is needed because pure padding packets that are contiguous are dropped in the forwarder. That affects the sequence number offset. So, we cannot apply a simple offset when munging an out-of-order packet as intervening padding only packets may have changed the offset.

The pure padding packets were not recorded in the offsets cache. This worked fine as long as the out-of-order packet is received only after one burst of padding only packets that were dropped in the forwarder. But, a sequence like

packets -> missing packet 1 -> packet -> padding only (dropped) -> missing packet -> packet -> padding only (dropped) -> missing packet 1

In this case, missing packet 1 would have used the wrong offset. That could lead to two packets at the decoder with the same sequence number. Not sure how each client handles it, but I can imagine that leading to corruption.