### PR TITLE
Do not overshoot when layer is locked.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -587,7 +587,7 @@ func (f *Forwarder) AllocateOptimal(availableLayers []int32, brs Bitrates, allow
 		} else {
 			if f.currentLayers.IsValid() && f.currentLayers.Spatial == f.requestLayerSpatial {
 				// current is locked to desired, stay there
-				alloc.targetLayers = f.targetLayers
+				alloc.targetLayers = f.currentLayers
 				alloc.requestLayerSpatial = f.requestLayerSpatial
 			} else {
 				// opportunistically latch on to anything

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -355,7 +355,6 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 
 	// stays the same if feed is not dry and current is valid, available and locked
 	f.currentLayers = VideoLayers{Spatial: 0, Temporal: 1}
-	f.targetLayers = VideoLayers{Spatial: 0, Temporal: 1}
 	f.requestLayerSpatial = 0
 	expectedTargetLayers = VideoLayers{
 		Spatial:  0,


### PR DESCRIPTION
One more challenging case. When current layer is already locked, should not set up for overshoot.