### PR TITLE
Support redis cluster mode

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -19,6 +19,13 @@ redis:
   # If you use a different set of credentials for sentinel add
   # sentinel_username: user
   # sentinel_password: pass
+  #
+  # To use cluster remove the address key above and add the following
+  # cluster_addresses:
+  # - livekit-redis-node-0.livekit-redis-headless:6379
+  # - livekit-redis-node-1.livekit-redis-headless:6380
+  # And it will use the password key above as cluster password
+  # And the db key will not be used due to cluster mode not support it.
 
 # WebRTC configuration
 rtc:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/livekit/protocol/logger"
+	redisLiveKit "github.com/livekit/protocol/redis"
 )
 
 var DefaultStunServers = []string{
@@ -33,21 +34,21 @@ const (
 )
 
 type Config struct {
-	Port           uint32             `yaml:"port"`
-	BindAddresses  []string           `yaml:"bind_addresses"`
-	PrometheusPort uint32             `yaml:"prometheus_port,omitempty"`
-	RTC            RTCConfig          `yaml:"rtc,omitempty"`
-	Redis          RedisConfig        `yaml:"redis,omitempty"`
-	Audio          AudioConfig        `yaml:"audio,omitempty"`
-	Video          VideoConfig        `yaml:"video,omitempty"`
-	Room           RoomConfig         `yaml:"room,omitempty"`
-	TURN           TURNConfig         `yaml:"turn,omitempty"`
-	Ingress        IngressConfig      `yaml:"ingress,omitempty"`
-	WebHook        WebHookConfig      `yaml:"webhook,omitempty"`
-	NodeSelector   NodeSelectorConfig `yaml:"node_selector,omitempty"`
-	KeyFile        string             `yaml:"key_file,omitempty"`
-	Keys           map[string]string  `yaml:"keys,omitempty"`
-	Region         string             `yaml:"region,omitempty"`
+	Port           uint32                   `yaml:"port"`
+	BindAddresses  []string                 `yaml:"bind_addresses"`
+	PrometheusPort uint32                   `yaml:"prometheus_port,omitempty"`
+	RTC            RTCConfig                `yaml:"rtc,omitempty"`
+	Redis          redisLiveKit.RedisConfig `yaml:"redis,omitempty"`
+	Audio          AudioConfig              `yaml:"audio,omitempty"`
+	Video          VideoConfig              `yaml:"video,omitempty"`
+	Room           RoomConfig               `yaml:"room,omitempty"`
+	TURN           TURNConfig               `yaml:"turn,omitempty"`
+	Ingress        IngressConfig            `yaml:"ingress,omitempty"`
+	WebHook        WebHookConfig            `yaml:"webhook,omitempty"`
+	NodeSelector   NodeSelectorConfig       `yaml:"node_selector,omitempty"`
+	KeyFile        string                   `yaml:"key_file,omitempty"`
+	Keys           map[string]string        `yaml:"keys,omitempty"`
+	Region         string                   `yaml:"region,omitempty"`
 	// LogLevel is deprecated
 	LogLevel string        `yaml:"log_level,omitempty"`
 	Logging  LoggingConfig `yaml:"logging,omitempty"`
@@ -132,18 +133,6 @@ type AudioConfig struct {
 
 type VideoConfig struct {
 	DynacastPauseDelay time.Duration `yaml:"dynacast_pause_delay,omitempty"`
-}
-
-type RedisConfig struct {
-	Address           string   `yaml:"address"`
-	Username          string   `yaml:"username"`
-	Password          string   `yaml:"password"`
-	DB                int      `yaml:"db"`
-	UseTLS            bool     `yaml:"use_tls"`
-	MasterName        string   `yaml:"sentinel_master_name"`
-	SentinelUsername  string   `yaml:"sentinel_username"`
-	SentinelPassword  string   `yaml:"sentinel_password"`
-	SentinelAddresses []string `yaml:"sentinel_addresses"`
 }
 
 type RoomConfig struct {
@@ -241,7 +230,7 @@ func NewConfig(confString string, strictMode bool, c *cli.Context, baseFlags []c
 		Video: VideoConfig{
 			DynacastPauseDelay: 5 * time.Second,
 		},
-		Redis: RedisConfig{},
+		Redis: redisLiveKit.RedisConfig{},
 		Room: RoomConfig{
 			AutoCreate: true,
 			EnabledCodecs: []CodecSpec{
@@ -329,14 +318,6 @@ func NewConfig(confString string, strictMode bool, c *cli.Context, baseFlags []c
 	}
 
 	return conf, nil
-}
-
-func (conf *Config) HasRedis() bool {
-	return conf.Redis.Address != "" || conf.Redis.SentinelAddresses != nil
-}
-
-func (conf *Config) UseSentinel() bool {
-	return conf.Redis.SentinelAddresses != nil
 }
 
 func (conf *Config) IsTURNSEnabled() bool {

--- a/pkg/service/wire.go
+++ b/pkg/service/wire.go
@@ -4,8 +4,6 @@
 package service
 
 import (
-	"context"
-	"crypto/tls"
 	"fmt"
 	"os"
 
@@ -20,6 +18,7 @@ import (
 	"github.com/livekit/protocol/ingress"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
+	redisLiveKit "github.com/livekit/protocol/redis"
 	"github.com/livekit/protocol/webhook"
 
 	"github.com/livekit/livekit-server/pkg/clientconfiguration"
@@ -118,53 +117,7 @@ func createWebhookNotifier(conf *config.Config, provider auth.KeyProvider) (webh
 }
 
 func createRedisClient(conf *config.Config) (redis.UniversalClient, error) {
-	if !conf.HasRedis() {
-		return nil, nil
-	}
-
-	var rc redis.UniversalClient
-	var tlsConfig *tls.Config
-
-	if conf.Redis.UseTLS {
-		tlsConfig = &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		}
-	}
-
-	values := make([]interface{}, 0)
-	values = append(values, "sentinel", conf.UseSentinel())
-	if conf.UseSentinel() {
-		values = append(values, "addr", conf.Redis.SentinelAddresses, "masterName", conf.Redis.MasterName)
-		rcOptions := &redis.FailoverOptions{
-			SentinelAddrs:    conf.Redis.SentinelAddresses,
-			SentinelUsername: conf.Redis.SentinelUsername,
-			SentinelPassword: conf.Redis.SentinelPassword,
-			MasterName:       conf.Redis.MasterName,
-			Username:         conf.Redis.Username,
-			Password:         conf.Redis.Password,
-			DB:               conf.Redis.DB,
-			TLSConfig:        tlsConfig,
-		}
-		rc = redis.NewFailoverClient(rcOptions)
-	} else {
-		values = append(values, "addr", conf.Redis.Address)
-		rcOptions := &redis.Options{
-			Addr:      conf.Redis.Address,
-			Username:  conf.Redis.Username,
-			Password:  conf.Redis.Password,
-			DB:        conf.Redis.DB,
-			TLSConfig: tlsConfig,
-		}
-		rc = redis.NewClient(rcOptions)
-	}
-	logger.Infow("using multi-node routing via redis", values...)
-
-	if err := rc.Ping(context.Background()).Err(); err != nil {
-		err = errors.Wrap(err, "unable to connect to redis")
-		return nil, err
-	}
-
-	return rc, nil
+	return redisLiveKit.GetRedisClient(conf.Redis)
 }
 
 func createStore(rc redis.UniversalClient) ObjectStore {

--- a/pkg/service/wire.go
+++ b/pkg/service/wire.go
@@ -17,7 +17,6 @@ import (
 	"github.com/livekit/protocol/egress"
 	"github.com/livekit/protocol/ingress"
 	"github.com/livekit/protocol/livekit"
-	"github.com/livekit/protocol/logger"
 	redisLiveKit "github.com/livekit/protocol/redis"
 	"github.com/livekit/protocol/webhook"
 


### PR DESCRIPTION
1. Use redisConfig of protocol instead of redisConfig to reduce duplicated code and support redis cluster configuration
2. Use create redis client function of protocol to instead of some function here to support redis cluster configuration too.