### PR TITLE
Do not calculate distance if max layers are not valid

### DIFF
--- a/pkg/sfu/streamtrackermanager.go
+++ b/pkg/sfu/streamtrackermanager.go
@@ -306,15 +306,15 @@ done:
 		}
 	}
 
+	if !maxLayers.IsValid() || s.maxTemporalLayerSeen < 0 {
+		return 0.0
+	}
+
 	distance := float64(0.0)
 	for sp := maxLayers.Spatial; sp <= s.getMaxExpectedLayerLocked(); sp++ {
 		for t := maxLayers.Temporal; t <= s.maxTemporalLayerSeen; t++ {
 			distance++
 		}
-	}
-
-	if s.maxTemporalLayerSeen < 0 {
-		return distance
 	}
 
 	return distance / float64(s.maxTemporalLayerSeen+1)


### PR DESCRIPTION
Was calculating an expected distance of 2.0 when both max layers were invalid and max temporal seen is invalid.