### PR TITLE
Ensure older participant session update does not go out after a newer

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -981,7 +981,7 @@ func (r *Room) pushAndDequeueUpdates(pi *livekit.ParticipantInfo, isImmediate bo
 				existing.State = livekit.ParticipantInfo_DISCONNECTED
 				updates = append(updates, existing)
 			} else {
-				// older session update, newer session has already been notified, so nothing to do
+				// older session update, newer session has already become active, so nothing to do
 				return nil
 			}
 		}

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -969,8 +969,6 @@ func (r *Room) pushAndDequeueUpdates(pi *livekit.ParticipantInfo, isImmediate bo
 			if pi.Version < existing.Version {
 				// out of order update
 				return nil
-			} else if shouldSend {
-				updates = append(updates, existing)
 			}
 		} else {
 			// different participant sessions

--- a/pkg/rtc/room_test.go
+++ b/pkg/rtc/room_test.go
@@ -211,28 +211,33 @@ func TestPushAndDequeueUpdates(t *testing.T) {
 		Sid:         "1",
 		IsPublisher: true,
 		Version:     1,
+		JoinedAt:    0,
 	}
 	publisher1v2 := &livekit.ParticipantInfo{
 		Identity:    identity,
 		Sid:         "1",
 		IsPublisher: true,
 		Version:     2,
+		JoinedAt:    1,
 	}
 	publisher2 := &livekit.ParticipantInfo{
 		Identity:    identity,
 		Sid:         "2",
 		IsPublisher: true,
 		Version:     1,
+		JoinedAt:    2,
 	}
 	subscriber1v1 := &livekit.ParticipantInfo{
 		Identity: identity,
 		Sid:      "1",
 		Version:  1,
+		JoinedAt: 0,
 	}
 	subscriber1v2 := &livekit.ParticipantInfo{
 		Identity: identity,
 		Sid:      "1",
 		Version:  2,
+		JoinedAt: 1,
 	}
 
 	requirePIEquals := func(t *testing.T, a, b *livekit.ParticipantInfo) {
@@ -265,6 +270,17 @@ func TestPushAndDequeueUpdates(t *testing.T) {
 				queued := rm.batchedUpdates[livekit.ParticipantIdentity(identity)]
 				require.NotNil(t, queued)
 				requirePIEquals(t, subscriber1v2, queued)
+			},
+		},
+		{
+			name:      "both versions updates when immediate",
+			pi:        subscriber1v2,
+			existing:  subscriber1v1,
+			immediate: true,
+			expected:  []*livekit.ParticipantInfo{subscriber1v1, subscriber1v2},
+			validate: func(t *testing.T, rm *Room, _ []*livekit.ParticipantInfo) {
+				queued := rm.batchedUpdates[livekit.ParticipantIdentity(identity)]
+				require.Nil(t, queued)
 			},
 		},
 		{

--- a/pkg/rtc/room_test.go
+++ b/pkg/rtc/room_test.go
@@ -277,7 +277,7 @@ func TestPushAndDequeueUpdates(t *testing.T) {
 			pi:        subscriber1v2,
 			existing:  subscriber1v1,
 			immediate: true,
-			expected:  []*livekit.ParticipantInfo{subscriber1v1, subscriber1v2},
+			expected:  []*livekit.ParticipantInfo{subscriber1v2},
 			validate: func(t *testing.T, rm *Room, _ []*livekit.ParticipantInfo) {
 				queued := rm.batchedUpdates[livekit.ParticipantIdentity(identity)]
 				require.Nil(t, queued)
@@ -310,7 +310,7 @@ func TestPushAndDequeueUpdates(t *testing.T) {
 			name:     "when switching to publisher, queue is cleared",
 			pi:       publisher1v2,
 			existing: subscriber1v1,
-			expected: []*livekit.ParticipantInfo{subscriber1v1, publisher1v2},
+			expected: []*livekit.ParticipantInfo{publisher1v2},
 			validate: func(t *testing.T, rm *Room, updates []*livekit.ParticipantInfo) {
 				require.Empty(t, rm.batchedUpdates)
 			},


### PR DESCRIPTION
session has joined.