### PR TITLE
Don't automatically add STUN servers if nodeIP set

### DIFF
--- a/pkg/rtc/config.go
+++ b/pkg/rtc/config.go
@@ -189,10 +189,11 @@ func NewWebRTCConfig(conf *config.Config, externalIP string) (*WebRTCConfig, err
 
 	if rtcConf.UseICELite {
 		s.SetLite(true)
-	} else if !rtcConf.UseExternalIP {
+	} else if rtcConf.NodeIP == "" && !rtcConf.UseExternalIP {
 		// use STUN servers for server to support NAT
 		// when deployed in production, we expect UseExternalIP to be used, and ports accessible
 		// this is not compatible with ICE Lite
+		// Do not automatically add STUN servers if nodeIP is set
 		if len(rtcConf.STUNServers) > 0 {
 			c.ICEServers = []webrtc.ICEServer{iceServerForStunServers(rtcConf.STUNServers)}
 		} else {


### PR DESCRIPTION
It's my understanding that the nodeIP config can be set to ensure that a specific IP is provided for the host candidate. The code being changed here was added as a convenience so that:
| By giving it STUN servers, it should be
| connectable even without passing in --node-ip explicitly

We'd prefer to be able to specify a nodeIP and then as a side effect have a STUN server added.