### PR TITLE
Make strict mode a param

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -156,7 +156,7 @@ func getConfig(c *cli.Context) (*config.Config, error) {
 		return nil, err
 	}
 
-	conf, err := config.NewConfig(confString, c)
+	conf, err := config.NewConfig(confString, true, c)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -205,7 +205,7 @@ type IngressConfig struct {
 	RTMPBaseURL string `yaml:"rtmp_base_url"`
 }
 
-func NewConfig(confString string, c *cli.Context) (*Config, error) {
+func NewConfig(confString string, strictMode bool, c *cli.Context) (*Config, error) {
 	// start with defaults
 	conf := &Config{
 		Port: 7880,
@@ -266,7 +266,7 @@ func NewConfig(confString string, c *cli.Context) (*Config, error) {
 	}
 	if confString != "" {
 		decoder := yaml.NewDecoder(strings.NewReader(confString))
-		decoder.KnownFields(true)
+		decoder.KnownFields(strictMode)
 		if err := decoder.Decode(conf); err != nil {
 			return nil, fmt.Errorf("could not parse config: %v", err)
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestConfig_UnmarshalKeys(t *testing.T) {
-	conf, err := NewConfig("", nil)
+	conf, err := NewConfig("", true, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, conf.unmarshalKeys("key1: secret1"))
@@ -17,7 +17,7 @@ func TestConfig_UnmarshalKeys(t *testing.T) {
 func TestConfig_DefaultsKept(t *testing.T) {
 	const content = `room:
   empty_timeout: 10`
-	conf, err := NewConfig(content, nil)
+	conf, err := NewConfig(content, true, nil)
 	require.NoError(t, err)
 	require.Equal(t, true, conf.Room.AutoCreate)
 	require.Equal(t, uint32(10), conf.Room.EmptyTimeout)
@@ -27,6 +27,6 @@ func TestConfig_UnknownKeys(t *testing.T) {
 	const content = `unknown: 10
 room:
   empty_timeout: 10`
-	_, err := NewConfig(content, nil)
+	_, err := NewConfig(content, true, nil)
 	require.Error(t, err)
 }

--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -443,7 +443,7 @@ func newParticipantForTestWithOpts(identity livekit.ParticipantIdentity, opts *p
 	if opts.protocolVersion == 0 {
 		opts.protocolVersion = 6
 	}
-	conf, _ := config.NewConfig("", nil)
+	conf, _ := config.NewConfig("", true, nil)
 	// disable mux, it doesn't play too well with unit test
 	conf.RTC.UDPPort = 0
 	conf.RTC.TCPPort = 0

--- a/pkg/service/roomallocator_test.go
+++ b/pkg/service/roomallocator_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestCreateRoom(t *testing.T) {
 	t.Run("ensure default room settings are applied", func(t *testing.T) {
-		conf, err := config.NewConfig("", nil)
+		conf, err := config.NewConfig("", true, nil)
 		require.NoError(t, err)
 
 		node, err := routing.NewLocalNode(conf)
@@ -32,7 +32,7 @@ func TestCreateRoom(t *testing.T) {
 	})
 
 	t.Run("reject new participants when track limit has been reached", func(t *testing.T) {
-		conf, err := config.NewConfig("", nil)
+		conf, err := config.NewConfig("", true, nil)
 		require.NoError(t, err)
 		conf.Limit.NumTracks = 10
 
@@ -48,7 +48,7 @@ func TestCreateRoom(t *testing.T) {
 	})
 
 	t.Run("reject new participants when bandwidth limit has been reached", func(t *testing.T) {
-		conf, err := config.NewConfig("", nil)
+		conf, err := config.NewConfig("", true, nil)
 		require.NoError(t, err)
 		conf.Limit.BytesPerSec = 100
 

--- a/test/integration_helpers.go
+++ b/test/integration_helpers.go
@@ -137,7 +137,7 @@ func waitUntilConnected(t *testing.T, clients ...*testclient.RTCClient) {
 
 func createSingleNodeServer(configUpdater func(*config.Config)) *service.LivekitServer {
 	var err error
-	conf, err := config.NewConfig("", nil)
+	conf, err := config.NewConfig("", true, nil)
 	if err != nil {
 		panic(fmt.Sprintf("could not create config: %v", err))
 	}
@@ -163,7 +163,7 @@ func createSingleNodeServer(configUpdater func(*config.Config)) *service.Livekit
 
 func createMultiNodeServer(nodeID string, port uint32) *service.LivekitServer {
 	var err error
-	conf, err := config.NewConfig("", nil)
+	conf, err := config.NewConfig("", true, nil)
 	if err != nil {
 		panic(fmt.Sprintf("could not create config: %v", err))
 	}

--- a/test/webhook_test.go
+++ b/test/webhook_test.go
@@ -105,7 +105,7 @@ func TestWebhooks(t *testing.T) {
 }
 
 func setupServerWithWebhook() (server *service.LivekitServer, testServer *webhookTestServer, finishFunc func(), err error) {
-	conf, err := config.NewConfig("", nil)
+	conf, err := config.NewConfig("", true, nil)
 	if err != nil {
 		panic(fmt.Sprintf("could not create config: %v", err))
 	}


### PR DESCRIPTION
So, a wrapping config (like cloud) can skip the strict mode check.