### PR TITLE
Fix connection quality in constrained up stream

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1452,7 +1452,7 @@ func (f *Forwarder) getTranslationParamsVideo(extPkt *buffer.ExtPacket, layer in
 			// if f.ddLayerSelector != nil {
 			// 	f.ddLayerSelector.SelectLayer(f.currentLayers)
 			// }
-			if f.currentLayers.Spatial >= f.maxLayers.Spatial || f.currentLayers.Spatial == f.maxPublishedLayer {
+			if f.currentLayers.Spatial >= f.maxLayers.Spatial {
 				tp.isSwitchingToMaxLayer = true
 			}
 		}
@@ -1517,10 +1517,9 @@ func (f *Forwarder) getTranslationParamsVideo(extPkt *buffer.ExtPacket, layer in
 			if found {
 				tp.isSwitchingToTargetLayer = true
 				f.clearParkedLayers()
-				if f.currentLayers.Spatial >= f.maxLayers.Spatial || f.currentLayers.Spatial == f.maxPublishedLayer {
+				if f.currentLayers.Spatial >= f.maxLayers.Spatial {
 					tp.isSwitchingToMaxLayer = true
 
-					// if maximum is attained, adjust target to enable fast path layer check in per-packet path
 					f.logger.Infow(
 						"reached max layer",
 						"current", f.currentLayers,
@@ -1531,6 +1530,9 @@ func (f *Forwarder) getTranslationParamsVideo(extPkt *buffer.ExtPacket, layer in
 						"maxPublished", f.maxPublishedLayer,
 						"feed", extPkt.Packet.SSRC,
 					)
+				}
+
+				if f.currentLayers.Spatial >= f.maxLayers.Spatial || f.currentLayers.Spatial == f.maxPublishedLayer {
 					f.targetLayers.Spatial = f.currentLayers.Spatial
 				}
 			}
@@ -1551,8 +1553,11 @@ func (f *Forwarder) getTranslationParamsVideo(extPkt *buffer.ExtPacket, layer in
 				)
 				f.currentLayers.Spatial = layer
 
-				if f.currentLayers.Spatial >= f.maxLayers.Spatial || f.currentLayers.Spatial == f.maxPublishedLayer {
+				if f.currentLayers.Spatial >= f.maxLayers.Spatial {
 					tp.isSwitchingToMaxLayer = true
+				}
+
+				if f.currentLayers.Spatial >= f.maxLayers.Spatial || f.currentLayers.Spatial == f.maxPublishedLayer {
 					f.targetLayers.Spatial = layer
 				}
 			}

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -440,9 +440,7 @@ func (w *WebRTCReceiver) OnBitrateReport(availableLayers []int32, bitrates Bitra
 		dt.UpTrackBitrateReport(availableLayers, bitrates)
 	}
 
-	if w.trackInfo.Source == livekit.TrackSource_SCREEN_SHARE {
-		w.connectionStats.AddLayerTransition(w.streamTrackerManager.DistanceToDesired(), time.Now())
-	}
+	w.connectionStats.AddLayerTransition(w.streamTrackerManager.DistanceToDesired(), time.Now())
 }
 
 func (w *WebRTCReceiver) GetLayeredBitrate() ([]int32, Bitrates) {


### PR DESCRIPTION
A few things
1. Have to use expected layer in upstream distance to desired. Using min(published, expected) means if expected is higher than published, it was not caught as a missed layer.
2. Forgot to remove layer transition update in one place. It was still constrained to screen share. This caused quality to not pick up after constraint is released.
3. Switching to max layer cannot be marked on max published. Same as point #1 above. Otherwise, dynacast would kick in and turn off highest layer.