### PR TITLE
Prevent subscription after participant close.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1948,6 +1948,11 @@ func (p *ParticipantImpl) onAnyTransportNegotiationFailed() {
 }
 
 func (p *ParticipantImpl) EnqueueSubscribeTrack(trackID livekit.TrackID, isRelayed bool, f func(sub types.LocalParticipant) error) {
+	// do not queue subscription is participant is already closed/disconnected
+	if p.isClosed.Load() || p.State() == livekit.ParticipantInfo_DISCONNECTED {
+		return
+	}
+
 	p.params.Logger.Debugw("queuing subscribe", "trackID", trackID, "relayed", isRelayed)
 
 	p.supervisor.UpdateSubscription(trackID, true)


### PR DESCRIPTION
It is possible that a subscription gets queued after participant is closed. This could happen due to provider track resolution taking some time. So, the sequence is
- Participant subscribes
- Provider track is in the process of resolution
- Participant closes in the mean time
- Provider track resolves and queues subscription Prevent subscription from going through if participant is already closed/disconnected.