### PR TITLE
Add default HTTP handler to 404

### DIFF
--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -99,7 +99,7 @@ func NewLivekitServer(conf *config.Config,
 	mux.Handle(ingressServer.PathPrefix(), ingressServer)
 	mux.Handle("/rtc", rtcService)
 	mux.HandleFunc("/rtc/validate", rtcService.Validate)
-	mux.HandleFunc("/", s.healthCheck)
+	mux.HandleFunc("/", s.defaultHandler)
 
 	s.httpServer = &http.Server{
 		Handler: configureMiddlewares(mux, middlewares...),
@@ -299,6 +299,14 @@ func (s *LivekitServer) debugInfo(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(err.Error()))
 	} else {
 		_, _ = w.Write(b)
+	}
+}
+
+func (s *LivekitServer) defaultHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/" {
+		s.healthCheck(w, r)
+	} else {
+		http.NotFound(w, r)
 	}
 }
 


### PR DESCRIPTION
* Fixes https://github.com/livekit/livekit/issues/1085
---

Adds a default handler to show 404 in case the URL pattern is unknown.
Having this logic in the handler of "/" seems to be the way as the doc states [here](https://pkg.go.dev/net/http#ServeMux) that:

> Note that since a pattern ending in a slash names a rooted subtree, the pattern "/" matches all paths not matched by other registered patterns, not just the URL with Path == "/".

## Test plan
No UT tests, as the change seems trivial and there are no unit tests for `serve.go`. But manual testing:

```
curl -X POST http://localhost:7880/twirp/livekit.RoomService/ListRooms \
    -d '{}' \
    -H 'Content-Type: Application/json' \
    -H 'Authorization: Bearer ...'
$ {"rooms":[]}


curl -X POST http://localhost:7880/
$ OK

curl -X POST 'http://localhost:7880/?someArgs=true'
$ OK

curl -X GET 'http://localhost:7880/'
$ OK

curl -X POST 'http://localhost:7880/a/path/that/does/not/exist'
$ 404 page not found
```