### PR TITLE
add memory used and total to node stats

### DIFF
--- a/cmd/server/commands.go
+++ b/cmd/server/commands.go
@@ -170,7 +170,8 @@ func listNodes(c *cli.Context) error {
 	table.SetAutoWrapText(false)
 	table.SetHeader([]string{
 		"ID", "IP Address", "Region",
-		"CPUs", "CPU Usage\nLoad Avg", "Memory Used/Total",
+		"CPUs", "CPU Usage\nLoad Avg",
+		"Memory Used/Total",
 		"Rooms", "Clients\nTracks In/Out",
 		"Bytes/s In/Out\nBytes Total", "Packets/s In/Out\nPackets Total", "System Dropped Pkts/s\nPkts/s Out/Dropped",
 		"Nack/s\nNack Total", "Retrans/s\nRetrans Total",
@@ -179,9 +180,9 @@ func listNodes(c *cli.Context) error {
 	table.SetColumnAlignment([]int{
 		tablewriter.ALIGN_CENTER, tablewriter.ALIGN_CENTER, tablewriter.ALIGN_CENTER,
 		tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT,
+		tablewriter.ALIGN_RIGHT,
 		tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT,
-		tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT,
-		tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT,
+		tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT,
 		tablewriter.ALIGN_RIGHT, tablewriter.ALIGN_RIGHT,
 		tablewriter.ALIGN_CENTER,
 	})
@@ -217,7 +218,8 @@ func listNodes(c *cli.Context) error {
 
 		table.Append([]string{
 			idAndState, node.Ip, node.Region,
-			cpus, cpuUsageAndLoadAvg, memUsage,
+			cpus, cpuUsageAndLoadAvg,
+			memUsage,
 			rooms, clientsAndTracks,
 			bytes, packets, sysPackets,
 			nacks, retransmit,

--- a/cmd/server/commands.go
+++ b/cmd/server/commands.go
@@ -170,9 +170,9 @@ func listNodes(c *cli.Context) error {
 	table.SetAutoWrapText(false)
 	table.SetHeader([]string{
 		"ID", "IP Address", "Region",
-		"CPUs", "CPU Usage\nLoad Avg",
+		"CPUs", "CPU Usage\nLoad Avg", "Memory Used/Total",
 		"Rooms", "Clients\nTracks In/Out",
-		"Bytes/s In/Out\nBytes Total", "Packets/s In/Out\nPackets Total", "System Dropped Pkts/s\nPkts/s Out / Dropped",
+		"Bytes/s In/Out\nBytes Total", "Packets/s In/Out\nPackets Total", "System Dropped Pkts/s\nPkts/s Out/Dropped",
 		"Nack/s\nNack Total", "Retrans/s\nRetrans Total",
 		"Started At\nUpdated At",
 	})
@@ -196,6 +196,7 @@ func listNodes(c *cli.Context) error {
 		cpus := strconv.Itoa(int(stats.NumCpus))
 		cpuUsageAndLoadAvg := fmt.Sprintf("%.2f %%\n%.2f %.2f %.2f", stats.CpuLoad*100,
 			stats.LoadAvgLast1Min, stats.LoadAvgLast5Min, stats.LoadAvgLast15Min)
+		memUsage := fmt.Sprintf("%s / %s", humanize.Bytes(stats.MemoryUsed), humanize.Bytes(stats.MemoryTotal))
 
 		// Room stats
 		rooms := strconv.Itoa(int(stats.NumRooms))
@@ -216,7 +217,7 @@ func listNodes(c *cli.Context) error {
 
 		table.Append([]string{
 			idAndState, node.Ip, node.Region,
-			cpus, cpuUsageAndLoadAvg,
+			cpus, cpuUsageAndLoadAvg, memUsage,
 			rooms, clientsAndTracks,
 			bytes, packets, sysPackets,
 			nacks, retransmit,

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20221221221243-f361fbe40290
 	github.com/livekit/mediatransportutil v0.0.0-20221007030528-7440725c362b
-	github.com/livekit/protocol v1.3.2-0.20230110060522-23a19c1d2445
+	github.com/livekit/protocol v1.3.2-0.20230110201647-34cae0997a36
 	github.com/livekit/psrpc v0.2.1
 	github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995
 	github.com/mackerelio/go-osstat v0.2.3

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20221221221243-f361fbe40290
 	github.com/livekit/mediatransportutil v0.0.0-20221007030528-7440725c362b
-	github.com/livekit/protocol v1.3.2-0.20221228091932-fa87d56355d2
+	github.com/livekit/protocol v1.3.2-0.20230110060522-23a19c1d2445
 	github.com/livekit/psrpc v0.2.1
 	github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995
 	github.com/mackerelio/go-osstat v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/livekit/mageutil v0.0.0-20221221221243-f361fbe40290 h1:ZVsQUuUOM9G7O3
 github.com/livekit/mageutil v0.0.0-20221221221243-f361fbe40290/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20221007030528-7440725c362b h1:RBNV8TckETSkIkKxcD12d8nZKVkB9GSY/sQlMoaruP4=
 github.com/livekit/mediatransportutil v0.0.0-20221007030528-7440725c362b/go.mod h1:1Dlx20JPoIKGP45eo+yuj0HjeE25zmyeX/EWHiPCjFw=
-github.com/livekit/protocol v1.3.2-0.20221228091932-fa87d56355d2 h1:Kj7tg1YxRZFeTQLJNm8x8KIdhFTgLCQ6QFNDio/2bOM=
-github.com/livekit/protocol v1.3.2-0.20221228091932-fa87d56355d2/go.mod h1:gwCG03nKlHlC9hTjL4pXQpn783ALhmbyhq65UZxqbb8=
+github.com/livekit/protocol v1.3.2-0.20230110060522-23a19c1d2445 h1:RId8pj78JzhcaXPazkB0TWjggRLQHT4AELZxpN8yzKs=
+github.com/livekit/protocol v1.3.2-0.20230110060522-23a19c1d2445/go.mod h1:gwCG03nKlHlC9hTjL4pXQpn783ALhmbyhq65UZxqbb8=
 github.com/livekit/psrpc v0.2.1 h1:ph/4egUMueUPoh5PZ/Aw4v6SH3wAbA+2t/GyCbpPKTg=
 github.com/livekit/psrpc v0.2.1/go.mod h1:MCe0xLdFPXmzogPiLrM94JIJbctb9+fAv5qYPkY2DXw=
 github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995 h1:vOaY2qvfLihDyeZtnGGN1Law9wRrw8BMGCr1TygTvMw=

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/livekit/mageutil v0.0.0-20221221221243-f361fbe40290 h1:ZVsQUuUOM9G7O3
 github.com/livekit/mageutil v0.0.0-20221221221243-f361fbe40290/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20221007030528-7440725c362b h1:RBNV8TckETSkIkKxcD12d8nZKVkB9GSY/sQlMoaruP4=
 github.com/livekit/mediatransportutil v0.0.0-20221007030528-7440725c362b/go.mod h1:1Dlx20JPoIKGP45eo+yuj0HjeE25zmyeX/EWHiPCjFw=
-github.com/livekit/protocol v1.3.2-0.20230110060522-23a19c1d2445 h1:RId8pj78JzhcaXPazkB0TWjggRLQHT4AELZxpN8yzKs=
-github.com/livekit/protocol v1.3.2-0.20230110060522-23a19c1d2445/go.mod h1:gwCG03nKlHlC9hTjL4pXQpn783ALhmbyhq65UZxqbb8=
+github.com/livekit/protocol v1.3.2-0.20230110201647-34cae0997a36 h1:SlWsB3XEt4fYYkcCeCES2V8CFkRYcX0ThdkNqWP4MPg=
+github.com/livekit/protocol v1.3.2-0.20230110201647-34cae0997a36/go.mod h1:gwCG03nKlHlC9hTjL4pXQpn783ALhmbyhq65UZxqbb8=
 github.com/livekit/psrpc v0.2.1 h1:ph/4egUMueUPoh5PZ/Aw4v6SH3wAbA+2t/GyCbpPKTg=
 github.com/livekit/psrpc v0.2.1/go.mod h1:MCe0xLdFPXmzogPiLrM94JIJbctb9+fAv5qYPkY2DXw=
 github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995 h1:vOaY2qvfLihDyeZtnGGN1Law9wRrw8BMGCr1TygTvMw=

--- a/pkg/telemetry/prometheus/node.go
+++ b/pkg/telemetry/prometheus/node.go
@@ -85,18 +85,6 @@ func Init(nodeID string, nodeType livekit.NodeType) {
 	initRoomStats(nodeID, nodeType)
 }
 
-func getMemoryStats() (memoryLoad float32, err error) {
-	memInfo, err := memory.Get()
-	if err != nil {
-		return
-	}
-
-	if memInfo.Total != 0 {
-		memoryLoad = float32(memInfo.Used) / float32(memInfo.Total)
-	}
-	return
-}
-
 func GetUpdatedNodeStats(prev *livekit.NodeStats, prevAverage *livekit.NodeStats) (*livekit.NodeStats, bool, error) {
 	loadAvg, err := loadavg.Get()
 	if err != nil {
@@ -108,9 +96,9 @@ func GetUpdatedNodeStats(prev *livekit.NodeStats, prevAverage *livekit.NodeStats
 		return nil, false, err
 	}
 
-	memoryLoad, _ := getMemoryStats()
 	// On MacOS, get "\"vm_stat\": executable file not found in $PATH" although it is in /usr/bin
 	// So, do not error out. Use the information if it is available.
+	memInfo, _ := memory.Get()
 
 	sysPackets, sysDroppedPackets, err := getTCStats()
 	if err != nil {
@@ -166,12 +154,13 @@ func GetUpdatedNodeStats(prev *livekit.NodeStats, prevAverage *livekit.NodeStats
 		ParticipantJoinPerSec:      prevAverage.ParticipantJoinPerSec,
 		NumCpus:                    numCPUs,
 		CpuLoad:                    cpuLoad,
+		MemoryTotal:                memInfo.Total,
+		MemoryUsed:                 memInfo.Used,
 		LoadAvgLast1Min:            float32(loadAvg.Loadavg1),
 		LoadAvgLast5Min:            float32(loadAvg.Loadavg5),
 		LoadAvgLast15Min:           float32(loadAvg.Loadavg15),
 		SysPacketsOut:              sysPackets,
 		SysPacketsDropped:          sysDroppedPackets,
-		MemoryLoad:                 memoryLoad,
 	}
 
 	// update stats


### PR DESCRIPTION
depends on https://github.com/livekit/protocol/pull/269

```
> ./bin/livekit-server --redis-host localhost:6379 --dev list-nodes
2023-01-09T22:22:38.116-0800	INFO	livekit	server/main.go:191	starting in development mode
2023-01-09T22:22:38.116-0800	INFO	livekit	server/main.go:194	no keys provided, using placeholder keys	{"API Key": "devkey", "API Secret": "secret"}
2023-01-09T22:22:38.116-0800	INFO	livekit	redis/redis.go:82	connecting to redis	{"simple": true, "addr": "localhost:6379"}
+-------------+---------------+--------+------+----------------+-------------------+-------+---------------+----------------+------------------+-----------------------+------------+---------------+---------------------+
|     ID      |  IP ADDRESS   | REGION | CPUS |   CPU USAGE    | MEMORY USED/TOTAL | ROOMS |    CLIENTS    | BYTES/S IN/OUT | PACKETS/S IN/OUT | SYSTEM DROPPED PKTS/S |   NACK/S   |   RETRANS/S   |     STARTED AT      |
|             |               |        |      |    LOAD AVG    |                   |       | TRACKS IN/OUT |  BYTES TOTAL   |  PACKETS TOTAL   |  PKTS/S OUT/DROPPED   | NACK TOTAL | RETRANS TOTAL |     UPDATED AT      |
+-------------+---------------+--------+------+----------------+-------------------+-------+---------------+----------------+------------------+-----------------------+------------+---------------+---------------------+
| ND_kGcb4fFz | xxx.xxx.x.xxx |        |   10 |         7.31 % |     13 GB / 16 GB |     0 |             0 |  0 Bps / 0 Bps |            0 / 0 |                0.00 % |       0.00 |          0.00 | 2023-01-10 06:21:44 |
|  (SERVING)  |               |        |      | 1.90 2.35 2.29 |                   |       |         0 / 0 |      0 B / 0 B |            0 / 0 |                 0 / 0 |          0 |             0 | 2023-01-10 06:22:37 |
+-------------+---------------+--------+------+----------------+-------------------+-------+---------------+----------------+------------------+-----------------------+------------+---------------+---------------------+
```