### PR TITLE
Remove Dependency descriptor extension when AV1 not preferred

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -510,7 +510,6 @@ func (b *Buffer) getExtPacket(rawPacket []byte, rtpPacket *rtp.Packet, arrivalTi
 			b.logger.Warnw("could not unmarshal VP8 packet", err)
 			return nil
 		}
-		ep.Payload = vp8Packet
 		ep.KeyFrame = vp8Packet.IsKeyFrame
 		if ep.DependencyDescriptor == nil {
 			ep.Temporal = int32(vp8Packet.TID)
@@ -519,6 +518,7 @@ func (b *Buffer) getExtPacket(rawPacket []byte, rtpPacket *rtp.Packet, arrivalTi
 			vp8Packet.TID = uint8(ep.Temporal)
 			ep.Spatial = InvalidLayerSpatial // vp8 don't have spatial scalability, reset to -1
 		}
+		ep.Payload = vp8Packet
 	case "video/h264":
 		ep.KeyFrame = IsH264Keyframe(rtpPacket.Payload)
 	case "video/av1":


### PR DESCRIPTION
When svc feature enabled in chrome, other codecs(VP8) will enable Dependency descriptor(DD) extension too, and VP8's header will not have TIDPresent/TID, since vp8 forward util rely on the TID of vp8 header, cause temporal layer switch can't work well with DD enabled. So remove DD extension if AV1 not preferred now, can open it after the vp8 forward utils works with it. 