### PR TITLE
Do not get tripped by default values.

### DIFF
--- a/pkg/rtc/signaldeduper/subscriptiondeduper_test.go
+++ b/pkg/rtc/signaldeduper/subscriptiondeduper_test.go
@@ -74,8 +74,21 @@ func TestSubscriptionDeduper(t *testing.T) {
 		}
 		require.True(t, sd.Dedupe("p0", us))
 
-		// update track settings, should not be a dupe
+		// update track settings with quality, should not be a dupe
 		uts := &livekit.SignalRequest{
+			Message: &livekit.SignalRequest_TrackSetting{
+				TrackSetting: &livekit.UpdateTrackSettings{
+					TrackSids: []string{
+						"p1.track1",
+					},
+					Quality: livekit.VideoQuality_LOW,
+				},
+			},
+		}
+		require.False(t, sd.Dedupe("p0", uts))
+
+		// update track settings with dimensions, should not be a dupe
+		uts = &livekit.SignalRequest{
 			Message: &livekit.SignalRequest_TrackSetting{
 				TrackSetting: &livekit.UpdateTrackSettings{
 					TrackSids: []string{


### PR DESCRIPTION
The following scenario declared the second message a dupe incorrectly
- UpdateSubscription{subscribe: true}: This message initialized quality to default which is livekit.VideoQuality_LOW
- UpdateTrackSettings{quality: livekit.VideoQuality_LOW} - this one got tripped as duplicate because the previous message initialized quality to LOW.

Fix it by recording whether track settings have been seen.

no auto subscribe + quality setting to LOW test failed before this change and passes with this change.