### PR TITLE
Fix minimum required go version

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '>=1.18'
+          go-version: '1.18'
 
       - name: Set up gotestfmt
         run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@v2.4.1

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Read our [deployment docs](https://docs.livekit.io/deploy/) for more information
 
 Pre-requisites:
 
-- Go 1.16+ is installed
+- Go 1.18+ is installed
 - GOPATH/bin is in your PATH
 
 Then run

--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -19,10 +19,10 @@ package rtc
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/pion/webrtc/v3/pkg/rtcerr"
+	"go.uber.org/atomic"
 
 	"github.com/livekit/livekit-server/pkg/rtc/types"
 	"github.com/livekit/livekit-server/pkg/sfu"

--- a/pkg/rtc/subscriptionmanager_test.go
+++ b/pkg/rtc/subscriptionmanager_test.go
@@ -18,11 +18,11 @@ package rtc
 
 import (
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/livekit/livekit-server/pkg/rtc/types"
 	"github.com/livekit/livekit-server/pkg/rtc/types/typesfakes"


### PR DESCRIPTION
#1455 
1. Fix wrong atomic pkg from go1.19 std sync/atomic to go.uber.org/atomic
2. CI config '>=1.18' may be using go1.19.6, fix to '1.18'
![%E}$7Q 7R1E~9L)I`ZL~FJC](https://user-images.githubusercontent.com/36127407/221749204-5b37cb2b-f22d-4a16-965c-276069409f91.png)
