### PR TITLE
Improve SubscriptionManagerTest resilience

### DIFF
--- a/pkg/rtc/subscriptionmanager_test.go
+++ b/pkg/rtc/subscriptionmanager_test.go
@@ -70,7 +70,6 @@ func TestSubscribe(t *testing.T) {
 		sm.SubscribeToTrack("track", "pub", "pubID")
 		s := sm.subscriptions["track"]
 		require.True(t, s.isDesired())
-		require.Nil(t, s.getSubscribedTrack())
 		require.Eventually(t, func() bool {
 			return subCount.Load() == 1
 		}, subSettleTimeout, subCheckInterval, "track was not subscribed")


### PR DESCRIPTION
This check fails on GH Actions occasionally due to timing differences.