### PR TITLE
Add option to issue full reconnect on a publication error.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -85,6 +85,9 @@ type RTCConfig struct {
 
 	// for testing, disable UDP
 	ForceTCP bool `yaml:"force_tcp,omitempty"`
+
+	// force a reconnect on a publication error
+	ReconnectOnPublicationError *bool `yaml:"reconnect_on_publication_error,omitempty"`
 }
 
 type TURNServer struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -42,10 +42,11 @@ func TestGeneratedFlags(t *testing.T) {
 	app.Flags = append(app.Flags, generatedFlags...)
 
 	set := flag.NewFlagSet("test", 0)
-	set.Bool("rtc.use_ice_lite", true, "")            // bool
-	set.String("redis.address", "localhost:6379", "") // string
-	set.Uint("prometheus_port", 9999, "")             // uint32
-	set.Bool("rtc.allow_tcp_fallback", true, "")      // pointer
+	set.Bool("rtc.use_ice_lite", true, "")                   // bool
+	set.String("redis.address", "localhost:6379", "")        // string
+	set.Uint("prometheus_port", 9999, "")                    // uint32
+	set.Bool("rtc.allow_tcp_fallback", true, "")             // pointer
+	set.Bool("rtc.reconnect_on_publication_error", true, "") // pointer
 
 	c := cli.NewContext(app, set, nil)
 	conf, err := NewConfig("", true, c, nil)
@@ -56,4 +57,6 @@ func TestGeneratedFlags(t *testing.T) {
 	require.Equal(t, uint32(9999), conf.PrometheusPort)
 	require.NotNil(t, conf.RTC.AllowTCPFallback)
 	require.True(t, *conf.RTC.AllowTCPFallback)
+	require.NotNil(t, conf.RTC.ReconnectOnPublicationError)
+	require.True(t, *conf.RTC.ReconnectOnPublicationError)
 }

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -84,6 +84,7 @@ const (
 	ParticipantCloseReasonNegotiateFailed
 	ParticipantCloseReasonMigrationRequested
 	ParticipantCloseReasonOvercommitted
+	ParticipantCloseReasonPublicationError
 )
 
 func (p ParticipantCloseReason) String() string {
@@ -122,10 +123,12 @@ func (p ParticipantCloseReason) String() string {
 		return "SIMULATE_SERVER_LEAVE"
 	case ParticipantCloseReasonNegotiateFailed:
 		return "NEGOTIATE_FAILED"
-	case ParticipantCloseReasonOvercommitted:
-		return "OVERCOMMITTED"
 	case ParticipantCloseReasonMigrationRequested:
 		return "MIGRATION_REQUESTED"
+	case ParticipantCloseReasonOvercommitted:
+		return "OVERCOMMITTED"
+	case ParticipantCloseReasonPublicationError:
+		return "PUBLICATION_ERROR"
 	default:
 		return fmt.Sprintf("%d", int(p))
 	}
@@ -156,7 +159,7 @@ func (p ParticipantCloseReason) ToDisconnectReason() livekit.DisconnectReason {
 		return livekit.DisconnectReason_SERVER_SHUTDOWN
 	case ParticipantCloseReasonOvercommitted:
 		return livekit.DisconnectReason_SERVER_SHUTDOWN
-	case ParticipantCloseReasonNegotiateFailed:
+	case ParticipantCloseReasonNegotiateFailed, ParticipantCloseReasonPublicationError:
 		return livekit.DisconnectReason_STATE_MISMATCH
 	default:
 		// the other types will map to unknown reason

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -280,6 +280,11 @@ func (r *RoomManager) StartSession(
 	if r.config.RTC.AllowTCPFallback != nil {
 		allowFallback = *r.config.RTC.AllowTCPFallback
 	}
+	// default do not force full reconnect on a publication error
+	reconnectOnPublicationError := false
+	if r.config.RTC.ReconnectOnPublicationError != nil {
+		reconnectOnPublicationError = *r.config.RTC.ReconnectOnPublicationError
+	}
 	participant, err = rtc.NewParticipant(rtc.ParticipantParams{
 		Identity:                pi.Identity,
 		Name:                    pi.Name,
@@ -307,6 +312,7 @@ func (r *RoomManager) StartSession(
 			}
 			return nil
 		},
+		ReconnectOnPublicationError: reconnectOnPublicationError,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Leaving the publication error timeout at 30 seconds as there are some publications taking long. Also, there are cases where the peer connection fails after 30 seconds. The peer connection failure happens after publication error is detected. But, 30 seconds is a good amount of time for publication to establish.