### PR TITLE
Set forceRelay to unset by default

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1049,7 +1049,8 @@ func (p *ParticipantImpl) setupTransportManager() error {
 		if iceConfig.PreferSub == types.PreferTls {
 			p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_ENABLED
 		} else {
-			p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_DISABLED
+			// UNSET indicates that clients could override RTCConfiguration to forceRelay
+			p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_UNSET
 		}
 		p.lock.Unlock()
 


### PR DESCRIPTION
Setting it to `DISABLED` could cause clients to override user preference to use relay.