### PR TITLE
Tweaks to prometheus participant counter

### DIFF
--- a/pkg/rtc/transportmanager.go
+++ b/pkg/rtc/transportmanager.go
@@ -83,6 +83,7 @@ func NewTransportManager(params TransportManagerParams) (*TransportManager, erro
 	t := &TransportManager{
 		params:         params,
 		mediaLossProxy: NewMediaLossProxy(MediaLossProxyParams{Logger: params.Logger}),
+		iceConfig:      &livekit.ICEConfig{},
 	}
 	t.mediaLossProxy.OnMediaLossUpdate(t.onMediaLossUpdate)
 


### PR DESCRIPTION
Ensure that we don't miss adding a count in migration scenarios

Unrelated fix: initializing ICEConfig to avoid panic.