### PR TITLE
Allow CORS responses to be cached to allow faster initial connection

### DIFF
--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -75,6 +75,8 @@ func NewLivekitServer(conf *config.Config,
 				return true
 			},
 			AllowedHeaders: []string{"*"},
+			// allow preflight to be cached for a day
+			MaxAge: 86400,
 		}),
 	}
 	if keyProvider != nil {


### PR DESCRIPTION
By setting MaxAge in CORS responses, JS SDK could cache responses upon initialization, before needing to initialize the connection. Allowing it to reduce initial connection delay.