### PR TITLE
Do not log TURN errors with prefix "error when handling datagram"

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -30,6 +30,9 @@ var (
 			"Error reading first packet from",
 			"error closing connection",
 		},
+		"turn": {
+			"error when handling datagram",
+		},
 	}
 )
 


### PR DESCRIPTION
These could happen normally in a poor network.