### PR TITLE
Fix handling of non-monotonic timestamps

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -24,6 +24,7 @@ import (
 	"github.com/livekit/livekit-server/pkg/sfu/buffer"
 	"github.com/livekit/livekit-server/pkg/sfu/connectionquality"
 	"github.com/livekit/livekit-server/pkg/telemetry"
+	utils2 "github.com/livekit/livekit-server/pkg/utils"
 	"github.com/livekit/mediatransportutil/pkg/twcc"
 	"github.com/livekit/protocol/auth"
 	"github.com/livekit/protocol/livekit"
@@ -90,6 +91,7 @@ type ParticipantParams struct {
 	GetParticipantInfo           func(pID livekit.ParticipantID) *livekit.ParticipantInfo
 	ReconnectOnPublicationError  bool
 	ReconnectOnSubscriptionError bool
+	VersionGenerator             utils2.TimedVersionGenerator
 }
 
 type ParticipantImpl struct {
@@ -1191,8 +1193,9 @@ func (p *ParticipantImpl) setupTransportManager() error {
 
 func (p *ParticipantImpl) setupUpTrackManager() {
 	p.UpTrackManager = NewUpTrackManager(UpTrackManagerParams{
-		SID:    p.params.SID,
-		Logger: p.params.Logger,
+		SID:              p.params.SID,
+		Logger:           p.params.Logger,
+		VersionGenerator: p.params.VersionGenerator,
 	})
 
 	p.UpTrackManager.OnPublishedTrackUpdated(func(track types.MediaTrack, onlyIfReady bool) {

--- a/pkg/rtc/uptrackmanager.go
+++ b/pkg/rtc/uptrackmanager.go
@@ -221,16 +221,17 @@ func (u *UpTrackManager) UpdateSubscriptionPermission(
 				u.lock.Unlock()
 				return nil
 			}
-			u.subscriptionPermissionVersion.Update(time.UnixMicro(timedVersion.UnixMicro))
+			u.subscriptionPermissionVersion.Update(tv)
 		} else {
 			u.subscriptionPermissionVersion = utils.NewTimedVersionFromProto(timedVersion)
 		}
 	} else {
+		tv := utils.NewTimedVersion(time.Now(), 0)
 		// use current time as the new/updated version
 		if u.subscriptionPermissionVersion == nil {
-			u.subscriptionPermissionVersion = utils.NewTimedVersion(time.Now(), 0)
+			u.subscriptionPermissionVersion = tv
 		} else {
-			u.subscriptionPermissionVersion.Update(time.Now())
+			u.subscriptionPermissionVersion.Update(tv)
 		}
 	}
 

--- a/pkg/rtc/uptrackmanager_test.go
+++ b/pkg/rtc/uptrackmanager_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/livekit/livekit-server/pkg/utils"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 
@@ -13,7 +14,8 @@ import (
 )
 
 var defaultUptrackManagerParams = UpTrackManagerParams{
-	Logger: logger.GetLogger(),
+	Logger:           logger.GetLogger(),
+	VersionGenerator: utils.NewDefaultTimedVersionGenerator(),
 }
 
 func TestUpdateSubscriptionPermission(t *testing.T) {

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/livekit/livekit-server/pkg/telemetry/prometheus"
+	serverutils "github.com/livekit/livekit-server/pkg/utils"
 	"github.com/livekit/livekit-server/version"
 	"github.com/livekit/protocol/auth"
 	"github.com/livekit/protocol/livekit"
@@ -49,6 +50,7 @@ type RoomManager struct {
 	telemetry         telemetry.TelemetryService
 	clientConfManager clientconfiguration.ClientConfigurationManager
 	egressLauncher    rtc.EgressLauncher
+	versionGenerator  serverutils.TimedVersionGenerator
 
 	rooms map[livekit.RoomName]*rtc.Room
 
@@ -63,8 +65,8 @@ func NewLocalRoomManager(
 	telemetry telemetry.TelemetryService,
 	clientConfManager clientconfiguration.ClientConfigurationManager,
 	egressLauncher rtc.EgressLauncher,
+	versionGenerator serverutils.TimedVersionGenerator,
 ) (*RoomManager, error) {
-
 	rtcConf, err := rtc.NewWebRTCConfig(conf, currentNode.Ip)
 	if err != nil {
 		return nil, err
@@ -79,6 +81,7 @@ func NewLocalRoomManager(
 		telemetry:         telemetry,
 		clientConfManager: clientConfManager,
 		egressLauncher:    egressLauncher,
+		versionGenerator:  versionGenerator,
 
 		rooms: make(map[livekit.RoomName]*rtc.Room),
 
@@ -326,6 +329,7 @@ func (r *RoomManager) StartSession(
 		},
 		ReconnectOnPublicationError:  reconnectOnPublicationError,
 		ReconnectOnSubscriptionError: reconnectOnSubscriptionError,
+		VersionGenerator:             r.versionGenerator,
 	})
 	if err != nil {
 		return err

--- a/pkg/service/wire.go
+++ b/pkg/service/wire.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/livekit/livekit-server/pkg/service/rpc"
+	"github.com/livekit/livekit-server/pkg/utils"
 	"github.com/livekit/protocol/auth"
 	"github.com/livekit/protocol/egress"
 	"github.com/livekit/protocol/ingress"
@@ -61,6 +62,7 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 		NewLocalRoomManager,
 		newTurnAuthHandler,
 		newInProcessTurnServer,
+		utils.NewDefaultTimedVersionGenerator,
 		NewLivekitServer,
 	)
 	return &LivekitServer{}, nil

--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -14,6 +14,7 @@ import (
 	"github.com/livekit/livekit-server/pkg/routing"
 	"github.com/livekit/livekit-server/pkg/service/rpc"
 	"github.com/livekit/livekit-server/pkg/telemetry"
+	"github.com/livekit/livekit-server/pkg/utils"
 	"github.com/livekit/protocol/auth"
 	"github.com/livekit/protocol/egress"
 	"github.com/livekit/protocol/ingress"
@@ -77,7 +78,8 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	ingressService := NewIngressService(ingressConfig, ingressRPCClient, ingressStore, roomService, telemetryService)
 	rtcService := NewRTCService(conf, roomAllocator, objectStore, router, currentNode, telemetryService)
 	clientConfigurationManager := createClientConfiguration()
-	roomManager, err := NewLocalRoomManager(conf, objectStore, currentNode, router, telemetryService, clientConfigurationManager, rtcEgressLauncher)
+	timedVersionGenerator := utils.NewDefaultTimedVersionGenerator()
+	roomManager, err := NewLocalRoomManager(conf, objectStore, currentNode, router, telemetryService, clientConfigurationManager, rtcEgressLauncher, timedVersionGenerator)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Timed version is inspired by Hybrid Clock. We used to have a mixed behavior by using time.Time:
* during local comparisons, it does increment monotonically
* when deserializing remote timestamps, we lose that attribute

So it's possible for two requests to be sent in the same microsecond, and for the latter one to be dropped.

To fix that behavior, I'm switching it to keeping timestamps for consistency, and accepting multiple updates in the same ms by incrementing ticks.