### PR TITLE
Handle the case of no packets in down stream tracks better.

### DIFF
--- a/pkg/sfu/connectionquality/connectionstats.go
+++ b/pkg/sfu/connectionquality/connectionstats.go
@@ -90,6 +90,7 @@ func (cs *ConnectionStats) updateScore(streams map[uint32]*buffer.StreamStatsWit
 			}
 			stat.packetsExpected += s.RTPStats.Packets + s.RTPStats.PacketsPadding
 			stat.packetsLost += s.RTPStats.PacketsLost
+			stat.packetsMissing += s.RTPStats.PacketsMissing
 			if stat.rttMax < s.RTPStats.RttMax {
 				stat.rttMax = s.RTPStats.RttMax
 			}

--- a/pkg/sfu/connectionquality/connectionstats.go
+++ b/pkg/sfu/connectionquality/connectionstats.go
@@ -77,30 +77,26 @@ func (cs *ConnectionStats) GetScoreAndQuality() (float32, livekit.ConnectionQual
 }
 
 func (cs *ConnectionStats) updateScore(streams map[uint32]*buffer.StreamStatsWithLayers, at time.Time) float32 {
-	if len(streams) == 0 {
-		cs.scorer.Update(nil, at)
-	} else {
-		var stat windowStat
-		for _, s := range streams {
-			if stat.startedAt.IsZero() || stat.startedAt.After(s.RTPStats.StartTime) {
-				stat.startedAt = s.RTPStats.StartTime
-			}
-			if stat.duration < s.RTPStats.Duration {
-				stat.duration = s.RTPStats.Duration
-			}
-			stat.packetsExpected += s.RTPStats.Packets + s.RTPStats.PacketsPadding
-			stat.packetsLost += s.RTPStats.PacketsLost
-			stat.packetsMissing += s.RTPStats.PacketsMissing
-			if stat.rttMax < s.RTPStats.RttMax {
-				stat.rttMax = s.RTPStats.RttMax
-			}
-			if stat.jitterMax < s.RTPStats.JitterMax {
-				stat.jitterMax = s.RTPStats.JitterMax
-			}
-			stat.bytes += s.RTPStats.Bytes - s.RTPStats.HeaderBytes // only use media payload size
+	var stat windowStat
+	for _, s := range streams {
+		if stat.startedAt.IsZero() || stat.startedAt.After(s.RTPStats.StartTime) {
+			stat.startedAt = s.RTPStats.StartTime
 		}
-		cs.scorer.Update(&stat, at)
+		if stat.duration < s.RTPStats.Duration {
+			stat.duration = s.RTPStats.Duration
+		}
+		stat.packetsExpected += s.RTPStats.Packets + s.RTPStats.PacketsPadding
+		stat.packetsLost += s.RTPStats.PacketsLost
+		stat.packetsMissing += s.RTPStats.PacketsMissing
+		if stat.rttMax < s.RTPStats.RttMax {
+			stat.rttMax = s.RTPStats.RttMax
+		}
+		if stat.jitterMax < s.RTPStats.JitterMax {
+			stat.jitterMax = s.RTPStats.JitterMax
+		}
+		stat.bytes += s.RTPStats.Bytes - s.RTPStats.HeaderBytes // only use media payload size
 	}
+	cs.scorer.Update(&stat, at)
 
 	mos, _ := cs.scorer.GetMOSAndQuality()
 	return mos
@@ -113,7 +109,6 @@ func (cs *ConnectionStats) getStat(at time.Time) *livekit.AnalyticsStat {
 
 	streams := cs.params.GetDeltaStats()
 	if len(streams) == 0 {
-		cs.updateScore(streams, at)
 		return nil
 	}
 

--- a/pkg/sfu/connectionquality/scorer.go
+++ b/pkg/sfu/connectionquality/scorer.go
@@ -30,6 +30,7 @@ type windowStat struct {
 	duration        time.Duration
 	packetsExpected uint32
 	packetsLost     uint32
+	packetsMissing  uint32
 	bytes           uint64
 	rttMax          uint32
 	jitterMax       float64
@@ -44,9 +45,14 @@ func (w *windowStat) calculatePacketScore(plw float64) float64 {
 		delayEffect = (effectiveDelay - 120.0) / 10.0
 	}
 
+	actualLost := w.packetsLost - w.packetsMissing
+	if int32(actualLost) < 0 {
+		actualLost = 0
+	}
+
 	lossEffect := float64(0.0)
 	if w.packetsExpected > 0 {
-		lossEffect = float64(w.packetsLost) * 100.0 / float64(w.packetsExpected)
+		lossEffect = float64(actualLost) * 100.0 / float64(w.packetsExpected)
 	}
 	lossEffect *= plw
 


### PR DESCRIPTION
Notify missing packets in forwarding path explicitly.
- Do not change expected packets. It should still be the difference between the newest and oldest sequence number in the window. But, actual loss = loss_reported_by_remote_side - missing_packets. So, make missing packets explicit and let the scorer calculate actual loss.

For receiver report driven streams, 0 packets means no RR received. So, declare the delta invalid. A few things to note here
- added 8 bytes to store packet time in sequence number cache which adds 16 KB of memory. That is not bad (100 MB for 6000+ streams)
- adds a bit of processing while getting interval stats. Reason being, the snapshots on down track side are tied to RTCP RR received from the remote side (the subscriber client). And there could be windows (as connection stats pulls every 5 seconds) without any data. The next window could have 10 seconds of data or maybe 5 seconds of previous window. So, using actual packet time to figure out start/duration rather than wall clock to tie closely to RTCP RR.