### PR TITLE
send padding packets of muted uptrack for go sdk

### DIFF
--- a/pkg/rtc/clientinfo.go
+++ b/pkg/rtc/clientinfo.go
@@ -19,12 +19,21 @@ func (c ClientInfo) isSafari() bool {
 	return c.ClientInfo != nil && strings.EqualFold(c.ClientInfo.Browser, "safari")
 }
 
+func (c ClientInfo) isGo() bool {
+	return c.ClientInfo != nil && c.ClientInfo.Sdk == livekit.ClientInfo_GO
+}
+
 func (c ClientInfo) SupportsAudioRED() bool {
 	return !c.isFirefox() && !c.isSafari()
 }
 
 func (c ClientInfo) SupportPrflxOverRelay() bool {
 	return !c.isFirefox()
+}
+
+// GoSDK(pion) relies on rtp packets to fire ontrack event, browsers and native (libwebrtc) rely on sdp
+func (c ClientInfo) FireTrackByRTPPacket() bool {
+	return c.isGo()
 }
 
 // CompareVersion compares two semver versions

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -970,6 +970,10 @@ func (p *ParticipantImpl) AddSubscribedTrack(subTrack types.SubscribedTrack, sou
 	settings := p.subscribedTracksSettings[subTrack.ID()]
 	p.lock.Unlock()
 
+	if p.params.ClientInfo.FireTrackByRTPPacket() {
+		subTrack.DownTrack().SetActivePaddingOnMuteUpTrack()
+	}
+
 	subTrack.OnBind(func() {
 		if p.TransportManager.HasSubscriberEverConnected() {
 			subTrack.DownTrack().SetConnected()

--- a/pkg/sfu/streamallocator.go
+++ b/pkg/sfu/streamallocator.go
@@ -1351,7 +1351,7 @@ func (t *Track) SetMaxLayers(layers VideoLayers) bool {
 }
 
 func (t *Track) WritePaddingRTP(bytesToSend int) int {
-	return t.downTrack.WritePaddingRTP(bytesToSend)
+	return t.downTrack.WritePaddingRTP(bytesToSend, false)
 }
 
 func (t *Track) AllocateOptimal(allowOvershoot bool) VideoAllocation {


### PR DESCRIPTION
Browser use sdp to fire tracks, but pion relies on the rtp packets to fire it. If a client based on go-sdk subscribed a muted video track, it will not fire `OnTrack` event until the publisher unmute it, so we send padding packet for the track to help the client in this case