### PR TITLE
Ignore inactive media.

### DIFF
--- a/pkg/rtc/participant_sdp.go
+++ b/pkg/rtc/participant_sdp.go
@@ -192,7 +192,7 @@ func (p *ParticipantImpl) configurePublisherAnswer(answer webrtc.SessionDescript
 		switch m.MediaName.Media {
 		case "audio":
 			_, ok := m.Attribute(sdp.AttrKeyInactive)
-			if !ok {
+			if ok {
 				continue
 			}
 			mid, ok := m.Attribute(sdp.AttrKeyMID)
@@ -203,7 +203,7 @@ func (p *ParticipantImpl) configurePublisherAnswer(answer webrtc.SessionDescript
 			var ti *livekit.TrackInfo
 			for _, om := range parsedOffer.MediaDescriptions {
 				_, ok := om.Attribute(sdp.AttrKeyInactive)
-				if !ok {
+				if ok {
 					continue
 				}
 				omid, ok := om.Attribute(sdp.AttrKeyMID)

--- a/pkg/rtc/participant_sdp.go
+++ b/pkg/rtc/participant_sdp.go
@@ -191,6 +191,10 @@ func (p *ParticipantImpl) configurePublisherAnswer(answer webrtc.SessionDescript
 	for _, m := range parsed.MediaDescriptions {
 		switch m.MediaName.Media {
 		case "audio":
+			_, ok := m.Attribute(sdp.AttrKeyInactive)
+			if !ok {
+				continue
+			}
 			mid, ok := m.Attribute(sdp.AttrKeyMID)
 			if !ok {
 				continue
@@ -198,6 +202,10 @@ func (p *ParticipantImpl) configurePublisherAnswer(answer webrtc.SessionDescript
 			// find track info from offer's stream id
 			var ti *livekit.TrackInfo
 			for _, om := range parsedOffer.MediaDescriptions {
+				_, ok := om.Attribute(sdp.AttrKeyInactive)
+				if !ok {
+					continue
+				}
 				omid, ok := om.Attribute(sdp.AttrKeyMID)
 				if ok && omid == mid {
 					streamID, ok := lksdp.ExtractStreamID(om)


### PR DESCRIPTION
Seeing some errors of
"track info not published prior to track".
Happens when trying to configure publisher answer for audio for DTX and stereo and trying to find a pending track. There are cases where there are inactive m-lines in SDP that is hitting this.