### PR TITLE
Switching to layer based quality for camera tracks also.

### DIFF
--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -79,7 +79,6 @@ type Snapshot struct {
 }
 
 type SnInfo struct {
-	pktTime       int64
 	hdrSize       uint16
 	pktSize       uint16
 	isPaddingOnly bool

--- a/pkg/sfu/connectionquality/connectionstats_test.go
+++ b/pkg/sfu/connectionquality/connectionstats_test.go
@@ -606,7 +606,7 @@ func TestConnectionQuality(t *testing.T) {
 						distance: 2.0,
 					},
 					{
-						distance: 2.7,
+						distance: 2.0,
 						offset:   1 * time.Second,
 					},
 				},

--- a/pkg/sfu/connectionquality/scorer.go
+++ b/pkg/sfu/connectionquality/scorer.go
@@ -19,7 +19,7 @@ const (
 	increaseFactor = float64(0.4) // slow increase
 	decreaseFactor = float64(0.8) // fast decrease
 
-	distanceWeight = float64(20.0) // each spatial layer missed drops a quality level
+	distanceWeight = float64(25.0) // each spatial layer missed drops a quality level
 
 	unmuteTimeThreshold = float64(0.5)
 )

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -946,22 +946,12 @@ func (d *DownTrack) UpTrackMaxTemporalLayerSeenChange(maxTemporalLayerSeen int32
 	d.forwarder.SetMaxTemporalLayerSeen(maxTemporalLayerSeen)
 }
 
-func (d *DownTrack) maybeAddTransition(bitrate int64, distance float64) {
+func (d *DownTrack) maybeAddTransition(_bitrate int64, distance float64) {
 	if d.kind == webrtc.RTPCodecTypeAudio {
 		return
 	}
 
-	ti := d.receiver.TrackInfo()
-	if ti == nil {
-		return
-	}
-
-	if ti.Source == livekit.TrackSource_SCREEN_SHARE {
-		d.connectionStats.AddLayerTransition(distance, time.Now())
-		return
-	}
-
-	d.connectionStats.AddBitrateTransition(bitrate, time.Now())
+	d.connectionStats.AddLayerTransition(distance, time.Now())
 }
 
 func (d *DownTrack) UpTrackBitrateReport(_availableLayers []int32, bitrates Bitrates) {

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -216,6 +216,7 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 	f.parkedLayers = InvalidLayers
 
 	// when max layers changes, target is opportunistic, but requested spatial layer should be at max
+	f.SetMaxTemporalLayerSeen(3)
 	f.maxLayers = VideoLayers{Spatial: 1, Temporal: 3}
 	expectedResult = VideoAllocation{
 		pauseReason:         VideoPauseReasonNone,
@@ -252,7 +253,7 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: expectedTargetLayers.Spatial,
 		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0,
+		distanceToDesired:   -0.5,
 	}
 	result = f.AllocateOptimal(nil, bitrates, true)
 	require.Equal(t, expectedResult, result)
@@ -275,7 +276,7 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: expectedTargetLayers.Spatial,
 		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0,
+		distanceToDesired:   -0.75,
 	}
 	result = f.AllocateOptimal(nil, emptyBitrates, true)
 	require.Equal(t, expectedResult, result)
@@ -294,7 +295,7 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 		targetLayers:        DefaultMaxLayers,
 		requestLayerSpatial: 2,
 		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0,
+		distanceToDesired:   -0.5,
 	}
 	result = f.AllocateOptimal([]int32{0, 1}, bitrates, true)
 	require.Equal(t, expectedResult, result)
@@ -311,7 +312,7 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 		targetLayers:        DefaultMaxLayers,
 		requestLayerSpatial: 2,
 		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0,
+		distanceToDesired:   -2.75,
 	}
 	result = f.AllocateOptimal([]int32{0, 1}, emptyBitrates, false)
 	require.Equal(t, expectedResult, result)
@@ -331,7 +332,7 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: 2,
 		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0,
+		distanceToDesired:   -0.5,
 	}
 	result = f.AllocateOptimal([]int32{0, 1}, bitrates, true)
 	require.Equal(t, expectedResult, result)
@@ -352,7 +353,7 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: 1,
 		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   1,
+		distanceToDesired:   0.5,
 	}
 	result = f.AllocateOptimal([]int32{1}, bitrates, true)
 	require.Equal(t, expectedResult, result)
@@ -374,7 +375,7 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: 0,
 		maxLayers:           f.maxLayers,
-		distanceToDesired:   0,
+		distanceToDesired:   -0.25,
 	}
 	result = f.AllocateOptimal([]int32{0, 1}, emptyBitrates, true)
 	require.Equal(t, expectedResult, result)
@@ -396,7 +397,7 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: 2,
 		maxLayers:           f.maxLayers,
-		distanceToDesired:   0,
+		distanceToDesired:   -2.75,
 	}
 	result = f.AllocateOptimal([]int32{0, 1}, emptyBitrates, true)
 	require.Equal(t, expectedResult, result)
@@ -408,6 +409,7 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 	f.SetMaxSpatialLayer(DefaultMaxLayerSpatial)
 	f.SetMaxTemporalLayer(DefaultMaxLayerTemporal)
 	f.SetMaxPublishedLayer(DefaultMaxLayerSpatial)
+	f.SetMaxTemporalLayerSeen(DefaultMaxLayerTemporal)
 
 	bitrates := Bitrates{
 		{1, 2, 3, 4},
@@ -447,7 +449,7 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: expectedTargetLayers.Spatial,
 		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   5,
+		distanceToDesired:   1.25,
 	}
 	result := f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -474,7 +476,7 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: expectedTargetLayers.Spatial,
 		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   11,
+		distanceToDesired:   2.75,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -521,7 +523,7 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: expectedTargetLayers.Spatial,
 		maxLayers:           expectedMaxLayers,
-		distanceToDesired:   -4,
+		distanceToDesired:   -1.75,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -565,7 +567,7 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: expectedTargetLayers.Spatial,
 		maxLayers:           expectedMaxLayers,
-		distanceToDesired:   0,
+		distanceToDesired:   0.25,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -598,7 +600,7 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 		targetLayers:        InvalidLayers,
 		requestLayerSpatial: InvalidLayerSpatial,
 		maxLayers:           expectedMaxLayers,
-		distanceToDesired:   0,
+		distanceToDesired:   0.25,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -649,6 +651,7 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 	f.SetMaxSpatialLayer(DefaultMaxLayerSpatial)
 	f.SetMaxTemporalLayer(DefaultMaxLayerTemporal)
 	f.SetMaxPublishedLayer(DefaultMaxLayerSpatial)
+	f.SetMaxTemporalLayerSeen(DefaultMaxLayerTemporal)
 
 	bitrates := Bitrates{
 		{1, 2, 3, 4},
@@ -678,7 +681,7 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 		targetLayers:        expectedLayers,
 		requestLayerSpatial: expectedLayers.Spatial,
 		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   9,
+		distanceToDesired:   2.25,
 	}
 	result := f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -707,7 +710,7 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 		targetLayers:        expectedLayers,
 		requestLayerSpatial: expectedLayers.Spatial,
 		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0,
+		distanceToDesired:   0.0,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -776,7 +779,7 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 		targetLayers:        expectedLayers,
 		requestLayerSpatial: expectedLayers.Spatial,
 		maxLayers:           expectedMaxLayers,
-		distanceToDesired:   -1,
+		distanceToDesired:   -1.0,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -815,7 +818,7 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 		targetLayers:        expectedLayers,
 		requestLayerSpatial: expectedLayers.Spatial,
 		maxLayers:           expectedMaxLayers,
-		distanceToDesired:   0,
+		distanceToDesired:   -0.5,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -830,7 +833,7 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 		targetLayers:        expectedLayers,
 		requestLayerSpatial: expectedLayers.Spatial,
 		maxLayers:           expectedMaxLayers,
-		distanceToDesired:   0,
+		distanceToDesired:   -0.5,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -883,6 +886,7 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 	f.SetMaxSpatialLayer(DefaultMaxLayerSpatial)
 	f.SetMaxTemporalLayer(DefaultMaxLayerTemporal)
 	f.SetMaxPublishedLayer(DefaultMaxLayerSpatial)
+	f.SetMaxTemporalLayerSeen(DefaultMaxLayerTemporal)
 
 	// when not in deficient state, does not boost
 	result, boosted = f.AllocateNextHigher(ChannelCapacityInfinity, bitrates, false)
@@ -918,7 +922,7 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: expectedTargetLayers.Spatial,
 		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   3,
+		distanceToDesired:   2.0,
 	}
 	result, boosted = f.AllocateNextHigher(ChannelCapacityInfinity, bitrates, false)
 	require.Equal(t, expectedResult, result)
@@ -946,7 +950,7 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: expectedTargetLayers.Spatial,
 		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   2,
+		distanceToDesired:   1.25,
 	}
 	result, boosted = f.AllocateNextHigher(ChannelCapacityInfinity, bitrates, false)
 	require.Equal(t, expectedResult, result)
@@ -970,7 +974,7 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: expectedTargetLayers.Spatial,
 		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   1,
+		distanceToDesired:   0.5,
 	}
 	result, boosted = f.AllocateNextHigher(ChannelCapacityInfinity, bitrates, false)
 	require.Equal(t, expectedResult, result)
@@ -992,7 +996,7 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: expectedTargetLayers.Spatial,
 		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0,
+		distanceToDesired:   0.0,
 	}
 	result, boosted = f.AllocateNextHigher(ChannelCapacityInfinity, bitrates, false)
 	require.Equal(t, expectedResult, result)
@@ -1027,7 +1031,7 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: expectedTargetLayers.Spatial,
 		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   4,
+		distanceToDesired:   2.25,
 	}
 	result, boosted = f.AllocateNextHigher(ChannelCapacityInfinity, bitrates, false)
 	require.Equal(t, expectedResult, result)
@@ -1045,7 +1049,7 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: expectedTargetLayers.Spatial,
 		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   4,
+		distanceToDesired:   2.25,
 	}
 	result, boosted = f.AllocateNextHigher(0, bitrates, false)
 	require.Equal(t, expectedResult, result)
@@ -1079,7 +1083,7 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 		targetLayers:        expectedTargetLayers,
 		requestLayerSpatial: expectedTargetLayers.Spatial,
 		maxLayers:           expectedMaxLayers,
-		distanceToDesired:   -1,
+		distanceToDesired:   -1.0,
 	}
 	// overshoot should return (1, 0) even if there is not enough capacity
 	result, boosted = f.AllocateNextHigher(bitrates[1][0]-1, bitrates, true)

--- a/pkg/sfu/streamtrackermanager.go
+++ b/pkg/sfu/streamtrackermanager.go
@@ -310,14 +310,10 @@ done:
 		return 0.0
 	}
 
-	distance := float64(0.0)
-	for sp := maxLayers.Spatial; sp <= s.getMaxExpectedLayerLocked(); sp++ {
-		for t := maxLayers.Temporal; t <= s.maxTemporalLayerSeen; t++ {
-			distance++
-		}
-	}
-
-	return distance / float64(s.maxTemporalLayerSeen+1)
+	distance :=
+		((s.getMaxExpectedLayerLocked() - maxLayers.Spatial) * (s.maxTemporalLayerSeen + 1)) +
+			(s.maxTemporalLayerSeen - maxLayers.Temporal)
+	return float64(distance) / float64(s.maxTemporalLayerSeen+1)
 }
 
 func (s *StreamTrackerManager) getMaxExpectedLayerLocked() int32 {


### PR DESCRIPTION
There are cases where the layer bit rate configuration is such that the expected bitrate difference is very high. For example, setting up layer 2 (f) layer for 1.7 Mbps and layer 1 (h) for 180 kbps. With bitrate based quality, a layer drop results in going to `POOR` quality rating. With layer based, it will drop one level only.

Also, cleaning up the distance to desired calculation a bit.

And increasing the weight of a layer drop so that one layer drop results in quality drop even with EWMA.