### PR TITLE
Do not enable bitrate based scoring for screen share.

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -882,6 +882,11 @@ func (d *DownTrack) maybeAddTransition(bitrate int64) {
 		return
 	}
 
+	ti := d.receiver.TrackInfo()
+	if ti == nil || ti.Source == livekit.TrackSource_SCREEN_SHARE {
+		return
+	}
+
 	d.connectionStats.AddTransition(bitrate, time.Now())
 }
 


### PR DESCRIPTION
Thought that I could enable it for down tracks as that will be based on measured bitrate. So, forwarded bit rate should be close to the expected bitrate if streaming is good.

But with screen share tracks, looks like there are two issues
- our stream tracker settings are so that measurement window is a lot longer, i. e. a transition would have been added to the scorer at a higher measured bitrate. Then the bit rate might have dropped quite a bit because of content becoming static. But, there is no updated measurement for a good portion of scorer analysis window. Currently, the bitrate is measured over 4 seconds (default config) for screen share streams and the connection quality analysis window is 5 seconds.
- Even if the measurement happens with a finer resolution (of course, that is prone to measuring 0 bit rate because of very low frame rate), it remains to be seen what is a good resolution so that it is not over/under estimated.

For now, disabling the bit rate based quality estimation mode for screen share track in down track direction also (NOTE: it was already disabled in up track direction because the actual bit rate could be signficantly different from advertised bitrate in TrackInfo)