### PR TITLE
Seed snapshots

### DIFF
--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -252,7 +252,6 @@ func (r *RTPStats) Seed(from *RTPStats) {
 	r.ntpSR = from.ntpSR
 	r.arrivalSR = from.arrivalSR
 
-	// snapshots are not cloned and should be recreated
 	r.nextSnapshotId = from.nextSnapshotId
 	for id, ss := range from.snapshots {
 		r.snapshots[id] = ss

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -491,6 +491,8 @@ func (r *RTPStats) UpdateFromReceiverReport(rr rtcp.ReceptionReport, rtt uint32)
 			fmt.Errorf("highestSN: existing: %d, received: %d", r.extHighestSNOverridden, rr.LastSequenceNumber),
 			"lastRRTime", r.lastRRTime,
 			"lastRR", r.lastRR,
+			"sinceLastRR", time.Since(r.lastRRTime),
+			"receivedRR", rr,
 		)
 	}
 }


### PR DESCRIPTION
- For one cycle after seeding, delta snap shot can get a huge gap because of snapshot iitializing from start if not present. Not a huge deal sa it should not affect functionality, but saving/restoring (at least with down track) snap shot is a big deal. So just do it.
- Have been seeing a bunch of cases of delta stats getting a lot of packets due to out-of-order (what seems like) receiver report. So, save the receiver report and log it when out-of-order is detected to understand if they are closely spaced or something else could be happening.