### PR TITLE
Additional case of subscribing to a closed track

### DIFF
--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -280,6 +280,13 @@ func (d *DummyReceiver) TrackInfo() *livekit.TrackInfo {
 	return nil
 }
 
+func (d *DummyReceiver) IsClosed() bool {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+		return r.IsClosed()
+	}
+	return false
+}
+
 func (d *DummyReceiver) GetPrimaryReceiverForRed() sfu.TrackReceiver {
 	// DummyReceiver used for video, it should not have RED codec
 	return d

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -39,6 +39,7 @@ type TrackReceiver interface {
 	StreamID() string
 	Codec() webrtc.RTPCodecParameters
 	HeaderExtensions() []webrtc.RTPHeaderExtensionParameter
+	IsClosed() bool
 
 	ReadRTP(buf []byte, layer uint8, sn uint16) (int, error)
 	GetLayeredBitrate() ([]int32, Bitrates)
@@ -247,6 +248,10 @@ func (w *WebRTCReceiver) OnMaxLayerChange(fn func(maxLayer int32)) {
 
 func (w *WebRTCReceiver) GetConnectionScore() float32 {
 	return w.connectionStats.GetScore()
+}
+
+func (w *WebRTCReceiver) IsClosed() bool {
+	return w.closed.Load()
 }
 
 func (w *WebRTCReceiver) SetRTT(rtt uint32) {

--- a/pkg/sfu/redprimaryreceiver.go
+++ b/pkg/sfu/redprimaryreceiver.go
@@ -88,6 +88,10 @@ func (r *RedPrimaryReceiver) DeleteDownTrack(subscriberID livekit.ParticipantID)
 	r.downTrackSpreader.Free(subscriberID)
 }
 
+func (r *RedPrimaryReceiver) IsClosed() bool {
+	return r.closed.Load()
+}
+
 func (r *RedPrimaryReceiver) CanClose() bool {
 	return r.closed.Load() || r.downTrackSpreader.DownTrackCount() == 0
 }

--- a/pkg/sfu/redreceiver.go
+++ b/pkg/sfu/redreceiver.go
@@ -89,6 +89,10 @@ func (r *RedReceiver) CanClose() bool {
 	return r.closed.Load() || r.downTrackSpreader.DownTrackCount() == 0
 }
 
+func (r *RedReceiver) IsClosed() bool {
+	return r.closed.Load()
+}
+
 func (r *RedReceiver) Close() {
 	r.closed.Store(true)
 	for _, dt := range r.downTrackSpreader.ResetAndGetDownTracks() {


### PR DESCRIPTION
When the publisher stops publishing, the individual receivers would close attached DownTracks first before notifying MediaTrackReceiver callbacks.

This means #1454 does not fix the issue entirely since there is still a window when we can subscribe to a closing track.