### PR TITLE
Cache RTPStats and seed on re-use

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -64,6 +64,7 @@ func NewMediaTrack(params MediaTrackParams) *MediaTrack {
 	t.MediaTrackReceiver = NewMediaTrackReceiver(MediaTrackReceiverParams{
 		TrackInfo:           params.TrackInfo,
 		MediaTrack:          t,
+		IsRelayed:           false,
 		ParticipantID:       params.ParticipantID,
 		ParticipantIdentity: params.ParticipantIdentity,
 		ParticipantVersion:  params.ParticipantVersion,

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -65,6 +65,7 @@ func (r *simulcastReceiver) Priority() int {
 type MediaTrackReceiverParams struct {
 	TrackInfo           *livekit.TrackInfo
 	MediaTrack          types.MediaTrack
+	IsRelayed           bool
 	ParticipantID       livekit.ParticipantID
 	ParticipantIdentity livekit.ParticipantIdentity
 	ParticipantVersion  uint32
@@ -108,6 +109,7 @@ func NewMediaTrackReceiver(params MediaTrackReceiverParams) *MediaTrackReceiver 
 
 	t.MediaTrackSubscriptions = NewMediaTrackSubscriptions(MediaTrackSubscriptionsParams{
 		MediaTrack:       params.MediaTrack,
+		IsRelayed:        params.IsRelayed,
 		BufferFactory:    params.BufferFactory,
 		ReceiverConfig:   params.ReceiverConfig,
 		SubscriberConfig: params.SubscriberConfig,
@@ -429,7 +431,7 @@ func (t *MediaTrackReceiver) AddSubscriber(sub types.LocalParticipant) error {
 	t.addPendingSubscribeOp(sub.ID())
 
 	trackID := t.ID()
-	sub.EnqueueSubscribeTrack(trackID, t.addSubscriber)
+	sub.EnqueueSubscribeTrack(trackID, t.params.IsRelayed, t.addSubscriber)
 	return nil
 }
 
@@ -499,7 +501,7 @@ func (t *MediaTrackReceiver) RemoveSubscriber(subscriberID livekit.ParticipantID
 	sub := subTrack.Subscriber()
 	t.addPendingSubscribeOp(sub.ID())
 
-	sub.EnqueueUnsubscribeTrack(subTrack.ID(), willBeResumed, t.removeSubscriber)
+	sub.EnqueueUnsubscribeTrack(subTrack.ID(), t.params.IsRelayed, willBeResumed, t.removeSubscriber)
 }
 
 func (t *MediaTrackReceiver) removeSubscriber(subscriberID livekit.ParticipantID, willBeResumed bool) (err error) {

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -308,12 +308,12 @@ type LocalParticipant interface {
 
 	UpdateRTT(rtt uint32)
 
-	CacheDownTrack(trackID livekit.TrackID, rtpTransceiver *webrtc.RTPTransceiver, forwarderState sfu.ForwarderState)
+	CacheDownTrack(trackID livekit.TrackID, rtpTransceiver *webrtc.RTPTransceiver, downTrackState sfu.DownTrackState)
 	UncacheDownTrack(rtpTransceiver *webrtc.RTPTransceiver)
-	GetCachedDownTrack(trackID livekit.TrackID) (*webrtc.RTPTransceiver, sfu.ForwarderState)
+	GetCachedDownTrack(trackID livekit.TrackID) (*webrtc.RTPTransceiver, sfu.DownTrackState)
 
-	EnqueueSubscribeTrack(trackID livekit.TrackID, f func(sub LocalParticipant) error)
-	EnqueueUnsubscribeTrack(trackID livekit.TrackID, willBeResumed bool, f func(subscriberID livekit.ParticipantID, willBeResumed bool) error)
+	EnqueueSubscribeTrack(trackID livekit.TrackID, isRelayed bool, f func(sub LocalParticipant) error)
+	EnqueueUnsubscribeTrack(trackID livekit.TrackID, isRelayed bool, willBeResumed bool, f func(subscriberID livekit.ParticipantID, willBeResumed bool) error)
 	ProcessSubscriptionRequestsQueue(trackID livekit.TrackID)
 	ClearInProgressAndProcessSubscriptionRequestsQueue(trackID livekit.TrackID)
 

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -75,12 +75,12 @@ type FakeLocalParticipant struct {
 		result2 *webrtc.RTPTransceiver
 		result3 error
 	}
-	CacheDownTrackStub        func(livekit.TrackID, *webrtc.RTPTransceiver, sfu.ForwarderState)
+	CacheDownTrackStub        func(livekit.TrackID, *webrtc.RTPTransceiver, sfu.DownTrackState)
 	cacheDownTrackMutex       sync.RWMutex
 	cacheDownTrackArgsForCall []struct {
 		arg1 livekit.TrackID
 		arg2 *webrtc.RTPTransceiver
-		arg3 sfu.ForwarderState
+		arg3 sfu.DownTrackState
 	}
 	CanPublishStub        func() bool
 	canPublishMutex       sync.RWMutex
@@ -163,18 +163,20 @@ type FakeLocalParticipant struct {
 	debugInfoReturnsOnCall map[int]struct {
 		result1 map[string]interface{}
 	}
-	EnqueueSubscribeTrackStub        func(livekit.TrackID, func(sub types.LocalParticipant) error)
+	EnqueueSubscribeTrackStub        func(livekit.TrackID, bool, func(sub types.LocalParticipant) error)
 	enqueueSubscribeTrackMutex       sync.RWMutex
 	enqueueSubscribeTrackArgsForCall []struct {
 		arg1 livekit.TrackID
-		arg2 func(sub types.LocalParticipant) error
+		arg2 bool
+		arg3 func(sub types.LocalParticipant) error
 	}
-	EnqueueUnsubscribeTrackStub        func(livekit.TrackID, bool, func(subscriberID livekit.ParticipantID, willBeResumed bool) error)
+	EnqueueUnsubscribeTrackStub        func(livekit.TrackID, bool, bool, func(subscriberID livekit.ParticipantID, willBeResumed bool) error)
 	enqueueUnsubscribeTrackMutex       sync.RWMutex
 	enqueueUnsubscribeTrackArgsForCall []struct {
 		arg1 livekit.TrackID
 		arg2 bool
-		arg3 func(subscriberID livekit.ParticipantID, willBeResumed bool) error
+		arg3 bool
+		arg4 func(subscriberID livekit.ParticipantID, willBeResumed bool) error
 	}
 	GetAdaptiveStreamStub        func() bool
 	getAdaptiveStreamMutex       sync.RWMutex
@@ -198,18 +200,18 @@ type FakeLocalParticipant struct {
 		result1 float64
 		result2 bool
 	}
-	GetCachedDownTrackStub        func(livekit.TrackID) (*webrtc.RTPTransceiver, sfu.ForwarderState)
+	GetCachedDownTrackStub        func(livekit.TrackID) (*webrtc.RTPTransceiver, sfu.DownTrackState)
 	getCachedDownTrackMutex       sync.RWMutex
 	getCachedDownTrackArgsForCall []struct {
 		arg1 livekit.TrackID
 	}
 	getCachedDownTrackReturns struct {
 		result1 *webrtc.RTPTransceiver
-		result2 sfu.ForwarderState
+		result2 sfu.DownTrackState
 	}
 	getCachedDownTrackReturnsOnCall map[int]struct {
 		result1 *webrtc.RTPTransceiver
-		result2 sfu.ForwarderState
+		result2 sfu.DownTrackState
 	}
 	GetClientConfigurationStub        func() *livekit.ClientConfiguration
 	getClientConfigurationMutex       sync.RWMutex
@@ -1044,12 +1046,12 @@ func (fake *FakeLocalParticipant) AddTransceiverFromTrackToSubscriberReturnsOnCa
 	}{result1, result2, result3}
 }
 
-func (fake *FakeLocalParticipant) CacheDownTrack(arg1 livekit.TrackID, arg2 *webrtc.RTPTransceiver, arg3 sfu.ForwarderState) {
+func (fake *FakeLocalParticipant) CacheDownTrack(arg1 livekit.TrackID, arg2 *webrtc.RTPTransceiver, arg3 sfu.DownTrackState) {
 	fake.cacheDownTrackMutex.Lock()
 	fake.cacheDownTrackArgsForCall = append(fake.cacheDownTrackArgsForCall, struct {
 		arg1 livekit.TrackID
 		arg2 *webrtc.RTPTransceiver
-		arg3 sfu.ForwarderState
+		arg3 sfu.DownTrackState
 	}{arg1, arg2, arg3})
 	stub := fake.CacheDownTrackStub
 	fake.recordInvocation("CacheDownTrack", []interface{}{arg1, arg2, arg3})
@@ -1065,13 +1067,13 @@ func (fake *FakeLocalParticipant) CacheDownTrackCallCount() int {
 	return len(fake.cacheDownTrackArgsForCall)
 }
 
-func (fake *FakeLocalParticipant) CacheDownTrackCalls(stub func(livekit.TrackID, *webrtc.RTPTransceiver, sfu.ForwarderState)) {
+func (fake *FakeLocalParticipant) CacheDownTrackCalls(stub func(livekit.TrackID, *webrtc.RTPTransceiver, sfu.DownTrackState)) {
 	fake.cacheDownTrackMutex.Lock()
 	defer fake.cacheDownTrackMutex.Unlock()
 	fake.CacheDownTrackStub = stub
 }
 
-func (fake *FakeLocalParticipant) CacheDownTrackArgsForCall(i int) (livekit.TrackID, *webrtc.RTPTransceiver, sfu.ForwarderState) {
+func (fake *FakeLocalParticipant) CacheDownTrackArgsForCall(i int) (livekit.TrackID, *webrtc.RTPTransceiver, sfu.DownTrackState) {
 	fake.cacheDownTrackMutex.RLock()
 	defer fake.cacheDownTrackMutex.RUnlock()
 	argsForCall := fake.cacheDownTrackArgsForCall[i]
@@ -1514,17 +1516,18 @@ func (fake *FakeLocalParticipant) DebugInfoReturnsOnCall(i int, result1 map[stri
 	}{result1}
 }
 
-func (fake *FakeLocalParticipant) EnqueueSubscribeTrack(arg1 livekit.TrackID, arg2 func(sub types.LocalParticipant) error) {
+func (fake *FakeLocalParticipant) EnqueueSubscribeTrack(arg1 livekit.TrackID, arg2 bool, arg3 func(sub types.LocalParticipant) error) {
 	fake.enqueueSubscribeTrackMutex.Lock()
 	fake.enqueueSubscribeTrackArgsForCall = append(fake.enqueueSubscribeTrackArgsForCall, struct {
 		arg1 livekit.TrackID
-		arg2 func(sub types.LocalParticipant) error
-	}{arg1, arg2})
+		arg2 bool
+		arg3 func(sub types.LocalParticipant) error
+	}{arg1, arg2, arg3})
 	stub := fake.EnqueueSubscribeTrackStub
-	fake.recordInvocation("EnqueueSubscribeTrack", []interface{}{arg1, arg2})
+	fake.recordInvocation("EnqueueSubscribeTrack", []interface{}{arg1, arg2, arg3})
 	fake.enqueueSubscribeTrackMutex.Unlock()
 	if stub != nil {
-		fake.EnqueueSubscribeTrackStub(arg1, arg2)
+		fake.EnqueueSubscribeTrackStub(arg1, arg2, arg3)
 	}
 }
 
@@ -1534,31 +1537,32 @@ func (fake *FakeLocalParticipant) EnqueueSubscribeTrackCallCount() int {
 	return len(fake.enqueueSubscribeTrackArgsForCall)
 }
 
-func (fake *FakeLocalParticipant) EnqueueSubscribeTrackCalls(stub func(livekit.TrackID, func(sub types.LocalParticipant) error)) {
+func (fake *FakeLocalParticipant) EnqueueSubscribeTrackCalls(stub func(livekit.TrackID, bool, func(sub types.LocalParticipant) error)) {
 	fake.enqueueSubscribeTrackMutex.Lock()
 	defer fake.enqueueSubscribeTrackMutex.Unlock()
 	fake.EnqueueSubscribeTrackStub = stub
 }
 
-func (fake *FakeLocalParticipant) EnqueueSubscribeTrackArgsForCall(i int) (livekit.TrackID, func(sub types.LocalParticipant) error) {
+func (fake *FakeLocalParticipant) EnqueueSubscribeTrackArgsForCall(i int) (livekit.TrackID, bool, func(sub types.LocalParticipant) error) {
 	fake.enqueueSubscribeTrackMutex.RLock()
 	defer fake.enqueueSubscribeTrackMutex.RUnlock()
 	argsForCall := fake.enqueueSubscribeTrackArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeLocalParticipant) EnqueueUnsubscribeTrack(arg1 livekit.TrackID, arg2 bool, arg3 func(subscriberID livekit.ParticipantID, willBeResumed bool) error) {
+func (fake *FakeLocalParticipant) EnqueueUnsubscribeTrack(arg1 livekit.TrackID, arg2 bool, arg3 bool, arg4 func(subscriberID livekit.ParticipantID, willBeResumed bool) error) {
 	fake.enqueueUnsubscribeTrackMutex.Lock()
 	fake.enqueueUnsubscribeTrackArgsForCall = append(fake.enqueueUnsubscribeTrackArgsForCall, struct {
 		arg1 livekit.TrackID
 		arg2 bool
-		arg3 func(subscriberID livekit.ParticipantID, willBeResumed bool) error
-	}{arg1, arg2, arg3})
+		arg3 bool
+		arg4 func(subscriberID livekit.ParticipantID, willBeResumed bool) error
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.EnqueueUnsubscribeTrackStub
-	fake.recordInvocation("EnqueueUnsubscribeTrack", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("EnqueueUnsubscribeTrack", []interface{}{arg1, arg2, arg3, arg4})
 	fake.enqueueUnsubscribeTrackMutex.Unlock()
 	if stub != nil {
-		fake.EnqueueUnsubscribeTrackStub(arg1, arg2, arg3)
+		fake.EnqueueUnsubscribeTrackStub(arg1, arg2, arg3, arg4)
 	}
 }
 
@@ -1568,17 +1572,17 @@ func (fake *FakeLocalParticipant) EnqueueUnsubscribeTrackCallCount() int {
 	return len(fake.enqueueUnsubscribeTrackArgsForCall)
 }
 
-func (fake *FakeLocalParticipant) EnqueueUnsubscribeTrackCalls(stub func(livekit.TrackID, bool, func(subscriberID livekit.ParticipantID, willBeResumed bool) error)) {
+func (fake *FakeLocalParticipant) EnqueueUnsubscribeTrackCalls(stub func(livekit.TrackID, bool, bool, func(subscriberID livekit.ParticipantID, willBeResumed bool) error)) {
 	fake.enqueueUnsubscribeTrackMutex.Lock()
 	defer fake.enqueueUnsubscribeTrackMutex.Unlock()
 	fake.EnqueueUnsubscribeTrackStub = stub
 }
 
-func (fake *FakeLocalParticipant) EnqueueUnsubscribeTrackArgsForCall(i int) (livekit.TrackID, bool, func(subscriberID livekit.ParticipantID, willBeResumed bool) error) {
+func (fake *FakeLocalParticipant) EnqueueUnsubscribeTrackArgsForCall(i int) (livekit.TrackID, bool, bool, func(subscriberID livekit.ParticipantID, willBeResumed bool) error) {
 	fake.enqueueUnsubscribeTrackMutex.RLock()
 	defer fake.enqueueUnsubscribeTrackMutex.RUnlock()
 	argsForCall := fake.enqueueUnsubscribeTrackArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeLocalParticipant) GetAdaptiveStream() bool {
@@ -1690,7 +1694,7 @@ func (fake *FakeLocalParticipant) GetAudioLevelReturnsOnCall(i int, result1 floa
 	}{result1, result2}
 }
 
-func (fake *FakeLocalParticipant) GetCachedDownTrack(arg1 livekit.TrackID) (*webrtc.RTPTransceiver, sfu.ForwarderState) {
+func (fake *FakeLocalParticipant) GetCachedDownTrack(arg1 livekit.TrackID) (*webrtc.RTPTransceiver, sfu.DownTrackState) {
 	fake.getCachedDownTrackMutex.Lock()
 	ret, specificReturn := fake.getCachedDownTrackReturnsOnCall[len(fake.getCachedDownTrackArgsForCall)]
 	fake.getCachedDownTrackArgsForCall = append(fake.getCachedDownTrackArgsForCall, struct {
@@ -1715,7 +1719,7 @@ func (fake *FakeLocalParticipant) GetCachedDownTrackCallCount() int {
 	return len(fake.getCachedDownTrackArgsForCall)
 }
 
-func (fake *FakeLocalParticipant) GetCachedDownTrackCalls(stub func(livekit.TrackID) (*webrtc.RTPTransceiver, sfu.ForwarderState)) {
+func (fake *FakeLocalParticipant) GetCachedDownTrackCalls(stub func(livekit.TrackID) (*webrtc.RTPTransceiver, sfu.DownTrackState)) {
 	fake.getCachedDownTrackMutex.Lock()
 	defer fake.getCachedDownTrackMutex.Unlock()
 	fake.GetCachedDownTrackStub = stub
@@ -1728,29 +1732,29 @@ func (fake *FakeLocalParticipant) GetCachedDownTrackArgsForCall(i int) livekit.T
 	return argsForCall.arg1
 }
 
-func (fake *FakeLocalParticipant) GetCachedDownTrackReturns(result1 *webrtc.RTPTransceiver, result2 sfu.ForwarderState) {
+func (fake *FakeLocalParticipant) GetCachedDownTrackReturns(result1 *webrtc.RTPTransceiver, result2 sfu.DownTrackState) {
 	fake.getCachedDownTrackMutex.Lock()
 	defer fake.getCachedDownTrackMutex.Unlock()
 	fake.GetCachedDownTrackStub = nil
 	fake.getCachedDownTrackReturns = struct {
 		result1 *webrtc.RTPTransceiver
-		result2 sfu.ForwarderState
+		result2 sfu.DownTrackState
 	}{result1, result2}
 }
 
-func (fake *FakeLocalParticipant) GetCachedDownTrackReturnsOnCall(i int, result1 *webrtc.RTPTransceiver, result2 sfu.ForwarderState) {
+func (fake *FakeLocalParticipant) GetCachedDownTrackReturnsOnCall(i int, result1 *webrtc.RTPTransceiver, result2 sfu.DownTrackState) {
 	fake.getCachedDownTrackMutex.Lock()
 	defer fake.getCachedDownTrackMutex.Unlock()
 	fake.GetCachedDownTrackStub = nil
 	if fake.getCachedDownTrackReturnsOnCall == nil {
 		fake.getCachedDownTrackReturnsOnCall = make(map[int]struct {
 			result1 *webrtc.RTPTransceiver
-			result2 sfu.ForwarderState
+			result2 sfu.DownTrackState
 		})
 	}
 	fake.getCachedDownTrackReturnsOnCall[i] = struct {
 		result1 *webrtc.RTPTransceiver
-		result2 sfu.ForwarderState
+		result2 sfu.DownTrackState
 	}{result1, result2}
 }
 

--- a/pkg/rtc/utils.go
+++ b/pkg/rtc/utils.go
@@ -152,10 +152,11 @@ func LoggerWithRoom(l logger.Logger, name livekit.RoomName, roomID livekit.RoomI
 	return logger.Logger(lr)
 }
 
-func LoggerWithTrack(l logger.Logger, trackID livekit.TrackID) logger.Logger {
+func LoggerWithTrack(l logger.Logger, trackID livekit.TrackID, isRelayed bool) logger.Logger {
 	lr := logr.Logger(l)
 	if trackID != "" {
 		lr = lr.WithValues("trackID", trackID)
+		lr = lr.WithValues("relayed", isRelayed)
 	}
 	return logger.Logger(lr)
 }

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -174,6 +174,86 @@ func NewRTPStats(params RTPStatsParams) *RTPStats {
 	}
 }
 
+func (r *RTPStats) Seed(from *RTPStats) {
+	if from == nil {
+		return
+	}
+
+	r.initialized = from.initialized
+	r.resyncOnNextPacket = from.resyncOnNextPacket
+
+	r.startTime = from.startTime
+	// do not clone endTime as a non-zero endTime indiacates an ended object
+
+	r.extStartSN = from.extStartSN
+	r.highestSN = from.highestSN
+	r.cycles = from.cycles
+
+	r.isRRSeen = from.isRRSeen
+	r.extHighestSNOverridden = from.extHighestSNOverridden
+
+	r.highestTS = from.highestTS
+	r.highestTime = from.highestTime
+
+	r.lastTransit = from.lastTransit
+
+	r.bytes = from.bytes
+	r.headerBytes = from.headerBytes
+	r.bytesDuplicate = from.bytesDuplicate
+	r.headerBytesDuplicate = from.headerBytesDuplicate
+	r.bytesPadding = from.bytesPadding
+	r.headerBytesPadding = from.headerBytesPadding
+	r.packetsDuplicate = from.packetsDuplicate
+	r.packetsPadding = from.packetsPadding
+
+	r.packetsOutOfOrder = from.packetsOutOfOrder
+
+	r.packetsLost = from.packetsLost
+	r.packetsLostOverridden = from.packetsLostOverridden
+
+	r.frames = from.frames
+
+	r.jitter = from.jitter
+	r.maxJitter = from.maxJitter
+	r.jitterOverridden = from.jitterOverridden
+	r.maxJitterOverridden = from.maxJitterOverridden
+
+	for idx := range from.snInfos {
+		r.snInfos[idx] = from.snInfos[idx]
+	}
+	r.snInfoWritePtr = from.snInfoWritePtr
+
+	for idx := range from.gapHistogram {
+		r.gapHistogram[idx] = from.gapHistogram[idx]
+	}
+
+	r.nacks = from.nacks
+	r.nackAcks = from.nackAcks
+	r.nackMisses = from.nackMisses
+	r.nackRepeated = from.nackRepeated
+
+	r.plis = from.plis
+	r.lastPli = from.lastPli
+
+	r.layerLockPlis = from.layerLockPlis
+	r.lastLayerLockPli = from.lastLayerLockPli
+
+	r.firs = from.firs
+	r.lastFir = from.lastFir
+
+	r.keyFrames = from.keyFrames
+	r.lastKeyFrame = from.lastKeyFrame
+
+	r.rtt = from.rtt
+	r.maxRtt = from.maxRtt
+
+	r.rtpSR = from.rtpSR
+	r.ntpSR = from.ntpSR
+	r.arrivalSR = from.arrivalSR
+
+	// snapshots are not cloned and should be recreated
+}
+
 func (r *RTPStats) SetLogger(logger logger.Logger) {
 	r.logger = logger
 }

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -218,14 +218,10 @@ func (r *RTPStats) Seed(from *RTPStats) {
 	r.jitterOverridden = from.jitterOverridden
 	r.maxJitterOverridden = from.maxJitterOverridden
 
-	for idx := range from.snInfos {
-		r.snInfos[idx] = from.snInfos[idx]
-	}
+	r.snInfos = from.snInfos
 	r.snInfoWritePtr = from.snInfoWritePtr
 
-	for idx := range from.gapHistogram {
-		r.gapHistogram[idx] = from.gapHistogram[idx]
-	}
+	r.gapHistogram = from.gapHistogram
 
 	r.nacks = from.nacks
 	r.nackAcks = from.nackAcks

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -176,6 +176,11 @@ type ForwarderState struct {
 	VP8        VP8MungerState
 }
 
+func (f ForwarderState) String() string {
+	return fmt.Sprintf("ForwarderState{lTSCalc: %d, rtp: %s, vp8: %s}",
+		f.LastTSCalc, f.RTP.String(), f.VP8.String())
+}
+
 // -------------------------------------------------------------------
 
 type Forwarder struct {

--- a/pkg/sfu/rtpmunger.go
+++ b/pkg/sfu/rtpmunger.go
@@ -1,6 +1,8 @@
 package sfu
 
 import (
+	"fmt"
+
 	"github.com/livekit/protocol/logger"
 
 	"github.com/livekit/livekit-server/pkg/sfu/buffer"
@@ -36,10 +38,18 @@ type SnTs struct {
 	timestamp      uint32
 }
 
+// ----------------------------------------------------------------------
+
 type RTPMungerState struct {
 	LastSN uint16
 	LastTS uint32
 }
+
+func (r RTPMungerState) String() string {
+	return fmt.Sprintf("RTPMungerState{lastSN: %d, lastTS: %d)", r.LastSN, r.LastTS)
+}
+
+// ----------------------------------------------------------------------
 
 type RTPMungerParams struct {
 	highestIncomingSN uint16

--- a/pkg/sfu/vp8munger.go
+++ b/pkg/sfu/vp8munger.go
@@ -1,6 +1,8 @@
 package sfu
 
 import (
+	"fmt"
+
 	"github.com/elliotchance/orderedmap"
 
 	"github.com/livekit/protocol/logger"
@@ -15,6 +17,8 @@ type TranslationParamsVP8 struct {
 	Header *buffer.VP8
 }
 
+// -----------------------------------------------------------
+
 type VP8MungerState struct {
 	ExtLastPictureId int32
 	PictureIdUsed    int
@@ -24,6 +28,13 @@ type VP8MungerState struct {
 	LastKeyIdx       uint8
 	KeyIdxUsed       int
 }
+
+func (v VP8MungerState) String() string {
+	return fmt.Sprintf("VP8MungerState{extLastPictureId: %d, pictureIdUsed: %+v, lastTl0PicIdx: %d, tl0PicIdxUsed: %+v, tidUsed: %+v, lastKeyIdx: %d, keyIdxUsed: %+v)",
+		v.ExtLastPictureId, v.PictureIdUsed, v.LastTl0PicIdx, v.Tl0PicIdxUsed, v.TidUsed, v.LastKeyIdx, v.KeyIdxUsed)
+}
+
+// -----------------------------------------------------------
 
 type VP8MungerParams struct {
 	pictureIdWrapHandler VP8PictureIdWrapHandler


### PR DESCRIPTION
When a cached down track is re-used, RTPStats was not cached. This caused sender reports getting out-of-sync with the remote side. Cache RTPStats and seed it on re-use.