### PR TITLE
Track subscription operations per source track.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,6 +93,9 @@ type RTCConfig struct {
 
 	// force a reconnect on a publication error
 	ReconnectOnPublicationError *bool `yaml:"reconnect_on_publication_error,omitempty"`
+
+	// force a reconnect on a subscription error
+	ReconnectOnSubscriptionError *bool `yaml:"reconnect_on_subscription_error,omitempty"`
 }
 
 type TURNServer struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -42,11 +42,12 @@ func TestGeneratedFlags(t *testing.T) {
 	app.Flags = append(app.Flags, generatedFlags...)
 
 	set := flag.NewFlagSet("test", 0)
-	set.Bool("rtc.use_ice_lite", true, "")                   // bool
-	set.String("redis.address", "localhost:6379", "")        // string
-	set.Uint("prometheus_port", 9999, "")                    // uint32
-	set.Bool("rtc.allow_tcp_fallback", true, "")             // pointer
-	set.Bool("rtc.reconnect_on_publication_error", true, "") // pointer
+	set.Bool("rtc.use_ice_lite", true, "")                     // bool
+	set.String("redis.address", "localhost:6379", "")          // string
+	set.Uint("prometheus_port", 9999, "")                      // uint32
+	set.Bool("rtc.allow_tcp_fallback", true, "")               // pointer
+	set.Bool("rtc.reconnect_on_publication_error", true, "")   // pointer
+	set.Bool("rtc.reconnect_on_subscription_error", false, "") // pointer
 
 	c := cli.NewContext(app, set, nil)
 	conf, err := NewConfig("", true, c, nil)
@@ -55,8 +56,13 @@ func TestGeneratedFlags(t *testing.T) {
 	require.True(t, conf.RTC.UseICELite)
 	require.Equal(t, "localhost:6379", conf.Redis.Address)
 	require.Equal(t, uint32(9999), conf.PrometheusPort)
+
 	require.NotNil(t, conf.RTC.AllowTCPFallback)
 	require.True(t, *conf.RTC.AllowTCPFallback)
+
 	require.NotNil(t, conf.RTC.ReconnectOnPublicationError)
 	require.True(t, *conf.RTC.ReconnectOnPublicationError)
+
+	require.NotNil(t, conf.RTC.ReconnectOnSubscriptionError)
+	require.False(t, *conf.RTC.ReconnectOnSubscriptionError)
 }

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -428,7 +428,7 @@ func (t *MediaTrackReceiver) removePendingSubscribeOp(subscriberID livekit.Parti
 
 // AddSubscriber subscribes sub to current mediaTrack
 func (t *MediaTrackReceiver) AddSubscriber(sub types.LocalParticipant) error {
-	if sub.EnqueueSubscribeTrack(t.ID(), t.params.IsRelayed, t.addSubscriber) {
+	if sub.EnqueueSubscribeTrack(t.ID(), t.params.MediaTrack, t.params.IsRelayed, t.addSubscriber) {
 		t.addPendingSubscribeOp(sub.ID())
 	}
 	return nil
@@ -506,7 +506,7 @@ func (t *MediaTrackReceiver) RemoveSubscriber(subscriberID livekit.ParticipantID
 	}
 
 	sub := subTrack.Subscriber()
-	if sub.EnqueueUnsubscribeTrack(subTrack.ID(), t.params.IsRelayed, willBeResumed, t.removeSubscriber) {
+	if sub.EnqueueUnsubscribeTrack(subTrack.ID(), t.params.MediaTrack, t.params.IsRelayed, willBeResumed, t.removeSubscriber) {
 		t.addPendingSubscribeOp(sub.ID())
 	}
 }

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -248,7 +248,7 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 
 	// since sub will lock, run it in a goroutine to avoid deadlocks
 	go func() {
-		sub.AddSubscribedTrack(subTrack)
+		sub.AddSubscribedTrack(subTrack, t.params.MediaTrack)
 		if !replacedTrack {
 			sub.Negotiate(false)
 		}
@@ -424,7 +424,7 @@ func (t *MediaTrackSubscriptions) downTrackClosed(
 		}
 	}
 
-	sub.RemoveSubscribedTrack(subTrack)
+	sub.RemoveSubscribedTrack(subTrack, t.params.MediaTrack)
 	if !willBeResumed {
 		sub.Negotiate(false)
 	}

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -924,6 +924,7 @@ func (p *ParticipantImpl) VerifySubscribeParticipantInfo(pID livekit.Participant
 func (p *ParticipantImpl) AddSubscribedTrack(subTrack types.SubscribedTrack, sourceTrack types.MediaTrack) {
 	p.lock.Lock()
 	if v, ok := p.trackPublisherVersion[subTrack.ID()]; ok && v > subTrack.PublisherVersion() {
+		p.supervisor.SetSubscribedTrack(subTrack.ID(), subTrack, sourceTrack)
 		p.lock.Unlock()
 		p.params.Logger.Infow("ignoring add subscribedTrack from older version",
 			"current", v,
@@ -971,6 +972,7 @@ func (p *ParticipantImpl) AddSubscribedTrack(subTrack types.SubscribedTrack, sou
 func (p *ParticipantImpl) RemoveSubscribedTrack(subTrack types.SubscribedTrack, sourceTrack types.MediaTrack) {
 	p.lock.Lock()
 	if v, ok := p.trackPublisherVersion[subTrack.ID()]; ok && v > subTrack.PublisherVersion() {
+		p.supervisor.ClearSubscribedTrack(subTrack.ID(), subTrack, sourceTrack)
 		p.lock.Unlock()
 		p.params.Logger.Infow("ignoring remove subscribedTrack from older version",
 			"current", v,

--- a/pkg/rtc/supervisor/participant_supervisor.go
+++ b/pkg/rtc/supervisor/participant_supervisor.go
@@ -18,24 +18,30 @@ type ParticipantSupervisorParams struct {
 	Logger logger.Logger
 }
 
+type trackMonitor struct {
+	opMon types.OperationMonitor
+	err   error
+}
+
 type ParticipantSupervisor struct {
 	params ParticipantSupervisorParams
 
 	lock                 sync.RWMutex
 	isPublisherConnected bool
-	publications         map[livekit.TrackID]types.OperationMonitor
-	subscriptions        map[livekit.TrackID]types.OperationMonitor
+	publications         map[livekit.TrackID]*trackMonitor
+	subscriptions        map[livekit.TrackID]*trackMonitor
 
 	isStopped atomic.Bool
 
-	onPublicationError func(trackID livekit.TrackID)
+	onPublicationError  func(trackID livekit.TrackID)
+	onSubscriptionError func(trackID livekit.TrackID)
 }
 
 func NewParticipantSupervisor(params ParticipantSupervisorParams) *ParticipantSupervisor {
 	p := &ParticipantSupervisor{
 		params:        params,
-		publications:  make(map[livekit.TrackID]types.OperationMonitor),
-		subscriptions: make(map[livekit.TrackID]types.OperationMonitor),
+		publications:  make(map[livekit.TrackID]*trackMonitor),
+		subscriptions: make(map[livekit.TrackID]*trackMonitor),
 	}
 
 	go p.checkState()
@@ -61,12 +67,26 @@ func (p *ParticipantSupervisor) getOnPublicationError() func(trackID livekit.Tra
 	return p.onPublicationError
 }
 
+func (p *ParticipantSupervisor) OnSubscriptionError(f func(trackID livekit.TrackID)) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.onSubscriptionError = f
+}
+
+func (p *ParticipantSupervisor) getOnSubscriptionError() func(trackID livekit.TrackID) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return p.onSubscriptionError
+}
+
 func (p *ParticipantSupervisor) SetPublisherPeerConnectionConnected(isConnected bool) {
 	p.lock.Lock()
 	p.isPublisherConnected = isConnected
 
 	for _, pm := range p.publications {
-		pm.PostEvent(types.OperationMonitorEventPublisherPeerConnectionConnected, p.isPublisherConnected)
+		pm.opMon.PostEvent(types.OperationMonitorEventPublisherPeerConnectionConnected, p.isPublisherConnected)
 	}
 	p.lock.Unlock()
 }
@@ -75,16 +95,18 @@ func (p *ParticipantSupervisor) AddPublication(trackID livekit.TrackID) {
 	p.lock.Lock()
 	pm, ok := p.publications[trackID]
 	if !ok {
-		pm = NewPublicationMonitor(
-			PublicationMonitorParams{
-				TrackID:                   trackID,
-				IsPeerConnectionConnected: p.isPublisherConnected,
-				Logger:                    p.params.Logger,
-			},
-		)
+		pm = &trackMonitor{
+			opMon: NewPublicationMonitor(
+				PublicationMonitorParams{
+					TrackID:                   trackID,
+					IsPeerConnectionConnected: p.isPublisherConnected,
+					Logger:                    p.params.Logger,
+				},
+			),
+		}
 		p.publications[trackID] = pm
 	}
-	pm.PostEvent(types.OperationMonitorEventAddPendingPublication, nil)
+	pm.opMon.PostEvent(types.OperationMonitorEventAddPendingPublication, nil)
 	p.lock.Unlock()
 }
 
@@ -92,7 +114,7 @@ func (p *ParticipantSupervisor) SetPublicationMute(trackID livekit.TrackID, isMu
 	p.lock.Lock()
 	pm, ok := p.publications[trackID]
 	if ok {
-		pm.PostEvent(types.OperationMonitorEventSetPublicationMute, isMuted)
+		pm.opMon.PostEvent(types.OperationMonitorEventSetPublicationMute, isMuted)
 	}
 	p.lock.Unlock()
 }
@@ -101,7 +123,7 @@ func (p *ParticipantSupervisor) SetPublishedTrack(trackID livekit.TrackID, pubTr
 	p.lock.RLock()
 	pm, ok := p.publications[trackID]
 	if ok {
-		pm.PostEvent(types.OperationMonitorEventSetPublishedTrack, pubTrack)
+		pm.opMon.PostEvent(types.OperationMonitorEventSetPublishedTrack, pubTrack)
 	}
 	p.lock.RUnlock()
 }
@@ -110,36 +132,56 @@ func (p *ParticipantSupervisor) ClearPublishedTrack(trackID livekit.TrackID, pub
 	p.lock.RLock()
 	pm, ok := p.publications[trackID]
 	if ok {
-		pm.PostEvent(types.OperationMonitorEventClearPublishedTrack, pubTrack)
+		pm.opMon.PostEvent(types.OperationMonitorEventClearPublishedTrack, pubTrack)
 	}
 	p.lock.RUnlock()
 }
 
-func (p *ParticipantSupervisor) UpdateSubscription(trackID livekit.TrackID, isSubscribed bool) {
+func (p *ParticipantSupervisor) UpdateSubscription(trackID livekit.TrackID, isSubscribe bool, sourceTrack types.MediaTrack) {
 	p.lock.Lock()
 	sm, ok := p.subscriptions[trackID]
 	if !ok {
-		sm = NewSubscriptionMonitor(SubscriptionMonitorParams{TrackID: trackID, Logger: p.params.Logger})
+		sm = &trackMonitor{
+			opMon: NewSubscriptionMonitor(SubscriptionMonitorParams{TrackID: trackID, Logger: p.params.Logger}),
+		}
 		p.subscriptions[trackID] = sm
 	}
-	sm.PostEvent(types.OperationMonitorEventUpdateSubscription, isSubscribed)
+	sm.opMon.PostEvent(
+		types.OperationMonitorEventUpdateSubscription,
+		SubscriptionOpParams{
+			SourceTrack: sourceTrack,
+			IsSubscribe: isSubscribe,
+		},
+	)
 	p.lock.Unlock()
 }
 
-func (p *ParticipantSupervisor) SetSubscribedTrack(trackID livekit.TrackID, subTrack types.SubscribedTrack) {
+func (p *ParticipantSupervisor) SetSubscribedTrack(trackID livekit.TrackID, subTrack types.SubscribedTrack, sourceTrack types.MediaTrack) {
 	p.lock.RLock()
 	sm, ok := p.subscriptions[trackID]
 	if ok {
-		sm.PostEvent(types.OperationMonitorEventSetSubscribedTrack, subTrack)
+		sm.opMon.PostEvent(
+			types.OperationMonitorEventSetSubscribedTrack,
+			UpdateSubscribedTrackParams{
+				SourceTrack:     sourceTrack,
+				SubscribedTrack: subTrack,
+			},
+		)
 	}
 	p.lock.RUnlock()
 }
 
-func (p *ParticipantSupervisor) ClearSubscribedTrack(trackID livekit.TrackID, subTrack types.SubscribedTrack) {
+func (p *ParticipantSupervisor) ClearSubscribedTrack(trackID livekit.TrackID, subTrack types.SubscribedTrack, sourceTrack types.MediaTrack) {
 	p.lock.RLock()
 	sm, ok := p.subscriptions[trackID]
 	if ok {
-		sm.PostEvent(types.OperationMonitorEventClearSubscribedTrack, subTrack)
+		sm.opMon.PostEvent(
+			types.OperationMonitorEventClearSubscribedTrack,
+			UpdateSubscribedTrackParams{
+				SourceTrack:     sourceTrack,
+				SubscribedTrack: subTrack,
+			},
+		)
 	}
 	p.lock.RUnlock()
 }
@@ -161,11 +203,18 @@ func (p *ParticipantSupervisor) checkPublications() {
 	var removablePublications []livekit.TrackID
 	p.lock.RLock()
 	for trackID, pm := range p.publications {
-		if err := pm.Check(); err != nil {
-			p.params.Logger.Errorw("supervisor error on publication", err, "trackID", trackID)
-			erroredPublications = append(erroredPublications, trackID)
+		if err := pm.opMon.Check(); err != nil {
+			if pm.err == nil {
+				p.params.Logger.Errorw("supervisor error on publication", err, "trackID", trackID)
+				pm.err = err
+				erroredPublications = append(erroredPublications, trackID)
+			}
 		} else {
-			if pm.IsIdle() {
+			if pm.err != nil {
+				p.params.Logger.Infow("supervisor publication recovered", "trackID", trackID)
+				pm.err = err
+			}
+			if pm.opMon.IsIdle() {
 				removablePublications = append(removablePublications, trackID)
 			}
 		}
@@ -186,13 +235,22 @@ func (p *ParticipantSupervisor) checkPublications() {
 }
 
 func (p *ParticipantSupervisor) checkSubscriptions() {
+	var erroredSubscriptions []livekit.TrackID
 	var removableSubscriptions []livekit.TrackID
 	p.lock.RLock()
 	for trackID, sm := range p.subscriptions {
-		if err := sm.Check(); err != nil {
-			p.params.Logger.Errorw("supervisor error on subscription", err, "trackID", trackID)
+		if err := sm.opMon.Check(); err != nil {
+			if sm.err == nil {
+				p.params.Logger.Errorw("supervisor error on subscription", err, "trackID", trackID)
+				sm.err = err
+				erroredSubscriptions = append(erroredSubscriptions, trackID)
+			}
 		} else {
-			if sm.IsIdle() {
+			if sm.err != nil {
+				p.params.Logger.Infow("supervisor subscription recovered", "trackID", trackID)
+				sm.err = err
+			}
+			if sm.opMon.IsIdle() {
 				removableSubscriptions = append(removableSubscriptions, trackID)
 			}
 		}
@@ -204,4 +262,10 @@ func (p *ParticipantSupervisor) checkSubscriptions() {
 		delete(p.subscriptions, trackID)
 	}
 	p.lock.Unlock()
+
+	if onSubscriptionError := p.getOnSubscriptionError(); onSubscriptionError != nil {
+		for _, trackID := range erroredSubscriptions {
+			onSubscriptionError(trackID)
+		}
+	}
 }

--- a/pkg/rtc/supervisor/publication_monitor.go
+++ b/pkg/rtc/supervisor/publication_monitor.go
@@ -116,7 +116,7 @@ func (p *PublicationMonitor) clearPublishedTrack(pubTrack types.LocalMediaTrack)
 	if p.publishedTrack == pubTrack {
 		p.publishedTrack = nil
 	} else {
-		p.params.Logger.Errorw("mismatched published track on clear", nil, "trackID", p.params.TrackID)
+		p.params.Logger.Errorw("supervisor: mismatched published track on clear", nil, "trackID", p.params.TrackID)
 	}
 
 	p.update()

--- a/pkg/rtc/supervisor/subscription_monitor.go
+++ b/pkg/rtc/supervisor/subscription_monitor.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	transitionWaitDuration = 10 * time.Second
+	transitionWaitDuration = 20 * time.Second
 )
 
 var (
@@ -25,6 +25,22 @@ type transition struct {
 	at          time.Time
 }
 
+type subscriptionOps struct {
+	desiredTransitions deque.Deque
+
+	subscribedTrack types.SubscribedTrack
+}
+
+type SubscriptionOpParams struct {
+	SourceTrack types.MediaTrack
+	IsSubscribe bool
+}
+
+type UpdateSubscribedTrackParams struct {
+	SourceTrack     types.MediaTrack
+	SubscribedTrack types.SubscribedTrack
+}
+
 type SubscriptionMonitorParams struct {
 	TrackID livekit.TrackID
 	Logger  logger.Logger
@@ -33,38 +49,36 @@ type SubscriptionMonitorParams struct {
 type SubscriptionMonitor struct {
 	params SubscriptionMonitorParams
 
-	lock               sync.RWMutex
-	desiredTransitions deque.Deque
-
-	subscribedTrack types.SubscribedTrack
-
-	lastError error
+	lock                    sync.RWMutex
+	subscriptionOpsBySource map[types.MediaTrack]*subscriptionOps
 }
 
 func NewSubscriptionMonitor(params SubscriptionMonitorParams) *SubscriptionMonitor {
 	s := &SubscriptionMonitor{
-		params: params,
+		params:                  params,
+		subscriptionOpsBySource: make(map[types.MediaTrack]*subscriptionOps),
 	}
-	s.desiredTransitions.SetMinCapacity(2)
 	return s
 }
 
 func (s *SubscriptionMonitor) PostEvent(ome types.OperationMonitorEvent, omd types.OperationMonitorData) {
 	switch ome {
 	case types.OperationMonitorEventUpdateSubscription:
-		s.updateSubscription(omd.(bool))
+		s.updateSubscription(omd.(SubscriptionOpParams))
 	case types.OperationMonitorEventSetSubscribedTrack:
-		s.setSubscribedTrack(omd.(types.SubscribedTrack))
+		s.setSubscribedTrack(omd.(UpdateSubscribedTrackParams))
 	case types.OperationMonitorEventClearSubscribedTrack:
-		s.clearSubscribedTrack(omd.(types.SubscribedTrack))
+		s.clearSubscribedTrack(omd.(UpdateSubscribedTrackParams))
 	}
 }
 
-func (s *SubscriptionMonitor) updateSubscription(isSubscribe bool) {
+func (s *SubscriptionMonitor) updateSubscription(params SubscriptionOpParams) {
 	s.lock.Lock()
-	s.desiredTransitions.PushBack(
+
+	so := s.getOrCreateSubscriptionOpsForSource(params.SourceTrack)
+	so.desiredTransitions.PushBack(
 		&transition{
-			isSubscribe: isSubscribe,
+			isSubscribe: params.IsSubscribe,
 			at:          time.Now(),
 		},
 	)
@@ -72,17 +86,19 @@ func (s *SubscriptionMonitor) updateSubscription(isSubscribe bool) {
 	s.lock.Unlock()
 }
 
-func (s *SubscriptionMonitor) setSubscribedTrack(subTrack types.SubscribedTrack) {
+func (s *SubscriptionMonitor) setSubscribedTrack(params UpdateSubscribedTrackParams) {
 	s.lock.Lock()
-	s.subscribedTrack = subTrack
+	so := s.getOrCreateSubscriptionOpsForSource(params.SourceTrack)
+	so.subscribedTrack = params.SubscribedTrack
 	s.update()
 	s.lock.Unlock()
 }
 
-func (s *SubscriptionMonitor) clearSubscribedTrack(subTrack types.SubscribedTrack) {
+func (s *SubscriptionMonitor) clearSubscribedTrack(params UpdateSubscribedTrackParams) {
 	s.lock.Lock()
-	if s.subscribedTrack == subTrack {
-		s.subscribedTrack = nil
+	so := s.getOrCreateSubscriptionOpsForSource(params.SourceTrack)
+	if so.subscribedTrack == params.SubscribedTrack {
+		so.subscribedTrack = nil
 	} else {
 		s.params.Logger.Errorw("mismatched subscribed track on clear", nil, "trackID", s.params.TrackID)
 	}
@@ -92,37 +108,27 @@ func (s *SubscriptionMonitor) clearSubscribedTrack(subTrack types.SubscribedTrac
 }
 
 func (s *SubscriptionMonitor) Check() error {
-	s.lock.RLock()
-	if s.lastError != nil {
-		s.lock.RUnlock()
-		// return an error only once
-		return nil
-	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
-	var tx *transition
-	if s.desiredTransitions.Len() > 0 {
-		tx = s.desiredTransitions.Front().(*transition)
-	}
-	s.lock.RUnlock()
-
-	if tx == nil {
-		return nil
-	}
-
-	if time.Since(tx.at) > transitionWaitDuration {
-		// timed out waiting for transition
-		var err error
-		if tx.isSubscribe {
-			err = errSubscribeTimeout
-		} else {
-			err = errUnsubscribeTimeout
+	for _, so := range s.subscriptionOpsBySource {
+		var tx *transition
+		if so.desiredTransitions.Len() > 0 {
+			tx = so.desiredTransitions.Front().(*transition)
 		}
 
-		s.lock.Lock()
-		s.lastError = err
-		s.lock.Unlock()
+		if tx == nil {
+			continue
+		}
 
-		return err
+		if time.Since(tx.at) > transitionWaitDuration {
+			// timed out waiting for transition
+			if tx.isSubscribe {
+				return errSubscribeTimeout
+			} else {
+				return errUnsubscribeTimeout
+			}
+		}
 	}
 
 	// give more time for transition to happen
@@ -133,26 +139,46 @@ func (s *SubscriptionMonitor) IsIdle() bool {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
-	return s.desiredTransitions.Len() == 0 && s.subscribedTrack == nil
+	return len(s.subscriptionOpsBySource) == 0
+}
+
+func (s *SubscriptionMonitor) getOrCreateSubscriptionOpsForSource(sourceTrack types.MediaTrack) *subscriptionOps {
+	so := s.subscriptionOpsBySource[sourceTrack]
+	if so == nil {
+		so = &subscriptionOps{}
+		so.desiredTransitions.SetMinCapacity(4)
+		s.subscriptionOpsBySource[sourceTrack] = so
+	}
+
+	return so
 }
 
 func (s *SubscriptionMonitor) update() {
-	for {
-		var tx *transition
-		if s.desiredTransitions.Len() > 0 {
-			tx = s.desiredTransitions.PopFront().(*transition)
-		}
+	var toReap []types.MediaTrack
+	for sourceTrack, so := range s.subscriptionOpsBySource {
+		for {
+			var tx *transition
+			if so.desiredTransitions.Len() > 0 {
+				tx = so.desiredTransitions.PopFront().(*transition)
+			}
 
-		if tx == nil {
-			return
-		}
+			if tx == nil {
+				break
+			}
 
-		if (tx.isSubscribe && s.subscribedTrack == nil) || (!tx.isSubscribe && s.subscribedTrack != nil) {
-			// put it back as the condition is not satisfied
-			s.desiredTransitions.PushFront(tx)
-			return
-		}
+			if (tx.isSubscribe && so.subscribedTrack == nil) || (!tx.isSubscribe && so.subscribedTrack != nil) {
+				// put it back as the condition is not satisfied
+				so.desiredTransitions.PushFront(tx)
+				break
+			}
 
-		s.lastError = nil
+			if so.desiredTransitions.Len() == 0 && so.subscribedTrack == nil {
+				toReap = append(toReap, sourceTrack)
+			}
+		}
+	}
+
+	for _, st := range toReap {
+		delete(s.subscriptionOpsBySource, st)
 	}
 }

--- a/pkg/rtc/supervisor/subscription_monitor.go
+++ b/pkg/rtc/supervisor/subscription_monitor.go
@@ -100,7 +100,7 @@ func (s *SubscriptionMonitor) clearSubscribedTrack(params UpdateSubscribedTrackP
 	if so.subscribedTrack == params.SubscribedTrack {
 		so.subscribedTrack = nil
 	} else {
-		s.params.Logger.Errorw("mismatched subscribed track on clear", nil, "trackID", s.params.TrackID)
+		s.params.Logger.Errorw("supervisor: mismatched subscribed track on clear", nil, "trackID", s.params.TrackID)
 	}
 
 	s.update()

--- a/pkg/rtc/supervisor/subscription_monitor.go
+++ b/pkg/rtc/supervisor/subscription_monitor.go
@@ -154,7 +154,6 @@ func (s *SubscriptionMonitor) getOrCreateSubscriptionOpsForSource(sourceTrack ty
 }
 
 func (s *SubscriptionMonitor) update() {
-	var toReap []types.MediaTrack
 	for sourceTrack, so := range s.subscriptionOpsBySource {
 		for {
 			var tx *transition
@@ -173,12 +172,8 @@ func (s *SubscriptionMonitor) update() {
 			}
 
 			if so.desiredTransitions.Len() == 0 && so.subscribedTrack == nil {
-				toReap = append(toReap, sourceTrack)
+				delete(s.subscriptionOpsBySource, sourceTrack)
 			}
 		}
-	}
-
-	for _, st := range toReap {
-		delete(s.subscriptionOpsBySource, st)
 	}
 }

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -262,8 +262,8 @@ type LocalParticipant interface {
 	RemoveTrackFromSubscriber(sender *webrtc.RTPSender) error
 
 	// subscriptions
-	AddSubscribedTrack(st SubscribedTrack)
-	RemoveSubscribedTrack(st SubscribedTrack)
+	AddSubscribedTrack(st SubscribedTrack, sourceTrack MediaTrack)
+	RemoveSubscribedTrack(st SubscribedTrack, sourceTrack MediaTrack)
 	UpdateSubscribedTrackSettings(trackID livekit.TrackID, settings *livekit.UpdateTrackSettings) error
 	GetSubscribedTracks() []SubscribedTrack
 	VerifySubscribeParticipantInfo(pID livekit.ParticipantID, version uint32)
@@ -312,9 +312,10 @@ type LocalParticipant interface {
 	UncacheDownTrack(rtpTransceiver *webrtc.RTPTransceiver)
 	GetCachedDownTrack(trackID livekit.TrackID) (*webrtc.RTPTransceiver, sfu.DownTrackState)
 
-	EnqueueSubscribeTrack(trackID livekit.TrackID, isRelayed bool, f func(sub LocalParticipant) error) bool
+	EnqueueSubscribeTrack(trackID livekit.TrackID, sourceTrack MediaTrack, isRelayed bool, f func(sub LocalParticipant) error) bool
 	EnqueueUnsubscribeTrack(
 		trackID livekit.TrackID,
+		sourceTrack MediaTrack,
 		isRelayed bool,
 		willBeResumed bool,
 		f func(subscriberID livekit.ParticipantID, willBeResumed bool) error,

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -23,10 +23,11 @@ type FakeLocalParticipant struct {
 		arg1 webrtc.ICECandidateInit
 		arg2 livekit.SignalTarget
 	}
-	AddSubscribedTrackStub        func(types.SubscribedTrack)
+	AddSubscribedTrackStub        func(types.SubscribedTrack, types.MediaTrack)
 	addSubscribedTrackMutex       sync.RWMutex
 	addSubscribedTrackArgsForCall []struct {
 		arg1 types.SubscribedTrack
+		arg2 types.MediaTrack
 	}
 	AddSubscriberStub        func(types.LocalParticipant, types.AddSubscriberParams) (int, error)
 	addSubscriberMutex       sync.RWMutex
@@ -167,12 +168,13 @@ type FakeLocalParticipant struct {
 	debugInfoReturnsOnCall map[int]struct {
 		result1 map[string]interface{}
 	}
-	EnqueueSubscribeTrackStub        func(livekit.TrackID, bool, func(sub types.LocalParticipant) error) bool
+	EnqueueSubscribeTrackStub        func(livekit.TrackID, types.MediaTrack, bool, func(sub types.LocalParticipant) error) bool
 	enqueueSubscribeTrackMutex       sync.RWMutex
 	enqueueSubscribeTrackArgsForCall []struct {
 		arg1 livekit.TrackID
-		arg2 bool
-		arg3 func(sub types.LocalParticipant) error
+		arg2 types.MediaTrack
+		arg3 bool
+		arg4 func(sub types.LocalParticipant) error
 	}
 	enqueueSubscribeTrackReturns struct {
 		result1 bool
@@ -180,13 +182,14 @@ type FakeLocalParticipant struct {
 	enqueueSubscribeTrackReturnsOnCall map[int]struct {
 		result1 bool
 	}
-	EnqueueUnsubscribeTrackStub        func(livekit.TrackID, bool, bool, func(subscriberID livekit.ParticipantID, willBeResumed bool) error) bool
+	EnqueueUnsubscribeTrackStub        func(livekit.TrackID, types.MediaTrack, bool, bool, func(subscriberID livekit.ParticipantID, willBeResumed bool) error) bool
 	enqueueUnsubscribeTrackMutex       sync.RWMutex
 	enqueueUnsubscribeTrackArgsForCall []struct {
 		arg1 livekit.TrackID
-		arg2 bool
+		arg2 types.MediaTrack
 		arg3 bool
-		arg4 func(subscriberID livekit.ParticipantID, willBeResumed bool) error
+		arg4 bool
+		arg5 func(subscriberID livekit.ParticipantID, willBeResumed bool) error
 	}
 	enqueueUnsubscribeTrackReturns struct {
 		result1 bool
@@ -506,10 +509,11 @@ type FakeLocalParticipant struct {
 		arg2 bool
 		arg3 bool
 	}
-	RemoveSubscribedTrackStub        func(types.SubscribedTrack)
+	RemoveSubscribedTrackStub        func(types.SubscribedTrack, types.MediaTrack)
 	removeSubscribedTrackMutex       sync.RWMutex
 	removeSubscribedTrackArgsForCall []struct {
 		arg1 types.SubscribedTrack
+		arg2 types.MediaTrack
 	}
 	RemoveSubscriberStub        func(types.LocalParticipant, livekit.TrackID, bool)
 	removeSubscriberMutex       sync.RWMutex
@@ -827,16 +831,17 @@ func (fake *FakeLocalParticipant) AddICECandidateArgsForCall(i int) (webrtc.ICEC
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeLocalParticipant) AddSubscribedTrack(arg1 types.SubscribedTrack) {
+func (fake *FakeLocalParticipant) AddSubscribedTrack(arg1 types.SubscribedTrack, arg2 types.MediaTrack) {
 	fake.addSubscribedTrackMutex.Lock()
 	fake.addSubscribedTrackArgsForCall = append(fake.addSubscribedTrackArgsForCall, struct {
 		arg1 types.SubscribedTrack
-	}{arg1})
+		arg2 types.MediaTrack
+	}{arg1, arg2})
 	stub := fake.AddSubscribedTrackStub
-	fake.recordInvocation("AddSubscribedTrack", []interface{}{arg1})
+	fake.recordInvocation("AddSubscribedTrack", []interface{}{arg1, arg2})
 	fake.addSubscribedTrackMutex.Unlock()
 	if stub != nil {
-		fake.AddSubscribedTrackStub(arg1)
+		fake.AddSubscribedTrackStub(arg1, arg2)
 	}
 }
 
@@ -846,17 +851,17 @@ func (fake *FakeLocalParticipant) AddSubscribedTrackCallCount() int {
 	return len(fake.addSubscribedTrackArgsForCall)
 }
 
-func (fake *FakeLocalParticipant) AddSubscribedTrackCalls(stub func(types.SubscribedTrack)) {
+func (fake *FakeLocalParticipant) AddSubscribedTrackCalls(stub func(types.SubscribedTrack, types.MediaTrack)) {
 	fake.addSubscribedTrackMutex.Lock()
 	defer fake.addSubscribedTrackMutex.Unlock()
 	fake.AddSubscribedTrackStub = stub
 }
 
-func (fake *FakeLocalParticipant) AddSubscribedTrackArgsForCall(i int) types.SubscribedTrack {
+func (fake *FakeLocalParticipant) AddSubscribedTrackArgsForCall(i int) (types.SubscribedTrack, types.MediaTrack) {
 	fake.addSubscribedTrackMutex.RLock()
 	defer fake.addSubscribedTrackMutex.RUnlock()
 	argsForCall := fake.addSubscribedTrackArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeLocalParticipant) AddSubscriber(arg1 types.LocalParticipant, arg2 types.AddSubscriberParams) (int, error) {
@@ -1562,20 +1567,21 @@ func (fake *FakeLocalParticipant) DebugInfoReturnsOnCall(i int, result1 map[stri
 	}{result1}
 }
 
-func (fake *FakeLocalParticipant) EnqueueSubscribeTrack(arg1 livekit.TrackID, arg2 bool, arg3 func(sub types.LocalParticipant) error) bool {
+func (fake *FakeLocalParticipant) EnqueueSubscribeTrack(arg1 livekit.TrackID, arg2 types.MediaTrack, arg3 bool, arg4 func(sub types.LocalParticipant) error) bool {
 	fake.enqueueSubscribeTrackMutex.Lock()
 	ret, specificReturn := fake.enqueueSubscribeTrackReturnsOnCall[len(fake.enqueueSubscribeTrackArgsForCall)]
 	fake.enqueueSubscribeTrackArgsForCall = append(fake.enqueueSubscribeTrackArgsForCall, struct {
 		arg1 livekit.TrackID
-		arg2 bool
-		arg3 func(sub types.LocalParticipant) error
-	}{arg1, arg2, arg3})
+		arg2 types.MediaTrack
+		arg3 bool
+		arg4 func(sub types.LocalParticipant) error
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.EnqueueSubscribeTrackStub
 	fakeReturns := fake.enqueueSubscribeTrackReturns
-	fake.recordInvocation("EnqueueSubscribeTrack", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("EnqueueSubscribeTrack", []interface{}{arg1, arg2, arg3, arg4})
 	fake.enqueueSubscribeTrackMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
@@ -1589,17 +1595,17 @@ func (fake *FakeLocalParticipant) EnqueueSubscribeTrackCallCount() int {
 	return len(fake.enqueueSubscribeTrackArgsForCall)
 }
 
-func (fake *FakeLocalParticipant) EnqueueSubscribeTrackCalls(stub func(livekit.TrackID, bool, func(sub types.LocalParticipant) error) bool) {
+func (fake *FakeLocalParticipant) EnqueueSubscribeTrackCalls(stub func(livekit.TrackID, types.MediaTrack, bool, func(sub types.LocalParticipant) error) bool) {
 	fake.enqueueSubscribeTrackMutex.Lock()
 	defer fake.enqueueSubscribeTrackMutex.Unlock()
 	fake.EnqueueSubscribeTrackStub = stub
 }
 
-func (fake *FakeLocalParticipant) EnqueueSubscribeTrackArgsForCall(i int) (livekit.TrackID, bool, func(sub types.LocalParticipant) error) {
+func (fake *FakeLocalParticipant) EnqueueSubscribeTrackArgsForCall(i int) (livekit.TrackID, types.MediaTrack, bool, func(sub types.LocalParticipant) error) {
 	fake.enqueueSubscribeTrackMutex.RLock()
 	defer fake.enqueueSubscribeTrackMutex.RUnlock()
 	argsForCall := fake.enqueueSubscribeTrackArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeLocalParticipant) EnqueueSubscribeTrackReturns(result1 bool) {
@@ -1625,21 +1631,22 @@ func (fake *FakeLocalParticipant) EnqueueSubscribeTrackReturnsOnCall(i int, resu
 	}{result1}
 }
 
-func (fake *FakeLocalParticipant) EnqueueUnsubscribeTrack(arg1 livekit.TrackID, arg2 bool, arg3 bool, arg4 func(subscriberID livekit.ParticipantID, willBeResumed bool) error) bool {
+func (fake *FakeLocalParticipant) EnqueueUnsubscribeTrack(arg1 livekit.TrackID, arg2 types.MediaTrack, arg3 bool, arg4 bool, arg5 func(subscriberID livekit.ParticipantID, willBeResumed bool) error) bool {
 	fake.enqueueUnsubscribeTrackMutex.Lock()
 	ret, specificReturn := fake.enqueueUnsubscribeTrackReturnsOnCall[len(fake.enqueueUnsubscribeTrackArgsForCall)]
 	fake.enqueueUnsubscribeTrackArgsForCall = append(fake.enqueueUnsubscribeTrackArgsForCall, struct {
 		arg1 livekit.TrackID
-		arg2 bool
+		arg2 types.MediaTrack
 		arg3 bool
-		arg4 func(subscriberID livekit.ParticipantID, willBeResumed bool) error
-	}{arg1, arg2, arg3, arg4})
+		arg4 bool
+		arg5 func(subscriberID livekit.ParticipantID, willBeResumed bool) error
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.EnqueueUnsubscribeTrackStub
 	fakeReturns := fake.enqueueUnsubscribeTrackReturns
-	fake.recordInvocation("EnqueueUnsubscribeTrack", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("EnqueueUnsubscribeTrack", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.enqueueUnsubscribeTrackMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
@@ -1653,17 +1660,17 @@ func (fake *FakeLocalParticipant) EnqueueUnsubscribeTrackCallCount() int {
 	return len(fake.enqueueUnsubscribeTrackArgsForCall)
 }
 
-func (fake *FakeLocalParticipant) EnqueueUnsubscribeTrackCalls(stub func(livekit.TrackID, bool, bool, func(subscriberID livekit.ParticipantID, willBeResumed bool) error) bool) {
+func (fake *FakeLocalParticipant) EnqueueUnsubscribeTrackCalls(stub func(livekit.TrackID, types.MediaTrack, bool, bool, func(subscriberID livekit.ParticipantID, willBeResumed bool) error) bool) {
 	fake.enqueueUnsubscribeTrackMutex.Lock()
 	defer fake.enqueueUnsubscribeTrackMutex.Unlock()
 	fake.EnqueueUnsubscribeTrackStub = stub
 }
 
-func (fake *FakeLocalParticipant) EnqueueUnsubscribeTrackArgsForCall(i int) (livekit.TrackID, bool, bool, func(subscriberID livekit.ParticipantID, willBeResumed bool) error) {
+func (fake *FakeLocalParticipant) EnqueueUnsubscribeTrackArgsForCall(i int) (livekit.TrackID, types.MediaTrack, bool, bool, func(subscriberID livekit.ParticipantID, willBeResumed bool) error) {
 	fake.enqueueUnsubscribeTrackMutex.RLock()
 	defer fake.enqueueUnsubscribeTrackMutex.RUnlock()
 	argsForCall := fake.enqueueUnsubscribeTrackArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeLocalParticipant) EnqueueUnsubscribeTrackReturns(result1 bool) {
@@ -3409,16 +3416,17 @@ func (fake *FakeLocalParticipant) RemovePublishedTrackArgsForCall(i int) (types.
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeLocalParticipant) RemoveSubscribedTrack(arg1 types.SubscribedTrack) {
+func (fake *FakeLocalParticipant) RemoveSubscribedTrack(arg1 types.SubscribedTrack, arg2 types.MediaTrack) {
 	fake.removeSubscribedTrackMutex.Lock()
 	fake.removeSubscribedTrackArgsForCall = append(fake.removeSubscribedTrackArgsForCall, struct {
 		arg1 types.SubscribedTrack
-	}{arg1})
+		arg2 types.MediaTrack
+	}{arg1, arg2})
 	stub := fake.RemoveSubscribedTrackStub
-	fake.recordInvocation("RemoveSubscribedTrack", []interface{}{arg1})
+	fake.recordInvocation("RemoveSubscribedTrack", []interface{}{arg1, arg2})
 	fake.removeSubscribedTrackMutex.Unlock()
 	if stub != nil {
-		fake.RemoveSubscribedTrackStub(arg1)
+		fake.RemoveSubscribedTrackStub(arg1, arg2)
 	}
 }
 
@@ -3428,17 +3436,17 @@ func (fake *FakeLocalParticipant) RemoveSubscribedTrackCallCount() int {
 	return len(fake.removeSubscribedTrackArgsForCall)
 }
 
-func (fake *FakeLocalParticipant) RemoveSubscribedTrackCalls(stub func(types.SubscribedTrack)) {
+func (fake *FakeLocalParticipant) RemoveSubscribedTrackCalls(stub func(types.SubscribedTrack, types.MediaTrack)) {
 	fake.removeSubscribedTrackMutex.Lock()
 	defer fake.removeSubscribedTrackMutex.Unlock()
 	fake.RemoveSubscribedTrackStub = stub
 }
 
-func (fake *FakeLocalParticipant) RemoveSubscribedTrackArgsForCall(i int) types.SubscribedTrack {
+func (fake *FakeLocalParticipant) RemoveSubscribedTrackArgsForCall(i int) (types.SubscribedTrack, types.MediaTrack) {
 	fake.removeSubscribedTrackMutex.RLock()
 	defer fake.removeSubscribedTrackMutex.RUnlock()
 	argsForCall := fake.removeSubscribedTrackArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeLocalParticipant) RemoveSubscriber(arg1 types.LocalParticipant, arg2 livekit.TrackID, arg3 bool) {

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -285,6 +285,11 @@ func (r *RoomManager) StartSession(
 	if r.config.RTC.ReconnectOnPublicationError != nil {
 		reconnectOnPublicationError = *r.config.RTC.ReconnectOnPublicationError
 	}
+	// default do not force full reconnect on a subscription error
+	reconnectOnSubscriptionError := false
+	if r.config.RTC.ReconnectOnSubscriptionError != nil {
+		reconnectOnSubscriptionError = *r.config.RTC.ReconnectOnSubscriptionError
+	}
 	participant, err = rtc.NewParticipant(rtc.ParticipantParams{
 		Identity:                pi.Identity,
 		Name:                    pi.Name,
@@ -312,7 +317,8 @@ func (r *RoomManager) StartSession(
 			}
 			return nil
 		},
-		ReconnectOnPublicationError: reconnectOnPublicationError,
+		ReconnectOnPublicationError:  reconnectOnPublicationError,
+		ReconnectOnSubscriptionError: reconnectOnSubscriptionError,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Subscriptions are a bit complex. There are a few challenges to tackle
- Repeated subscriptions
- Switching subscription from remote -> local or vice-versa
- Multiple unsubscriptions (because of removing subscriber and removing all subscribers when publishing track goes away)
- As all subscribe operations are queued, cannot determine if something is a duplicate when queuing the operation.
- DownTrack close happen in other paths by just calling `DownTrack.Close()` where the supervisor does not know about a transition.

Given these, doing a simple desired vs actual becomes quite tricky. Actually, that is one of the reasons I had done the transitions queue and ensuring expected transitions happen accounting for duplicate transitions too. I am sure there is simplification possible, but given the complexity of this, taking a smaller step described below. Can iterate to potentially make things simpler over time.

From logs of sessions, the only issue seems to be unsubscribe timing out. That happens with migration when source switches from remote -> local or vice-versa because the previous source does an unsubscribe transisiton, but the new source is already set.

The solution to that is to maintain expected transitions per source track and ensure those happen properly. Implementing that change here.

Also a couple of other things
- Some clean up
- Introduce a config to issue a full reconnect on subscription failure. Not enabled by default. Can be enabled after monitoring sessions for false negatives.