### PR TITLE
Send stream start on initial start

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -1593,9 +1593,9 @@ func (d *DownTrack) GetNackStats() (totalPackets uint32, totalRepeatedNACKs uint
 func (d *DownTrack) onBindAndConnected() {
 	if d.connected.Load() && d.bound.Load() && !d.bindAndConnectedOnce.Swap(true) {
 		if d.kind == webrtc.RTPCodecTypeVideo {
-			targetLayers := d.forwarder.TargetLayers()
-			if targetLayers != InvalidLayers {
-				d.receiver.SendPLI(targetLayers.Spatial, true)
+			_, layer := d.forwarder.CheckSync()
+			if layer != InvalidLayerSpatial {
+				d.receiver.SendPLI(layer, true)
 			}
 		}
 

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1515,10 +1515,10 @@ func (f *Forwarder) getTranslationParamsVideo(extPkt *buffer.ExtPacket, layer in
 						"feed", extPkt.Packet.SSRC,
 					)
 					f.currentLayers.Spatial = layer
-					f.targetLayers.Spatial = layer
 
 					if f.currentLayers.Spatial >= f.maxLayers.Spatial || f.currentLayers.Spatial == f.maxPublishedLayer {
 						tp.isSwitchingToMaxLayer = true
+						f.targetLayers.Spatial = layer
 					}
 				}
 			}

--- a/pkg/sfu/streamallocator.go
+++ b/pkg/sfu/streamallocator.go
@@ -1340,6 +1340,7 @@ func newTrack(
 		isSimulcast: isSimulcast,
 		publisherID: publisherID,
 		logger:      logger,
+		isPaused:    true,
 	}
 	t.SetPriority(0)
 	t.SetMaxLayers(downTrack.MaxLayers())


### PR DESCRIPTION
A couple of other bits
1. Use request layer for sending PLI on bind and connected.
2. When adjusting for overshoot, do not adjust target unless current is at max. If not, it could get stuck in a lower layer in the following scenario a. Overshoot to layer 2 b. Max layer is 1, start sending PLI c. Get key frame for layer 0, adjust for overshoot as we have something at a layer lower than max. d. Adjust for overshoot. e. Setting target to max means that current and target are equal and no further adjustment happens.