### PR TITLE
Fix potentially nil access in buffer

### DIFF
--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -705,11 +705,16 @@ func (w *WebRTCReceiver) GetRTCPSenderReportDataExt(layer int32) *buffer.RTCPSen
 	w.bufferMu.RLock()
 	defer w.bufferMu.RUnlock()
 
-	if layer == InvalidLayerSpatial || int(layer) >= len(w.buffers) {
+	if layer == InvalidLayerSpatial {
 		return nil
 	}
 
-	return w.buffers[layer].GetSenderReportDataExt()
+	buffer := w.getBufferLocked(layer)
+	if buffer == nil {
+		return nil
+	}
+
+	return buffer.GetSenderReportDataExt()
 }
 
 func (w *WebRTCReceiver) GetReferenceLayerRTPTimestamp(ts uint32, layer int32, referenceLayer int32) (uint32, error) {


### PR DESCRIPTION
Looks like a corner case panic. It's not clear to me why DummyReceiver is used in this case.

```
github.com/livekit/livekit-server/pkg/rtc.Recover
	/go/pkg/mod/github.com/livekit/livekit-server@v1.3.4-0.20230120023931-6a8e86c3a3ff/pkg/rtc/utils.go:126
runtime.gopanic
	/usr/local/go/src/runtime/panic.go:884
runtime.panicmem
	/usr/local/go/src/runtime/panic.go:260
runtime.sigpanic
	/usr/local/go/src/runtime/signal_unix.go:835
github.com/livekit/livekit-server/pkg/sfu/buffer.(*Buffer).GetSenderReportData
	/go/pkg/mod/github.com/livekit/livekit-server@v1.3.4-0.20230120023931-6a8e86c3a3ff/pkg/sfu/buffer/buffer.go:637
github.com/livekit/livekit-server/pkg/sfu.(*WebRTCReceiver).GetRTCPSenderReportData
	/go/pkg/mod/github.com/livekit/livekit-server@v1.3.4-0.20230120023931-6a8e86c3a3ff/pkg/sfu/receiver.go:709
github.com/livekit/livekit-server/pkg/rtc.(*DummyReceiver).GetRTCPSenderReportData
	/go/pkg/mod/github.com/livekit/livekit-server@v1.3.4-0.20230120023931-6a8e86c3a3ff/pkg/rtc/wrappedreceiver.go:294
github.com/livekit/livekit-server/pkg/sfu.(*DownTrack).CreateSenderReport
	/go/pkg/mod/github.com/livekit/livekit-server@v1.3.4-0.20230120023931-6a8e86c3a3ff/pkg/sfu/downtrack.go:977
github.com/livekit/livekit-server/pkg/rtc.(*ParticipantImpl).subscriberRTCPWorker
	/go/pkg/mod/github.com/livekit/livekit-server@v1.3.4-0.20230120023931-6a8e86c3a3ff/pkg/rtc/participant.go:1404
```