### PR TITLE
Increase max wait for media node to respond

### DIFF
--- a/pkg/service/rtcservice.go
+++ b/pkg/service/rtcservice.go
@@ -24,6 +24,10 @@ import (
 	"github.com/livekit/livekit-server/pkg/telemetry/prometheus"
 )
 
+const (
+	maxInitialResponseWait = 10 * time.Second
+)
+
 type RTCService struct {
 	router        routing.MessageRouter
 	roomAllocator RoomAllocator
@@ -203,7 +207,7 @@ func (s *RTCService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// wait for the first message before upgrading to websocket. If no one is
 	// responding to our connection attempt, we should terminate the connection
 	// instead of waiting forever on the WebSocket
-	initialResponse, err := readInitialResponse(resSource, 5*time.Second)
+	initialResponse, err := readInitialResponse(resSource, maxInitialResponseWait)
 	if err != nil {
 		prometheus.ServiceOperationCounter.WithLabelValues("signal_ws", "error", "initial_response").Add(1)
 		handleError(w, http.StatusInternalServerError, err, loggerFields...)


### PR DESCRIPTION
In extreme cases, media nodes could take more than 5s to spin up the session. Increasing this timeout to 10s reduces the number of disconnections due to edge cases.