### PR TITLE
Send stream state paused only when it is paused due to bandwidth limitation.

### DIFF
--- a/pkg/sfu/videolayerselector.go
+++ b/pkg/sfu/videolayerselector.go
@@ -98,7 +98,7 @@ func (s *DDVideoLayerSelector) Select(expPkt *buffer.ExtPacket, tp *TranslationP
 		// expPkt.DependencyDescriptor.FrameDependencies.SpatialId, expPkt.DependencyDescriptor.FrameDependencies.TemporalId))
 		return false
 	} else if dti == dd.DecodeTargetSwitch {
-		tp.switchingToTargetLayer = true
+		tp.isSwitchingToTargetLayer = true
 	}
 
 	// DD-TODO : add frame to forwarded queue if entire frame is forwarded


### PR DESCRIPTION
When stream is resumed after a stream is paused, an active update is
sent. Note that this means if there are intervening events like
mute/unmute between pause and resume, resume will be sent.