### PR TITLE
don't assume uname in /usr/bin/

### DIFF
--- a/install-livekit.sh
+++ b/install-livekit.sh
@@ -59,7 +59,7 @@ then
   abort "Installer is only supported on Linux."
 fi
 
-ARCH="$(/usr/bin/uname -m)"
+ARCH="$(uname -m)"
 
 # fix arch on linux
 if [[ "${ARCH}" == "aarch64" ]]


### PR DESCRIPTION
uname exists in /bin on Ubuntu.  As such, the installation fails.               
                                                                                
The script determines the OS without specifying the complete path to uname.  Do  the same in order to determine ARCH.