### PR TITLE
Support disable dynacast.

### DIFF
--- a/pkg/rtc/clientinfo.go
+++ b/pkg/rtc/clientinfo.go
@@ -77,3 +77,7 @@ func (c ClientInfo) SupportsICETCP() bool {
 	// most SDKs support ICE/TCP
 	return true
 }
+
+func (c ClientInfo) SupportsChangeRTPSenderEncodingActive() bool {
+	return !c.isFirefox()
+}

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -92,6 +92,7 @@ type ParticipantParams struct {
 	ReconnectOnPublicationError  bool
 	ReconnectOnSubscriptionError bool
 	VersionGenerator             utils2.TimedVersionGenerator
+	DisableDynacast              bool
 }
 
 type ParticipantImpl struct {
@@ -1475,6 +1476,10 @@ func (p *ParticipantImpl) onStreamStateChange(update *sfu.StreamStateUpdate) err
 }
 
 func (p *ParticipantImpl) onSubscribedMaxQualityChange(trackID livekit.TrackID, subscribedQualities []*livekit.SubscribedCodec, maxSubscribedQualites []types.SubscribedCodecQuality) error {
+	if p.params.DisableDynacast {
+		return nil
+	}
+
 	if len(subscribedQualities) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Added a flag to throttle dynacast messages to the publisher.

Added a helper method to check if a client supports setting `active` field in RTP sender encoding. This can be used to disable dynacast based on some other feature flag/config settings.