### PR TITLE
Tweaks to reduce supervisor error logs

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1317,6 +1317,7 @@ func (p *ParticipantImpl) onICECandidate(c *webrtc.ICECandidate, target livekit.
 }
 
 func (p *ParticipantImpl) onPublisherInitialConnected() {
+	p.supervisor.SetPublisherPeerConnectionConnected(true)
 	go p.publisherRTCPWorker()
 }
 
@@ -2061,6 +2062,9 @@ func (p *ParticipantImpl) onAnyTransportNegotiationFailed() {
 		},
 	})
 	p.CloseSignalConnection()
+
+	// on a full reconnect, no need to supervise this participant anymore
+	p.supervisor.Stop()
 }
 
 func (p *ParticipantImpl) EnqueueSubscribeTrack(trackID livekit.TrackID, f func(sub types.LocalParticipant) error) {

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -431,6 +431,7 @@ const (
 	OperationMonitorEventUpdateSubscription OperationMonitorEvent = iota
 	OperationMonitorEventSetSubscribedTrack
 	OperationMonitorEventClearSubscribedTrack
+	OperationMonitorEventPublisherPeerConnectionConnected
 	OperationMonitorEventAddPendingPublication
 	OperationMonitorEventSetPublicationMute
 	OperationMonitorEventSetPublishedTrack
@@ -445,6 +446,8 @@ func (o OperationMonitorEvent) String() string {
 		return "SET_SUBSCRIBED_TRACK"
 	case OperationMonitorEventClearSubscribedTrack:
 		return "CLEAR_SUBSCRIBED_TRACK"
+	case OperationMonitorEventPublisherPeerConnectionConnected:
+		return "PUBLISHER_PEER_CONNECTION_CONNECTED"
 	case OperationMonitorEventAddPendingPublication:
 		return "ADD_PENDING_PUBLICATION"
 	case OperationMonitorEventSetPublicationMute:


### PR DESCRIPTION
Seeing some supervisor error logs under two conditions
- Issuing a full reconnect - client should close this session and form a new one. So, supervisor errors on the to be closed session is not useful.
- Some times it takes a long time for publisher PC to establish. If publish monitor timer stars when a pending track is added, the time out fires before ICE/DTLS is established. So, include a condition to start timer on publication monitor only after peer connection is connected.