### PR TITLE
Callback support for migrate state change.

### DIFF
--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -299,6 +299,7 @@ type LocalParticipant interface {
 
 	// callbacks
 	OnStateChange(func(p LocalParticipant, oldState livekit.ParticipantInfo_State))
+	OnMigrateStateChange(func(p LocalParticipant, migrateState MigrateState))
 	// OnTrackPublished - remote added a track
 	OnTrackPublished(func(LocalParticipant, MediaTrack))
 	// OnTrackUpdated - one of its publishedTracks changed in status

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -450,6 +450,11 @@ type FakeLocalParticipant struct {
 	onICEConfigChangedArgsForCall []struct {
 		arg1 func(participant types.LocalParticipant, iceConfig *livekit.ICEConfig)
 	}
+	OnMigrateStateChangeStub        func(func(p types.LocalParticipant, migrateState types.MigrateState))
+	onMigrateStateChangeMutex       sync.RWMutex
+	onMigrateStateChangeArgsForCall []struct {
+		arg1 func(p types.LocalParticipant, migrateState types.MigrateState)
+	}
 	OnParticipantUpdateStub        func(func(types.LocalParticipant))
 	onParticipantUpdateMutex       sync.RWMutex
 	onParticipantUpdateArgsForCall []struct {
@@ -3115,6 +3120,38 @@ func (fake *FakeLocalParticipant) OnICEConfigChangedArgsForCall(i int) func(part
 	return argsForCall.arg1
 }
 
+func (fake *FakeLocalParticipant) OnMigrateStateChange(arg1 func(p types.LocalParticipant, migrateState types.MigrateState)) {
+	fake.onMigrateStateChangeMutex.Lock()
+	fake.onMigrateStateChangeArgsForCall = append(fake.onMigrateStateChangeArgsForCall, struct {
+		arg1 func(p types.LocalParticipant, migrateState types.MigrateState)
+	}{arg1})
+	stub := fake.OnMigrateStateChangeStub
+	fake.recordInvocation("OnMigrateStateChange", []interface{}{arg1})
+	fake.onMigrateStateChangeMutex.Unlock()
+	if stub != nil {
+		fake.OnMigrateStateChangeStub(arg1)
+	}
+}
+
+func (fake *FakeLocalParticipant) OnMigrateStateChangeCallCount() int {
+	fake.onMigrateStateChangeMutex.RLock()
+	defer fake.onMigrateStateChangeMutex.RUnlock()
+	return len(fake.onMigrateStateChangeArgsForCall)
+}
+
+func (fake *FakeLocalParticipant) OnMigrateStateChangeCalls(stub func(func(p types.LocalParticipant, migrateState types.MigrateState))) {
+	fake.onMigrateStateChangeMutex.Lock()
+	defer fake.onMigrateStateChangeMutex.Unlock()
+	fake.OnMigrateStateChangeStub = stub
+}
+
+func (fake *FakeLocalParticipant) OnMigrateStateChangeArgsForCall(i int) func(p types.LocalParticipant, migrateState types.MigrateState) {
+	fake.onMigrateStateChangeMutex.RLock()
+	defer fake.onMigrateStateChangeMutex.RUnlock()
+	argsForCall := fake.onMigrateStateChangeArgsForCall[i]
+	return argsForCall.arg1
+}
+
 func (fake *FakeLocalParticipant) OnParticipantUpdate(arg1 func(types.LocalParticipant)) {
 	fake.onParticipantUpdateMutex.Lock()
 	fake.onParticipantUpdateArgsForCall = append(fake.onParticipantUpdateArgsForCall, struct {
@@ -5229,6 +5266,8 @@ func (fake *FakeLocalParticipant) Invocations() map[string][][]interface{} {
 	defer fake.onDataPacketMutex.RUnlock()
 	fake.onICEConfigChangedMutex.RLock()
 	defer fake.onICEConfigChangedMutex.RUnlock()
+	fake.onMigrateStateChangeMutex.RLock()
+	defer fake.onMigrateStateChangeMutex.RUnlock()
 	fake.onParticipantUpdateMutex.RLock()
 	defer fake.onParticipantUpdateMutex.RUnlock()
 	fake.onReceiverReportMutex.RLock()

--- a/pkg/utils/changenotifier.go
+++ b/pkg/utils/changenotifier.go
@@ -16,9 +16,7 @@
 
 package utils
 
-import (
-	"sync"
-)
+import "sync"
 
 type ChangeNotifier struct {
 	lock      sync.Mutex


### PR DESCRIPTION
This can be used to detect changes in migrate state and signal migration completion to remote nodes.