### PR TITLE
Server-side workaround for JS SDK's inability to handle ReconnectResponse

### DIFF
--- a/pkg/rtc/clientinfo.go
+++ b/pkg/rtc/clientinfo.go
@@ -36,10 +36,40 @@ func (c ClientInfo) FireTrackByRTPPacket() bool {
 	return c.isGo()
 }
 
-// CompareVersion compares two semver versions
+func (c ClientInfo) CanHandleReconnectResponse() bool {
+	if c.Sdk == livekit.ClientInfo_JS {
+		// JS cannot handle new responses before 1.6.4
+		if c.compareVersion("1.6.4") < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (c ClientInfo) SupportsICETCP() bool {
+	if c.ClientInfo == nil {
+		return false
+	}
+	if c.ClientInfo.Sdk == livekit.ClientInfo_GO {
+		// Go does not support active TCP
+		return false
+	}
+	if c.ClientInfo.Sdk == livekit.ClientInfo_SWIFT {
+		// ICE/TCP added in 1.0.5
+		return c.compareVersion("1.0.5") >= 0
+	}
+	// most SDKs support ICE/TCP
+	return true
+}
+
+func (c ClientInfo) SupportsChangeRTPSenderEncodingActive() bool {
+	return !c.isFirefox()
+}
+
+// compareVersion compares a semver against the current client SDK version
 // returning 1 if current version is greater than version
 // 0 if they are the same, and -1 if it's an earlier version
-func (c ClientInfo) CompareVersion(version string) int {
+func (c ClientInfo) compareVersion(version string) int {
 	if c.ClientInfo == nil {
 		return -1
 	}
@@ -61,23 +91,4 @@ func (c ClientInfo) CompareVersion(version string) int {
 		}
 	}
 	return 0
-}
-
-func (c ClientInfo) SupportsICETCP() bool {
-	if c.ClientInfo == nil {
-		return false
-	}
-	if c.ClientInfo.Sdk == livekit.ClientInfo_GO {
-		return false
-	}
-	if c.ClientInfo.Sdk == livekit.ClientInfo_SWIFT {
-		// ICE/TCP added in 1.0.5
-		return c.CompareVersion("1.0.5") >= 0
-	}
-	// most SDKs support ICE/TCP
-	return true
-}
-
-func (c ClientInfo) SupportsChangeRTPSenderEncodingActive() bool {
-	return !c.isFirefox()
 }

--- a/pkg/rtc/clientinfo.go
+++ b/pkg/rtc/clientinfo.go
@@ -38,8 +38,8 @@ func (c ClientInfo) FireTrackByRTPPacket() bool {
 
 func (c ClientInfo) CanHandleReconnectResponse() bool {
 	if c.Sdk == livekit.ClientInfo_JS {
-		// JS cannot handle new responses before 1.6.4
-		if c.compareVersion("1.6.4") < 0 {
+		// JS handles Reconnect explicitly in 1.6.3, prior to 1.6.4 it could not handle unknown responses
+		if c.compareVersion("1.6.3") < 0 {
 			return false
 		}
 	}

--- a/pkg/rtc/clientinfo_test.go
+++ b/pkg/rtc/clientinfo_test.go
@@ -30,9 +30,9 @@ func TestClientInfo_CompareVersion(t *testing.T) {
 			Version: "1",
 		},
 	}
-	require.Equal(t, 1, c.CompareVersion("0.1.0"))
-	require.Equal(t, 0, c.CompareVersion("1.0.0"))
-	require.Equal(t, -1, c.CompareVersion("1.0.5"))
+	require.Equal(t, 1, c.compareVersion("0.1.0"))
+	require.Equal(t, 0, c.compareVersion("1.0.0"))
+	require.Equal(t, -1, c.compareVersion("1.0.5"))
 }
 
 func TestClientInfo_SupportsICETCP(t *testing.T) {

--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -175,6 +175,9 @@ func (p *ParticipantImpl) SendRefreshToken(token string) error {
 }
 
 func (p *ParticipantImpl) SendReconnectResponse(reconnectResponse *livekit.ReconnectResponse) error {
+	if !p.params.ClientInfo.CanHandleReconnectResponse() {
+		return nil
+	}
 	return p.writeMessage(&livekit.SignalResponse{
 		Message: &livekit.SignalResponse_Reconnect{
 			Reconnect: reconnectResponse,


### PR DESCRIPTION
See: https://github.com/livekit/client-sdk-js/pull/568

This bug is triggered the most often when server places client in TCP mode.