### PR TITLE
Send unpublished callback unconditionally.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1638,18 +1638,16 @@ func (p *ParticipantImpl) addMediaTrack(signalCid string, sdpCid string, ti *liv
 			!p.IsClosed(),
 		)
 
-		isUnpublished := false
 		// re-use Track sid
 		p.pendingTracksLock.Lock()
 		if pti := p.pendingTracks[signalCid]; pti != nil {
 			p.sendTrackPublished(signalCid, pti.trackInfos[0])
 		} else {
 			p.unpublishedTracks = append(p.unpublishedTracks, ti)
-			isUnpublished = true
 		}
 		p.pendingTracksLock.Unlock()
 
-		if isUnpublished && !p.IsClosed() {
+		if !p.IsClosed() {
 			// unpublished events aren't necessary when participant is closed
 			p.params.Logger.Debugw("unpublished track", "trackID", ti.Sid, "trackInfo", ti)
 			p.lock.RLock()

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -795,7 +795,7 @@ func (d *DownTrack) CloseWithFlush(flush bool) {
 	d.bindLock.Unlock()
 	d.connectionStats.Close()
 	d.rtpStats.Stop()
-	d.logger.Infow("rtp stats", "direction", "downstream", "mime", d.mime, "stats", d.rtpStats.ToString())
+	d.logger.Infow("rtp stats", "direction", "downstream", "mime", d.mime, "ssrc", d.ssrc, "stats", d.rtpStats.ToString())
 
 	if d.onMaxLayerChanged != nil && d.kind == webrtc.RTPCodecTypeVideo {
 		d.onMaxLayerChanged(d, InvalidLayerSpatial)


### PR DESCRIPTION
Even if an add track has been queued and can be used immediately when the previous incarnation unpublishes, send the unpublished callback as the track was technically unpublished and republished. The re-publish will pick the same track SID when the pending track is queued as it will get the SID from an existing published track.