### PR TITLE
Add config for active red encoding

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -176,6 +176,8 @@ keys:
 #   update_interval: 500
 #   # to prevent speaker updates from too jumpy, smooth out values over N samples
 #   smooth_intervals: 4
+#   # enable red encoding downtrack for opus only audio up track
+#   active_red_encoding: true
 
 # turn server
 # turn:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -150,6 +150,8 @@ type AudioConfig struct {
 	// smoothing for audioLevel values sent to the client.
 	// audioLevel will be an average of `smooth_intervals`, 0 to disable
 	SmoothIntervals uint32 `yaml:"smooth_intervals"`
+	// enable red encoding downtrack for opus only audio up track
+	ActiveREDEncoding bool `yaml:"active_red_encoding"`
 }
 
 type StreamTrackerPacketConfig struct {

--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -70,6 +70,7 @@ func NewMediaTrack(params MediaTrackParams) *MediaTrack {
 		ParticipantVersion:  params.ParticipantVersion,
 		ReceiverConfig:      params.ReceiverConfig,
 		SubscriberConfig:    params.SubscriberConfig,
+		AudioConfig:         params.AudioConfig,
 		Telemetry:           params.Telemetry,
 		Logger:              params.Logger,
 	})

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -15,6 +15,7 @@ import (
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 
+	"github.com/livekit/livekit-server/pkg/config"
 	"github.com/livekit/livekit-server/pkg/rtc/types"
 	"github.com/livekit/livekit-server/pkg/sfu"
 	"github.com/livekit/livekit-server/pkg/sfu/buffer"
@@ -74,6 +75,7 @@ type MediaTrackReceiverParams struct {
 	ParticipantVersion  uint32
 	ReceiverConfig      ReceiverConfig
 	SubscriberConfig    DirectionConfig
+	AudioConfig         config.AudioConfig
 	Telemetry           telemetry.TelemetryService
 	Logger              logger.Logger
 }
@@ -474,7 +476,7 @@ func (t *MediaTrackReceiver) AddSubscriber(sub types.LocalParticipant) (types.Su
 		StreamId:       streamId,
 		UpstreamCodecs: potentialCodecs,
 		Logger:         tLogger,
-		DisableRed:     t.trackInfo.GetDisableRed(),
+		DisableRed:     t.trackInfo.GetDisableRed() || !t.params.AudioConfig.ActiveREDEncoding,
 	})
 	return t.MediaTrackSubscriptions.AddSubscriber(sub, wr)
 }


### PR DESCRIPTION
There are user reports of noise issues from ff to chrome, which might be caused by the red encoding for opus only up track. This PR adds a config and disables it as default. We will enable it after the issue has been addressed.