### PR TITLE
Minor clean up of media track & friends module

### DIFF
--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -360,7 +360,7 @@ type MediaTrack interface {
 	UpdateVideoLayers(layers []*livekit.VideoLayer)
 	IsSimulcast() bool
 
-	Close()
+	Close(willBeResumed bool)
 
 	// callbacks
 	AddOnClose(func())
@@ -369,7 +369,6 @@ type MediaTrack interface {
 	AddSubscriber(participant LocalParticipant) error
 	RemoveSubscriber(participantID livekit.ParticipantID, willBeResumed bool)
 	IsSubscriber(subID livekit.ParticipantID) bool
-	InitiateClose(willBeResumed bool)
 	RevokeDisallowedSubscribers(allowedSubscriberIdentities []livekit.ParticipantIdentity) []livekit.ParticipantIdentity
 	GetAllSubscribers() []livekit.ParticipantID
 	GetNumSubscribers() int
@@ -378,6 +377,7 @@ type MediaTrack interface {
 	GetQualityForDimension(width, height uint32) livekit.VideoQuality
 
 	Receivers() []sfu.TrackReceiver
+	ClearAllReceivers(willBeResumed bool)
 }
 
 //counterfeiter:generate . LocalMediaTrack

--- a/pkg/rtc/types/typesfakes/fake_local_media_track.go
+++ b/pkg/rtc/types/typesfakes/fake_local_media_track.go
@@ -26,9 +26,15 @@ type FakeLocalMediaTrack struct {
 	addSubscriberReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CloseStub        func()
+	ClearAllReceiversStub        func(bool)
+	clearAllReceiversMutex       sync.RWMutex
+	clearAllReceiversArgsForCall []struct {
+		arg1 bool
+	}
+	CloseStub        func(bool)
 	closeMutex       sync.RWMutex
 	closeArgsForCall []struct {
+		arg1 bool
 	}
 	GetAllSubscribersStub        func() []livekit.ParticipantID
 	getAllSubscribersMutex       sync.RWMutex
@@ -104,11 +110,6 @@ type FakeLocalMediaTrack struct {
 	}
 	iDReturnsOnCall map[int]struct {
 		result1 livekit.TrackID
-	}
-	InitiateCloseStub        func(bool)
-	initiateCloseMutex       sync.RWMutex
-	initiateCloseArgsForCall []struct {
-		arg1 bool
 	}
 	IsMutedStub        func() bool
 	isMutedMutex       sync.RWMutex
@@ -376,15 +377,48 @@ func (fake *FakeLocalMediaTrack) AddSubscriberReturnsOnCall(i int, result1 error
 	}{result1}
 }
 
-func (fake *FakeLocalMediaTrack) Close() {
+func (fake *FakeLocalMediaTrack) ClearAllReceivers(arg1 bool) {
+	fake.clearAllReceiversMutex.Lock()
+	fake.clearAllReceiversArgsForCall = append(fake.clearAllReceiversArgsForCall, struct {
+		arg1 bool
+	}{arg1})
+	stub := fake.ClearAllReceiversStub
+	fake.recordInvocation("ClearAllReceivers", []interface{}{arg1})
+	fake.clearAllReceiversMutex.Unlock()
+	if stub != nil {
+		fake.ClearAllReceiversStub(arg1)
+	}
+}
+
+func (fake *FakeLocalMediaTrack) ClearAllReceiversCallCount() int {
+	fake.clearAllReceiversMutex.RLock()
+	defer fake.clearAllReceiversMutex.RUnlock()
+	return len(fake.clearAllReceiversArgsForCall)
+}
+
+func (fake *FakeLocalMediaTrack) ClearAllReceiversCalls(stub func(bool)) {
+	fake.clearAllReceiversMutex.Lock()
+	defer fake.clearAllReceiversMutex.Unlock()
+	fake.ClearAllReceiversStub = stub
+}
+
+func (fake *FakeLocalMediaTrack) ClearAllReceiversArgsForCall(i int) bool {
+	fake.clearAllReceiversMutex.RLock()
+	defer fake.clearAllReceiversMutex.RUnlock()
+	argsForCall := fake.clearAllReceiversArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeLocalMediaTrack) Close(arg1 bool) {
 	fake.closeMutex.Lock()
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
-	}{})
+		arg1 bool
+	}{arg1})
 	stub := fake.CloseStub
-	fake.recordInvocation("Close", []interface{}{})
+	fake.recordInvocation("Close", []interface{}{arg1})
 	fake.closeMutex.Unlock()
 	if stub != nil {
-		fake.CloseStub()
+		fake.CloseStub(arg1)
 	}
 }
 
@@ -394,10 +428,17 @@ func (fake *FakeLocalMediaTrack) CloseCallCount() int {
 	return len(fake.closeArgsForCall)
 }
 
-func (fake *FakeLocalMediaTrack) CloseCalls(stub func()) {
+func (fake *FakeLocalMediaTrack) CloseCalls(stub func(bool)) {
 	fake.closeMutex.Lock()
 	defer fake.closeMutex.Unlock()
 	fake.CloseStub = stub
+}
+
+func (fake *FakeLocalMediaTrack) CloseArgsForCall(i int) bool {
+	fake.closeMutex.RLock()
+	defer fake.closeMutex.RUnlock()
+	argsForCall := fake.closeArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeLocalMediaTrack) GetAllSubscribers() []livekit.ParticipantID {
@@ -789,38 +830,6 @@ func (fake *FakeLocalMediaTrack) IDReturnsOnCall(i int, result1 livekit.TrackID)
 	fake.iDReturnsOnCall[i] = struct {
 		result1 livekit.TrackID
 	}{result1}
-}
-
-func (fake *FakeLocalMediaTrack) InitiateClose(arg1 bool) {
-	fake.initiateCloseMutex.Lock()
-	fake.initiateCloseArgsForCall = append(fake.initiateCloseArgsForCall, struct {
-		arg1 bool
-	}{arg1})
-	stub := fake.InitiateCloseStub
-	fake.recordInvocation("InitiateClose", []interface{}{arg1})
-	fake.initiateCloseMutex.Unlock()
-	if stub != nil {
-		fake.InitiateCloseStub(arg1)
-	}
-}
-
-func (fake *FakeLocalMediaTrack) InitiateCloseCallCount() int {
-	fake.initiateCloseMutex.RLock()
-	defer fake.initiateCloseMutex.RUnlock()
-	return len(fake.initiateCloseArgsForCall)
-}
-
-func (fake *FakeLocalMediaTrack) InitiateCloseCalls(stub func(bool)) {
-	fake.initiateCloseMutex.Lock()
-	defer fake.initiateCloseMutex.Unlock()
-	fake.InitiateCloseStub = stub
-}
-
-func (fake *FakeLocalMediaTrack) InitiateCloseArgsForCall(i int) bool {
-	fake.initiateCloseMutex.RLock()
-	defer fake.initiateCloseMutex.RUnlock()
-	argsForCall := fake.initiateCloseArgsForCall[i]
-	return argsForCall.arg1
 }
 
 func (fake *FakeLocalMediaTrack) IsMuted() bool {
@@ -1769,6 +1778,8 @@ func (fake *FakeLocalMediaTrack) Invocations() map[string][][]interface{} {
 	defer fake.addOnCloseMutex.RUnlock()
 	fake.addSubscriberMutex.RLock()
 	defer fake.addSubscriberMutex.RUnlock()
+	fake.clearAllReceiversMutex.RLock()
+	defer fake.clearAllReceiversMutex.RUnlock()
 	fake.closeMutex.RLock()
 	defer fake.closeMutex.RUnlock()
 	fake.getAllSubscribersMutex.RLock()
@@ -1785,8 +1796,6 @@ func (fake *FakeLocalMediaTrack) Invocations() map[string][][]interface{} {
 	defer fake.hasSdpCidMutex.RUnlock()
 	fake.iDMutex.RLock()
 	defer fake.iDMutex.RUnlock()
-	fake.initiateCloseMutex.RLock()
-	defer fake.initiateCloseMutex.RUnlock()
 	fake.isMutedMutex.RLock()
 	defer fake.isMutedMutex.RUnlock()
 	fake.isSimulcastMutex.RLock()

--- a/pkg/rtc/types/typesfakes/fake_media_track.go
+++ b/pkg/rtc/types/typesfakes/fake_media_track.go
@@ -26,9 +26,15 @@ type FakeMediaTrack struct {
 	addSubscriberReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CloseStub        func()
+	ClearAllReceiversStub        func(bool)
+	clearAllReceiversMutex       sync.RWMutex
+	clearAllReceiversArgsForCall []struct {
+		arg1 bool
+	}
+	CloseStub        func(bool)
 	closeMutex       sync.RWMutex
 	closeArgsForCall []struct {
+		arg1 bool
 	}
 	GetAllSubscribersStub        func() []livekit.ParticipantID
 	getAllSubscribersMutex       sync.RWMutex
@@ -71,11 +77,6 @@ type FakeMediaTrack struct {
 	}
 	iDReturnsOnCall map[int]struct {
 		result1 livekit.TrackID
-	}
-	InitiateCloseStub        func(bool)
-	initiateCloseMutex       sync.RWMutex
-	initiateCloseArgsForCall []struct {
-		arg1 bool
 	}
 	IsMutedStub        func() bool
 	isMutedMutex       sync.RWMutex
@@ -312,15 +313,48 @@ func (fake *FakeMediaTrack) AddSubscriberReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeMediaTrack) Close() {
+func (fake *FakeMediaTrack) ClearAllReceivers(arg1 bool) {
+	fake.clearAllReceiversMutex.Lock()
+	fake.clearAllReceiversArgsForCall = append(fake.clearAllReceiversArgsForCall, struct {
+		arg1 bool
+	}{arg1})
+	stub := fake.ClearAllReceiversStub
+	fake.recordInvocation("ClearAllReceivers", []interface{}{arg1})
+	fake.clearAllReceiversMutex.Unlock()
+	if stub != nil {
+		fake.ClearAllReceiversStub(arg1)
+	}
+}
+
+func (fake *FakeMediaTrack) ClearAllReceiversCallCount() int {
+	fake.clearAllReceiversMutex.RLock()
+	defer fake.clearAllReceiversMutex.RUnlock()
+	return len(fake.clearAllReceiversArgsForCall)
+}
+
+func (fake *FakeMediaTrack) ClearAllReceiversCalls(stub func(bool)) {
+	fake.clearAllReceiversMutex.Lock()
+	defer fake.clearAllReceiversMutex.Unlock()
+	fake.ClearAllReceiversStub = stub
+}
+
+func (fake *FakeMediaTrack) ClearAllReceiversArgsForCall(i int) bool {
+	fake.clearAllReceiversMutex.RLock()
+	defer fake.clearAllReceiversMutex.RUnlock()
+	argsForCall := fake.clearAllReceiversArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeMediaTrack) Close(arg1 bool) {
 	fake.closeMutex.Lock()
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
-	}{})
+		arg1 bool
+	}{arg1})
 	stub := fake.CloseStub
-	fake.recordInvocation("Close", []interface{}{})
+	fake.recordInvocation("Close", []interface{}{arg1})
 	fake.closeMutex.Unlock()
 	if stub != nil {
-		fake.CloseStub()
+		fake.CloseStub(arg1)
 	}
 }
 
@@ -330,10 +364,17 @@ func (fake *FakeMediaTrack) CloseCallCount() int {
 	return len(fake.closeArgsForCall)
 }
 
-func (fake *FakeMediaTrack) CloseCalls(stub func()) {
+func (fake *FakeMediaTrack) CloseCalls(stub func(bool)) {
 	fake.closeMutex.Lock()
 	defer fake.closeMutex.Unlock()
 	fake.CloseStub = stub
+}
+
+func (fake *FakeMediaTrack) CloseArgsForCall(i int) bool {
+	fake.closeMutex.RLock()
+	defer fake.closeMutex.RUnlock()
+	argsForCall := fake.closeArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeMediaTrack) GetAllSubscribers() []livekit.ParticipantID {
@@ -555,38 +596,6 @@ func (fake *FakeMediaTrack) IDReturnsOnCall(i int, result1 livekit.TrackID) {
 	fake.iDReturnsOnCall[i] = struct {
 		result1 livekit.TrackID
 	}{result1}
-}
-
-func (fake *FakeMediaTrack) InitiateClose(arg1 bool) {
-	fake.initiateCloseMutex.Lock()
-	fake.initiateCloseArgsForCall = append(fake.initiateCloseArgsForCall, struct {
-		arg1 bool
-	}{arg1})
-	stub := fake.InitiateCloseStub
-	fake.recordInvocation("InitiateClose", []interface{}{arg1})
-	fake.initiateCloseMutex.Unlock()
-	if stub != nil {
-		fake.InitiateCloseStub(arg1)
-	}
-}
-
-func (fake *FakeMediaTrack) InitiateCloseCallCount() int {
-	fake.initiateCloseMutex.RLock()
-	defer fake.initiateCloseMutex.RUnlock()
-	return len(fake.initiateCloseArgsForCall)
-}
-
-func (fake *FakeMediaTrack) InitiateCloseCalls(stub func(bool)) {
-	fake.initiateCloseMutex.Lock()
-	defer fake.initiateCloseMutex.Unlock()
-	fake.InitiateCloseStub = stub
-}
-
-func (fake *FakeMediaTrack) InitiateCloseArgsForCall(i int) bool {
-	fake.initiateCloseMutex.RLock()
-	defer fake.initiateCloseMutex.RUnlock()
-	argsForCall := fake.initiateCloseArgsForCall[i]
-	return argsForCall.arg1
 }
 
 func (fake *FakeMediaTrack) IsMuted() bool {
@@ -1355,6 +1364,8 @@ func (fake *FakeMediaTrack) Invocations() map[string][][]interface{} {
 	defer fake.addOnCloseMutex.RUnlock()
 	fake.addSubscriberMutex.RLock()
 	defer fake.addSubscriberMutex.RUnlock()
+	fake.clearAllReceiversMutex.RLock()
+	defer fake.clearAllReceiversMutex.RUnlock()
 	fake.closeMutex.RLock()
 	defer fake.closeMutex.RUnlock()
 	fake.getAllSubscribersMutex.RLock()
@@ -1365,8 +1376,6 @@ func (fake *FakeMediaTrack) Invocations() map[string][][]interface{} {
 	defer fake.getQualityForDimensionMutex.RUnlock()
 	fake.iDMutex.RLock()
 	defer fake.iDMutex.RUnlock()
-	fake.initiateCloseMutex.RLock()
-	defer fake.initiateCloseMutex.RUnlock()
 	fake.isMutedMutex.RLock()
 	defer fake.isMutedMutex.RUnlock()
 	fake.isSimulcastMutex.RLock()

--- a/pkg/rtc/uptrackmanager.go
+++ b/pkg/rtc/uptrackmanager.go
@@ -67,7 +67,7 @@ func (u *UpTrackManager) Close(willBeResumed bool) {
 
 	// remove all subscribers
 	for _, t := range u.GetPublishedTracks() {
-		t.InitiateClose(willBeResumed)
+		t.ClearAllReceivers(willBeResumed)
 	}
 
 	if notify && u.onClose != nil {
@@ -328,9 +328,10 @@ func (u *UpTrackManager) AddPublishedTrack(track types.MediaTrack) {
 }
 
 func (u *UpTrackManager) RemovePublishedTrack(track types.MediaTrack, willBeResumed bool, shouldClose bool) {
-	track.InitiateClose(willBeResumed)
 	if shouldClose {
-		track.Close()
+		track.Close(willBeResumed)
+	} else {
+		track.ClearAllReceivers(willBeResumed)
 	}
 	u.lock.Lock()
 	delete(u.publishedTracks, track.ID())


### PR DESCRIPTION
- ClearAllReceivers instead of InitiateClose. Basically, it is clearing all receivers and removing all subscribers. So, use that.
- Use state in MediaTrackReceiver. Although, it is only open or closed and a isClosed boolean should suffice, mirroring remote tracks for consistency