### PR TITLE
Added track success & muted events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
+replace github.com/livekit/protocol => ../protocol
+
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20221221221243-f361fbe40290
 	github.com/livekit/mediatransportutil v0.0.0-20230111071722-904079e94a7c
-	github.com/livekit/protocol v1.3.2-0.20230111195642-abfad31c5f93
+	github.com/livekit/protocol v1.3.2-0.20230115231942-8a49ab3e6c26
 	github.com/livekit/psrpc v0.2.1
 	github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995
 	github.com/mackerelio/go-osstat v0.2.3
@@ -52,8 +52,6 @@ require (
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/yaml.v3 v3.0.1
 )
-
-replace github.com/livekit/protocol => ../protocol
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20221221221243-f361fbe40290
 	github.com/livekit/mediatransportutil v0.0.0-20230111071722-904079e94a7c
-	github.com/livekit/protocol v1.3.2-0.20230115231942-8a49ab3e6c26
+	github.com/livekit/protocol v1.3.2
 	github.com/livekit/psrpc v0.2.1
 	github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995
 	github.com/mackerelio/go-osstat v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/livekit/mageutil v0.0.0-20221221221243-f361fbe40290 h1:ZVsQUuUOM9G7O3
 github.com/livekit/mageutil v0.0.0-20221221221243-f361fbe40290/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20230111071722-904079e94a7c h1:wdzwTJjCpzy2FDmwdyVVGVa4+U9iv3E4Jy9qUDe/ubw=
 github.com/livekit/mediatransportutil v0.0.0-20230111071722-904079e94a7c/go.mod h1:1Dlx20JPoIKGP45eo+yuj0HjeE25zmyeX/EWHiPCjFw=
-github.com/livekit/protocol v1.3.2-0.20230111195642-abfad31c5f93 h1:KBW2Puv2tdZELD+zCtGLw/X9vLe9975jEFMFOOpSRGI=
-github.com/livekit/protocol v1.3.2-0.20230111195642-abfad31c5f93/go.mod h1:gwCG03nKlHlC9hTjL4pXQpn783ALhmbyhq65UZxqbb8=
+github.com/livekit/protocol v1.3.2-0.20230115231942-8a49ab3e6c26 h1:R8kLYEnKhaG+zkvGRzyww64TzXnBS30w0lbjZGt1QtE=
+github.com/livekit/protocol v1.3.2-0.20230115231942-8a49ab3e6c26/go.mod h1:gwCG03nKlHlC9hTjL4pXQpn783ALhmbyhq65UZxqbb8=
 github.com/livekit/psrpc v0.2.1 h1:ph/4egUMueUPoh5PZ/Aw4v6SH3wAbA+2t/GyCbpPKTg=
 github.com/livekit/psrpc v0.2.1/go.mod h1:MCe0xLdFPXmzogPiLrM94JIJbctb9+fAv5qYPkY2DXw=
 github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995 h1:vOaY2qvfLihDyeZtnGGN1Law9wRrw8BMGCr1TygTvMw=

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/livekit/mageutil v0.0.0-20221221221243-f361fbe40290 h1:ZVsQUuUOM9G7O3
 github.com/livekit/mageutil v0.0.0-20221221221243-f361fbe40290/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20230111071722-904079e94a7c h1:wdzwTJjCpzy2FDmwdyVVGVa4+U9iv3E4Jy9qUDe/ubw=
 github.com/livekit/mediatransportutil v0.0.0-20230111071722-904079e94a7c/go.mod h1:1Dlx20JPoIKGP45eo+yuj0HjeE25zmyeX/EWHiPCjFw=
-github.com/livekit/protocol v1.3.2-0.20230115231942-8a49ab3e6c26 h1:R8kLYEnKhaG+zkvGRzyww64TzXnBS30w0lbjZGt1QtE=
-github.com/livekit/protocol v1.3.2-0.20230115231942-8a49ab3e6c26/go.mod h1:gwCG03nKlHlC9hTjL4pXQpn783ALhmbyhq65UZxqbb8=
+github.com/livekit/protocol v1.3.2 h1:3goGWbB5HFRb3tMjog8KP0nvZL1Fy6zut3W1psBzqE4=
+github.com/livekit/protocol v1.3.2/go.mod h1:gwCG03nKlHlC9hTjL4pXQpn783ALhmbyhq65UZxqbb8=
 github.com/livekit/psrpc v0.2.1 h1:ph/4egUMueUPoh5PZ/Aw4v6SH3wAbA+2t/GyCbpPKTg=
 github.com/livekit/psrpc v0.2.1/go.mod h1:MCe0xLdFPXmzogPiLrM94JIJbctb9+fAv5qYPkY2DXw=
 github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995 h1:vOaY2qvfLihDyeZtnGGN1Law9wRrw8BMGCr1TygTvMw=

--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -247,13 +247,6 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.Tra
 				if t.dynacastManager != nil {
 					t.dynacastManager.Close()
 				}
-				t.params.Telemetry.TrackUnpublished(
-					context.Background(),
-					t.PublisherID(),
-					t.PublisherIdentity(),
-					t.ToProto(),
-					uint32(track.SSRC()),
-				)
 			}
 		})
 		newWR.OnStatsUpdate(func(_ *sfu.WebRTCReceiver, stat *livekit.AnalyticsStat) {

--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -277,12 +277,6 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.Tra
 				t.params.Logger.Debugw("primary codec published, set potential codecs", "potential", potentialCodecs)
 				t.MediaTrackReceiver.SetPotentialCodecs(potentialCodecs, parameters.HeaderExtensions)
 			}
-			t.params.Telemetry.TrackPublished(
-				context.Background(),
-				t.PublisherID(),
-				t.PublisherIdentity(),
-				t.ToProto(),
-			)
 		}
 
 		newWR.OnMaxLayerChange(t.onMaxLayerChange)

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -229,7 +229,7 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 		}
 	}
 
-	// wthether re-using or stopping remove transceiver from cache
+	// whether re-using or stopping remove transceiver from cache
 	// NOTE: safety net, if somehow a cached transceiver is re-used by a different track
 	sub.UncacheDownTrack(transceiver)
 
@@ -258,15 +258,6 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 		}
 	}()
 
-	t.params.Telemetry.TrackSubscribed(
-		context.Background(),
-		subscriberID,
-		t.params.MediaTrack.ToProto(),
-		&livekit.ParticipantInfo{
-			Sid:      string(t.params.MediaTrack.PublisherID()),
-			Identity: string(t.params.MediaTrack.PublisherIdentity()),
-		},
-	)
 	return nil
 }
 

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1783,6 +1783,17 @@ func (p *ParticipantImpl) addMediaTrack(signalCid string, sdpCid string, ti *liv
 	mt.AddOnClose(func() {
 		p.supervisor.ClearPublishedTrack(livekit.TrackID(ti.Sid), mt)
 
+		// not logged when closing
+		if !p.isClosed.Load() {
+			p.params.Telemetry.TrackUnpublished(
+				context.Background(),
+				p.ID(),
+				p.Identity(),
+				mt.ToProto(),
+			)
+		}
+		p.MigrateState()
+
 		// re-use track sid
 		p.pendingTracksLock.Lock()
 		if pti := p.pendingTracks[signalCid]; pti != nil {

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -608,7 +608,7 @@ func (p *ParticipantImpl) SetMigrateInfo(
 	for _, t := range mediaTracks {
 		ti := t.GetTrack()
 
-		p.supervisor.AddPublication(livekit.TrackID(ti.Sid), ti.Type, nil)
+		p.supervisor.AddPublication(livekit.TrackID(ti.Sid), nil)
 		p.supervisor.SetPublicationMute(livekit.TrackID(ti.Sid), ti.Muted)
 
 		p.pendingTracks[t.GetCid()] = &pendingTrackInfo{trackInfos: []*livekit.TrackInfo{ti}, migrated: true}
@@ -1577,7 +1577,7 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 	}
 
 	p.params.Telemetry.TrackPublishRequested(context.Background(), p.ID(), p.Identity(), ti)
-	p.supervisor.AddPublication(livekit.TrackID(ti.Sid), ti.Type, func(t types.LocalMediaTrack) {
+	p.supervisor.AddPublication(livekit.TrackID(ti.Sid), func(t types.LocalMediaTrack) {
 		p.params.Telemetry.TrackPublished(
 			context.Background(),
 			t.PublisherID(),
@@ -1790,6 +1790,7 @@ func (p *ParticipantImpl) addMediaTrack(signalCid string, sdpCid string, ti *liv
 				p.ID(),
 				p.Identity(),
 				mt.ToProto(),
+				true,
 			)
 		}
 		p.MigrateState()

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -608,7 +608,7 @@ func (p *ParticipantImpl) SetMigrateInfo(
 	for _, t := range mediaTracks {
 		ti := t.GetTrack()
 
-		p.supervisor.AddPublication(livekit.TrackID(ti.Sid), ti.Type)
+		p.supervisor.AddPublication(livekit.TrackID(ti.Sid), ti.Type, nil)
 		p.supervisor.SetPublicationMute(livekit.TrackID(ti.Sid), ti.Muted)
 
 		p.pendingTracks[t.GetCid()] = &pendingTrackInfo{trackInfos: []*livekit.TrackInfo{ti}, migrated: true}
@@ -984,7 +984,16 @@ func (p *ParticipantImpl) AddSubscribedTrack(subTrack types.SubscribedTrack, sou
 	onSubscribedTo := p.onSubscribedTo
 
 	p.subscribedTracks[subTrack.ID()] = subTrack
+	// TODO: I believe we have yet to negotiate with the subscriber, so it's a bit early to consider the track been
+	// successfully subscribed to
+	// ideally we consider it's successful after the participant has answered that offer OR we've received the
+	// first receiver report
+	// will move the telemetry options when this is implemented
 	p.supervisor.SetSubscribedTrack(subTrack.ID(), subTrack, sourceTrack)
+	p.params.Telemetry.TrackSubscribed(context.Background(), p.ID(), sourceTrack.ToProto(), &livekit.ParticipantInfo{
+		Identity: string(subTrack.PublisherIdentity()),
+		Sid:      string(subTrack.PublisherID()),
+	})
 
 	settings := p.subscribedTracksSettings[subTrack.ID()]
 	p.lock.Unlock()
@@ -1567,10 +1576,17 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 		})
 	}
 
+	p.params.Telemetry.TrackPublishRequested(context.Background(), p.ID(), p.Identity(), ti)
+	p.supervisor.AddPublication(livekit.TrackID(ti.Sid), ti.Type, func(t types.LocalMediaTrack) {
+		p.params.Telemetry.TrackPublished(
+			context.Background(),
+			t.PublisherID(),
+			t.PublisherIdentity(),
+			t.ToProto(),
+		)
+	})
+	p.supervisor.SetPublicationMute(livekit.TrackID(ti.Sid), ti.Muted)
 	if p.getPublishedTrackBySignalCid(req.Cid) != nil || p.getPublishedTrackBySdpCid(req.Cid) != nil || p.pendingTracks[req.Cid] != nil {
-		p.supervisor.AddPublication(livekit.TrackID(ti.Sid), ti.Type)
-		p.supervisor.SetPublicationMute(livekit.TrackID(ti.Sid), ti.Muted)
-
 		if p.pendingTracks[req.Cid] == nil {
 			p.pendingTracks[req.Cid] = &pendingTrackInfo{trackInfos: []*livekit.TrackInfo{ti}}
 		} else {
@@ -1579,9 +1595,6 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 		p.params.Logger.Infow("pending track queued", "trackID", ti.Sid, "track", ti.String(), "request", req.String())
 		return nil
 	}
-
-	p.supervisor.AddPublication(livekit.TrackID(ti.Sid), ti.Type)
-	p.supervisor.SetPublicationMute(livekit.TrackID(ti.Sid), ti.Muted)
 
 	p.pendingTracks[req.Cid] = &pendingTrackInfo{trackInfos: []*livekit.TrackInfo{ti}}
 	p.params.Logger.Infow("pending track added", "trackID", ti.Sid, "track", ti.String(), "request", req.String())
@@ -1613,6 +1626,10 @@ func (p *ParticipantImpl) setTrackMuted(trackID livekit.TrackID, muted bool) {
 	p.supervisor.SetPublicationMute(trackID, muted)
 
 	track := p.UpTrackManager.SetPublishedTrackMuted(trackID, muted)
+	var trackInfo *livekit.TrackInfo
+	if track != nil {
+		trackInfo = track.ToProto()
+	}
 
 	isPending := false
 	p.pendingTracksLock.RLock()
@@ -1621,10 +1638,19 @@ func (p *ParticipantImpl) setTrackMuted(trackID livekit.TrackID, muted bool) {
 			if livekit.TrackID(ti.Sid) == trackID {
 				ti.Muted = muted
 				isPending = true
+				trackInfo = ti
 			}
 		}
 	}
 	p.pendingTracksLock.RUnlock()
+
+	if trackInfo != nil {
+		if muted {
+			p.params.Telemetry.TrackMuted(context.Background(), p.ID(), trackInfo)
+		} else {
+			p.params.Telemetry.TrackUnmuted(context.Background(), p.ID(), trackInfo)
+		}
+	}
 
 	if !isPending && track == nil {
 		p.params.Logger.Warnw("could not locate track", nil, "trackID", trackID)
@@ -2085,6 +2111,15 @@ func (p *ParticipantImpl) EnqueueSubscribeTrack(trackID livekit.TrackID, sourceT
 	p.params.Logger.Debugw("queuing subscribe", "trackID", trackID, "relayed", isRelayed)
 
 	p.supervisor.UpdateSubscription(trackID, true, sourceTrack)
+	p.params.Telemetry.TrackSubscribeRequested(
+		context.Background(),
+		p.ID(),
+		sourceTrack.ToProto(),
+		&livekit.ParticipantInfo{
+			Sid:      string(sourceTrack.PublisherID()),
+			Identity: string(sourceTrack.PublisherIdentity()),
+		},
+	)
 
 	p.lock.Lock()
 	p.subscriptionRequestsQueue[trackID] = append(p.subscriptionRequestsQueue[trackID], SubscribeRequest{

--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/atomic"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/livekit/livekit-server/pkg/telemetry/telemetryfakes"
 	"github.com/livekit/protocol/auth"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
@@ -481,6 +482,7 @@ func newParticipantForTestWithOpts(identity livekit.ParticipantIdentity, opts *p
 		ClientConf:        opts.clientConf,
 		ClientInfo:        ClientInfo{ClientInfo: opts.clientInfo},
 		Logger:            LoggerWithParticipant(logger.GetLogger(), identity, sid, false),
+		Telemetry:         &telemetryfakes.FakeTelemetryService{},
 	})
 	p.isPublisher.Store(opts.publisher)
 	p.updateState(livekit.ParticipantInfo_ACTIVE)

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -369,7 +369,6 @@ func (r *Room) ResumeParticipant(p types.LocalParticipant, responseSink routing.
 		return err
 	}
 
-	r.telemetry.ParticipantResumed(context.Background(), r.ToProto(), p.ToProto())
 	p.ICERestart(nil)
 	return nil
 }

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -369,6 +369,7 @@ func (r *Room) ResumeParticipant(p types.LocalParticipant, responseSink routing.
 		return err
 	}
 
+	r.telemetry.ParticipantResumed(context.Background(), r.ToProto(), p.ToProto())
 	p.ICERestart(nil)
 	return nil
 }

--- a/pkg/rtc/supervisor/participant_supervisor.go
+++ b/pkg/rtc/supervisor/participant_supervisor.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	monitorInterval = 3 * time.Second
+	monitorInterval = 1 * time.Second
 )
 
 type ParticipantSupervisorParams struct {
@@ -92,7 +92,7 @@ func (p *ParticipantSupervisor) SetPublisherPeerConnectionConnected(isConnected 
 	p.lock.Unlock()
 }
 
-func (p *ParticipantSupervisor) AddPublication(trackID livekit.TrackID, trackType livekit.TrackType) {
+func (p *ParticipantSupervisor) AddPublication(trackID livekit.TrackID, trackType livekit.TrackType, onSuccess func(track types.LocalMediaTrack)) {
 	p.lock.Lock()
 	pm, ok := p.publications[trackID]
 	if !ok {
@@ -102,6 +102,7 @@ func (p *ParticipantSupervisor) AddPublication(trackID livekit.TrackID, trackTyp
 					TrackID:                   trackID,
 					IsPeerConnectionConnected: p.isPublisherConnected,
 					Logger:                    p.params.Logger,
+					OnSuccess:                 onSuccess,
 				},
 			),
 		}

--- a/pkg/rtc/supervisor/participant_supervisor.go
+++ b/pkg/rtc/supervisor/participant_supervisor.go
@@ -92,7 +92,7 @@ func (p *ParticipantSupervisor) SetPublisherPeerConnectionConnected(isConnected 
 	p.lock.Unlock()
 }
 
-func (p *ParticipantSupervisor) AddPublication(trackID livekit.TrackID, trackType livekit.TrackType, onSuccess func(track types.LocalMediaTrack)) {
+func (p *ParticipantSupervisor) AddPublication(trackID livekit.TrackID, onSuccess func(track types.LocalMediaTrack)) {
 	p.lock.Lock()
 	pm, ok := p.publications[trackID]
 	if !ok {
@@ -108,7 +108,7 @@ func (p *ParticipantSupervisor) AddPublication(trackID livekit.TrackID, trackTyp
 		}
 		p.publications[trackID] = pm
 	}
-	pm.opMon.PostEvent(types.OperationMonitorEventAddPendingPublication, trackType.String())
+	pm.opMon.PostEvent(types.OperationMonitorEventAddPendingPublication, nil)
 	p.lock.Unlock()
 }
 

--- a/pkg/rtc/supervisor/publication_monitor.go
+++ b/pkg/rtc/supervisor/publication_monitor.go
@@ -58,7 +58,7 @@ func (p *PublicationMonitor) PostEvent(ome types.OperationMonitorEvent, omd type
 	case types.OperationMonitorEventPublisherPeerConnectionConnected:
 		p.setConnected(omd.(bool))
 	case types.OperationMonitorEventAddPendingPublication:
-		p.addPending(omd.(string))
+		p.addPending()
 	case types.OperationMonitorEventSetPublicationMute:
 		p.setMute(omd.(bool))
 	case types.OperationMonitorEventSetPublishedTrack:
@@ -68,7 +68,7 @@ func (p *PublicationMonitor) PostEvent(ome types.OperationMonitorEvent, omd type
 	}
 }
 
-func (p *PublicationMonitor) addPending(trackType string) {
+func (p *PublicationMonitor) addPending() {
 	p.lock.Lock()
 	p.desiredPublishes.PushBack(
 		&publish{

--- a/pkg/rtc/supervisor/publication_monitor.go
+++ b/pkg/rtc/supervisor/publication_monitor.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gammazero/deque"
 
 	"github.com/livekit/livekit-server/pkg/rtc/types"
-	"github.com/livekit/livekit-server/pkg/telemetry/prometheus"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 )
@@ -29,6 +28,7 @@ type PublicationMonitorParams struct {
 	TrackID                   livekit.TrackID
 	IsPeerConnectionConnected bool
 	Logger                    logger.Logger
+	OnSuccess                 func(t types.LocalMediaTrack)
 }
 
 type PublicationMonitor struct {
@@ -69,8 +69,6 @@ func (p *PublicationMonitor) PostEvent(ome types.OperationMonitorEvent, omd type
 }
 
 func (p *PublicationMonitor) addPending(trackType string) {
-	prometheus.AddPublishAttempt(trackType)
-
 	p.lock.Lock()
 	p.desiredPublishes.PushBack(
 		&publish{
@@ -171,7 +169,9 @@ func (p *PublicationMonitor) update() {
 		}
 
 		if pub.isStart && p.publishedTrack != nil {
-			prometheus.AddPublishSuccess(p.publishedTrack.Kind().String())
+			if p.params.OnSuccess != nil {
+				p.params.OnSuccess(p.publishedTrack)
+			}
 		}
 
 		if (pub.isStart && p.publishedTrack == nil) || (!pub.isStart && p.publishedTrack != nil) {

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -248,6 +248,7 @@ func (r *RoomManager) StartSession(
 				logger.Warnw("could not resume participant", err, "participant", pi.Identity)
 				return err
 			}
+			r.telemetry.ParticipantResumed(ctx, room.ToProto(), participant.ToProto(), livekit.NodeID(r.currentNode.Id))
 			go r.rtcSessionWorker(room, participant, requestSource)
 			return nil
 		} else {

--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -180,7 +180,9 @@ func (t *telemetryService) TrackPublishRequested(
 	t.enqueue(func() {
 		prometheus.AddPublishAttempt(track.Type.String())
 		room := t.getRoomDetails(participantID)
-
+		if room == nil {
+			return
+		}
 		ev := newTrackEvent(livekit.AnalyticsEventType_TRACK_PUBLISH_REQUESTED, room, participantID, track)
 		ev.Participant.Identity = string(identity)
 		t.SendEvent(ctx, ev)
@@ -198,6 +200,9 @@ func (t *telemetryService) TrackPublished(
 		prometheus.AddPublishSuccess(track.Type.String())
 
 		room := t.getRoomDetails(participantID)
+		if room == nil {
+			return
+		}
 		participant := &livekit.ParticipantInfo{
 			Sid:      string(participantID),
 			Identity: string(identity),
@@ -217,11 +222,11 @@ func (t *telemetryService) TrackPublished(
 
 func (t *telemetryService) TrackPublishedUpdate(ctx context.Context, participantID livekit.ParticipantID, track *livekit.TrackInfo) {
 	t.enqueue(func() {
-		ev := t.getRoomDetails(participantID)
-		if ev == nil {
+		room := t.getRoomDetails(participantID)
+		if room == nil {
 			return
 		}
-		t.SendEvent(ctx, newTrackEvent(livekit.AnalyticsEventType_TRACK_PUBLISHED_UPDATE, ev, participantID, track))
+		t.SendEvent(ctx, newTrackEvent(livekit.AnalyticsEventType_TRACK_PUBLISHED_UPDATE, room, participantID, track))
 	})
 }
 
@@ -234,6 +239,9 @@ func (t *telemetryService) TrackMaxSubscribedVideoQuality(
 ) {
 	t.enqueue(func() {
 		room := t.getRoomDetails(participantID)
+		if room == nil {
+			return
+		}
 		ev := newTrackEvent(livekit.AnalyticsEventType_TRACK_MAX_SUBSCRIBED_VIDEO_QUALITY, room, participantID, track)
 		ev.MaxSubscribedVideoQuality = maxQuality
 		ev.Mime = mime
@@ -249,6 +257,9 @@ func (t *telemetryService) TrackSubscribeRequested(
 ) {
 	t.enqueue(func() {
 		room := t.getRoomDetails(participantID)
+		if room == nil {
+			return
+		}
 		ev := newTrackEvent(livekit.AnalyticsEventType_TRACK_SUBSCRIBE_REQUESTED, room, participantID, track)
 		ev.Publisher = publisher
 		t.SendEvent(ctx, ev)
@@ -265,6 +276,9 @@ func (t *telemetryService) TrackSubscribed(
 		prometheus.AddSubscribedTrack(track.Type.String())
 
 		room := t.getRoomDetails(participantID)
+		if room == nil {
+			return
+		}
 		ev := newTrackEvent(livekit.AnalyticsEventType_TRACK_SUBSCRIBED, room, participantID, track)
 		ev.Publisher = publisher
 		t.SendEvent(ctx, ev)
@@ -276,6 +290,9 @@ func (t *telemetryService) TrackUnsubscribed(ctx context.Context, participantID 
 		prometheus.SubSubscribedTrack(track.Type.String())
 
 		room := t.getRoomDetails(participantID)
+		if room == nil {
+			return
+		}
 		t.SendEvent(ctx, newTrackEvent(livekit.AnalyticsEventType_TRACK_UNSUBSCRIBED, room, participantID, track))
 	})
 }
@@ -291,6 +308,9 @@ func (t *telemetryService) TrackUnpublished(
 		prometheus.SubPublishedTrack(track.Type.String())
 
 		room := t.getRoomDetails(participantID)
+		if room == nil {
+			return
+		}
 		participant := &livekit.ParticipantInfo{
 			Sid:      string(participantID),
 			Identity: string(identity),
@@ -313,6 +333,9 @@ func (t *telemetryService) TrackMuted(
 ) {
 	t.enqueue(func() {
 		room := t.getRoomDetails(participantID)
+		if room == nil {
+			return
+		}
 
 		t.SendEvent(ctx, newTrackEvent(livekit.AnalyticsEventType_TRACK_MUTED, room, participantID, track))
 	})
@@ -325,6 +348,9 @@ func (t *telemetryService) TrackUnmuted(
 ) {
 	t.enqueue(func() {
 		room := t.getRoomDetails(participantID)
+		if room == nil {
+			return
+		}
 
 		t.SendEvent(ctx, newTrackEvent(livekit.AnalyticsEventType_TRACK_UNMUTED, room, participantID, track))
 	})

--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -80,16 +80,10 @@ func (t *telemetryService) ParticipantJoined(
 		)
 
 		if shouldSendEvent {
-			t.SendEvent(ctx, &livekit.AnalyticsEvent{
-				Type:          livekit.AnalyticsEventType_PARTICIPANT_JOINED,
-				Timestamp:     timestamppb.Now(),
-				RoomId:        room.Sid,
-				ParticipantId: participant.Sid,
-				Participant:   participant,
-				Room:          room,
-				ClientInfo:    clientInfo,
-				ClientMeta:    clientMeta,
-			})
+			ev := newParticipantEvent(livekit.AnalyticsEventType_PARTICIPANT_JOINED, room, participant)
+			ev.ClientInfo = clientInfo
+			ev.ClientMeta = clientMeta
+			t.SendEvent(ctx, ev)
 		}
 	})
 }
@@ -125,15 +119,24 @@ func (t *telemetryService) ParticipantActive(
 		}
 		worker.SetConnected()
 
-		t.SendEvent(ctx, &livekit.AnalyticsEvent{
-			Type:          livekit.AnalyticsEventType_PARTICIPANT_ACTIVE,
-			Timestamp:     timestamppb.Now(),
-			RoomId:        room.Sid,
-			ParticipantId: participant.Sid,
-			Participant:   participant,
-			Room:          room,
-			ClientMeta:    clientMeta,
-		})
+		ev := newParticipantEvent(livekit.AnalyticsEventType_PARTICIPANT_ACTIVE, room, participant)
+		ev.ClientMeta = clientMeta
+		t.SendEvent(ctx, ev)
+	})
+}
+
+func (t *telemetryService) ParticipantResumed(
+	ctx context.Context,
+	room *livekit.Room,
+	participant *livekit.ParticipantInfo,
+) {
+	t.enqueue(func() {
+		if _, ok := t.getWorker(livekit.ParticipantID(participant.Sid)); !ok {
+			// only when participant is active on this instance
+			return
+		}
+
+		t.SendEvent(ctx, newParticipantEvent(livekit.AnalyticsEventType_PARTICIPANT_RESUMED, room, participant))
 	})
 }
 
@@ -163,15 +166,24 @@ func (t *telemetryService) ParticipantLeft(ctx context.Context,
 				Participant: participant,
 			})
 
-			t.SendEvent(ctx, &livekit.AnalyticsEvent{
-				Type:          livekit.AnalyticsEventType_PARTICIPANT_LEFT,
-				Timestamp:     timestamppb.Now(),
-				RoomId:        room.Sid,
-				ParticipantId: participant.Sid,
-				Participant:   participant,
-				Room:          room,
-			})
+			t.SendEvent(ctx, newParticipantEvent(livekit.AnalyticsEventType_PARTICIPANT_LEFT, room, participant))
 		}
+	})
+}
+
+func (t *telemetryService) TrackPublishRequested(
+	ctx context.Context,
+	participantID livekit.ParticipantID,
+	identity livekit.ParticipantIdentity,
+	track *livekit.TrackInfo,
+) {
+	t.enqueue(func() {
+		prometheus.AddPublishAttempt(track.Type.String())
+		room := t.getRoomDetails(participantID)
+
+		ev := newTrackEvent(livekit.AnalyticsEventType_TRACK_PUBLISH_REQUESTED, room, participantID, track)
+		ev.Participant.Identity = string(identity)
+		t.SendEvent(ctx, ev)
 	})
 }
 
@@ -183,47 +195,33 @@ func (t *telemetryService) TrackPublished(
 ) {
 	t.enqueue(func() {
 		prometheus.AddPublishedTrack(track.Type.String())
+		prometheus.AddPublishSuccess(track.Type.String())
 
-		roomID, roomName := t.getRoomDetails(participantID)
+		room := t.getRoomDetails(participantID)
+		participant := &livekit.ParticipantInfo{
+			Sid:      string(participantID),
+			Identity: string(identity),
+		}
 		t.NotifyEvent(ctx, &livekit.WebhookEvent{
-			Event: webhook.EventTrackPublished,
-			Room: &livekit.Room{
-				Sid:  string(roomID),
-				Name: string(roomName),
-			},
-			Participant: &livekit.ParticipantInfo{
-				Sid:      string(participantID),
-				Identity: string(identity),
-			},
-			Track: track,
+			Event:       webhook.EventTrackPublished,
+			Room:        room,
+			Participant: participant,
+			Track:       track,
 		})
 
-		t.SendEvent(ctx, &livekit.AnalyticsEvent{
-			Type:          livekit.AnalyticsEventType_TRACK_PUBLISHED,
-			Timestamp:     timestamppb.Now(),
-			RoomId:        string(roomID),
-			ParticipantId: string(participantID),
-			Participant: &livekit.ParticipantInfo{
-				Sid:      string(participantID),
-				Identity: string(identity),
-			},
-			Track: track,
-			Room:  &livekit.Room{Name: string(roomName)},
-		})
+		ev := newTrackEvent(livekit.AnalyticsEventType_TRACK_PUBLISHED, room, participantID, track)
+		ev.Participant = participant
+		t.SendEvent(ctx, ev)
 	})
 }
 
 func (t *telemetryService) TrackPublishedUpdate(ctx context.Context, participantID livekit.ParticipantID, track *livekit.TrackInfo) {
 	t.enqueue(func() {
-		roomID, roomName := t.getRoomDetails(participantID)
-		t.SendEvent(ctx, &livekit.AnalyticsEvent{
-			Type:          livekit.AnalyticsEventType_TRACK_PUBLISHED_UPDATE,
-			Timestamp:     timestamppb.Now(),
-			RoomId:        string(roomID),
-			ParticipantId: string(participantID),
-			Track:         track,
-			Room:          &livekit.Room{Name: string(roomName)},
-		})
+		ev := t.getRoomDetails(participantID)
+		if ev == nil {
+			return
+		}
+		t.SendEvent(ctx, newTrackEvent(livekit.AnalyticsEventType_TRACK_PUBLISHED_UPDATE, ev, participantID, track))
 	})
 }
 
@@ -235,17 +233,25 @@ func (t *telemetryService) TrackMaxSubscribedVideoQuality(
 	maxQuality livekit.VideoQuality,
 ) {
 	t.enqueue(func() {
-		roomID, roomName := t.getRoomDetails(participantID)
-		t.SendEvent(ctx, &livekit.AnalyticsEvent{
-			Type:                      livekit.AnalyticsEventType_TRACK_MAX_SUBSCRIBED_VIDEO_QUALITY,
-			Timestamp:                 timestamppb.Now(),
-			RoomId:                    string(roomID),
-			ParticipantId:             string(participantID),
-			Track:                     track,
-			Room:                      &livekit.Room{Name: string(roomName)},
-			MaxSubscribedVideoQuality: maxQuality,
-			Mime:                      mime,
-		})
+		room := t.getRoomDetails(participantID)
+		ev := newTrackEvent(livekit.AnalyticsEventType_TRACK_MAX_SUBSCRIBED_VIDEO_QUALITY, room, participantID, track)
+		ev.MaxSubscribedVideoQuality = maxQuality
+		ev.Mime = mime
+		t.SendEvent(ctx, ev)
+	})
+}
+
+func (t *telemetryService) TrackSubscribeRequested(
+	ctx context.Context,
+	participantID livekit.ParticipantID,
+	track *livekit.TrackInfo,
+	publisher *livekit.ParticipantInfo,
+) {
+	t.enqueue(func() {
+		room := t.getRoomDetails(participantID)
+		ev := newTrackEvent(livekit.AnalyticsEventType_TRACK_SUBSCRIBE_REQUESTED, room, participantID, track)
+		ev.Publisher = publisher
+		t.SendEvent(ctx, ev)
 	})
 }
 
@@ -258,16 +264,10 @@ func (t *telemetryService) TrackSubscribed(
 	t.enqueue(func() {
 		prometheus.AddSubscribedTrack(track.Type.String())
 
-		roomID, roomName := t.getRoomDetails(participantID)
-		t.SendEvent(ctx, &livekit.AnalyticsEvent{
-			Type:          livekit.AnalyticsEventType_TRACK_SUBSCRIBED,
-			Timestamp:     timestamppb.Now(),
-			RoomId:        string(roomID),
-			ParticipantId: string(participantID),
-			Track:         track,
-			Room:          &livekit.Room{Name: string(roomName)},
-			Publisher:     publisher,
-		})
+		room := t.getRoomDetails(participantID)
+		ev := newTrackEvent(livekit.AnalyticsEventType_TRACK_SUBSCRIBED, room, participantID, track)
+		ev.Publisher = publisher
+		t.SendEvent(ctx, ev)
 	})
 }
 
@@ -275,15 +275,8 @@ func (t *telemetryService) TrackUnsubscribed(ctx context.Context, participantID 
 	t.enqueue(func() {
 		prometheus.SubSubscribedTrack(track.Type.String())
 
-		roomID, roomName := t.getRoomDetails(participantID)
-		t.SendEvent(ctx, &livekit.AnalyticsEvent{
-			Type:          livekit.AnalyticsEventType_TRACK_UNSUBSCRIBED,
-			Timestamp:     timestamppb.Now(),
-			RoomId:        string(roomID),
-			ParticipantId: string(participantID),
-			TrackId:       track.Sid,
-			Room:          &livekit.Room{Name: string(roomName)},
-		})
+		room := t.getRoomDetails(participantID)
+		t.SendEvent(ctx, newTrackEvent(livekit.AnalyticsEventType_TRACK_UNSUBSCRIBED, room, participantID, track))
 	})
 }
 
@@ -295,31 +288,45 @@ func (t *telemetryService) TrackUnpublished(
 	ssrc uint32,
 ) {
 	t.enqueue(func() {
-		roomID, roomName := t.getRoomDetails(participantID)
-
 		prometheus.SubPublishedTrack(track.Type.String())
 
+		room := t.getRoomDetails(participantID)
+		participant := &livekit.ParticipantInfo{
+			Sid:      string(participantID),
+			Identity: string(identity),
+		}
 		t.NotifyEvent(ctx, &livekit.WebhookEvent{
-			Event: webhook.EventTrackUnpublished,
-			Room: &livekit.Room{
-				Sid:  string(roomID),
-				Name: string(roomName),
-			},
-			Participant: &livekit.ParticipantInfo{
-				Sid:      string(participantID),
-				Identity: string(identity),
-			},
-			Track: track,
+			Event:       webhook.EventTrackUnpublished,
+			Room:        room,
+			Participant: participant,
+			Track:       track,
 		})
 
-		t.SendEvent(ctx, &livekit.AnalyticsEvent{
-			Type:          livekit.AnalyticsEventType_TRACK_UNPUBLISHED,
-			Timestamp:     timestamppb.Now(),
-			RoomId:        string(roomID),
-			ParticipantId: string(participantID),
-			TrackId:       track.Sid,
-			Room:          &livekit.Room{Name: string(roomName)},
-		})
+		t.SendEvent(ctx, newTrackEvent(livekit.AnalyticsEventType_TRACK_UNPUBLISHED, room, participantID, track))
+	})
+}
+
+func (t *telemetryService) TrackMuted(
+	ctx context.Context,
+	participantID livekit.ParticipantID,
+	track *livekit.TrackInfo,
+) {
+	t.enqueue(func() {
+		room := t.getRoomDetails(participantID)
+
+		t.SendEvent(ctx, newTrackEvent(livekit.AnalyticsEventType_TRACK_MUTED, room, participantID, track))
+	})
+}
+
+func (t *telemetryService) TrackUnmuted(
+	ctx context.Context,
+	participantID livekit.ParticipantID,
+	track *livekit.TrackInfo,
+) {
+	t.enqueue(func() {
+		room := t.getRoomDetails(participantID)
+
+		t.SendEvent(ctx, newTrackEvent(livekit.AnalyticsEventType_TRACK_UNMUTED, room, participantID, track))
 	})
 }
 
@@ -330,13 +337,7 @@ func (t *telemetryService) EgressStarted(ctx context.Context, info *livekit.Egre
 			EgressInfo: info,
 		})
 
-		t.SendEvent(ctx, &livekit.AnalyticsEvent{
-			Type:      livekit.AnalyticsEventType_EGRESS_STARTED,
-			Timestamp: timestamppb.Now(),
-			EgressId:  info.EgressId,
-			RoomId:    info.RoomId,
-			Egress:    info,
-		})
+		t.SendEvent(ctx, newEgressEvent(livekit.AnalyticsEventType_EGRESS_STARTED, info))
 	})
 }
 
@@ -347,20 +348,54 @@ func (t *telemetryService) EgressEnded(ctx context.Context, info *livekit.Egress
 			EgressInfo: info,
 		})
 
-		t.SendEvent(ctx, &livekit.AnalyticsEvent{
-			Type:      livekit.AnalyticsEventType_EGRESS_ENDED,
-			Timestamp: timestamppb.Now(),
-			EgressId:  info.EgressId,
-			RoomId:    info.RoomId,
-			Egress:    info,
-		})
+		t.SendEvent(ctx, newEgressEvent(livekit.AnalyticsEventType_EGRESS_ENDED, info))
 	})
 }
 
-func (t *telemetryService) getRoomDetails(participantID livekit.ParticipantID) (livekit.RoomID, livekit.RoomName) {
+// returns a livekit.Room with only name and sid filled out
+// returns nil if room is not found
+func (t *telemetryService) getRoomDetails(participantID livekit.ParticipantID) *livekit.Room {
 	if worker, ok := t.getWorker(participantID); ok {
-		return worker.roomID, worker.roomName
+		return &livekit.Room{
+			Sid:  string(worker.roomID),
+			Name: string(worker.roomName),
+		}
 	}
 
-	return "", ""
+	return nil
+}
+
+func newRoomEvent(event livekit.AnalyticsEventType, room *livekit.Room) *livekit.AnalyticsEvent {
+	return &livekit.AnalyticsEvent{
+		Type:      event,
+		Timestamp: timestamppb.Now(),
+		RoomId:    room.Sid,
+		Room:      room,
+	}
+}
+
+func newParticipantEvent(event livekit.AnalyticsEventType, room *livekit.Room, participant *livekit.ParticipantInfo) *livekit.AnalyticsEvent {
+	ev := newRoomEvent(event, room)
+	ev.ParticipantId = participant.Sid
+	ev.Participant = participant
+	return ev
+}
+
+func newTrackEvent(event livekit.AnalyticsEventType, room *livekit.Room, participantID livekit.ParticipantID, track *livekit.TrackInfo) *livekit.AnalyticsEvent {
+	ev := newParticipantEvent(event, room, &livekit.ParticipantInfo{
+		Sid: string(participantID),
+	})
+	ev.TrackId = track.Sid
+	ev.Track = track
+	return ev
+}
+
+func newEgressEvent(event livekit.AnalyticsEventType, egress *livekit.EgressInfo) *livekit.AnalyticsEvent {
+	return &livekit.AnalyticsEvent{
+		Type:      event,
+		Timestamp: timestamppb.Now(),
+		EgressId:  egress.EgressId,
+		RoomId:    egress.RoomId,
+		Egress:    egress,
+	}
 }

--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -129,14 +129,14 @@ func (t *telemetryService) ParticipantResumed(
 	ctx context.Context,
 	room *livekit.Room,
 	participant *livekit.ParticipantInfo,
+	nodeID livekit.NodeID,
 ) {
 	t.enqueue(func() {
-		if _, ok := t.getWorker(livekit.ParticipantID(participant.Sid)); !ok {
-			// only when participant is active on this instance
-			return
+		ev := newParticipantEvent(livekit.AnalyticsEventType_PARTICIPANT_RESUMED, room, participant)
+		ev.ClientMeta = &livekit.AnalyticsClientMeta{
+			Node: string(nodeID),
 		}
-
-		t.SendEvent(ctx, newParticipantEvent(livekit.AnalyticsEventType_PARTICIPANT_RESUMED, room, participant))
+		t.SendEvent(ctx, ev)
 	})
 }
 

--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -302,10 +302,13 @@ func (t *telemetryService) TrackUnpublished(
 	participantID livekit.ParticipantID,
 	identity livekit.ParticipantIdentity,
 	track *livekit.TrackInfo,
-	ssrc uint32,
+	shouldSendEvent bool,
 ) {
 	t.enqueue(func() {
 		prometheus.SubPublishedTrack(track.Type.String())
+		if !shouldSendEvent {
+			return
+		}
 
 		room := t.getRoomDetails(participantID)
 		if room == nil {

--- a/pkg/telemetry/stats_test.go
+++ b/pkg/telemetry/stats_test.go
@@ -457,7 +457,7 @@ func Test_OnUpstreamRTCP_SeveralTracks(t *testing.T) {
 	require.True(t, found2)
 
 	// remove 1 track - track stats were flushed above, so no more calls to SendStats
-	fixture.sut.TrackUnpublished(context.Background(), partSID, identity, &livekit.TrackInfo{Sid: string(trackID2)}, 0)
+	fixture.sut.TrackUnpublished(context.Background(), partSID, identity, &livekit.TrackInfo{Sid: string(trackID2)}, true)
 
 	// flush
 	fixture.flush()

--- a/pkg/telemetry/telemetryfakes/fake_telemetry_service.go
+++ b/pkg/telemetry/telemetryfakes/fake_telemetry_service.go
@@ -58,6 +58,13 @@ type FakeTelemetryService struct {
 		arg3 *livekit.ParticipantInfo
 		arg4 bool
 	}
+	ParticipantResumedStub        func(context.Context, *livekit.Room, *livekit.ParticipantInfo)
+	participantResumedMutex       sync.RWMutex
+	participantResumedArgsForCall []struct {
+		arg1 context.Context
+		arg2 *livekit.Room
+		arg3 *livekit.ParticipantInfo
+	}
 	RoomEndedStub        func(context.Context, *livekit.Room)
 	roomEndedMutex       sync.RWMutex
 	roomEndedArgsForCall []struct {
@@ -91,6 +98,21 @@ type FakeTelemetryService struct {
 		arg4 string
 		arg5 livekit.VideoQuality
 	}
+	TrackMutedStub        func(context.Context, livekit.ParticipantID, *livekit.TrackInfo)
+	trackMutedMutex       sync.RWMutex
+	trackMutedArgsForCall []struct {
+		arg1 context.Context
+		arg2 livekit.ParticipantID
+		arg3 *livekit.TrackInfo
+	}
+	TrackPublishRequestedStub        func(context.Context, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo)
+	trackPublishRequestedMutex       sync.RWMutex
+	trackPublishRequestedArgsForCall []struct {
+		arg1 context.Context
+		arg2 livekit.ParticipantID
+		arg3 livekit.ParticipantIdentity
+		arg4 *livekit.TrackInfo
+	}
 	TrackPublishedStub        func(context.Context, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo)
 	trackPublishedMutex       sync.RWMutex
 	trackPublishedArgsForCall []struct {
@@ -114,6 +136,14 @@ type FakeTelemetryService struct {
 		arg3 livekit.TrackID
 		arg4 *livekit.AnalyticsStat
 	}
+	TrackSubscribeRequestedStub        func(context.Context, livekit.ParticipantID, *livekit.TrackInfo, *livekit.ParticipantInfo)
+	trackSubscribeRequestedMutex       sync.RWMutex
+	trackSubscribeRequestedArgsForCall []struct {
+		arg1 context.Context
+		arg2 livekit.ParticipantID
+		arg3 *livekit.TrackInfo
+		arg4 *livekit.ParticipantInfo
+	}
 	TrackSubscribedStub        func(context.Context, livekit.ParticipantID, *livekit.TrackInfo, *livekit.ParticipantInfo)
 	trackSubscribedMutex       sync.RWMutex
 	trackSubscribedArgsForCall []struct {
@@ -121,6 +151,13 @@ type FakeTelemetryService struct {
 		arg2 livekit.ParticipantID
 		arg3 *livekit.TrackInfo
 		arg4 *livekit.ParticipantInfo
+	}
+	TrackUnmutedStub        func(context.Context, livekit.ParticipantID, *livekit.TrackInfo)
+	trackUnmutedMutex       sync.RWMutex
+	trackUnmutedArgsForCall []struct {
+		arg1 context.Context
+		arg2 livekit.ParticipantID
+		arg3 *livekit.TrackInfo
 	}
 	TrackUnpublishedStub        func(context.Context, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, uint32)
 	trackUnpublishedMutex       sync.RWMutex
@@ -372,6 +409,40 @@ func (fake *FakeTelemetryService) ParticipantLeftArgsForCall(i int) (context.Con
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
+func (fake *FakeTelemetryService) ParticipantResumed(arg1 context.Context, arg2 *livekit.Room, arg3 *livekit.ParticipantInfo) {
+	fake.participantResumedMutex.Lock()
+	fake.participantResumedArgsForCall = append(fake.participantResumedArgsForCall, struct {
+		arg1 context.Context
+		arg2 *livekit.Room
+		arg3 *livekit.ParticipantInfo
+	}{arg1, arg2, arg3})
+	stub := fake.ParticipantResumedStub
+	fake.recordInvocation("ParticipantResumed", []interface{}{arg1, arg2, arg3})
+	fake.participantResumedMutex.Unlock()
+	if stub != nil {
+		fake.ParticipantResumedStub(arg1, arg2, arg3)
+	}
+}
+
+func (fake *FakeTelemetryService) ParticipantResumedCallCount() int {
+	fake.participantResumedMutex.RLock()
+	defer fake.participantResumedMutex.RUnlock()
+	return len(fake.participantResumedArgsForCall)
+}
+
+func (fake *FakeTelemetryService) ParticipantResumedCalls(stub func(context.Context, *livekit.Room, *livekit.ParticipantInfo)) {
+	fake.participantResumedMutex.Lock()
+	defer fake.participantResumedMutex.Unlock()
+	fake.ParticipantResumedStub = stub
+}
+
+func (fake *FakeTelemetryService) ParticipantResumedArgsForCall(i int) (context.Context, *livekit.Room, *livekit.ParticipantInfo) {
+	fake.participantResumedMutex.RLock()
+	defer fake.participantResumedMutex.RUnlock()
+	argsForCall := fake.participantResumedArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
 func (fake *FakeTelemetryService) RoomEnded(arg1 context.Context, arg2 *livekit.Room) {
 	fake.roomEndedMutex.Lock()
 	fake.roomEndedArgsForCall = append(fake.roomEndedArgsForCall, struct {
@@ -545,6 +616,75 @@ func (fake *FakeTelemetryService) TrackMaxSubscribedVideoQualityArgsForCall(i in
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
+func (fake *FakeTelemetryService) TrackMuted(arg1 context.Context, arg2 livekit.ParticipantID, arg3 *livekit.TrackInfo) {
+	fake.trackMutedMutex.Lock()
+	fake.trackMutedArgsForCall = append(fake.trackMutedArgsForCall, struct {
+		arg1 context.Context
+		arg2 livekit.ParticipantID
+		arg3 *livekit.TrackInfo
+	}{arg1, arg2, arg3})
+	stub := fake.TrackMutedStub
+	fake.recordInvocation("TrackMuted", []interface{}{arg1, arg2, arg3})
+	fake.trackMutedMutex.Unlock()
+	if stub != nil {
+		fake.TrackMutedStub(arg1, arg2, arg3)
+	}
+}
+
+func (fake *FakeTelemetryService) TrackMutedCallCount() int {
+	fake.trackMutedMutex.RLock()
+	defer fake.trackMutedMutex.RUnlock()
+	return len(fake.trackMutedArgsForCall)
+}
+
+func (fake *FakeTelemetryService) TrackMutedCalls(stub func(context.Context, livekit.ParticipantID, *livekit.TrackInfo)) {
+	fake.trackMutedMutex.Lock()
+	defer fake.trackMutedMutex.Unlock()
+	fake.TrackMutedStub = stub
+}
+
+func (fake *FakeTelemetryService) TrackMutedArgsForCall(i int) (context.Context, livekit.ParticipantID, *livekit.TrackInfo) {
+	fake.trackMutedMutex.RLock()
+	defer fake.trackMutedMutex.RUnlock()
+	argsForCall := fake.trackMutedArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeTelemetryService) TrackPublishRequested(arg1 context.Context, arg2 livekit.ParticipantID, arg3 livekit.ParticipantIdentity, arg4 *livekit.TrackInfo) {
+	fake.trackPublishRequestedMutex.Lock()
+	fake.trackPublishRequestedArgsForCall = append(fake.trackPublishRequestedArgsForCall, struct {
+		arg1 context.Context
+		arg2 livekit.ParticipantID
+		arg3 livekit.ParticipantIdentity
+		arg4 *livekit.TrackInfo
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.TrackPublishRequestedStub
+	fake.recordInvocation("TrackPublishRequested", []interface{}{arg1, arg2, arg3, arg4})
+	fake.trackPublishRequestedMutex.Unlock()
+	if stub != nil {
+		fake.TrackPublishRequestedStub(arg1, arg2, arg3, arg4)
+	}
+}
+
+func (fake *FakeTelemetryService) TrackPublishRequestedCallCount() int {
+	fake.trackPublishRequestedMutex.RLock()
+	defer fake.trackPublishRequestedMutex.RUnlock()
+	return len(fake.trackPublishRequestedArgsForCall)
+}
+
+func (fake *FakeTelemetryService) TrackPublishRequestedCalls(stub func(context.Context, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo)) {
+	fake.trackPublishRequestedMutex.Lock()
+	defer fake.trackPublishRequestedMutex.Unlock()
+	fake.TrackPublishRequestedStub = stub
+}
+
+func (fake *FakeTelemetryService) TrackPublishRequestedArgsForCall(i int) (context.Context, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo) {
+	fake.trackPublishRequestedMutex.RLock()
+	defer fake.trackPublishRequestedMutex.RUnlock()
+	argsForCall := fake.trackPublishRequestedArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
 func (fake *FakeTelemetryService) TrackPublished(arg1 context.Context, arg2 livekit.ParticipantID, arg3 livekit.ParticipantIdentity, arg4 *livekit.TrackInfo) {
 	fake.trackPublishedMutex.Lock()
 	fake.trackPublishedArgsForCall = append(fake.trackPublishedArgsForCall, struct {
@@ -649,6 +789,41 @@ func (fake *FakeTelemetryService) TrackStatsArgsForCall(i int) (livekit.StreamTy
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
+func (fake *FakeTelemetryService) TrackSubscribeRequested(arg1 context.Context, arg2 livekit.ParticipantID, arg3 *livekit.TrackInfo, arg4 *livekit.ParticipantInfo) {
+	fake.trackSubscribeRequestedMutex.Lock()
+	fake.trackSubscribeRequestedArgsForCall = append(fake.trackSubscribeRequestedArgsForCall, struct {
+		arg1 context.Context
+		arg2 livekit.ParticipantID
+		arg3 *livekit.TrackInfo
+		arg4 *livekit.ParticipantInfo
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.TrackSubscribeRequestedStub
+	fake.recordInvocation("TrackSubscribeRequested", []interface{}{arg1, arg2, arg3, arg4})
+	fake.trackSubscribeRequestedMutex.Unlock()
+	if stub != nil {
+		fake.TrackSubscribeRequestedStub(arg1, arg2, arg3, arg4)
+	}
+}
+
+func (fake *FakeTelemetryService) TrackSubscribeRequestedCallCount() int {
+	fake.trackSubscribeRequestedMutex.RLock()
+	defer fake.trackSubscribeRequestedMutex.RUnlock()
+	return len(fake.trackSubscribeRequestedArgsForCall)
+}
+
+func (fake *FakeTelemetryService) TrackSubscribeRequestedCalls(stub func(context.Context, livekit.ParticipantID, *livekit.TrackInfo, *livekit.ParticipantInfo)) {
+	fake.trackSubscribeRequestedMutex.Lock()
+	defer fake.trackSubscribeRequestedMutex.Unlock()
+	fake.TrackSubscribeRequestedStub = stub
+}
+
+func (fake *FakeTelemetryService) TrackSubscribeRequestedArgsForCall(i int) (context.Context, livekit.ParticipantID, *livekit.TrackInfo, *livekit.ParticipantInfo) {
+	fake.trackSubscribeRequestedMutex.RLock()
+	defer fake.trackSubscribeRequestedMutex.RUnlock()
+	argsForCall := fake.trackSubscribeRequestedArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
 func (fake *FakeTelemetryService) TrackSubscribed(arg1 context.Context, arg2 livekit.ParticipantID, arg3 *livekit.TrackInfo, arg4 *livekit.ParticipantInfo) {
 	fake.trackSubscribedMutex.Lock()
 	fake.trackSubscribedArgsForCall = append(fake.trackSubscribedArgsForCall, struct {
@@ -682,6 +857,40 @@ func (fake *FakeTelemetryService) TrackSubscribedArgsForCall(i int) (context.Con
 	defer fake.trackSubscribedMutex.RUnlock()
 	argsForCall := fake.trackSubscribedArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeTelemetryService) TrackUnmuted(arg1 context.Context, arg2 livekit.ParticipantID, arg3 *livekit.TrackInfo) {
+	fake.trackUnmutedMutex.Lock()
+	fake.trackUnmutedArgsForCall = append(fake.trackUnmutedArgsForCall, struct {
+		arg1 context.Context
+		arg2 livekit.ParticipantID
+		arg3 *livekit.TrackInfo
+	}{arg1, arg2, arg3})
+	stub := fake.TrackUnmutedStub
+	fake.recordInvocation("TrackUnmuted", []interface{}{arg1, arg2, arg3})
+	fake.trackUnmutedMutex.Unlock()
+	if stub != nil {
+		fake.TrackUnmutedStub(arg1, arg2, arg3)
+	}
+}
+
+func (fake *FakeTelemetryService) TrackUnmutedCallCount() int {
+	fake.trackUnmutedMutex.RLock()
+	defer fake.trackUnmutedMutex.RUnlock()
+	return len(fake.trackUnmutedArgsForCall)
+}
+
+func (fake *FakeTelemetryService) TrackUnmutedCalls(stub func(context.Context, livekit.ParticipantID, *livekit.TrackInfo)) {
+	fake.trackUnmutedMutex.Lock()
+	defer fake.trackUnmutedMutex.Unlock()
+	fake.TrackUnmutedStub = stub
+}
+
+func (fake *FakeTelemetryService) TrackUnmutedArgsForCall(i int) (context.Context, livekit.ParticipantID, *livekit.TrackInfo) {
+	fake.trackUnmutedMutex.RLock()
+	defer fake.trackUnmutedMutex.RUnlock()
+	argsForCall := fake.trackUnmutedArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeTelemetryService) TrackUnpublished(arg1 context.Context, arg2 livekit.ParticipantID, arg3 livekit.ParticipantIdentity, arg4 *livekit.TrackInfo, arg5 uint32) {
@@ -771,6 +980,8 @@ func (fake *FakeTelemetryService) Invocations() map[string][][]interface{} {
 	defer fake.participantJoinedMutex.RUnlock()
 	fake.participantLeftMutex.RLock()
 	defer fake.participantLeftMutex.RUnlock()
+	fake.participantResumedMutex.RLock()
+	defer fake.participantResumedMutex.RUnlock()
 	fake.roomEndedMutex.RLock()
 	defer fake.roomEndedMutex.RUnlock()
 	fake.roomStartedMutex.RLock()
@@ -781,14 +992,22 @@ func (fake *FakeTelemetryService) Invocations() map[string][][]interface{} {
 	defer fake.sendStatsMutex.RUnlock()
 	fake.trackMaxSubscribedVideoQualityMutex.RLock()
 	defer fake.trackMaxSubscribedVideoQualityMutex.RUnlock()
+	fake.trackMutedMutex.RLock()
+	defer fake.trackMutedMutex.RUnlock()
+	fake.trackPublishRequestedMutex.RLock()
+	defer fake.trackPublishRequestedMutex.RUnlock()
 	fake.trackPublishedMutex.RLock()
 	defer fake.trackPublishedMutex.RUnlock()
 	fake.trackPublishedUpdateMutex.RLock()
 	defer fake.trackPublishedUpdateMutex.RUnlock()
 	fake.trackStatsMutex.RLock()
 	defer fake.trackStatsMutex.RUnlock()
+	fake.trackSubscribeRequestedMutex.RLock()
+	defer fake.trackSubscribeRequestedMutex.RUnlock()
 	fake.trackSubscribedMutex.RLock()
 	defer fake.trackSubscribedMutex.RUnlock()
+	fake.trackUnmutedMutex.RLock()
+	defer fake.trackUnmutedMutex.RUnlock()
 	fake.trackUnpublishedMutex.RLock()
 	defer fake.trackUnpublishedMutex.RUnlock()
 	fake.trackUnsubscribedMutex.RLock()

--- a/pkg/telemetry/telemetryfakes/fake_telemetry_service.go
+++ b/pkg/telemetry/telemetryfakes/fake_telemetry_service.go
@@ -58,12 +58,13 @@ type FakeTelemetryService struct {
 		arg3 *livekit.ParticipantInfo
 		arg4 bool
 	}
-	ParticipantResumedStub        func(context.Context, *livekit.Room, *livekit.ParticipantInfo)
+	ParticipantResumedStub        func(context.Context, *livekit.Room, *livekit.ParticipantInfo, livekit.NodeID)
 	participantResumedMutex       sync.RWMutex
 	participantResumedArgsForCall []struct {
 		arg1 context.Context
 		arg2 *livekit.Room
 		arg3 *livekit.ParticipantInfo
+		arg4 livekit.NodeID
 	}
 	RoomEndedStub        func(context.Context, *livekit.Room)
 	roomEndedMutex       sync.RWMutex
@@ -159,14 +160,14 @@ type FakeTelemetryService struct {
 		arg2 livekit.ParticipantID
 		arg3 *livekit.TrackInfo
 	}
-	TrackUnpublishedStub        func(context.Context, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, uint32)
+	TrackUnpublishedStub        func(context.Context, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, bool)
 	trackUnpublishedMutex       sync.RWMutex
 	trackUnpublishedArgsForCall []struct {
 		arg1 context.Context
 		arg2 livekit.ParticipantID
 		arg3 livekit.ParticipantIdentity
 		arg4 *livekit.TrackInfo
-		arg5 uint32
+		arg5 bool
 	}
 	TrackUnsubscribedStub        func(context.Context, livekit.ParticipantID, *livekit.TrackInfo)
 	trackUnsubscribedMutex       sync.RWMutex
@@ -409,18 +410,19 @@ func (fake *FakeTelemetryService) ParticipantLeftArgsForCall(i int) (context.Con
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeTelemetryService) ParticipantResumed(arg1 context.Context, arg2 *livekit.Room, arg3 *livekit.ParticipantInfo) {
+func (fake *FakeTelemetryService) ParticipantResumed(arg1 context.Context, arg2 *livekit.Room, arg3 *livekit.ParticipantInfo, arg4 livekit.NodeID) {
 	fake.participantResumedMutex.Lock()
 	fake.participantResumedArgsForCall = append(fake.participantResumedArgsForCall, struct {
 		arg1 context.Context
 		arg2 *livekit.Room
 		arg3 *livekit.ParticipantInfo
-	}{arg1, arg2, arg3})
+		arg4 livekit.NodeID
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.ParticipantResumedStub
-	fake.recordInvocation("ParticipantResumed", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("ParticipantResumed", []interface{}{arg1, arg2, arg3, arg4})
 	fake.participantResumedMutex.Unlock()
 	if stub != nil {
-		fake.ParticipantResumedStub(arg1, arg2, arg3)
+		fake.ParticipantResumedStub(arg1, arg2, arg3, arg4)
 	}
 }
 
@@ -430,17 +432,17 @@ func (fake *FakeTelemetryService) ParticipantResumedCallCount() int {
 	return len(fake.participantResumedArgsForCall)
 }
 
-func (fake *FakeTelemetryService) ParticipantResumedCalls(stub func(context.Context, *livekit.Room, *livekit.ParticipantInfo)) {
+func (fake *FakeTelemetryService) ParticipantResumedCalls(stub func(context.Context, *livekit.Room, *livekit.ParticipantInfo, livekit.NodeID)) {
 	fake.participantResumedMutex.Lock()
 	defer fake.participantResumedMutex.Unlock()
 	fake.ParticipantResumedStub = stub
 }
 
-func (fake *FakeTelemetryService) ParticipantResumedArgsForCall(i int) (context.Context, *livekit.Room, *livekit.ParticipantInfo) {
+func (fake *FakeTelemetryService) ParticipantResumedArgsForCall(i int) (context.Context, *livekit.Room, *livekit.ParticipantInfo, livekit.NodeID) {
 	fake.participantResumedMutex.RLock()
 	defer fake.participantResumedMutex.RUnlock()
 	argsForCall := fake.participantResumedArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeTelemetryService) RoomEnded(arg1 context.Context, arg2 *livekit.Room) {
@@ -893,14 +895,14 @@ func (fake *FakeTelemetryService) TrackUnmutedArgsForCall(i int) (context.Contex
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeTelemetryService) TrackUnpublished(arg1 context.Context, arg2 livekit.ParticipantID, arg3 livekit.ParticipantIdentity, arg4 *livekit.TrackInfo, arg5 uint32) {
+func (fake *FakeTelemetryService) TrackUnpublished(arg1 context.Context, arg2 livekit.ParticipantID, arg3 livekit.ParticipantIdentity, arg4 *livekit.TrackInfo, arg5 bool) {
 	fake.trackUnpublishedMutex.Lock()
 	fake.trackUnpublishedArgsForCall = append(fake.trackUnpublishedArgsForCall, struct {
 		arg1 context.Context
 		arg2 livekit.ParticipantID
 		arg3 livekit.ParticipantIdentity
 		arg4 *livekit.TrackInfo
-		arg5 uint32
+		arg5 bool
 	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.TrackUnpublishedStub
 	fake.recordInvocation("TrackUnpublished", []interface{}{arg1, arg2, arg3, arg4, arg5})
@@ -916,13 +918,13 @@ func (fake *FakeTelemetryService) TrackUnpublishedCallCount() int {
 	return len(fake.trackUnpublishedArgsForCall)
 }
 
-func (fake *FakeTelemetryService) TrackUnpublishedCalls(stub func(context.Context, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, uint32)) {
+func (fake *FakeTelemetryService) TrackUnpublishedCalls(stub func(context.Context, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, bool)) {
 	fake.trackUnpublishedMutex.Lock()
 	defer fake.trackUnpublishedMutex.Unlock()
 	fake.TrackUnpublishedStub = stub
 }
 
-func (fake *FakeTelemetryService) TrackUnpublishedArgsForCall(i int) (context.Context, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, uint32) {
+func (fake *FakeTelemetryService) TrackUnpublishedArgsForCall(i int) (context.Context, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, bool) {
 	fake.trackUnpublishedMutex.RLock()
 	defer fake.trackUnpublishedMutex.RUnlock()
 	argsForCall := fake.trackUnpublishedArgsForCall[i]

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -26,7 +26,7 @@ type TelemetryService interface {
 	// ParticipantActive - a participant establishes media connection
 	ParticipantActive(ctx context.Context, room *livekit.Room, participant *livekit.ParticipantInfo, clientMeta *livekit.AnalyticsClientMeta)
 	// ParticipantResumed - there has been an ICE restart or connection resume attempt
-	ParticipantResumed(ctx context.Context, room *livekit.Room, participant *livekit.ParticipantInfo)
+	ParticipantResumed(ctx context.Context, room *livekit.Room, participant *livekit.ParticipantInfo, nodeID livekit.NodeID)
 	// ParticipantLeft - the participant leaves the room, only sent if ParticipantActive has been called before
 	ParticipantLeft(ctx context.Context, room *livekit.Room, participant *livekit.ParticipantInfo, shouldSendEvent bool)
 	// TrackPublishRequested - a publication attempt has been received

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -34,7 +34,7 @@ type TelemetryService interface {
 	// TrackPublished - a publication attempt has been successful
 	TrackPublished(ctx context.Context, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo)
 	// TrackUnpublished - a participant unpublished a track
-	TrackUnpublished(ctx context.Context, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo, ssrc uint32)
+	TrackUnpublished(ctx context.Context, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo, shouldSendEvent bool)
 	// TrackSubscribeRequested - a participant requested to subscribe to a track
 	TrackSubscribeRequested(ctx context.Context, participantID livekit.ParticipantID, track *livekit.TrackInfo, publisher *livekit.ParticipantInfo)
 	// TrackSubscribed - a participant subscribed to a track successfully

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -15,20 +15,39 @@ import (
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . TelemetryService
 type TelemetryService interface {
-	// stats
+	// TrackStats is called periodically for each track in both directions (published/subscribed)
 	TrackStats(streamType livekit.StreamType, participantID livekit.ParticipantID, trackID livekit.TrackID, stat *livekit.AnalyticsStat)
 
 	// events
 	RoomStarted(ctx context.Context, room *livekit.Room)
 	RoomEnded(ctx context.Context, room *livekit.Room)
+	// ParticipantJoined - a participant establishes signal connection to a room
 	ParticipantJoined(ctx context.Context, room *livekit.Room, participant *livekit.ParticipantInfo, clientInfo *livekit.ClientInfo, clientMeta *livekit.AnalyticsClientMeta, shouldSendEvent bool)
+	// ParticipantActive - a participant establishes media connection
 	ParticipantActive(ctx context.Context, room *livekit.Room, participant *livekit.ParticipantInfo, clientMeta *livekit.AnalyticsClientMeta)
+	// ParticipantResumed - there has been an ICE restart or connection resume attempt
+	ParticipantResumed(ctx context.Context, room *livekit.Room, participant *livekit.ParticipantInfo)
+	// ParticipantLeft - the participant leaves the room, only sent if ParticipantActive has been called before
 	ParticipantLeft(ctx context.Context, room *livekit.Room, participant *livekit.ParticipantInfo, shouldSendEvent bool)
+	// TrackPublishRequested - a publication attempt has been received
+	TrackPublishRequested(ctx context.Context, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo)
+	// TrackPublished - a publication attempt has been successful
 	TrackPublished(ctx context.Context, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo)
+	// TrackUnpublished - a participant unpublished a track
 	TrackUnpublished(ctx context.Context, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo, ssrc uint32)
+	// TrackSubscribeRequested - a participant requested to subscribe to a track
+	TrackSubscribeRequested(ctx context.Context, participantID livekit.ParticipantID, track *livekit.TrackInfo, publisher *livekit.ParticipantInfo)
+	// TrackSubscribed - a participant subscribed to a track successfully
 	TrackSubscribed(ctx context.Context, participantID livekit.ParticipantID, track *livekit.TrackInfo, publisher *livekit.ParticipantInfo)
+	// TrackUnsubscribed - a participant unsubscribed from a track successfully
 	TrackUnsubscribed(ctx context.Context, participantID livekit.ParticipantID, track *livekit.TrackInfo)
+	// TrackMuted - the publisher has muted the Track
+	TrackMuted(ctx context.Context, participantID livekit.ParticipantID, track *livekit.TrackInfo)
+	// TrackUnmuted - the publisher has muted the Track
+	TrackUnmuted(ctx context.Context, participantID livekit.ParticipantID, track *livekit.TrackInfo)
+	// TrackPublishedUpdate - track metadata has been updated
 	TrackPublishedUpdate(ctx context.Context, participantID livekit.ParticipantID, track *livekit.TrackInfo)
+	// TrackMaxSubscribedVideoQuality - publisher is notified of the max quality subscribers desire
 	TrackMaxSubscribedVideoQuality(ctx context.Context, participantID livekit.ParticipantID, track *livekit.TrackInfo, mime string, maxQuality livekit.VideoQuality)
 	EgressStarted(ctx context.Context, info *livekit.EgressInfo)
 	EgressEnded(ctx context.Context, info *livekit.EgressInfo)

--- a/pkg/utils/timed_version.go
+++ b/pkg/utils/timed_version.go
@@ -60,6 +60,8 @@ func (t *TimedVersion) Update(other *TimedVersion) {
 	if other.After(t) {
 		t.ts = other.ts
 		t.ticks = other.ticks
+	} else {
+
 	}
 	t.lock.Unlock()
 }

--- a/pkg/utils/timed_version.go
+++ b/pkg/utils/timed_version.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -85,4 +86,11 @@ func (t *TimedVersion) ToProto() *livekit.TimedVersion {
 		UnixMicro: t.ts,
 		Ticks:     t.ticks,
 	}
+}
+
+func (t *TimedVersion) String() string {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	return fmt.Sprintf("%d.%d", t.ts, t.ticks)
 }

--- a/pkg/utils/timed_version.go
+++ b/pkg/utils/timed_version.go
@@ -61,8 +61,6 @@ func (t *TimedVersion) Update(other *TimedVersion) {
 	if other.After(t) {
 		t.ts = other.ts
 		t.ticks = other.ticks
-	} else {
-
 	}
 	t.lock.Unlock()
 }

--- a/pkg/utils/timed_version_test.go
+++ b/pkg/utils/timed_version_test.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 LiveKit, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimedVersion(t *testing.T) {
+	gen := NewDefaultTimedVersionGenerator()
+	tv1 := gen.New()
+	tv2 := gen.New()
+	tv3 := gen.New()
+
+	assert.True(t, tv3.After(tv1))
+	assert.True(t, tv3.After(tv2))
+	assert.True(t, tv2.After(tv1))
+
+	tv2.Update(tv3)
+	assert.True(t, tv2.After(tv1))
+	// tv3 and tv2 are equivalent after update
+	assert.False(t, tv3.After(tv2))
+}


### PR DESCRIPTION
Related to https://github.com/livekit/protocol/pull/273

This PR adds:
* ParticipantResumed - for when ICE restart or migration had occured
* TrackPublishRequested - when we initiate a publication
* TrackSubscribeRequested - when we initiate a subscription
* TrackMuted - publisher muted track
* TrackUnmuted - publisher unmuted track

TrackPublish/TrackSubcribe events will indicate when those actions have been successful, to differentiate.