### PR TITLE
Prevent subscribing to track that's closing

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -242,6 +242,7 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.Tra
 		)
 		newWR.SetRTCPCh(t.params.RTCPChan)
 		newWR.OnCloseHandler(func() {
+			t.MediaTrackReceiver.SetClosing()
 			t.MediaTrackReceiver.ClearReceiver(mime, false)
 			if t.MediaTrackReceiver.TryClose() {
 				if t.dynacastManager != nil {
@@ -349,6 +350,7 @@ func (t *MediaTrack) Restart() {
 }
 
 func (t *MediaTrack) Close(willBeResumed bool) {
+	t.MediaTrackReceiver.SetClosing()
 	if t.dynacastManager != nil {
 		t.dynacastManager.Close()
 	}

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -36,6 +36,7 @@ type mediaTrackReceiverState int
 
 const (
 	mediaTrackReceiverStateOpen mediaTrackReceiverState = iota
+	mediaTrackReceiverStateClosing
 	mediaTrackReceiverStateClosed
 )
 
@@ -43,6 +44,8 @@ func (m mediaTrackReceiverState) String() string {
 	switch m {
 	case mediaTrackReceiverStateOpen:
 		return "OPEN"
+	case mediaTrackReceiverStateClosing:
+		return "CLOSING"
 	case mediaTrackReceiverStateClosed:
 		return "CLOSED"
 	default:
@@ -289,6 +292,20 @@ func (t *MediaTrackReceiver) OnMediaLossFeedback(f func(dt *sfu.DownTrack, rr *r
 
 func (t *MediaTrackReceiver) OnVideoLayerUpdate(f func(layers []*livekit.VideoLayer)) {
 	t.onVideoLayerUpdate = f
+}
+
+func (t *MediaTrackReceiver) IsOpen() bool {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+	return t.state == mediaTrackReceiverStateOpen
+}
+
+func (t *MediaTrackReceiver) SetClosing() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if t.state == mediaTrackReceiverStateOpen {
+		t.state = mediaTrackReceiverStateClosing
+	}
 }
 
 func (t *MediaTrackReceiver) TryClose() bool {

--- a/pkg/rtc/roomtrackmanager.go
+++ b/pkg/rtc/roomtrackmanager.go
@@ -82,7 +82,15 @@ func (r *RoomTrackManager) GetTrackInfo(trackID livekit.TrackID) *TrackInfo {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
-	return r.tracks[trackID]
+	info := r.tracks[trackID]
+	if info == nil {
+		return nil
+	}
+	// when track is about to close, do not resolve
+	if info.Track != nil && !info.Track.IsOpen() {
+		return nil
+	}
+	return info
 }
 
 func (r *RoomTrackManager) NotifyTrackChanged(trackID livekit.TrackID) {

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -372,6 +372,7 @@ type MediaTrack interface {
 	IsSimulcast() bool
 
 	Close(willBeResumed bool)
+	IsOpen() bool
 
 	// callbacks
 	AddOnClose(func())

--- a/pkg/rtc/types/typesfakes/fake_local_media_track.go
+++ b/pkg/rtc/types/typesfakes/fake_local_media_track.go
@@ -126,16 +126,6 @@ type FakeLocalMediaTrack struct {
 	iDReturnsOnCall map[int]struct {
 		result1 livekit.TrackID
 	}
-	IsClosingStub        func() bool
-	isClosingMutex       sync.RWMutex
-	isClosingArgsForCall []struct {
-	}
-	isClosingReturns struct {
-		result1 bool
-	}
-	isClosingReturnsOnCall map[int]struct {
-		result1 bool
-	}
 	IsMutedStub        func() bool
 	isMutedMutex       sync.RWMutex
 	isMutedArgsForCall []struct {
@@ -144,6 +134,16 @@ type FakeLocalMediaTrack struct {
 		result1 bool
 	}
 	isMutedReturnsOnCall map[int]struct {
+		result1 bool
+	}
+	IsOpenStub        func() bool
+	isOpenMutex       sync.RWMutex
+	isOpenArgsForCall []struct {
+	}
+	isOpenReturns struct {
+		result1 bool
+	}
+	isOpenReturnsOnCall map[int]struct {
 		result1 bool
 	}
 	IsSimulcastStub        func() bool
@@ -923,59 +923,6 @@ func (fake *FakeLocalMediaTrack) IDReturnsOnCall(i int, result1 livekit.TrackID)
 	}{result1}
 }
 
-func (fake *FakeLocalMediaTrack) IsClosing() bool {
-	fake.isClosingMutex.Lock()
-	ret, specificReturn := fake.isClosingReturnsOnCall[len(fake.isClosingArgsForCall)]
-	fake.isClosingArgsForCall = append(fake.isClosingArgsForCall, struct {
-	}{})
-	stub := fake.IsClosingStub
-	fakeReturns := fake.isClosingReturns
-	fake.recordInvocation("IsClosing", []interface{}{})
-	fake.isClosingMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeLocalMediaTrack) IsClosingCallCount() int {
-	fake.isClosingMutex.RLock()
-	defer fake.isClosingMutex.RUnlock()
-	return len(fake.isClosingArgsForCall)
-}
-
-func (fake *FakeLocalMediaTrack) IsClosingCalls(stub func() bool) {
-	fake.isClosingMutex.Lock()
-	defer fake.isClosingMutex.Unlock()
-	fake.IsClosingStub = stub
-}
-
-func (fake *FakeLocalMediaTrack) IsClosingReturns(result1 bool) {
-	fake.isClosingMutex.Lock()
-	defer fake.isClosingMutex.Unlock()
-	fake.IsClosingStub = nil
-	fake.isClosingReturns = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *FakeLocalMediaTrack) IsClosingReturnsOnCall(i int, result1 bool) {
-	fake.isClosingMutex.Lock()
-	defer fake.isClosingMutex.Unlock()
-	fake.IsClosingStub = nil
-	if fake.isClosingReturnsOnCall == nil {
-		fake.isClosingReturnsOnCall = make(map[int]struct {
-			result1 bool
-		})
-	}
-	fake.isClosingReturnsOnCall[i] = struct {
-		result1 bool
-	}{result1}
-}
-
 func (fake *FakeLocalMediaTrack) IsMuted() bool {
 	fake.isMutedMutex.Lock()
 	ret, specificReturn := fake.isMutedReturnsOnCall[len(fake.isMutedArgsForCall)]
@@ -1025,6 +972,59 @@ func (fake *FakeLocalMediaTrack) IsMutedReturnsOnCall(i int, result1 bool) {
 		})
 	}
 	fake.isMutedReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeLocalMediaTrack) IsOpen() bool {
+	fake.isOpenMutex.Lock()
+	ret, specificReturn := fake.isOpenReturnsOnCall[len(fake.isOpenArgsForCall)]
+	fake.isOpenArgsForCall = append(fake.isOpenArgsForCall, struct {
+	}{})
+	stub := fake.IsOpenStub
+	fakeReturns := fake.isOpenReturns
+	fake.recordInvocation("IsOpen", []interface{}{})
+	fake.isOpenMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLocalMediaTrack) IsOpenCallCount() int {
+	fake.isOpenMutex.RLock()
+	defer fake.isOpenMutex.RUnlock()
+	return len(fake.isOpenArgsForCall)
+}
+
+func (fake *FakeLocalMediaTrack) IsOpenCalls(stub func() bool) {
+	fake.isOpenMutex.Lock()
+	defer fake.isOpenMutex.Unlock()
+	fake.IsOpenStub = stub
+}
+
+func (fake *FakeLocalMediaTrack) IsOpenReturns(result1 bool) {
+	fake.isOpenMutex.Lock()
+	defer fake.isOpenMutex.Unlock()
+	fake.IsOpenStub = nil
+	fake.isOpenReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeLocalMediaTrack) IsOpenReturnsOnCall(i int, result1 bool) {
+	fake.isOpenMutex.Lock()
+	defer fake.isOpenMutex.Unlock()
+	fake.IsOpenStub = nil
+	if fake.isOpenReturnsOnCall == nil {
+		fake.isOpenReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.isOpenReturnsOnCall[i] = struct {
 		result1 bool
 	}{result1}
 }
@@ -1942,10 +1942,10 @@ func (fake *FakeLocalMediaTrack) Invocations() map[string][][]interface{} {
 	defer fake.hasSdpCidMutex.RUnlock()
 	fake.iDMutex.RLock()
 	defer fake.iDMutex.RUnlock()
-	fake.isClosingMutex.RLock()
-	defer fake.isClosingMutex.RUnlock()
 	fake.isMutedMutex.RLock()
 	defer fake.isMutedMutex.RUnlock()
+	fake.isOpenMutex.RLock()
+	defer fake.isOpenMutex.RUnlock()
 	fake.isSimulcastMutex.RLock()
 	defer fake.isSimulcastMutex.RUnlock()
 	fake.isSubscriberMutex.RLock()

--- a/pkg/rtc/types/typesfakes/fake_local_media_track.go
+++ b/pkg/rtc/types/typesfakes/fake_local_media_track.go
@@ -126,6 +126,16 @@ type FakeLocalMediaTrack struct {
 	iDReturnsOnCall map[int]struct {
 		result1 livekit.TrackID
 	}
+	IsClosingStub        func() bool
+	isClosingMutex       sync.RWMutex
+	isClosingArgsForCall []struct {
+	}
+	isClosingReturns struct {
+		result1 bool
+	}
+	isClosingReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	IsMutedStub        func() bool
 	isMutedMutex       sync.RWMutex
 	isMutedArgsForCall []struct {
@@ -910,6 +920,59 @@ func (fake *FakeLocalMediaTrack) IDReturnsOnCall(i int, result1 livekit.TrackID)
 	}
 	fake.iDReturnsOnCall[i] = struct {
 		result1 livekit.TrackID
+	}{result1}
+}
+
+func (fake *FakeLocalMediaTrack) IsClosing() bool {
+	fake.isClosingMutex.Lock()
+	ret, specificReturn := fake.isClosingReturnsOnCall[len(fake.isClosingArgsForCall)]
+	fake.isClosingArgsForCall = append(fake.isClosingArgsForCall, struct {
+	}{})
+	stub := fake.IsClosingStub
+	fakeReturns := fake.isClosingReturns
+	fake.recordInvocation("IsClosing", []interface{}{})
+	fake.isClosingMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLocalMediaTrack) IsClosingCallCount() int {
+	fake.isClosingMutex.RLock()
+	defer fake.isClosingMutex.RUnlock()
+	return len(fake.isClosingArgsForCall)
+}
+
+func (fake *FakeLocalMediaTrack) IsClosingCalls(stub func() bool) {
+	fake.isClosingMutex.Lock()
+	defer fake.isClosingMutex.Unlock()
+	fake.IsClosingStub = stub
+}
+
+func (fake *FakeLocalMediaTrack) IsClosingReturns(result1 bool) {
+	fake.isClosingMutex.Lock()
+	defer fake.isClosingMutex.Unlock()
+	fake.IsClosingStub = nil
+	fake.isClosingReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeLocalMediaTrack) IsClosingReturnsOnCall(i int, result1 bool) {
+	fake.isClosingMutex.Lock()
+	defer fake.isClosingMutex.Unlock()
+	fake.IsClosingStub = nil
+	if fake.isClosingReturnsOnCall == nil {
+		fake.isClosingReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.isClosingReturnsOnCall[i] = struct {
+		result1 bool
 	}{result1}
 }
 
@@ -1879,6 +1942,8 @@ func (fake *FakeLocalMediaTrack) Invocations() map[string][][]interface{} {
 	defer fake.hasSdpCidMutex.RUnlock()
 	fake.iDMutex.RLock()
 	defer fake.iDMutex.RUnlock()
+	fake.isClosingMutex.RLock()
+	defer fake.isClosingMutex.RUnlock()
 	fake.isMutedMutex.RLock()
 	defer fake.isMutedMutex.RUnlock()
 	fake.isSimulcastMutex.RLock()

--- a/pkg/rtc/types/typesfakes/fake_media_track.go
+++ b/pkg/rtc/types/typesfakes/fake_media_track.go
@@ -93,6 +93,16 @@ type FakeMediaTrack struct {
 	iDReturnsOnCall map[int]struct {
 		result1 livekit.TrackID
 	}
+	IsClosingStub        func() bool
+	isClosingMutex       sync.RWMutex
+	isClosingArgsForCall []struct {
+	}
+	isClosingReturns struct {
+		result1 bool
+	}
+	isClosingReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	IsMutedStub        func() bool
 	isMutedMutex       sync.RWMutex
 	isMutedArgsForCall []struct {
@@ -676,6 +686,59 @@ func (fake *FakeMediaTrack) IDReturnsOnCall(i int, result1 livekit.TrackID) {
 	}
 	fake.iDReturnsOnCall[i] = struct {
 		result1 livekit.TrackID
+	}{result1}
+}
+
+func (fake *FakeMediaTrack) IsClosing() bool {
+	fake.isClosingMutex.Lock()
+	ret, specificReturn := fake.isClosingReturnsOnCall[len(fake.isClosingArgsForCall)]
+	fake.isClosingArgsForCall = append(fake.isClosingArgsForCall, struct {
+	}{})
+	stub := fake.IsClosingStub
+	fakeReturns := fake.isClosingReturns
+	fake.recordInvocation("IsClosing", []interface{}{})
+	fake.isClosingMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeMediaTrack) IsClosingCallCount() int {
+	fake.isClosingMutex.RLock()
+	defer fake.isClosingMutex.RUnlock()
+	return len(fake.isClosingArgsForCall)
+}
+
+func (fake *FakeMediaTrack) IsClosingCalls(stub func() bool) {
+	fake.isClosingMutex.Lock()
+	defer fake.isClosingMutex.Unlock()
+	fake.IsClosingStub = stub
+}
+
+func (fake *FakeMediaTrack) IsClosingReturns(result1 bool) {
+	fake.isClosingMutex.Lock()
+	defer fake.isClosingMutex.Unlock()
+	fake.IsClosingStub = nil
+	fake.isClosingReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeMediaTrack) IsClosingReturnsOnCall(i int, result1 bool) {
+	fake.isClosingMutex.Lock()
+	defer fake.isClosingMutex.Unlock()
+	fake.IsClosingStub = nil
+	if fake.isClosingReturnsOnCall == nil {
+		fake.isClosingReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.isClosingReturnsOnCall[i] = struct {
+		result1 bool
 	}{result1}
 }
 
@@ -1459,6 +1522,8 @@ func (fake *FakeMediaTrack) Invocations() map[string][][]interface{} {
 	defer fake.getTemporalLayerForSpatialFpsMutex.RUnlock()
 	fake.iDMutex.RLock()
 	defer fake.iDMutex.RUnlock()
+	fake.isClosingMutex.RLock()
+	defer fake.isClosingMutex.RUnlock()
 	fake.isMutedMutex.RLock()
 	defer fake.isMutedMutex.RUnlock()
 	fake.isSimulcastMutex.RLock()

--- a/pkg/rtc/types/typesfakes/fake_media_track.go
+++ b/pkg/rtc/types/typesfakes/fake_media_track.go
@@ -93,16 +93,6 @@ type FakeMediaTrack struct {
 	iDReturnsOnCall map[int]struct {
 		result1 livekit.TrackID
 	}
-	IsClosingStub        func() bool
-	isClosingMutex       sync.RWMutex
-	isClosingArgsForCall []struct {
-	}
-	isClosingReturns struct {
-		result1 bool
-	}
-	isClosingReturnsOnCall map[int]struct {
-		result1 bool
-	}
 	IsMutedStub        func() bool
 	isMutedMutex       sync.RWMutex
 	isMutedArgsForCall []struct {
@@ -111,6 +101,16 @@ type FakeMediaTrack struct {
 		result1 bool
 	}
 	isMutedReturnsOnCall map[int]struct {
+		result1 bool
+	}
+	IsOpenStub        func() bool
+	isOpenMutex       sync.RWMutex
+	isOpenArgsForCall []struct {
+	}
+	isOpenReturns struct {
+		result1 bool
+	}
+	isOpenReturnsOnCall map[int]struct {
 		result1 bool
 	}
 	IsSimulcastStub        func() bool
@@ -689,59 +689,6 @@ func (fake *FakeMediaTrack) IDReturnsOnCall(i int, result1 livekit.TrackID) {
 	}{result1}
 }
 
-func (fake *FakeMediaTrack) IsClosing() bool {
-	fake.isClosingMutex.Lock()
-	ret, specificReturn := fake.isClosingReturnsOnCall[len(fake.isClosingArgsForCall)]
-	fake.isClosingArgsForCall = append(fake.isClosingArgsForCall, struct {
-	}{})
-	stub := fake.IsClosingStub
-	fakeReturns := fake.isClosingReturns
-	fake.recordInvocation("IsClosing", []interface{}{})
-	fake.isClosingMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeMediaTrack) IsClosingCallCount() int {
-	fake.isClosingMutex.RLock()
-	defer fake.isClosingMutex.RUnlock()
-	return len(fake.isClosingArgsForCall)
-}
-
-func (fake *FakeMediaTrack) IsClosingCalls(stub func() bool) {
-	fake.isClosingMutex.Lock()
-	defer fake.isClosingMutex.Unlock()
-	fake.IsClosingStub = stub
-}
-
-func (fake *FakeMediaTrack) IsClosingReturns(result1 bool) {
-	fake.isClosingMutex.Lock()
-	defer fake.isClosingMutex.Unlock()
-	fake.IsClosingStub = nil
-	fake.isClosingReturns = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *FakeMediaTrack) IsClosingReturnsOnCall(i int, result1 bool) {
-	fake.isClosingMutex.Lock()
-	defer fake.isClosingMutex.Unlock()
-	fake.IsClosingStub = nil
-	if fake.isClosingReturnsOnCall == nil {
-		fake.isClosingReturnsOnCall = make(map[int]struct {
-			result1 bool
-		})
-	}
-	fake.isClosingReturnsOnCall[i] = struct {
-		result1 bool
-	}{result1}
-}
-
 func (fake *FakeMediaTrack) IsMuted() bool {
 	fake.isMutedMutex.Lock()
 	ret, specificReturn := fake.isMutedReturnsOnCall[len(fake.isMutedArgsForCall)]
@@ -791,6 +738,59 @@ func (fake *FakeMediaTrack) IsMutedReturnsOnCall(i int, result1 bool) {
 		})
 	}
 	fake.isMutedReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeMediaTrack) IsOpen() bool {
+	fake.isOpenMutex.Lock()
+	ret, specificReturn := fake.isOpenReturnsOnCall[len(fake.isOpenArgsForCall)]
+	fake.isOpenArgsForCall = append(fake.isOpenArgsForCall, struct {
+	}{})
+	stub := fake.IsOpenStub
+	fakeReturns := fake.isOpenReturns
+	fake.recordInvocation("IsOpen", []interface{}{})
+	fake.isOpenMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeMediaTrack) IsOpenCallCount() int {
+	fake.isOpenMutex.RLock()
+	defer fake.isOpenMutex.RUnlock()
+	return len(fake.isOpenArgsForCall)
+}
+
+func (fake *FakeMediaTrack) IsOpenCalls(stub func() bool) {
+	fake.isOpenMutex.Lock()
+	defer fake.isOpenMutex.Unlock()
+	fake.IsOpenStub = stub
+}
+
+func (fake *FakeMediaTrack) IsOpenReturns(result1 bool) {
+	fake.isOpenMutex.Lock()
+	defer fake.isOpenMutex.Unlock()
+	fake.IsOpenStub = nil
+	fake.isOpenReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeMediaTrack) IsOpenReturnsOnCall(i int, result1 bool) {
+	fake.isOpenMutex.Lock()
+	defer fake.isOpenMutex.Unlock()
+	fake.IsOpenStub = nil
+	if fake.isOpenReturnsOnCall == nil {
+		fake.isOpenReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.isOpenReturnsOnCall[i] = struct {
 		result1 bool
 	}{result1}
 }
@@ -1522,10 +1522,10 @@ func (fake *FakeMediaTrack) Invocations() map[string][][]interface{} {
 	defer fake.getTemporalLayerForSpatialFpsMutex.RUnlock()
 	fake.iDMutex.RLock()
 	defer fake.iDMutex.RUnlock()
-	fake.isClosingMutex.RLock()
-	defer fake.isClosingMutex.RUnlock()
 	fake.isMutedMutex.RLock()
 	defer fake.isMutedMutex.RUnlock()
+	fake.isOpenMutex.RLock()
+	defer fake.isOpenMutex.RUnlock()
 	fake.isSimulcastMutex.RLock()
 	defer fake.isSimulcastMutex.RUnlock()
 	fake.isSubscriberMutex.RLock()


### PR DESCRIPTION
Due to the order of events in MediaTrackReceiver and friends, SubscribedTrack will be closed before the track is removed from RoomTrackManager.

Because of this, when a track is unpublished, it's possible to be subscribed to the track as it's closing.

By introducing a closing state, we'd prevent accidental subscription to closing tracks.