### PR TITLE
Do not warn when notifier isn't configured

### DIFF
--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -16,7 +15,6 @@ import (
 
 func (t *telemetryService) NotifyEvent(ctx context.Context, event *livekit.WebhookEvent) {
 	if t.notifier == nil {
-		logger.Warnw("failed to notify webhook", errors.New("no notifier"), "event", event.Event)
 		return
 	}
 


### PR DESCRIPTION
By default there are no webhook URLs to notify, so a notifier isn't created.