### PR TITLE
Enforce config fields, fail on unknown keys

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/mitchellh/go-homedir"
@@ -258,7 +259,9 @@ func NewConfig(confString string, c *cli.Context) (*Config, error) {
 		Keys: map[string]string{},
 	}
 	if confString != "" {
-		if err := yaml.Unmarshal([]byte(confString), conf); err != nil {
+		decoder := yaml.NewDecoder(strings.NewReader(confString))
+		decoder.KnownFields(true)
+		if err := decoder.Decode(conf); err != nil {
 			return nil, fmt.Errorf("could not parse config: %v", err)
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,3 +22,11 @@ func TestConfig_DefaultsKept(t *testing.T) {
 	require.Equal(t, true, conf.Room.AutoCreate)
 	require.Equal(t, uint32(10), conf.Room.EmptyTimeout)
 }
+
+func TestConfig_UnknownKeys(t *testing.T) {
+	const content = `unknown: 10
+room:
+  empty_timeout: 10`
+	_, err := NewConfig(content, nil)
+	require.Error(t, err)
+}


### PR DESCRIPTION
If/when users have a typo or misindentation in their config file, we would have silently failed to assign the value and moved on.

With this change it'll error out, alerting user of the problem.