### PR TITLE
Trigger max layer switch when downgrading.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1641,6 +1641,10 @@ func (f *Forwarder) getTranslationParamsVideo(extPkt *buffer.ExtPacket, layer in
 					f.logger.Infow("adjusting overshoot", "current", f.currentLayers, "target", f.targetLayers, "adjuted", layer)
 					f.currentLayers.Spatial = layer
 					f.targetLayers.Spatial = layer
+
+					if f.currentLayers.Spatial >= f.maxLayers.Spatial || f.currentLayers.Spatial == (f.numAdvertisedLayers-1) {
+						tp.isSwitchingToMaxLayer = true
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When downgrading (could be due to overshoot or opportunistically locking to a higher layer), need to check if the max layer notification needs to be done so that dynacast has the right max layer for the participant corresponding to this downtrack.