### PR TITLE
Allow /rtc/validate to return room not found message

### DIFF
--- a/pkg/service/interfaces.go
+++ b/pkg/service/interfaces.go
@@ -60,4 +60,5 @@ type IngressStore interface {
 //counterfeiter:generate . RoomAllocator
 type RoomAllocator interface {
 	CreateRoom(ctx context.Context, req *livekit.CreateRoomRequest) (*livekit.Room, error)
+	ValidateCreateRoom(ctx context.Context, roomName livekit.RoomName) error
 }

--- a/pkg/service/roomallocator.go
+++ b/pkg/service/roomallocator.go
@@ -117,6 +117,17 @@ func (r *StandardRoomAllocator) CreateRoom(ctx context.Context, req *livekit.Cre
 	return rm, nil
 }
 
+func (r *StandardRoomAllocator) ValidateCreateRoom(ctx context.Context, roomName livekit.RoomName) error {
+	// when auto create is disabled, we'll check to ensure it's already created
+	if !r.config.Room.AutoCreate {
+		_, _, err := r.roomStore.LoadRoom(ctx, roomName, false)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func applyDefaultRoomConfig(room *livekit.Room, conf *config.RoomConfig) {
 	room.EmptyTimeout = conf.EmptyTimeout
 	room.MaxParticipants = conf.MaxParticipants

--- a/pkg/service/rtcservice.go
+++ b/pkg/service/rtcservice.go
@@ -188,7 +188,6 @@ func (s *RTCService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ctx := utils.ContextWithAttempt(r.Context(), i)
 		cr, err = s.startConnection(ctx, roomName, pi, connectionTimeout)
 		if err == nil {
-			// do not retry room not found errors
 			break
 		}
 		if i < 2 {

--- a/pkg/service/rtcservice.go
+++ b/pkg/service/rtcservice.go
@@ -80,18 +80,20 @@ func (s *RTCService) Validate(w http.ResponseWriter, r *http.Request) {
 
 func (s *RTCService) validate(r *http.Request) (livekit.RoomName, routing.ParticipantInit, int, error) {
 	claims := GetGrants(r.Context())
+	var pi routing.ParticipantInit
+
 	// require a claim
 	if claims == nil || claims.Video == nil {
-		return "", routing.ParticipantInit{}, http.StatusUnauthorized, rtc.ErrPermissionDenied
+		return "", pi, http.StatusUnauthorized, rtc.ErrPermissionDenied
 	}
 
 	onlyName, err := EnsureJoinPermission(r.Context())
 	if err != nil {
-		return "", routing.ParticipantInit{}, http.StatusUnauthorized, err
+		return "", pi, http.StatusUnauthorized, err
 	}
 
 	if claims.Identity == "" {
-		return "", routing.ParticipantInit{}, http.StatusBadRequest, ErrIdentityEmpty
+		return "", pi, http.StatusBadRequest, ErrIdentityEmpty
 	}
 
 	roomName := livekit.RoomName(r.FormValue("room"))
@@ -116,17 +118,27 @@ func (s *RTCService) validate(r *http.Request) (livekit.RoomName, routing.Partic
 		claims.Identity += "#" + publishParam
 	}
 
+	// room allocator validations
+	err = s.roomAllocator.ValidateCreateRoom(r.Context(), roomName)
+	if err != nil {
+		if errors.Is(err, ErrRoomNotFound) {
+			return "", pi, http.StatusNotFound, err
+		} else {
+			return "", pi, http.StatusInternalServerError, err
+		}
+	}
+
 	region := ""
 	if router, ok := s.router.(routing.Router); ok {
 		region = router.GetRegion()
 		if foundNode, err := router.GetNodeForRoom(r.Context(), roomName); err == nil {
 			if selector.LimitsReached(s.limits, foundNode.Stats) {
-				return "", routing.ParticipantInit{}, http.StatusServiceUnavailable, rtc.ErrLimitExceeded
+				return "", pi, http.StatusServiceUnavailable, rtc.ErrLimitExceeded
 			}
 		}
 	}
 
-	pi := routing.ParticipantInit{
+	pi = routing.ParticipantInit{
 		Reconnect:     boolValue(reconnectParam),
 		Identity:      livekit.ParticipantIdentity(claims.Identity),
 		Name:          livekit.ParticipantName(claims.Name),
@@ -169,18 +181,6 @@ func (s *RTCService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"remote", false,
 	}
 
-	// when auto create is disabled, we'll check to ensure it's already created
-	if !s.config.Room.AutoCreate {
-		_, _, err := s.store.LoadRoom(context.Background(), roomName, false)
-		if err == ErrRoomNotFound {
-			handleError(w, http.StatusNotFound, err, loggerFields...)
-			return
-		} else if err != nil {
-			handleError(w, http.StatusInternalServerError, err, loggerFields...)
-			return
-		}
-	}
-
 	// give it a few attempts to start session
 	var cr connectionResult
 	for i := 0; i < 3; i++ {
@@ -188,6 +188,7 @@ func (s *RTCService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ctx := utils.ContextWithAttempt(r.Context(), i)
 		cr, err = s.startConnection(ctx, roomName, pi, connectionTimeout)
 		if err == nil {
+			// do not retry room not found errors
 			break
 		}
 		if i < 2 {

--- a/pkg/service/servicefakes/fake_room_allocator.go
+++ b/pkg/service/servicefakes/fake_room_allocator.go
@@ -24,6 +24,18 @@ type FakeRoomAllocator struct {
 		result1 *livekit.Room
 		result2 error
 	}
+	ValidateCreateRoomStub        func(context.Context, livekit.RoomName) error
+	validateCreateRoomMutex       sync.RWMutex
+	validateCreateRoomArgsForCall []struct {
+		arg1 context.Context
+		arg2 livekit.RoomName
+	}
+	validateCreateRoomReturns struct {
+		result1 error
+	}
+	validateCreateRoomReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -93,11 +105,75 @@ func (fake *FakeRoomAllocator) CreateRoomReturnsOnCall(i int, result1 *livekit.R
 	}{result1, result2}
 }
 
+func (fake *FakeRoomAllocator) ValidateCreateRoom(arg1 context.Context, arg2 livekit.RoomName) error {
+	fake.validateCreateRoomMutex.Lock()
+	ret, specificReturn := fake.validateCreateRoomReturnsOnCall[len(fake.validateCreateRoomArgsForCall)]
+	fake.validateCreateRoomArgsForCall = append(fake.validateCreateRoomArgsForCall, struct {
+		arg1 context.Context
+		arg2 livekit.RoomName
+	}{arg1, arg2})
+	stub := fake.ValidateCreateRoomStub
+	fakeReturns := fake.validateCreateRoomReturns
+	fake.recordInvocation("ValidateCreateRoom", []interface{}{arg1, arg2})
+	fake.validateCreateRoomMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeRoomAllocator) ValidateCreateRoomCallCount() int {
+	fake.validateCreateRoomMutex.RLock()
+	defer fake.validateCreateRoomMutex.RUnlock()
+	return len(fake.validateCreateRoomArgsForCall)
+}
+
+func (fake *FakeRoomAllocator) ValidateCreateRoomCalls(stub func(context.Context, livekit.RoomName) error) {
+	fake.validateCreateRoomMutex.Lock()
+	defer fake.validateCreateRoomMutex.Unlock()
+	fake.ValidateCreateRoomStub = stub
+}
+
+func (fake *FakeRoomAllocator) ValidateCreateRoomArgsForCall(i int) (context.Context, livekit.RoomName) {
+	fake.validateCreateRoomMutex.RLock()
+	defer fake.validateCreateRoomMutex.RUnlock()
+	argsForCall := fake.validateCreateRoomArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeRoomAllocator) ValidateCreateRoomReturns(result1 error) {
+	fake.validateCreateRoomMutex.Lock()
+	defer fake.validateCreateRoomMutex.Unlock()
+	fake.ValidateCreateRoomStub = nil
+	fake.validateCreateRoomReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeRoomAllocator) ValidateCreateRoomReturnsOnCall(i int, result1 error) {
+	fake.validateCreateRoomMutex.Lock()
+	defer fake.validateCreateRoomMutex.Unlock()
+	fake.ValidateCreateRoomStub = nil
+	if fake.validateCreateRoomReturnsOnCall == nil {
+		fake.validateCreateRoomReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.validateCreateRoomReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeRoomAllocator) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.createRoomMutex.RLock()
 	defer fake.createRoomMutex.RUnlock()
+	fake.validateCreateRoomMutex.RLock()
+	defer fake.validateCreateRoomMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
It's not always possible for WebSocket clients to obtain status code or error messages returned during WS Upgrade. Moving autocreation validation to an explicit interface in the validation step so the /rtc/validate would be able to return an appropriate message.