### PR TITLE
ensure onPacket is not nil in rtcpreader callback

### DIFF
--- a/pkg/sfu/buffer/rtcpreader.go
+++ b/pkg/sfu/buffer/rtcpreader.go
@@ -22,7 +22,7 @@ func (r *RTCPReader) Write(p []byte) (n int, err error) {
 		err = io.EOF
 		return
 	}
-	if f, ok := r.onPacket.Load().(func([]byte)); ok {
+	if f, ok := r.onPacket.Load().(func([]byte)); ok && f != nil {
 		f(p)
 	}
 	return


### PR DESCRIPTION
when downtrack closed during rtcp reader got a packet, the nil onPacket callback might cause nil pointer panic