### PR TITLE
Use available layers in optimal allocation.

### DIFF
--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -187,11 +187,11 @@ func (d *DummyReceiver) ReadRTP(buf []byte, layer uint8, sn uint16) (int, error)
 	return 0, errors.New("no receiver")
 }
 
-func (d *DummyReceiver) GetLayeredBitrate() sfu.Bitrates {
+func (d *DummyReceiver) GetLayeredBitrate() ([]int32, sfu.Bitrates) {
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.GetLayeredBitrate()
 	}
-	return sfu.Bitrates{}
+	return nil, sfu.Bitrates{}
 }
 
 func (d *DummyReceiver) GetAudioLevel() (float64, bool) {

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -943,7 +943,8 @@ func (d *DownTrack) IsDeficient() bool {
 }
 
 func (d *DownTrack) BandwidthRequested() int64 {
-	return d.forwarder.BandwidthRequested(d.receiver.GetLayeredBitrate())
+	_, brs := d.receiver.GetLayeredBitrate()
+	return d.forwarder.BandwidthRequested(brs)
 }
 
 func (d *DownTrack) DistanceToDesired() int32 {
@@ -951,13 +952,15 @@ func (d *DownTrack) DistanceToDesired() int32 {
 }
 
 func (d *DownTrack) AllocateOptimal(allowOvershoot bool) VideoAllocation {
-	allocation := d.forwarder.AllocateOptimal(d.receiver.GetLayeredBitrate(), allowOvershoot)
+	al, brs := d.receiver.GetLayeredBitrate()
+	allocation := d.forwarder.AllocateOptimal(al, brs, allowOvershoot)
 	d.maybeStartKeyFrameRequester()
 	return allocation
 }
 
 func (d *DownTrack) ProvisionalAllocatePrepare() {
-	d.forwarder.ProvisionalAllocatePrepare(d.receiver.GetLayeredBitrate())
+	_, brs := d.receiver.GetLayeredBitrate()
+	d.forwarder.ProvisionalAllocatePrepare(brs)
 }
 
 func (d *DownTrack) ProvisionalAllocate(availableChannelCapacity int64, layers VideoLayers, allowPause bool, allowOvershoot bool) int64 {
@@ -983,19 +986,22 @@ func (d *DownTrack) ProvisionalAllocateCommit() VideoAllocation {
 }
 
 func (d *DownTrack) AllocateNextHigher(availableChannelCapacity int64, allowOvershoot bool) (VideoAllocation, bool) {
-	allocation, available := d.forwarder.AllocateNextHigher(availableChannelCapacity, d.receiver.GetLayeredBitrate(), allowOvershoot)
+	_, brs := d.receiver.GetLayeredBitrate()
+	allocation, available := d.forwarder.AllocateNextHigher(availableChannelCapacity, brs, allowOvershoot)
 	d.maybeStartKeyFrameRequester()
 	return allocation, available
 }
 
 func (d *DownTrack) GetNextHigherTransition(allowOvershoot bool) (VideoTransition, bool) {
-	transition, available := d.forwarder.GetNextHigherTransition(d.receiver.GetLayeredBitrate(), allowOvershoot)
+	_, brs := d.receiver.GetLayeredBitrate()
+	transition, available := d.forwarder.GetNextHigherTransition(brs, allowOvershoot)
 	d.logger.Debugw("stream: get next higher layer", "transition", transition, "available", available)
 	return transition, available
 }
 
 func (d *DownTrack) Pause() VideoAllocation {
-	allocation := d.forwarder.Pause(d.receiver.GetLayeredBitrate())
+	_, brs := d.receiver.GetLayeredBitrate()
+	allocation := d.forwarder.Pause(brs)
 	d.maybeStartKeyFrameRequester()
 	return allocation
 }

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -31,25 +31,7 @@ var (
 
 type AudioLevelHandle func(level uint8, duration uint32)
 
-// ---------------------------------------------------
-
 type Bitrates [DefaultMaxLayerSpatial + 1][DefaultMaxLayerTemporal + 1]int64
-
-func (b *Bitrates) GetLayers() []int32 {
-	layers := []int32{}
-	for i := 0; i < len(b); i++ {
-		for j := 0; j < len(b[0]); j++ {
-			if b[i][j] != 0 {
-				layers = append(layers, int32(i))
-				break
-			}
-		}
-	}
-
-	return layers
-}
-
-// ---------------------------------------------------
 
 // TrackReceiver defines an interface receive media from remote peer
 type TrackReceiver interface {
@@ -59,7 +41,7 @@ type TrackReceiver interface {
 	HeaderExtensions() []webrtc.RTPHeaderExtensionParameter
 
 	ReadRTP(buf []byte, layer uint8, sn uint16) (int, error)
-	GetLayeredBitrate() Bitrates
+	GetLayeredBitrate() ([]int32, Bitrates)
 
 	GetAudioLevel() (float64, bool)
 
@@ -421,7 +403,7 @@ func (w *WebRTCReceiver) downTrackBitrateAvailabilityChange() {
 	}
 }
 
-func (w *WebRTCReceiver) GetLayeredBitrate() Bitrates {
+func (w *WebRTCReceiver) GetLayeredBitrate() ([]int32, Bitrates) {
 	return w.streamTrackerManager.GetLayeredBitrate()
 }
 

--- a/pkg/sfu/streamtrackermanager.go
+++ b/pkg/sfu/streamtrackermanager.go
@@ -303,7 +303,7 @@ func (s *StreamTrackerManager) GetMaxExpectedLayer() int32 {
 	return maxExpectedLayer
 }
 
-func (s *StreamTrackerManager) GetLayeredBitrate() Bitrates {
+func (s *StreamTrackerManager) GetLayeredBitrate() ([]int32, Bitrates) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
@@ -334,7 +334,10 @@ func (s *StreamTrackerManager) GetLayeredBitrate() Bitrates {
 		}
 	}
 
-	return br
+	availableLayers := make([]int32, len(s.availableLayers))
+	copy(availableLayers, s.availableLayers)
+
+	return availableLayers, br
 }
 
 func (s *StreamTrackerManager) hasSpatialLayerLocked(layer int32) bool {


### PR DESCRIPTION
Addressing edge case where a layer stopped before bitrate could be measured. Purely bit rate based change deduction missed this as the before and after did not have bit rates.

Use available layers to look for changes, especially currently forwarding layer going away.

Also, simplifying bits. Only in the optimal allocation path, these things are required. When congested, bitrate is always needed. So, for optimal path, just look at available layer changes and adjust.

Don't need to look for bitrate based layer changes. Clean up that code.