### PR TITLE
CreateRoom API to actually create the room on an RTC node

### DIFF
--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -219,6 +219,10 @@ func (r *RoomManager) StartSession(
 	}
 	defer room.Release()
 
+	// only create the room, but don't start a participant session
+	if pi.Identity == "" {
+		return nil
+	}
 	participant := room.GetParticipant(pi.Identity)
 	if participant != nil {
 		// When reconnecting, it means WS has interrupted by underlying peer connection is still ok

--- a/pkg/service/roomservice.go
+++ b/pkg/service/roomservice.go
@@ -61,6 +61,17 @@ func (s *RoomService) CreateRoom(ctx context.Context, req *livekit.CreateRoomReq
 		return nil, err
 	}
 
+	// actually start the room on an RTC node, to ensure metadata & empty timeout functionality
+	_, sink, source, err := s.router.StartParticipantSignal(ctx,
+		livekit.RoomName(req.Name),
+		routing.ParticipantInit{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	sink.Close()
+	source.Close()
+
 	if req.Egress != nil && req.Egress.Room != nil {
 		egress := &livekit.StartEgressRequest{
 			Request: &livekit.StartEgressRequest_RoomComposite{

--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -328,7 +328,7 @@ func (s *LivekitServer) healthCheck(w http.ResponseWriter, _ *http.Request) {
 
 // worker to perform periodic tasks per node
 func (s *LivekitServer) backgroundWorker() {
-	roomTicker := time.NewTicker(30 * time.Second)
+	roomTicker := time.NewTicker(1 * time.Second)
 	defer roomTicker.Stop()
 	for {
 		select {


### PR DESCRIPTION
Previously, CreateRoom only created the room in storage, but did not hydrate it on an RTC node. This has caused strange behaviors such as emptyTimeout not working correctly (#1109).

Also reduced room reap worker to consistently reap rooms. Fixes #241