### PR TITLE
Create response channel before sending StartSession

### DIFF
--- a/pkg/routing/redisrouter.go
+++ b/pkg/routing/redisrouter.go
@@ -155,6 +155,10 @@ func (r *RedisRouter) StartParticipantSignal(ctx context.Context, roomName livek
 		return
 	}
 
+	// index by connectionID, since there may be multiple connections for the participant
+	// set up response channel before sending StartSession and be ready to receive responses.
+	resChan := r.getOrCreateMessageChannel(r.responseChannels, string(connectionID))
+
 	sink := NewRTCNodeSink(r.rc, livekit.NodeID(rtcNode.Id), pKey)
 
 	// serialize claims
@@ -169,8 +173,6 @@ func (r *RedisRouter) StartParticipantSignal(ctx context.Context, roomName livek
 		return
 	}
 
-	// index by connectionID, since there may be multiple connections for the participant
-	resChan := r.getOrCreateMessageChannel(r.responseChannels, string(connectionID))
 	return connectionID, sink, resChan, nil
 }
 


### PR DESCRIPTION
We have some cases of JoinResponse getting missed. Seems like that could happen if the response channel is not set up before the media node sends JoinResponse. So create the response channel before sending StartSession.