### PR TITLE
Prevent rtx buffer and forwarding path colliding

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -366,7 +366,6 @@ func (b *Buffer) SetRTT(rtt uint32) {
 func (b *Buffer) calc(pkt []byte, arrivalTime int64) {
 	pktBuf, err := b.bucket.AddPacket(pkt)
 	if err != nil {
-		// RAJA-TODO:this could be doing state update out-of-order, fix this
 		//
 		// Even when erroring, do
 		//  1. state update

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -404,6 +404,8 @@ func (b *Buffer) calc(pkt []byte, arrivalTime int64) {
 		return
 	}
 	b.extPackets.PushBack(ep)
+
+	b.doFpsCalc(ep)
 }
 
 func (b *Buffer) patchExtPacket(ep *ExtPacket, buf []byte) *ExtPacket {

--- a/pkg/sfu/buffer/buffer_test.go
+++ b/pkg/sfu/buffer/buffer_test.go
@@ -146,20 +146,11 @@ func TestNack(t *testing.T) {
 }
 
 func TestNewBuffer(t *testing.T) {
-	type args struct {
-		options Options
-	}
 	tests := []struct {
 		name string
-		args args
 	}{
 		{
 			name: "Must not be nil and add packets in sequence",
-			args: args{
-				options: Options{
-					MaxBitRate: 1e6,
-				},
-			},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pion/webrtc/v3"
 	"go.uber.org/atomic"
 
+	"github.com/livekit/mediatransportutil/pkg/bucket"
 	"github.com/livekit/mediatransportutil/pkg/twcc"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
@@ -516,6 +517,7 @@ func (w *WebRTCReceiver) getDeltaStats() map[uint32]*buffer.StreamStatsWithLayer
 }
 
 func (w *WebRTCReceiver) forwardRTP(layer int32) {
+	pktBuf := make([]byte, bucket.MaxPktSize)
 	tracker := w.streamTrackerManager.GetTracker(layer)
 
 	defer func() {
@@ -541,7 +543,7 @@ func (w *WebRTCReceiver) forwardRTP(layer int32) {
 		buf := w.buffers[layer]
 		redPktWriter := w.redPktWriter
 		w.bufferMu.RUnlock()
-		pkt, err := buf.ReadExtended()
+		pkt, err := buf.ReadExtended(pktBuf)
 		if err == io.EOF {
 			return
 		}


### PR DESCRIPTION
Received packets are put into RTX buffer which is
a circular buffer and the packet (sequence number) is queued for forwarding. If the RTX buffer fills up
and cycles before forwarding happens, forwarding
would pick the wrong packet (as it is holding a
reference to a byte slice in the RTX buffer) to forward.

Prevent it by moving reading from RTX buffer just
before forwarding. Adds an extra copy from RTX buffer -> temp buffer for forwarding, but ensures that forwarding buffer is not used by another go routine.