### PR TITLE
Connection quality misc changes

### DIFF
--- a/pkg/sfu/connectionquality/scorer.go
+++ b/pkg/sfu/connectionquality/scorer.go
@@ -286,7 +286,7 @@ func (q *qualityScorer) Update(stat *windowStat, at time.Time) {
 		q.score = score
 		q.params.Logger.Infow(
 			"quality drop",
-			"reaason", reason,
+			"reason", reason,
 			"score", q.score,
 			"quality", scoreToConnectionQuality(q.score),
 			"window", ws,

--- a/pkg/sfu/connectionquality/scorer.go
+++ b/pkg/sfu/connectionquality/scorer.go
@@ -50,7 +50,12 @@ func (w *windowStat) calculatePacketScore(plw float64) float64 {
 	}
 	lossEffect *= plw
 
-	return maxScore - delayEffect - lossEffect
+	score := maxScore - delayEffect - lossEffect
+	if score < 0.0 {
+		score = 0.0
+	}
+
+	return score
 }
 
 func (w *windowStat) calculateByteScore(expectedBitrate int64) float64 {


### PR DESCRIPTION
1. Call scorer.Update() with nil stat when no data available so that scorer can synthesise window with proper window time.
2. Substract out loss in interval to account for packets not sent at all.
3. Fix `packetsNotFound` variable in `getIntervalStats`. I remember this working at some point. Not sure if I fat fingered in another PR and deleted the increment line.
4. Logging a bit more when no packets expected. Those can get noisy especially when track is muted. But, seeing some unexplained instances of no packets leading to quality drop. So, temporary logging to get a bit more information.