### PR TITLE
Use purely RR based RTT.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1
-	github.com/livekit/mediatransportutil v0.0.0-20230111071722-904079e94a7c
+	github.com/livekit/mediatransportutil v0.0.0-20230130133657-96cfb115473a
 	github.com/livekit/protocol v1.3.3-0.20230127213545-10b378e3bc1e
 	github.com/livekit/psrpc v0.2.4
 	github.com/livekit/rtcscore-go v0.0.0-20220815072451-20ee10ae1995

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/lithammer/shortuuid/v4 v4.0.0 h1:QRbbVkfgNippHOS8PXDkti4NaWeyYfcBTHtw
 github.com/lithammer/shortuuid/v4 v4.0.0/go.mod h1:Zs8puNcrvf2rV9rTH51ZLLcj7ZXqQI3lv67aw4KiB1Y=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkDaKb5iXdynYrzB84ErPPO4LbRASk58=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
-github.com/livekit/mediatransportutil v0.0.0-20230111071722-904079e94a7c h1:wdzwTJjCpzy2FDmwdyVVGVa4+U9iv3E4Jy9qUDe/ubw=
-github.com/livekit/mediatransportutil v0.0.0-20230111071722-904079e94a7c/go.mod h1:1Dlx20JPoIKGP45eo+yuj0HjeE25zmyeX/EWHiPCjFw=
+github.com/livekit/mediatransportutil v0.0.0-20230130133657-96cfb115473a h1:5UkGQpskXp7HcBmyrCwWtO7ygDWbqtjN09Yva4l/nyE=
+github.com/livekit/mediatransportutil v0.0.0-20230130133657-96cfb115473a/go.mod h1:1Dlx20JPoIKGP45eo+yuj0HjeE25zmyeX/EWHiPCjFw=
 github.com/livekit/protocol v1.3.3-0.20230127213545-10b378e3bc1e h1:T+qUuDHioL5Q5Gzjun9tB65oaC9+zWmeWlcvpG+iilc=
 github.com/livekit/protocol v1.3.3-0.20230127213545-10b378e3bc1e/go.mod h1:gwCG03nKlHlC9hTjL4pXQpn783ALhmbyhq65UZxqbb8=
 github.com/livekit/psrpc v0.2.4 h1:Fdxq56uJAIpRHCTgJsvp7ozw51dKtUmD3nxSXq9pCLs=

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -478,7 +478,7 @@ func (r *RTPStats) UpdateFromReceiverReport(rr rtcp.ReceptionReport) (rtt uint32
 	if err == nil {
 		isRttChanged = rtt != r.rtt
 	} else {
-		if err != mediatransportutil.ErrNoLastSenderReport {
+		if err != mediatransportutil.ErrRttNoLastSenderReport {
 			r.logger.Warnw("error getting rtt", err)
 		}
 	}

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -478,7 +478,7 @@ func (r *RTPStats) UpdateFromReceiverReport(rr rtcp.ReceptionReport) (rtt uint32
 	if err == nil {
 		isRttChanged = rtt != r.rtt
 	} else {
-		if err.Error() != "no last SR" {
+		if err != mediatransportutil.ErrNoLastSenderReport {
 			r.logger.Warnw("error getting rtt", err)
 		}
 	}

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -172,8 +172,6 @@ type RTPStats struct {
 	maxRtt uint32
 
 	srDataExt *RTCPSenderReportDataExt
-	lastSRNTP mediatransportutil.NtpTime
-	lastSRAt  time.Time
 
 	nextSnapshotId uint32
 	snapshots      map[uint32]*Snapshot
@@ -269,8 +267,6 @@ func (r *RTPStats) Seed(from *RTPStats) {
 	} else {
 		r.srDataExt = nil
 	}
-	r.lastSRNTP = from.lastSRNTP
-	r.lastSRAt = from.lastSRAt
 
 	r.nextSnapshotId = from.nextSnapshotId
 	for id, ss := range from.snapshots {
@@ -478,11 +474,13 @@ func (r *RTPStats) UpdateFromReceiverReport(rr rtcp.ReceptionReport) (rtt uint32
 		return
 	}
 
-	rtt, err := mediatransportutil.GetRttMs(&rr, r.lastSRNTP, r.lastSRAt)
+	rtt, err := mediatransportutil.GetRttMsFromReceiverReportOnly(&rr)
 	if err == nil {
 		isRttChanged = rtt != r.rtt
 	} else {
-		r.logger.Warnw("error getting rtt", err)
+		if err.Error() != "no last SR" {
+			r.logger.Warnw("error getting rtt", err)
+		}
 	}
 
 	if r.lastRRTime.IsZero() || r.extHighestSNOverridden <= rr.LastSequenceNumber {
@@ -765,9 +763,6 @@ func (r *RTPStats) GetRtcpSenderReport(ssrc uint32, srDataExt *RTCPSenderReportD
 	} else {
 		nowRTP = srDataExt.SenderReportData.RTPTimestamp + uint32(now.Sub(smoothedLocalTimeOfLatestSenderReportNTP).Milliseconds()*int64(r.params.ClockRate)/1000)
 	}
-
-	r.lastSRNTP = nowNTP
-	r.lastSRAt = time.Now()
 
 	return &rtcp.SenderReport{
 		SSRC:        ssrc,


### PR DESCRIPTION
With normalization of NTP time stamp to local time, don't need to keep track of NTP time of publisher + local time of when a report is sent. RTT calculations can happen with RR only.

Also, do not log errors when RTT cannot be calculated due to no last SR. This can happen if the receiver sends an RR before it receives an SR. As SFU is doing SRs once in 5 seconds, it is possible some RRs happen before the first SR.