### PR TITLE
Check for not nil ICECandidatePair

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -970,7 +970,7 @@ func (t *PCTransport) GetICEConnectionType() types.ICEConnectionType {
 		return unknown
 	}
 	p, err := t.getSelectedPair()
-	if err != nil {
+	if err != nil || p == nil {
 		return unknown
 	}
 


### PR DESCRIPTION
GetSelectedICECandidatePair can return nil for the candidate pair if not available even if the error is nil. Protect against the nil de-reference panic.