### PR TITLE
fix: unable to notify webhook when egress ending with EGRESS_LIMIT_REACHED

### DIFF
--- a/pkg/service/ioinfo.go
+++ b/pkg/service/ioinfo.go
@@ -71,7 +71,8 @@ func (s *IOInfoService) UpdateEgressInfo(ctx context.Context, info *livekit.Egre
 	switch info.Status {
 	case livekit.EgressStatus_EGRESS_COMPLETE,
 		livekit.EgressStatus_EGRESS_FAILED,
-		livekit.EgressStatus_EGRESS_ABORTED:
+		livekit.EgressStatus_EGRESS_ABORTED,
+		livekit.EgressStatus_EGRESS_LIMIT_REACHED:
 
 		// make sure endedAt is set so it eventually gets deleted
 		if info.EndedAt == 0 {


### PR DESCRIPTION
fix: unable to notify webhook when egress ending with EGRESS_LIMIT_REACHED