### PR TITLE
Limit layer to num advertised.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -746,7 +746,7 @@ func (f *Forwarder) AllocateOptimal(brs Bitrates, allowOvershoot bool) VideoAllo
 			} else {
 				// opportunisitically latch on to anything
 				alloc.targetLayers = VideoLayers{
-					Spatial:  f.numAdvertisedLayers,
+					Spatial:  int32(math.Max(0, float64(f.numAdvertisedLayers-1))),
 					Temporal: DefaultMaxLayerTemporal,
 				}
 			}

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -746,7 +746,7 @@ func (f *Forwarder) AllocateOptimal(brs Bitrates, allowOvershoot bool) VideoAllo
 			} else {
 				// opportunisitically latch on to anything
 				alloc.targetLayers = VideoLayers{
-					Spatial:  DefaultMaxLayerSpatial,
+					Spatial:  f.numAdvertisedLayers,
 					Temporal: DefaultMaxLayerTemporal,
 				}
 			}

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -197,10 +197,11 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 	f.Mute(false)
 
 	// feed dry state, target set to maximum for opportunistic start
+	f.SetNumAdvertisedLayers(3)
 	f.lastAllocation.state = VideoAllocationStateNone
 	disable(f)
 	expectedTargetLayers := VideoLayers{
-		Spatial:  DefaultMaxLayerSpatial,
+		Spatial:  2,
 		Temporal: DefaultMaxLayerTemporal,
 	}
 	expectedResult = VideoAllocation{


### PR DESCRIPTION
Otherwise, this leads to invalid layer for non-simulcast tracks.