### PR TITLE
Handle case of layer stop without bitrate.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -582,11 +582,13 @@ func (f *Forwarder) AllocateOptimal(availableLayers []int32, brs Bitrates, allow
 				}
 			}
 			alloc.targetLayers.Temporal = DefaultMaxLayerTemporal
+
+			alloc.requestLayerSpatial = alloc.targetLayers.Spatial
 		} else {
 			// opportunistically latch on to anything
 			opportunisticAlloc()
+			alloc.requestLayerSpatial = int32(math.Min(float64(f.maxLayers.Spatial), float64(f.maxPublishedLayer)))
 		}
-		alloc.requestLayerSpatial = int32(math.Min(float64(f.maxLayers.Spatial), float64(f.maxPublishedLayer)))
 	}
 
 	if !alloc.targetLayers.IsValid() {

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -370,7 +370,7 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 		bandwidthDelta:      0,
 		bitrates:            emptyBitrates,
 		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: 0,
+		requestLayerSpatial: 1,
 		maxLayers:           expectedMaxLayers,
 		distanceToDesired:   0,
 	}


### PR DESCRIPTION
Missed this in the last commit. Sorry.
The case of
- locking to a layer
- that layer stops
- re-allocation

This should trigger a key frame request to the max available layer. So, have to set the request layer to max available.