### PR TITLE
Warn on out-of-order RTCP RR.

### DIFF
--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -450,30 +450,37 @@ func (r *RTPStats) UpdateFromReceiverReport(extHighestSN uint32, packetsLost uin
 		return
 	}
 
+	if !r.isRRSeen || r.extHighestSNOverridden < extHighestSN {
+		r.extHighestSNOverridden = extHighestSN
+		r.packetsLostOverridden = packetsLost
+
+		r.rtt = rtt
+		if rtt > r.maxRtt {
+			r.maxRtt = rtt
+		}
+
+		r.jitterOverridden = jitter
+		if jitter > r.maxJitterOverridden {
+			r.maxJitterOverridden = jitter
+		}
+
+		// update snapshots
+		for _, s := range r.snapshots {
+			if rtt > s.maxRtt {
+				s.maxRtt = rtt
+			}
+
+			if jitter > s.maxJitterOverridden {
+				s.maxJitterOverridden = jitter
+			}
+		}
+	} else {
+		r.logger.Warnw(
+			"receiver report potentially out of order",
+			fmt.Errorf("highestSN: existing: %d, received: %d", r.extHighestSNOverridden, extHighestSN),
+		)
+	}
 	r.isRRSeen = true
-	r.extHighestSNOverridden = extHighestSN
-	r.packetsLostOverridden = packetsLost
-
-	r.rtt = rtt
-	if rtt > r.maxRtt {
-		r.maxRtt = rtt
-	}
-
-	r.jitterOverridden = jitter
-	if jitter > r.maxJitterOverridden {
-		r.maxJitterOverridden = jitter
-	}
-
-	// update snapshots
-	for _, s := range r.snapshots {
-		if rtt > s.maxRtt {
-			s.maxRtt = rtt
-		}
-
-		if jitter > s.maxJitterOverridden {
-			s.maxJitterOverridden = jitter
-		}
-	}
 }
 
 func (r *RTPStats) UpdateNack(nackCount uint32) {


### PR DESCRIPTION
Have been seeing a few instances of "too many packets expected in delta" when trying to generate RTCP SR on down track. Actual sequence numbers indicate that start is after the end.

As down track RTPStats are driven by receiver report, wondering if we are getting RTCP_RR out-of-order somehow causing this to happen. Cannot find any other reason for this.

So, accepting RTCP_RR based update only if the sequence number is higher than existing and also logging a warning with sequence numbers if they look out-of-order.