### PR TITLE
Prevent PLI layer lock getting stuck.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1500,26 +1500,26 @@ func (f *Forwarder) getTranslationParamsVideo(extPkt *buffer.ExtPacket, layer in
 					f.targetLayers.Spatial = f.currentLayers.Spatial
 				}
 			}
-		} else {
-			// if locked to higher than max layer due to overshoot, check if it can be dialed back
-			if f.targetLayers.Spatial > f.maxLayers.Spatial {
-				if layer <= f.maxLayers.Spatial && extPkt.KeyFrame {
-					f.logger.Infow(
-						"adjusting overshoot",
-						"current", f.currentLayers,
-						"target", f.targetLayers,
-						"max", f.maxLayers,
-						"layer", layer,
-						"req", f.requestLayerSpatial,
-						"maxPublished", f.maxPublishedLayer,
-						"feed", extPkt.Packet.SSRC,
-					)
-					f.currentLayers.Spatial = layer
+		}
 
-					if f.currentLayers.Spatial >= f.maxLayers.Spatial || f.currentLayers.Spatial == f.maxPublishedLayer {
-						tp.isSwitchingToMaxLayer = true
-						f.targetLayers.Spatial = layer
-					}
+		// if locked to higher than max layer due to overshoot, check if it can be dialed back
+		if f.currentLayers.Spatial > f.maxLayers.Spatial {
+			if layer <= f.maxLayers.Spatial && extPkt.KeyFrame {
+				f.logger.Infow(
+					"adjusting overshoot",
+					"current", f.currentLayers,
+					"target", f.targetLayers,
+					"max", f.maxLayers,
+					"layer", layer,
+					"req", f.requestLayerSpatial,
+					"maxPublished", f.maxPublishedLayer,
+					"feed", extPkt.Packet.SSRC,
+				)
+				f.currentLayers.Spatial = layer
+
+				if f.currentLayers.Spatial >= f.maxLayers.Spatial || f.currentLayers.Spatial == f.maxPublishedLayer {
+					tp.isSwitchingToMaxLayer = true
+					f.targetLayers.Spatial = layer
 				}
 			}
 		}


### PR DESCRIPTION
In the following scenario, PLI layer lock got stuck at the wrong layer
- target is at 2 to allow overshoot
- current gets to 1, but can't get higher because publisher is not publishing higher layer
- max layer changed to 0

Because of adjusting for overshoot only when current == target, it never happened and layer lock PLI kept asking for layer 0. Although, key frames were received, switch did not happen.

Always check for overshoot adjustment possibility against current layer.