### PR TITLE
Improved robustness of subscription stack

### DIFF
--- a/pkg/rtc/errors.go
+++ b/pkg/rtc/errors.go
@@ -14,7 +14,6 @@ var (
 	ErrMissingGrants           = errors.New("VideoGrant is missing")
 
 	// Track subscription related
-	ErrPublisherNotConnected = errors.New("publisher is not connected")
 	ErrNoTrackPermission     = errors.New("participant is not allowed to subscribe to this track")
 	ErrNoSubscribePermission = errors.New("participant is not given permission to subscribe to tracks")
 	ErrTrackNotFound         = errors.New("track cannot be found")

--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -63,8 +63,12 @@ func TestTrackPublishing(t *testing.T) {
 		track.IDReturns("id")
 		published := false
 		updated := false
+		unpublished := false
 		p.OnTrackUpdated(func(p types.LocalParticipant, track types.MediaTrack) {
 			updated = true
+		})
+		p.OnTrackUnpublished(func(p types.LocalParticipant, track types.MediaTrack) {
+			unpublished = true
 		})
 		p.OnTrackPublished(func(p types.LocalParticipant, track types.MediaTrack) {
 			published = true
@@ -78,7 +82,8 @@ func TestTrackPublishing(t *testing.T) {
 
 		track.AddOnCloseArgsForCall(0)()
 		require.Len(t, p.UpTrackManager.publishedTracks, 0)
-		require.True(t, updated)
+		require.True(t, unpublished)
+		require.False(t, updated)
 	})
 
 	t.Run("sends back trackPublished event", func(t *testing.T) {

--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -63,27 +63,17 @@ func TestTrackPublishing(t *testing.T) {
 		track.IDReturns("id")
 		published := false
 		updated := false
-		unpublished := false
 		p.OnTrackUpdated(func(p types.LocalParticipant, track types.MediaTrack) {
 			updated = true
-		})
-		p.OnTrackUnpublished(func(p types.LocalParticipant, track types.MediaTrack) {
-			unpublished = true
 		})
 		p.OnTrackPublished(func(p types.LocalParticipant, track types.MediaTrack) {
 			published = true
 		})
 		p.UpTrackManager.AddPublishedTrack(track)
 		p.handleTrackPublished(track)
-
 		require.True(t, published)
 		require.False(t, updated)
 		require.Len(t, p.UpTrackManager.publishedTracks, 1)
-
-		track.AddOnCloseArgsForCall(0)()
-		require.Len(t, p.UpTrackManager.publishedTracks, 0)
-		require.True(t, unpublished)
-		require.False(t, updated)
 	})
 
 	t.Run("sends back trackPublished event", func(t *testing.T) {

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -766,7 +766,6 @@ func (r *Room) onTrackPublished(participant types.LocalParticipant, track types.
 	}
 
 	r.trackManager.AddTrack(track, participant.Identity(), participant.ID())
-	r.trackManager.NotifyTrackChanged(track.ID())
 
 	// auto track egress
 	if r.internal != nil && r.internal.TrackEgress != nil {

--- a/pkg/rtc/roomtrackmanager.go
+++ b/pkg/rtc/roomtrackmanager.go
@@ -82,10 +82,7 @@ func (r *RoomTrackManager) GetTrackInfo(trackID livekit.TrackID) *TrackInfo {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
-	if info, ok := r.tracks[trackID]; ok {
-		return info
-	}
-	return nil
+	return r.tracks[trackID]
 }
 
 func (r *RoomTrackManager) NotifyTrackChanged(trackID livekit.TrackID) {

--- a/pkg/rtc/roomtrackmanager.go
+++ b/pkg/rtc/roomtrackmanager.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023 LiveKit, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rtc
+
+import (
+	"sync"
+
+	"github.com/livekit/livekit-server/pkg/rtc/types"
+	"github.com/livekit/livekit-server/pkg/utils"
+	"github.com/livekit/protocol/livekit"
+)
+
+// RoomTrackManager holds tracks that are published to the room
+type RoomTrackManager struct {
+	lock            sync.RWMutex
+	changedNotifier *utils.ChangeNotifierManager
+	removedNotifier *utils.ChangeNotifierManager
+	tracks          map[livekit.TrackID]*TrackInfo
+}
+
+type TrackInfo struct {
+	Track             types.MediaTrack
+	PublisherIdentity livekit.ParticipantIdentity
+	PublisherID       livekit.ParticipantID
+}
+
+func NewRoomTrackManager() *RoomTrackManager {
+	return &RoomTrackManager{
+		tracks:          make(map[livekit.TrackID]*TrackInfo),
+		changedNotifier: utils.NewChangeNotifierManager(),
+		removedNotifier: utils.NewChangeNotifierManager(),
+	}
+}
+
+func (r *RoomTrackManager) AddTrack(track types.MediaTrack, publisherIdentity livekit.ParticipantIdentity, publisherID livekit.ParticipantID) {
+	r.lock.Lock()
+	r.tracks[track.ID()] = &TrackInfo{
+		Track:             track,
+		PublisherIdentity: publisherIdentity,
+		PublisherID:       publisherID,
+	}
+	r.lock.Unlock()
+
+	r.NotifyTrackChanged(track.ID())
+}
+
+func (r *RoomTrackManager) RemoveTrack(track types.MediaTrack) {
+	r.lock.Lock()
+	// ensure we are removing the same track as added
+	info, ok := r.tracks[track.ID()]
+	if !ok || info.Track != track {
+		r.lock.Unlock()
+		return
+	}
+	delete(r.tracks, track.ID())
+	r.lock.Unlock()
+
+	n := r.removedNotifier.GetNotifier(string(track.ID()))
+	if n != nil {
+		n.NotifyChanged()
+	}
+
+	r.changedNotifier.RemoveNotifier(string(track.ID()), true)
+	r.removedNotifier.RemoveNotifier(string(track.ID()), true)
+}
+
+func (r *RoomTrackManager) GetTrackInfo(trackID livekit.TrackID) *TrackInfo {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	if info, ok := r.tracks[trackID]; ok {
+		return info
+	}
+	return nil
+}
+
+func (r *RoomTrackManager) NotifyTrackChanged(trackID livekit.TrackID) {
+	n := r.changedNotifier.GetNotifier(string(trackID))
+	if n != nil {
+		n.NotifyChanged()
+	}
+}
+
+// HasObservers lets caller know if the current media track has any observers
+// this is used to signal interest in the track. when another MediaTrack with the same
+// trackID is being used, track is not considered to be observed.
+func (r *RoomTrackManager) HasObservers(track types.MediaTrack) bool {
+	n := r.changedNotifier.GetNotifier(string(track.ID()))
+	if n == nil || !n.HasObservers() {
+		return false
+	}
+
+	info := r.GetTrackInfo(track.ID())
+	if info == nil || info.Track != track {
+		return false
+	}
+	return true
+}
+
+func (r *RoomTrackManager) GetOrCreateTrackChangeNotifier(trackID livekit.TrackID) *utils.ChangeNotifier {
+	return r.changedNotifier.GetOrCreateNotifier(string(trackID))
+}
+
+func (r *RoomTrackManager) GetOrCreateTrackRemoveNotifier(trackID livekit.TrackID) *utils.ChangeNotifier {
+	return r.removedNotifier.GetOrCreateNotifier(string(trackID))
+}

--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -400,7 +400,7 @@ func (m *SubscriptionManager) subscribe(s *trackSubscription) error {
 	if res.TrackRemovedNotifier != nil && s.setRemovedNotifier(res.TrackRemovedNotifier) {
 		res.TrackRemovedNotifier.AddObserver(string(m.params.Participant.ID()), func() {
 			// source track removed, we would unsubscribe
-			s.logger.Debugw("removing subscription since source track was removed")
+			s.logger.Debugw("unsubscribing track since source track was removed")
 			s.setDesired(false)
 		})
 	}

--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -600,12 +600,6 @@ func (s *trackSubscription) getPublisherID() livekit.ParticipantID {
 	return s.publisherID
 }
 
-func (s *trackSubscription) getPublisherIdentity() livekit.ParticipantIdentity {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	return s.publisherIdentity
-}
-
 func (s *trackSubscription) setDesired(desired bool) bool {
 	s.lock.Lock()
 	if desired {

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -268,7 +268,7 @@ type LocalParticipant interface {
 	RemoveTrackFromSubscriber(sender *webrtc.RTPSender) error
 
 	// subscriptions
-	SubscribeToTrack(trackID livekit.TrackID, publisherIdentity livekit.ParticipantIdentity, publisherID livekit.ParticipantID)
+	SubscribeToTrack(trackID livekit.TrackID)
 	UnsubscribeFromTrack(trackID livekit.TrackID)
 	UpdateSubscribedTrackSettings(trackID livekit.TrackID, settings *livekit.UpdateTrackSettings)
 	GetSubscribedTracks() []SubscribedTrack
@@ -303,6 +303,8 @@ type LocalParticipant interface {
 	OnTrackPublished(func(LocalParticipant, MediaTrack))
 	// OnTrackUpdated - one of its publishedTracks changed in status
 	OnTrackUpdated(callback func(LocalParticipant, MediaTrack))
+	// OnTrackUnpublished - a track was unpublished
+	OnTrackUnpublished(callback func(LocalParticipant, MediaTrack))
 	// OnParticipantUpdate - metadata or permission is updated
 	OnParticipantUpdate(callback func(LocalParticipant))
 	OnDataPacket(callback func(LocalParticipant, *livekit.DataPacket))
@@ -342,7 +344,7 @@ type Room interface {
 	SyncState(participant LocalParticipant, state *livekit.SyncState) error
 	SimulateScenario(participant LocalParticipant, scenario *livekit.SimulateScenario) error
 	UpdateVideoLayers(participant Participant, updateVideoLayers *livekit.UpdateVideoLayers) error
-	ResolveMediaTrackForSubscriber(subIdentity livekit.ParticipantIdentity, publisherID livekit.ParticipantID, trackID livekit.TrackID) (MediaResolverResult, error)
+	ResolveMediaTrackForSubscriber(subIdentity livekit.ParticipantIdentity, trackID livekit.TrackID) MediaResolverResult
 }
 
 // MediaTrack represents a media track
@@ -439,14 +441,17 @@ type ChangeNotifier interface {
 }
 
 type MediaResolverResult struct {
-	TrackChangeNotifier ChangeNotifier
-	Track               MediaTrack
+	TrackChangedNotifier ChangeNotifier
+	TrackRemovedNotifier ChangeNotifier
+	Track                MediaTrack
 	// is permission given to the requesting participant
-	HasPermission bool
+	HasPermission     bool
+	PublisherID       livekit.ParticipantID
+	PublisherIdentity livekit.ParticipantIdentity
 }
 
 // MediaTrackResolver locates a specific media track for a subscriber
-type MediaTrackResolver func(livekit.ParticipantIdentity, livekit.ParticipantID, livekit.TrackID) (MediaResolverResult, error)
+type MediaTrackResolver func(livekit.ParticipantIdentity, livekit.TrackID) MediaResolverResult
 
 // Supervisor/operation monitor related definitions
 type OperationMonitorEvent int

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -475,6 +475,11 @@ type FakeLocalParticipant struct {
 	onTrackPublishedArgsForCall []struct {
 		arg1 func(types.LocalParticipant, types.MediaTrack)
 	}
+	OnTrackUnpublishedStub        func(func(types.LocalParticipant, types.MediaTrack))
+	onTrackUnpublishedMutex       sync.RWMutex
+	onTrackUnpublishedArgsForCall []struct {
+		arg1 func(types.LocalParticipant, types.MediaTrack)
+	}
 	OnTrackUpdatedStub        func(func(types.LocalParticipant, types.MediaTrack))
 	onTrackUpdatedMutex       sync.RWMutex
 	onTrackUpdatedArgsForCall []struct {
@@ -662,12 +667,10 @@ type FakeLocalParticipant struct {
 	stateReturnsOnCall map[int]struct {
 		result1 livekit.ParticipantInfo_State
 	}
-	SubscribeToTrackStub        func(livekit.TrackID, livekit.ParticipantIdentity, livekit.ParticipantID)
+	SubscribeToTrackStub        func(livekit.TrackID)
 	subscribeToTrackMutex       sync.RWMutex
 	subscribeToTrackArgsForCall []struct {
 		arg1 livekit.TrackID
-		arg2 livekit.ParticipantIdentity
-		arg3 livekit.ParticipantID
 	}
 	SubscriberAsPrimaryStub        func() bool
 	subscriberAsPrimaryMutex       sync.RWMutex
@@ -3266,6 +3269,38 @@ func (fake *FakeLocalParticipant) OnTrackPublishedArgsForCall(i int) func(types.
 	return argsForCall.arg1
 }
 
+func (fake *FakeLocalParticipant) OnTrackUnpublished(arg1 func(types.LocalParticipant, types.MediaTrack)) {
+	fake.onTrackUnpublishedMutex.Lock()
+	fake.onTrackUnpublishedArgsForCall = append(fake.onTrackUnpublishedArgsForCall, struct {
+		arg1 func(types.LocalParticipant, types.MediaTrack)
+	}{arg1})
+	stub := fake.OnTrackUnpublishedStub
+	fake.recordInvocation("OnTrackUnpublished", []interface{}{arg1})
+	fake.onTrackUnpublishedMutex.Unlock()
+	if stub != nil {
+		fake.OnTrackUnpublishedStub(arg1)
+	}
+}
+
+func (fake *FakeLocalParticipant) OnTrackUnpublishedCallCount() int {
+	fake.onTrackUnpublishedMutex.RLock()
+	defer fake.onTrackUnpublishedMutex.RUnlock()
+	return len(fake.onTrackUnpublishedArgsForCall)
+}
+
+func (fake *FakeLocalParticipant) OnTrackUnpublishedCalls(stub func(func(types.LocalParticipant, types.MediaTrack))) {
+	fake.onTrackUnpublishedMutex.Lock()
+	defer fake.onTrackUnpublishedMutex.Unlock()
+	fake.OnTrackUnpublishedStub = stub
+}
+
+func (fake *FakeLocalParticipant) OnTrackUnpublishedArgsForCall(i int) func(types.LocalParticipant, types.MediaTrack) {
+	fake.onTrackUnpublishedMutex.RLock()
+	defer fake.onTrackUnpublishedMutex.RUnlock()
+	argsForCall := fake.onTrackUnpublishedArgsForCall[i]
+	return argsForCall.arg1
+}
+
 func (fake *FakeLocalParticipant) OnTrackUpdated(arg1 func(types.LocalParticipant, types.MediaTrack)) {
 	fake.onTrackUpdatedMutex.Lock()
 	fake.onTrackUpdatedArgsForCall = append(fake.onTrackUpdatedArgsForCall, struct {
@@ -4327,18 +4362,16 @@ func (fake *FakeLocalParticipant) StateReturnsOnCall(i int, result1 livekit.Part
 	}{result1}
 }
 
-func (fake *FakeLocalParticipant) SubscribeToTrack(arg1 livekit.TrackID, arg2 livekit.ParticipantIdentity, arg3 livekit.ParticipantID) {
+func (fake *FakeLocalParticipant) SubscribeToTrack(arg1 livekit.TrackID) {
 	fake.subscribeToTrackMutex.Lock()
 	fake.subscribeToTrackArgsForCall = append(fake.subscribeToTrackArgsForCall, struct {
 		arg1 livekit.TrackID
-		arg2 livekit.ParticipantIdentity
-		arg3 livekit.ParticipantID
-	}{arg1, arg2, arg3})
+	}{arg1})
 	stub := fake.SubscribeToTrackStub
-	fake.recordInvocation("SubscribeToTrack", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("SubscribeToTrack", []interface{}{arg1})
 	fake.subscribeToTrackMutex.Unlock()
 	if stub != nil {
-		fake.SubscribeToTrackStub(arg1, arg2, arg3)
+		fake.SubscribeToTrackStub(arg1)
 	}
 }
 
@@ -4348,17 +4381,17 @@ func (fake *FakeLocalParticipant) SubscribeToTrackCallCount() int {
 	return len(fake.subscribeToTrackArgsForCall)
 }
 
-func (fake *FakeLocalParticipant) SubscribeToTrackCalls(stub func(livekit.TrackID, livekit.ParticipantIdentity, livekit.ParticipantID)) {
+func (fake *FakeLocalParticipant) SubscribeToTrackCalls(stub func(livekit.TrackID)) {
 	fake.subscribeToTrackMutex.Lock()
 	defer fake.subscribeToTrackMutex.Unlock()
 	fake.SubscribeToTrackStub = stub
 }
 
-func (fake *FakeLocalParticipant) SubscribeToTrackArgsForCall(i int) (livekit.TrackID, livekit.ParticipantIdentity, livekit.ParticipantID) {
+func (fake *FakeLocalParticipant) SubscribeToTrackArgsForCall(i int) livekit.TrackID {
 	fake.subscribeToTrackMutex.RLock()
 	defer fake.subscribeToTrackMutex.RUnlock()
 	argsForCall := fake.subscribeToTrackArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1
 }
 
 func (fake *FakeLocalParticipant) SubscriberAsPrimary() bool {
@@ -5167,6 +5200,8 @@ func (fake *FakeLocalParticipant) Invocations() map[string][][]interface{} {
 	defer fake.onSubscribeStatusChangedMutex.RUnlock()
 	fake.onTrackPublishedMutex.RLock()
 	defer fake.onTrackPublishedMutex.RUnlock()
+	fake.onTrackUnpublishedMutex.RLock()
+	defer fake.onTrackUnpublishedMutex.RUnlock()
 	fake.onTrackUpdatedMutex.RLock()
 	defer fake.onTrackUpdatedMutex.RUnlock()
 	fake.protocolVersionMutex.RLock()

--- a/pkg/rtc/types/typesfakes/fake_room.go
+++ b/pkg/rtc/types/typesfakes/fake_room.go
@@ -36,20 +36,17 @@ type FakeRoom struct {
 		arg2 livekit.ParticipantID
 		arg3 types.ParticipantCloseReason
 	}
-	ResolveMediaTrackForSubscriberStub        func(livekit.ParticipantIdentity, livekit.ParticipantID, livekit.TrackID) (types.MediaResolverResult, error)
+	ResolveMediaTrackForSubscriberStub        func(livekit.ParticipantIdentity, livekit.TrackID) types.MediaResolverResult
 	resolveMediaTrackForSubscriberMutex       sync.RWMutex
 	resolveMediaTrackForSubscriberArgsForCall []struct {
 		arg1 livekit.ParticipantIdentity
-		arg2 livekit.ParticipantID
-		arg3 livekit.TrackID
+		arg2 livekit.TrackID
 	}
 	resolveMediaTrackForSubscriberReturns struct {
 		result1 types.MediaResolverResult
-		result2 error
 	}
 	resolveMediaTrackForSubscriberReturnsOnCall map[int]struct {
 		result1 types.MediaResolverResult
-		result2 error
 	}
 	SimulateScenarioStub        func(types.LocalParticipant, *livekit.SimulateScenario) error
 	simulateScenarioMutex       sync.RWMutex
@@ -251,25 +248,24 @@ func (fake *FakeRoom) RemoveParticipantArgsForCall(i int) (livekit.ParticipantId
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeRoom) ResolveMediaTrackForSubscriber(arg1 livekit.ParticipantIdentity, arg2 livekit.ParticipantID, arg3 livekit.TrackID) (types.MediaResolverResult, error) {
+func (fake *FakeRoom) ResolveMediaTrackForSubscriber(arg1 livekit.ParticipantIdentity, arg2 livekit.TrackID) types.MediaResolverResult {
 	fake.resolveMediaTrackForSubscriberMutex.Lock()
 	ret, specificReturn := fake.resolveMediaTrackForSubscriberReturnsOnCall[len(fake.resolveMediaTrackForSubscriberArgsForCall)]
 	fake.resolveMediaTrackForSubscriberArgsForCall = append(fake.resolveMediaTrackForSubscriberArgsForCall, struct {
 		arg1 livekit.ParticipantIdentity
-		arg2 livekit.ParticipantID
-		arg3 livekit.TrackID
-	}{arg1, arg2, arg3})
+		arg2 livekit.TrackID
+	}{arg1, arg2})
 	stub := fake.ResolveMediaTrackForSubscriberStub
 	fakeReturns := fake.resolveMediaTrackForSubscriberReturns
-	fake.recordInvocation("ResolveMediaTrackForSubscriber", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("ResolveMediaTrackForSubscriber", []interface{}{arg1, arg2})
 	fake.resolveMediaTrackForSubscriberMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1
 }
 
 func (fake *FakeRoom) ResolveMediaTrackForSubscriberCallCount() int {
@@ -278,43 +274,40 @@ func (fake *FakeRoom) ResolveMediaTrackForSubscriberCallCount() int {
 	return len(fake.resolveMediaTrackForSubscriberArgsForCall)
 }
 
-func (fake *FakeRoom) ResolveMediaTrackForSubscriberCalls(stub func(livekit.ParticipantIdentity, livekit.ParticipantID, livekit.TrackID) (types.MediaResolverResult, error)) {
+func (fake *FakeRoom) ResolveMediaTrackForSubscriberCalls(stub func(livekit.ParticipantIdentity, livekit.TrackID) types.MediaResolverResult) {
 	fake.resolveMediaTrackForSubscriberMutex.Lock()
 	defer fake.resolveMediaTrackForSubscriberMutex.Unlock()
 	fake.ResolveMediaTrackForSubscriberStub = stub
 }
 
-func (fake *FakeRoom) ResolveMediaTrackForSubscriberArgsForCall(i int) (livekit.ParticipantIdentity, livekit.ParticipantID, livekit.TrackID) {
+func (fake *FakeRoom) ResolveMediaTrackForSubscriberArgsForCall(i int) (livekit.ParticipantIdentity, livekit.TrackID) {
 	fake.resolveMediaTrackForSubscriberMutex.RLock()
 	defer fake.resolveMediaTrackForSubscriberMutex.RUnlock()
 	argsForCall := fake.resolveMediaTrackForSubscriberArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeRoom) ResolveMediaTrackForSubscriberReturns(result1 types.MediaResolverResult, result2 error) {
+func (fake *FakeRoom) ResolveMediaTrackForSubscriberReturns(result1 types.MediaResolverResult) {
 	fake.resolveMediaTrackForSubscriberMutex.Lock()
 	defer fake.resolveMediaTrackForSubscriberMutex.Unlock()
 	fake.ResolveMediaTrackForSubscriberStub = nil
 	fake.resolveMediaTrackForSubscriberReturns = struct {
 		result1 types.MediaResolverResult
-		result2 error
-	}{result1, result2}
+	}{result1}
 }
 
-func (fake *FakeRoom) ResolveMediaTrackForSubscriberReturnsOnCall(i int, result1 types.MediaResolverResult, result2 error) {
+func (fake *FakeRoom) ResolveMediaTrackForSubscriberReturnsOnCall(i int, result1 types.MediaResolverResult) {
 	fake.resolveMediaTrackForSubscriberMutex.Lock()
 	defer fake.resolveMediaTrackForSubscriberMutex.Unlock()
 	fake.ResolveMediaTrackForSubscriberStub = nil
 	if fake.resolveMediaTrackForSubscriberReturnsOnCall == nil {
 		fake.resolveMediaTrackForSubscriberReturnsOnCall = make(map[int]struct {
 			result1 types.MediaResolverResult
-			result2 error
 		})
 	}
 	fake.resolveMediaTrackForSubscriberReturnsOnCall[i] = struct {
 		result1 types.MediaResolverResult
-		result2 error
-	}{result1, result2}
+	}{result1}
 }
 
 func (fake *FakeRoom) SimulateScenario(arg1 types.LocalParticipant, arg2 *livekit.SimulateScenario) error {

--- a/pkg/rtc/uptrackmanager.go
+++ b/pkg/rtc/uptrackmanager.go
@@ -38,7 +38,7 @@ type UpTrackManager struct {
 
 	// callbacks & handlers
 	onClose        func()
-	onTrackUpdated func(track types.MediaTrack, onlyIfReady bool)
+	onTrackUpdated func(track types.MediaTrack)
 }
 
 func NewUpTrackManager(params UpTrackManagerParams) *UpTrackManager {
@@ -83,7 +83,7 @@ func (u *UpTrackManager) ToProto() []*livekit.TrackInfo {
 	return trackInfos
 }
 
-func (u *UpTrackManager) OnPublishedTrackUpdated(f func(track types.MediaTrack, onlyIfReady bool)) {
+func (u *UpTrackManager) OnPublishedTrackUpdated(f func(track types.MediaTrack)) {
 	u.onTrackUpdated = f
 }
 
@@ -99,7 +99,7 @@ func (u *UpTrackManager) SetPublishedTrackMuted(trackID livekit.TrackID, muted b
 		if currentMuted != track.IsMuted() {
 			u.params.Logger.Infow("publisher mute status changed", "trackID", trackID, "muted", track.IsMuted())
 			if u.onTrackUpdated != nil {
-				u.onTrackUpdated(track, false)
+				u.onTrackUpdated(track)
 			}
 		}
 	}
@@ -232,7 +232,7 @@ func (u *UpTrackManager) UpdateVideoLayers(updateVideoLayers *livekit.UpdateVide
 
 	track.UpdateVideoLayers(updateVideoLayers.Layers)
 	if u.onTrackUpdated != nil {
-		u.onTrackUpdated(track, false)
+		u.onTrackUpdated(track)
 	}
 
 	return nil
@@ -259,11 +259,6 @@ func (u *UpTrackManager) AddPublishedTrack(track types.MediaTrack) {
 			notifyClose = true
 		}
 		u.lock.Unlock()
-
-		// only send this when client is in a ready state
-		if u.onTrackUpdated != nil {
-			u.onTrackUpdated(track, true)
-		}
 
 		if notifyClose && u.onClose != nil {
 			u.onClose()

--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -243,14 +243,12 @@ func (t *telemetryService) TrackSubscribeRequested(
 	ctx context.Context,
 	participantID livekit.ParticipantID,
 	track *livekit.TrackInfo,
-	publisher *livekit.ParticipantInfo,
 ) {
 	t.enqueue(func() {
 		prometheus.RecordTrackSubscribeAttempt()
 
 		room := t.getRoomDetails(participantID)
 		ev := newTrackEvent(livekit.AnalyticsEventType_TRACK_SUBSCRIBE_REQUESTED, room, participantID, track)
-		ev.Publisher = publisher
 		t.SendEvent(ctx, ev)
 	})
 }

--- a/pkg/telemetry/telemetryfakes/fake_telemetry_service.go
+++ b/pkg/telemetry/telemetryfakes/fake_telemetry_service.go
@@ -144,13 +144,12 @@ type FakeTelemetryService struct {
 		arg4 error
 		arg5 bool
 	}
-	TrackSubscribeRequestedStub        func(context.Context, livekit.ParticipantID, *livekit.TrackInfo, *livekit.ParticipantInfo)
+	TrackSubscribeRequestedStub        func(context.Context, livekit.ParticipantID, *livekit.TrackInfo)
 	trackSubscribeRequestedMutex       sync.RWMutex
 	trackSubscribeRequestedArgsForCall []struct {
 		arg1 context.Context
 		arg2 livekit.ParticipantID
 		arg3 *livekit.TrackInfo
-		arg4 *livekit.ParticipantInfo
 	}
 	TrackSubscribedStub        func(context.Context, livekit.ParticipantID, *livekit.TrackInfo, *livekit.ParticipantInfo, bool)
 	trackSubscribedMutex       sync.RWMutex
@@ -834,19 +833,18 @@ func (fake *FakeTelemetryService) TrackSubscribeFailedArgsForCall(i int) (contex
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
-func (fake *FakeTelemetryService) TrackSubscribeRequested(arg1 context.Context, arg2 livekit.ParticipantID, arg3 *livekit.TrackInfo, arg4 *livekit.ParticipantInfo) {
+func (fake *FakeTelemetryService) TrackSubscribeRequested(arg1 context.Context, arg2 livekit.ParticipantID, arg3 *livekit.TrackInfo) {
 	fake.trackSubscribeRequestedMutex.Lock()
 	fake.trackSubscribeRequestedArgsForCall = append(fake.trackSubscribeRequestedArgsForCall, struct {
 		arg1 context.Context
 		arg2 livekit.ParticipantID
 		arg3 *livekit.TrackInfo
-		arg4 *livekit.ParticipantInfo
-	}{arg1, arg2, arg3, arg4})
+	}{arg1, arg2, arg3})
 	stub := fake.TrackSubscribeRequestedStub
-	fake.recordInvocation("TrackSubscribeRequested", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("TrackSubscribeRequested", []interface{}{arg1, arg2, arg3})
 	fake.trackSubscribeRequestedMutex.Unlock()
 	if stub != nil {
-		fake.TrackSubscribeRequestedStub(arg1, arg2, arg3, arg4)
+		fake.TrackSubscribeRequestedStub(arg1, arg2, arg3)
 	}
 }
 
@@ -856,17 +854,17 @@ func (fake *FakeTelemetryService) TrackSubscribeRequestedCallCount() int {
 	return len(fake.trackSubscribeRequestedArgsForCall)
 }
 
-func (fake *FakeTelemetryService) TrackSubscribeRequestedCalls(stub func(context.Context, livekit.ParticipantID, *livekit.TrackInfo, *livekit.ParticipantInfo)) {
+func (fake *FakeTelemetryService) TrackSubscribeRequestedCalls(stub func(context.Context, livekit.ParticipantID, *livekit.TrackInfo)) {
 	fake.trackSubscribeRequestedMutex.Lock()
 	defer fake.trackSubscribeRequestedMutex.Unlock()
 	fake.TrackSubscribeRequestedStub = stub
 }
 
-func (fake *FakeTelemetryService) TrackSubscribeRequestedArgsForCall(i int) (context.Context, livekit.ParticipantID, *livekit.TrackInfo, *livekit.ParticipantInfo) {
+func (fake *FakeTelemetryService) TrackSubscribeRequestedArgsForCall(i int) (context.Context, livekit.ParticipantID, *livekit.TrackInfo) {
 	fake.trackSubscribeRequestedMutex.RLock()
 	defer fake.trackSubscribeRequestedMutex.RUnlock()
 	argsForCall := fake.trackSubscribeRequestedArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeTelemetryService) TrackSubscribed(arg1 context.Context, arg2 livekit.ParticipantID, arg3 *livekit.TrackInfo, arg4 *livekit.ParticipantInfo, arg5 bool) {

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -36,7 +36,7 @@ type TelemetryService interface {
 	// TrackUnpublished - a participant unpublished a track
 	TrackUnpublished(ctx context.Context, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo, shouldSendEvent bool)
 	// TrackSubscribeRequested - a participant requested to subscribe to a track
-	TrackSubscribeRequested(ctx context.Context, participantID livekit.ParticipantID, track *livekit.TrackInfo, publisher *livekit.ParticipantInfo)
+	TrackSubscribeRequested(ctx context.Context, participantID livekit.ParticipantID, track *livekit.TrackInfo)
 	// TrackSubscribed - a participant subscribed to a track successfully
 	TrackSubscribed(ctx context.Context, participantID livekit.ParticipantID, track *livekit.TrackInfo, publisher *livekit.ParticipantInfo, shouldSendEvent bool)
 	// TrackUnsubscribed - a participant unsubscribed from a track successfully


### PR DESCRIPTION
UpdateSubscription had a shortcoming where when it couldn't find the participant, it ignored the request.

This PR further removes the reliance of current publisher state from subscribers.
- SubscribeToTrack only takes in a trackID
- Introduced RoomTrackManager to maintain all published tracks to a room
- Added TrackUnpublished event to clearly indicate when a track has been removed
- SubscribeRequested event no longer include information about the publisher