### PR TITLE
base62 encode user provided name/identity.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,10 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/golang-lru v0.6.0
+	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20221002073820-d9198083cfdc
 	github.com/livekit/mediatransportutil v0.0.0-20221007030528-7440725c362b
-	github.com/livekit/protocol v1.3.0
+	github.com/livekit/protocol v1.3.1-0.20221210053957-e43a6056a641
 	github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995
 	github.com/mackerelio/go-osstat v0.2.3
 	github.com/magefile/mage v1.14.0
@@ -66,7 +67,6 @@ require (
 	github.com/google/subcommands v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/josharian/native v1.0.0 // indirect
-	github.com/jxskiss/base62 v1.1.0 // indirect
 	github.com/lithammer/shortuuid/v3 v3.0.7 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/livekit/mageutil v0.0.0-20221002073820-d9198083cfdc h1:e3GIA9AL6h4a38
 github.com/livekit/mageutil v0.0.0-20221002073820-d9198083cfdc/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20221007030528-7440725c362b h1:RBNV8TckETSkIkKxcD12d8nZKVkB9GSY/sQlMoaruP4=
 github.com/livekit/mediatransportutil v0.0.0-20221007030528-7440725c362b/go.mod h1:1Dlx20JPoIKGP45eo+yuj0HjeE25zmyeX/EWHiPCjFw=
-github.com/livekit/protocol v1.3.0 h1:9rzcKrLxZQIsL5Us2ZARmAkTw1dZJMF3WJoS6MCZUIw=
-github.com/livekit/protocol v1.3.0/go.mod h1:87MLIMbKaZs0SbDebMw1b7n/gD5utwEDq3zIRYcHJHA=
+github.com/livekit/protocol v1.3.1-0.20221210053957-e43a6056a641 h1:CXGhAjIOaq/yzQz7OVEqN2CZcEZ8J3Bq7GbMufe35CA=
+github.com/livekit/protocol v1.3.1-0.20221210053957-e43a6056a641/go.mod h1:87MLIMbKaZs0SbDebMw1b7n/gD5utwEDq3zIRYcHJHA=
 github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995 h1:vOaY2qvfLihDyeZtnGGN1Law9wRrw8BMGCr1TygTvMw=
 github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995/go.mod h1:116ych8UaEs9vfIE8n6iZCZ30iagUFTls0vRmC+Ix5U=
 github.com/mackerelio/go-osstat v0.2.3 h1:jAMXD5erlDE39kdX2CU7YwCGRcxIO33u/p8+Fhe5dJw=

--- a/pkg/routing/localrouter.go
+++ b/pkg/routing/localrouter.go
@@ -92,7 +92,7 @@ func (r *LocalRouter) StartParticipantSignal(ctx context.Context, roomName livek
 	// create a new connection id
 	connectionID = livekit.ConnectionID(utils.NewGuid("CO_"))
 	// index channels by roomName | identity
-	key := participantKeyLegacy(roomName, pi.Identity)
+	key := participantKey(roomName, pi.Identity)
 	key = key + "|" + livekit.ParticipantKey(connectionID)
 
 	// close older channels if one already exists

--- a/pkg/routing/utils.go
+++ b/pkg/routing/utils.go
@@ -1,22 +1,50 @@
 package routing
 
 import (
-	"errors"
+	"fmt"
 	"strings"
+
+	"github.com/jxskiss/base62"
 
 	"github.com/livekit/protocol/livekit"
 )
 
 func participantKey(roomName livekit.RoomName, identity livekit.ParticipantIdentity) livekit.ParticipantKey {
-	return livekit.ParticipantKey(string(roomName) + "|" + string(identity))
+	return livekit.ParticipantKey(encode(string(roomName), string(identity)))
 }
 
 func parseParticipantKey(pkey livekit.ParticipantKey) (roomName livekit.RoomName, identity livekit.ParticipantIdentity, err error) {
-	parts := strings.Split(string(pkey), "|")
-	if len(parts) != 2 {
-		err = errors.New("invalid participant key")
+	parts, err := decode(string(pkey))
+	if err != nil {
+		return
+	}
+	if len(parts) == 2 {
+		roomName = livekit.RoomName(parts[0])
+		identity = livekit.ParticipantIdentity(parts[1])
 		return
 	}
 
-	return livekit.RoomName(parts[0]), livekit.ParticipantIdentity(parts[1]), nil
+	err = fmt.Errorf("invalid participant key: %s", pkey)
+	return
+}
+
+func encode(str ...string) string {
+	encoded := make([]string, 0, len(str))
+	for _, s := range str {
+		encoded = append(encoded, base62.EncodeToString([]byte(s)))
+	}
+	return strings.Join(encoded, "|")
+}
+
+func decode(encoded string) ([]string, error) {
+	split := strings.Split(encoded, "|")
+	decoded := make([]string, 0, len(split))
+	for _, s := range split {
+		part, err := base62.DecodeString(s)
+		if err != nil {
+			return nil, err
+		}
+		decoded = append(decoded, string(part))
+	}
+	return decoded, nil
 }

--- a/pkg/routing/utils.go
+++ b/pkg/routing/utils.go
@@ -9,6 +9,22 @@ import (
 	"github.com/livekit/protocol/livekit"
 )
 
+func participantKeyLegacy(roomName livekit.RoomName, identity livekit.ParticipantIdentity) livekit.ParticipantKey {
+	return livekit.ParticipantKey(string(roomName) + "|" + string(identity))
+}
+
+func parseParticipantKeyLegacy(pkey livekit.ParticipantKey) (roomName livekit.RoomName, identity livekit.ParticipantIdentity, err error) {
+	parts := strings.Split(string(pkey), "|")
+	if len(parts) == 2 {
+		roomName = livekit.RoomName(parts[0])
+		identity = livekit.ParticipantIdentity(parts[1])
+		return
+	}
+
+	err = fmt.Errorf("invalid participant key: %s", pkey)
+	return
+}
+
 func participantKey(roomName livekit.RoomName, identity livekit.ParticipantIdentity) livekit.ParticipantKey {
 	return livekit.ParticipantKey(encode(string(roomName), string(identity)))
 }

--- a/pkg/routing/utils_test.go
+++ b/pkg/routing/utils_test.go
@@ -1,0 +1,49 @@
+package routing
+
+import (
+	"testing"
+
+	"github.com/livekit/protocol/livekit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUtils_ParticipantKey(t *testing.T) {
+	// encode/decode empty
+	encoded := participantKey("", "")
+	roomName, identity, err := parseParticipantKey(encoded)
+	require.NoError(t, err)
+	require.Equal(t, livekit.RoomName(""), roomName)
+	require.Equal(t, livekit.ParticipantIdentity(""), identity)
+
+	// decode invalid
+	roomName, identity, err = parseParticipantKey("abcd")
+	require.Error(t, err)
+
+	// encode/decode without delimiter
+	encoded = participantKey("room1", "identity1")
+	roomName, identity, err = parseParticipantKey(encoded)
+	require.NoError(t, err)
+	require.Equal(t, livekit.RoomName("room1"), roomName)
+	require.Equal(t, livekit.ParticipantIdentity("identity1"), identity)
+
+	// encode/decode with delimiter in roomName
+	encoded = participantKey("room1|alter_room1", "identity1")
+	roomName, identity, err = parseParticipantKey(encoded)
+	require.NoError(t, err)
+	require.Equal(t, livekit.RoomName("room1|alter_room1"), roomName)
+	require.Equal(t, livekit.ParticipantIdentity("identity1"), identity)
+
+	// encode/decode with delimiter in identity
+	encoded = participantKey("room1", "identity1|alter-identity1")
+	roomName, identity, err = parseParticipantKey(encoded)
+	require.NoError(t, err)
+	require.Equal(t, livekit.RoomName("room1"), roomName)
+	require.Equal(t, livekit.ParticipantIdentity("identity1|alter-identity1"), identity)
+
+	// encode/decode with delimiter in both and multiple delimiters in both
+	encoded = participantKey("room1|alter_room1|again_room1", "identity1|alter-identity1|again-identity1")
+	roomName, identity, err = parseParticipantKey(encoded)
+	require.NoError(t, err)
+	require.Equal(t, livekit.RoomName("room1|alter_room1|again_room1"), roomName)
+	require.Equal(t, livekit.ParticipantIdentity("identity1|alter-identity1|again-identity1"), identity)
+}

--- a/pkg/routing/utils_test.go
+++ b/pkg/routing/utils_test.go
@@ -16,7 +16,7 @@ func TestUtils_ParticipantKey(t *testing.T) {
 	require.Equal(t, livekit.ParticipantIdentity(""), identity)
 
 	// decode invalid
-	roomName, identity, err = parseParticipantKey("abcd")
+	_, _, err = parseParticipantKey("abcd")
 	require.Error(t, err)
 
 	// encode/decode without delimiter


### PR DESCRIPTION
To ensure there are no clashes with internal delimiter while generating keys.