### PR TITLE
command to show help with hidden generated flags

### DIFF
--- a/cmd/server/commands.go
+++ b/cmd/server/commands.go
@@ -15,6 +15,7 @@ import (
 	"github.com/livekit/protocol/auth"
 	"github.com/livekit/protocol/utils"
 
+	"github.com/livekit/livekit-server/pkg/config"
 	"github.com/livekit/livekit-server/pkg/routing"
 	"github.com/livekit/livekit-server/pkg/service"
 )
@@ -65,6 +66,16 @@ func printPorts(c *cli.Context) error {
 		fmt.Println(p)
 	}
 	return nil
+}
+
+func hiddenHelp(c *cli.Context) error {
+	generatedFlags, err := config.GenerateCLIFlags(baseFlags, false)
+	if err != nil {
+		return err
+	}
+
+	c.App.Flags = append(baseFlags, generatedFlags...)
+	return cli.ShowAppHelp(c)
 }
 
 func createToken(c *cli.Context) error {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -102,7 +102,7 @@ func init() {
 }
 
 func main() {
-	generatedFlags, err := config.GenerateCLIFlags(baseFlags)
+	generatedFlags, err := config.GenerateCLIFlags(baseFlags, true)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -152,6 +152,11 @@ func main() {
 				Name:   "list-nodes",
 				Usage:  "list all nodes",
 				Action: listNodes,
+			},
+			{
+				Name:   "hidden-help",
+				Usage:  "prints app help and includes all hidden generated configuration flags",
+				Action: hiddenHelp,
 			},
 		},
 		Version: version.Version,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,8 +24,7 @@ var DefaultStunServers = []string{
 type CongestionControlProbeMode string
 
 const (
-	generatedCLIFlagsHidden = true
-	generatedCLIFlagUsage   = "generated"
+	generatedCLIFlagUsage = "generated"
 
 	CongestionControlProbeModePadding CongestionControlProbeMode = "padding"
 	CongestionControlProbeModeMedia   CongestionControlProbeMode = "media"
@@ -398,7 +397,7 @@ func (conf *Config) ToCLIFlagNames(existingFlags []cli.Flag) map[string]reflect.
 	return flagNames
 }
 
-func GenerateCLIFlags(existingFlags []cli.Flag) ([]cli.Flag, error) {
+func GenerateCLIFlags(existingFlags []cli.Flag, hidden bool) ([]cli.Flag, error) {
 	blankConfig := &Config{}
 	flags := []cli.Flag{}
 	for name, value := range blankConfig.ToCLIFlagNames(existingFlags) {
@@ -415,42 +414,42 @@ func GenerateCLIFlags(existingFlags []cli.Flag) ([]cli.Flag, error) {
 			flag = &cli.BoolFlag{
 				Name:   name,
 				Usage:  generatedCLIFlagUsage,
-				Hidden: generatedCLIFlagsHidden,
+				Hidden: hidden,
 			}
 		case reflect.String:
 			flag = &cli.StringFlag{
 				Name:    name,
 				EnvVars: []string{envVar},
 				Usage:   generatedCLIFlagUsage,
-				Hidden:  generatedCLIFlagsHidden,
+				Hidden:  hidden,
 			}
 		case reflect.Int, reflect.Int32:
 			flag = &cli.IntFlag{
 				Name:    name,
 				EnvVars: []string{envVar},
 				Usage:   generatedCLIFlagUsage,
-				Hidden:  generatedCLIFlagsHidden,
+				Hidden:  hidden,
 			}
 		case reflect.Int64:
 			flag = &cli.Int64Flag{
 				Name:    name,
 				EnvVars: []string{envVar},
 				Usage:   generatedCLIFlagUsage,
-				Hidden:  generatedCLIFlagsHidden,
+				Hidden:  hidden,
 			}
 		case reflect.Uint8, reflect.Uint16, reflect.Uint32:
 			flag = &cli.UintFlag{
 				Name:    name,
 				EnvVars: []string{envVar},
 				Usage:   generatedCLIFlagUsage,
-				Hidden:  generatedCLIFlagsHidden,
+				Hidden:  hidden,
 			}
 		case reflect.Float32:
 			flag = &cli.Float64Flag{
 				Name:    name,
 				EnvVars: []string{envVar},
 				Usage:   generatedCLIFlagUsage,
-				Hidden:  generatedCLIFlagsHidden,
+				Hidden:  hidden,
 			}
 		case reflect.Slice:
 			// TODO

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -34,7 +34,7 @@ room:
 }
 
 func TestGeneratedFlags(t *testing.T) {
-	generatedFlags, err := GenerateCLIFlags(nil)
+	generatedFlags, err := GenerateCLIFlags(nil, false)
 	require.NoError(t, err)
 
 	app := cli.NewApp()


### PR DESCRIPTION
```
> ./bin/livekit-server hidden-help
NAME:
   livekit-server - High performance WebRTC server

USAGE:
   livekit-server [global options] command [command options] [arguments...]

VERSION:
   1.3.1

DESCRIPTION:
   run without subcommands to start the server

COMMANDS:
   generate-keys  generates an API key and secret pair
   ports          print ports that server is configured to use
   list-nodes     list all nodes
   hidden-help    prints app help and includes all hidden generated configuration flags
   help, h        Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --bind value [ --bind value ]                            IP address to listen on, use flag multiple times to specify multiple addresses
   --config value                                           path to LiveKit config file
   --config-body value                                      LiveKit config in YAML, typically passed in as an environment var in a container [$LIVEKIT_CONFIG]
   --key-file value                                         path to file that contains API keys/secrets
   --keys value                                             api keys (key: secret\n) [$LIVEKIT_KEYS]
   --region value                                           region of the current node. Used by regionaware node selector [$LIVEKIT_REGION]
   --node-ip value                                          IP address of the current node, used to advertise to clients. Automatically determined by default [$NODE_IP]
   --udp-port value                                         Single UDP port to use for WebRTC traffic (default: 0) [$UDP_PORT]
   --redis-host value                                       host (incl. port) to redis server [$REDIS_HOST]
   --redis-password value                                   password to redis [$REDIS_PASSWORD]
   --turn-cert value                                        tls cert file for TURN server [$LIVEKIT_TURN_CERT]
   --turn-key value                                         tls key file for TURN server [$LIVEKIT_TURN_KEY]
   --memprofile file                                        write memory profile to file
   --dev                                                    sets log-level to debug, console formatter, and /debug/pprof. insecure for production (default: false)
   --audio.smooth_intervals value                           generated (default: 0) [$LIVEKIT_AUDIO_SMOOTH_INTERVALS]
   --room.max_metadata_size value                           generated (default: 0) [$LIVEKIT_ROOM_MAX_METADATA_SIZE]
   --turn.relay_range_end value                             generated (default: 0) [$LIVEKIT_TURN_RELAY_RANGE_END]
   --rtc.congestion_control.enabled                         generated (default: false)
   --key_file value                                         generated [$LIVEKIT_KEY_FILE]
   --rtc.packet_buffer_size value                           generated (default: 0) [$LIVEKIT_RTC_PACKET_BUFFER_SIZE]
   --redis.sentinel_master_name value                       generated [$LIVEKIT_REDIS_SENTINEL_MASTER_NAME]
   --audio.active_level value                               generated (default: 0) [$LIVEKIT_AUDIO_ACTIVE_LEVEL]
   --turn.domain value                                      generated [$LIVEKIT_TURN_DOMAIN]
   --node_selector.sysload_limit value                      generated (default: 0) [$LIVEKIT_NODE_SELECTOR_SYSLOAD_LIMIT]
   --rtc.port_range_start value                             generated (default: 0) [$LIVEKIT_RTC_PORT_RANGE_START]
   --rtc.congestion_control.min_channel_capacity value      generated (default: 0) [$LIVEKIT_RTC_CONGESTION_CONTROL_MIN_CHANNEL_CAPACITY]
   --rtc.tcp_port value                                     generated (default: 0) [$LIVEKIT_RTC_TCP_PORT]
   --rtc.allow_tcp_fallback                                 generated (default: false)
   --ingress.rtmp_base_url value                            generated [$LIVEKIT_INGRESS_RTMP_BASE_URL]
   --webhook.api_key value                                  generated [$LIVEKIT_WEBHOOK_API_KEY]
   --redis.address value                                    generated [$LIVEKIT_REDIS_ADDRESS]
   --turn.relay_range_start value                           generated (default: 0) [$LIVEKIT_TURN_RELAY_RANGE_START]
   --node_selector.kind value                               generated [$LIVEKIT_NODE_SELECTOR_KIND]
   --rtc.pli_throttle.low_quality value                     generated (default: 0) [$LIVEKIT_RTC_PLI_THROTTLE_LOW_QUALITY]
   --rtc.use_ice_lite                                       generated (default: false)
   --room.auto_create                                       generated (default: false)
   --node_selector.sort_by value                            generated [$LIVEKIT_NODE_SELECTOR_SORT_BY]
   --port value                                             generated (default: 0) [$LIVEKIT_PORT]
   --rtc.udp_port value                                     generated (default: 0) [$LIVEKIT_RTC_UDP_PORT]
   --rtc.use_external_ip                                    generated (default: false)
   --turn.tls_port value                                    generated (default: 0) [$LIVEKIT_TURN_TLS_PORT]
   --rtc.node_ip value                                      generated [$LIVEKIT_RTC_NODE_IP]
   --node_selector.cpu_load_limit value                     generated (default: 0) [$LIVEKIT_NODE_SELECTOR_CPU_LOAD_LIMIT]
   --rtc.congestion_control.padding_mode value              generated [$LIVEKIT_RTC_CONGESTION_CONTROL_PADDING_MODE]
   --rtc.congestion_control.send_side_bandwidth_estimation  generated (default: false)
   --redis.db value                                         generated (default: 0) [$LIVEKIT_REDIS_DB]
   --turn.key_file value                                    generated [$LIVEKIT_TURN_KEY_FILE]
   --rtc.pli_throttle.mid_quality value                     generated (default: 0) [$LIVEKIT_RTC_PLI_THROTTLE_MID_QUALITY]
   --audio.update_interval value                            generated (default: 0) [$LIVEKIT_AUDIO_UPDATE_INTERVAL]
   --prometheus_port value                                  generated (default: 0) [$LIVEKIT_PROMETHEUS_PORT]
   --log_level value                                        generated [$LIVEKIT_LOG_LEVEL]
   --rtc.force_tcp                                          generated (default: false)
   --video.dynacast_pause_delay value                       generated (default: 0) [$LIVEKIT_VIDEO_DYNACAST_PAUSE_DELAY]
   --room.enable_remote_unmute                              generated (default: false)
   --turn.udp_port value                                    generated (default: 0) [$LIVEKIT_TURN_UDP_PORT]
   --rtc.congestion_control.allow_pause                     generated (default: false)
   --redis.sentinel_username value                          generated [$LIVEKIT_REDIS_SENTINEL_USERNAME]
   --logging.pion_level value                               generated [$LIVEKIT_LOGGING_PION_LEVEL]
   --limit.bytes_per_sec value                              generated (default: 0) [$LIVEKIT_LIMIT_BYTES_PER_SEC]
   --development                                            generated (default: false)
   --redis.password value                                   generated [$LIVEKIT_REDIS_PASSWORD]
   --turn.cert_file value                                   generated [$LIVEKIT_TURN_CERT_FILE]
   --rtc.pli_throttle.high_quality value                    generated (default: 0) [$LIVEKIT_RTC_PLI_THROTTLE_HIGH_QUALITY]
   --redis.username value                                   generated [$LIVEKIT_REDIS_USERNAME]
   --redis.use_tls                                          generated (default: false)
   --turn.external_tls                                      generated (default: false)
   --rtc.port_range_end value                               generated (default: 0) [$LIVEKIT_RTC_PORT_RANGE_END]
   --audio.min_percentile value                             generated (default: 0) [$LIVEKIT_AUDIO_MIN_PERCENTILE]
   --turn.enabled                                           generated (default: false)
   --redis.sentinel_password value                          generated [$LIVEKIT_REDIS_SENTINEL_PASSWORD]
   --room.max_participants value                            generated (default: 0) [$LIVEKIT_ROOM_MAX_PARTICIPANTS]
   --room.empty_timeout value                               generated (default: 0) [$LIVEKIT_ROOM_EMPTY_TIMEOUT]
   --limit.num_tracks value                                 generated (default: 0) [$LIVEKIT_LIMIT_NUM_TRACKS]
```