### PR TITLE
Return early if already subscribed.

### DIFF
--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -418,8 +418,11 @@ func (m *SubscriptionManager) subscribe(s *trackSubscription) error {
 	}
 
 	subTrack, err := track.AddSubscriber(m.params.Participant)
-	if err != nil && err != errAlreadySubscribed {
-		// ignore already subscribed error
+	if err != nil {
+		if err == errAlreadySubscribed {
+			// ignore already subscribed error
+			return nil
+		}
 		return err
 	}
 	subTrack.OnClose(func(willBeResumed bool) {

--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -425,24 +425,25 @@ func (m *SubscriptionManager) subscribe(s *trackSubscription) error {
 	}
 
 	subTrack, err := track.AddSubscriber(m.params.Participant)
-	if err != nil {
-		if err == errAlreadySubscribed {
-			// ignore already subscribed error
-			return nil
-		}
+	if err != nil && err != errAlreadySubscribed {
+		// ignore already subscribed error
 		return err
 	}
-	subTrack.OnClose(func(willBeResumed bool) {
-		m.handleSubscribedTrackClose(s, willBeResumed)
-	})
-	subTrack.AddOnBind(func() {
-		s.setBound()
-		s.maybeRecordSuccess(m.params.Telemetry, m.params.Participant.ID())
-	})
-	s.setSubscribedTrack(subTrack)
+	if subTrack != nil { // could be nil if already subscribed
+		subTrack.OnClose(func(willBeResumed bool) {
+			m.handleSubscribedTrackClose(s, willBeResumed)
+		})
+		subTrack.AddOnBind(func() {
+			s.setBound()
+			s.maybeRecordSuccess(m.params.Telemetry, m.params.Participant.ID())
+		})
+		s.setSubscribedTrack(subTrack)
 
-	if subTrack.NeedsNegotiation() {
-		m.params.Participant.Negotiate(false)
+		if subTrack.NeedsNegotiation() {
+			m.params.Participant.Negotiate(false)
+		}
+
+		go m.params.OnTrackSubscribed(subTrack)
 	}
 
 	// add mark the participant as someone we've subscribed to
@@ -458,8 +459,6 @@ func (m *SubscriptionManager) subscribe(s *trackSubscription) error {
 	}
 	pTracks[s.trackID] = struct{}{}
 	m.lock.Unlock()
-
-	go m.params.OnTrackSubscribed(subTrack)
 
 	if changedCB != nil && firstSubscribe {
 		go changedCB(publisherID, true)

--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -429,7 +429,7 @@ func (m *SubscriptionManager) subscribe(s *trackSubscription) error {
 		// ignore already subscribed error
 		return err
 	}
-	if subTrack != nil { // could be nil if already subscribed
+	if err == nil && subTrack != nil { // subTrack could be nil if already subscribed
 		subTrack.OnClose(func(willBeResumed bool) {
 			m.handleSubscribedTrackClose(s, willBeResumed)
 		})


### PR DESCRIPTION
When already subscribed, returned `subTrack` is nil. Return early, but do not return an error.