### PR TITLE
Add layer mute notification

### DIFF
--- a/pkg/sfu/connectionquality/connectionstats.go
+++ b/pkg/sfu/connectionquality/connectionstats.go
@@ -86,6 +86,10 @@ func (cs *ConnectionStats) AddBitrateTransition(bitrate int64, at time.Time) {
 	cs.scorer.AddBitrateTransition(bitrate, at)
 }
 
+func (cs *ConnectionStats) UpdateLayerMute(isMuted bool, at time.Time) {
+	cs.scorer.UpdateLayerMute(isMuted, at)
+}
+
 func (cs *ConnectionStats) AddLayerTransition(distance float64, at time.Time) {
 	cs.scorer.AddLayerTransition(distance, at)
 }

--- a/pkg/sfu/connectionquality/connectionstats_test.go
+++ b/pkg/sfu/connectionquality/connectionstats_test.go
@@ -1,7 +1,6 @@
 package connectionquality
 
 import (
-	"fmt"	// REMOVE
 	"math"
 	"testing"
 	"time"
@@ -300,7 +299,6 @@ func TestConnectionQuality(t *testing.T) {
 		require.Equal(t, livekit.ConnectionQuality_EXCELLENT, quality)
 
 		// test layer mute via UpdateLayerMute API
-		fmt.Printf("last run\n")	// REMOVE
 		cs.AddBitrateTransition(1_000_000, now)
 		cs.AddBitrateTransition(2_000_000, now.Add(2*time.Second))
 

--- a/pkg/sfu/connectionquality/scorer.go
+++ b/pkg/sfu/connectionquality/scorer.go
@@ -167,8 +167,6 @@ func (q *qualityScorer) AddBitrateTransition(bitrate int64, at time.Time) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
-	q.params.Logger.Infow("RAJA adding bitrate transition", "bitrate", bitrate, "at", at)	// REMOVE
-	fmt.Printf("RAJA adding bitrate transition, bitrate: %d, at: %+v\n", bitrate, at)	// REMOVE
 	q.bitrateTransitions = append(q.bitrateTransitions, bitrateTransition{
 		startedAt: at,
 		bitrate:   bitrate,
@@ -176,13 +174,11 @@ func (q *qualityScorer) AddBitrateTransition(bitrate int64, at time.Time) {
 
 	if bitrate == 0 {
 		if !q.isLayerMuted() {
-			fmt.Printf("muting layer at: %+v\n", at)	// REMOVE
 			q.layerMutedAt = at
 			q.score = maxScore
 		}
 	} else {
 		if q.isLayerMuted() {
-			fmt.Printf("unmuting layer at: %+v\n", at)	// REMOVE
 			q.layerUnmutedAt = at
 		}
 	}
@@ -216,7 +212,6 @@ func (q *qualityScorer) AddLayerTransition(distance float64, at time.Time) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
-	q.params.Logger.Infow("RAJA adding layer transition", "distance", distance, "at", at)	// REMOVE
 	q.layerTransitions = append(q.layerTransitions, layerTransition{
 		startedAt: at,
 		distance:  distance,
@@ -237,7 +232,6 @@ func (q *qualityScorer) Update(stat *windowStat, at time.Time) {
 	//       to stable and quality EXCELLENT for responsiveness. On an unmute, the
 	//       entire window data is considered (as long as enough time has passed since
 	//       unmute) including the data before mute.
-	fmt.Printf("m: %+v, iu: %+v, il: %+v\n", q.isMuted(), q.isUnmutedEnough(at), q.isLayerMuted())	// REMOVE
 	if q.isMuted() || !q.isUnmutedEnough(at) || q.isLayerMuted() {
 		q.lastUpdateAt = at
 		return
@@ -275,18 +269,6 @@ func (q *qualityScorer) Update(stat *windowStat, at time.Time) {
 		factor = decreaseFactor
 	}
 	score = factor*score + (1.0-factor)*q.score
-	fmt.Printf( "RAJA quality update, score: %0.2f\n", score) // REMOVE
-	q.params.Logger.Infow(
-		"RAJA quality update",
-		"reason", reason,
-		"prevScore", q.score,
-		"prevQuality", scoreToConnectionQuality(q.score),
-		"score", score,
-		"quality", scoreToConnectionQuality(score),
-		"stat", stat,
-		"expectedBitrate", expectedBitrate,
-		"expectedDistance", expectedDistance,
-	)	// REMOVE
 	// WARNING NOTE: comparing protobuf enum values directly (livekit.ConnectionQuality)
 	if scoreToConnectionQuality(q.score) > scoreToConnectionQuality(score) {
 		q.params.Logger.Infow(
@@ -317,7 +299,6 @@ func (q *qualityScorer) isUnmutedEnough(at time.Time) bool {
 	} else {
 		sinceUnmute = at.Sub(q.unmutedAt)
 	}
-	fmt.Printf("sincenUmute: %+v, at: %+v\n", sinceUnmute, at)	// REMOVE
 
 	var sinceLayerUnmute time.Duration
 	if q.layerUnmutedAt.IsZero() {
@@ -325,7 +306,6 @@ func (q *qualityScorer) isUnmutedEnough(at time.Time) bool {
 	} else {
 		sinceLayerUnmute = at.Sub(q.layerUnmutedAt)
 	}
-	fmt.Printf("sinceLayerUnmute: %+v, at: %+v\n", sinceLayerUnmute, at)	// REMOVE
 
 	validDuration := sinceUnmute
 	if sinceLayerUnmute < validDuration {
@@ -333,7 +313,6 @@ func (q *qualityScorer) isUnmutedEnough(at time.Time) bool {
 	}
 
 	sinceLastUpdate := at.Sub(q.lastUpdateAt)
-	fmt.Printf("valid: %+v, sinceLastUpdate: %+v\n", validDuration, sinceLastUpdate)	// REMOVE
 
 	return validDuration.Seconds()/sinceLastUpdate.Seconds() > unmuteTimeThreshold
 }

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1772,6 +1772,17 @@ done:
 	if !targetLayers.IsValid() {
 		distance++
 	}
+	fmt.Printf("RAJA ml: %+v, mal: %+v, aml: %+v, mpl: %d, mtls: %d, tl: %+v, atl: %+v, brs: %+v, d: %d\n",
+		maxLayers,
+		VideoLayers{Spatial: maxAvailableSpatial, Temporal: maxAvailableTemporal},
+		adjustedMaxLayers,
+		maxPublishedLayer,
+		maxTemporalLayerSeen,
+		targetLayers,
+		adjustedTargetLayers,
+		brs,
+		distance,
+	)	// REMOVE
 
 	return float64(distance) / float64(maxTemporalLayerSeen+1)
 }

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1772,17 +1772,6 @@ done:
 	if !targetLayers.IsValid() {
 		distance++
 	}
-	fmt.Printf("RAJA ml: %+v, mal: %+v, aml: %+v, mpl: %d, mtls: %d, tl: %+v, atl: %+v, brs: %+v, d: %d\n",
-		maxLayers,
-		VideoLayers{Spatial: maxAvailableSpatial, Temporal: maxAvailableTemporal},
-		adjustedMaxLayers,
-		maxPublishedLayer,
-		maxTemporalLayerSeen,
-		targetLayers,
-		adjustedTargetLayers,
-		brs,
-		distance,
-	)	// REMOVE
 
 	return float64(distance) / float64(maxTemporalLayerSeen+1)
 }

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -380,6 +380,7 @@ func (w *WebRTCReceiver) AddDownTrack(track TrackSender) error {
 
 	track.TrackInfoAvailable()
 	track.UpTrackMaxPublishedLayerChange(w.streamTrackerManager.GetMaxPublishedLayer())
+	track.UpTrackMaxTemporalLayerSeenChange(w.streamTrackerManager.GetMaxTemporalLayerSeen())
 
 	w.downTrackSpreader.Store(track)
 	return nil

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -388,7 +388,13 @@ func (w *WebRTCReceiver) AddDownTrack(track TrackSender) error {
 func (w *WebRTCReceiver) SetMaxExpectedSpatialLayer(layer int32) {
 	w.streamTrackerManager.SetMaxExpectedSpatialLayer(layer)
 
-	w.connectionStats.AddLayerTransition(w.streamTrackerManager.DistanceToDesired(), time.Now())
+	now := time.Now()
+	if layer == InvalidLayerSpatial {
+		w.connectionStats.UpdateLayerMute(true, now)
+	} else {
+		w.connectionStats.UpdateLayerMute(false, now)
+		w.connectionStats.AddLayerTransition(w.streamTrackerManager.DistanceToDesired(), now)
+	}
 }
 
 // StreamTrackerManagerListener.OnAvailableLayersChanged

--- a/pkg/sfu/streamtrackermanager.go
+++ b/pkg/sfu/streamtrackermanager.go
@@ -321,15 +321,6 @@ done:
 	return float64(distance) / float64(s.maxTemporalLayerSeen+1)
 }
 
-func (s *StreamTrackerManager) getMaxExpectedLayerLocked() int32 {
-	// find min of <expected, published> layer
-	maxExpectedLayer := s.maxExpectedLayer
-	if maxExpectedLayer > s.maxPublishedLayer {
-		maxExpectedLayer = s.maxPublishedLayer
-	}
-	return maxExpectedLayer
-}
-
 func (s *StreamTrackerManager) GetMaxPublishedLayer() int32 {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
@@ -536,6 +527,13 @@ func (s *StreamTrackerManager) GetReferenceLayerRTPTimestamp(ts uint32, layer in
 	// Add the offset to layer's ts to map it to corresponding RTP timestamp in
 	// the reference layer.
 	return ts + (srRef.SenderReportData.RTPTimestamp - normalizedTS), nil
+}
+
+func (s *StreamTrackerManager) GetMaxTemporalLayerSeen() int32 {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return s.maxTemporalLayerSeen
 }
 
 func (s *StreamTrackerManager) updateMaxTemporalLayerSeen(brs Bitrates) {

--- a/pkg/sfu/streamtrackermanager.go
+++ b/pkg/sfu/streamtrackermanager.go
@@ -242,6 +242,7 @@ func (s *StreamTrackerManager) IsPaused() bool {
 }
 
 func (s *StreamTrackerManager) SetMaxExpectedSpatialLayer(layer int32) int32 {
+	s.logger.Infow("RAJA setting max expected layer", "layer", layer)	// REMOVE
 	s.lock.Lock()
 	prev := s.maxExpectedLayer
 	if layer <= s.maxExpectedLayer {
@@ -290,7 +291,7 @@ func (s *StreamTrackerManager) DistanceToDesired() float64 {
 		return 0
 	}
 
-	_, brs := s.getLayeredBitrateLocked()
+	al, brs := s.getLayeredBitrateLocked()
 
 	maxLayers := InvalidLayers
 done:
@@ -306,6 +307,7 @@ done:
 		}
 	}
 
+	// RAJA-TODO: need to take available layers into account
 	adjustedMaxLayers := maxLayers
 	if !maxLayers.IsValid() {
 		adjustedMaxLayers = VideoLayers{Spatial: 0, Temporal: 0}
@@ -317,6 +319,15 @@ done:
 	if !maxLayers.IsValid() {
 		distance++
 	}
+	s.logger.Infow("RAJA stm",
+		"ml", maxLayers,
+		"aml", adjustedMaxLayers,
+		"mel", s.maxExpectedLayer,
+		"mtls", s.maxTemporalLayerSeen,
+		"al", al,
+		"brs", brs,
+		"d", distance,
+	)	// REMOVE
 
 	return float64(distance) / float64(s.maxTemporalLayerSeen+1)
 }
@@ -575,6 +586,7 @@ func (s *StreamTrackerManager) bitrateReporter() {
 
 		case <-ticker.C:
 			al, brs := s.GetLayeredBitrate()
+			s.logger.Infow("RAJA measured bitrates", "al", al, "brs", brs)	// REMOVE
 			s.updateMaxTemporalLayerSeen(brs)
 
 			if listener := s.getListener(); listener != nil {

--- a/pkg/sfu/streamtrackermanager.go
+++ b/pkg/sfu/streamtrackermanager.go
@@ -242,7 +242,7 @@ func (s *StreamTrackerManager) IsPaused() bool {
 }
 
 func (s *StreamTrackerManager) SetMaxExpectedSpatialLayer(layer int32) int32 {
-	s.logger.Infow("RAJA setting max expected layer", "layer", layer)	// REMOVE
+	s.logger.Infow("RAJA setting max expected layer", "layer", layer) // REMOVE
 	s.lock.Lock()
 	prev := s.maxExpectedLayer
 	if layer <= s.maxExpectedLayer {
@@ -319,15 +319,6 @@ done:
 	if !maxLayers.IsValid() {
 		distance++
 	}
-	s.logger.Infow("RAJA stm",
-		"ml", maxLayers,
-		"aml", adjustedMaxLayers,
-		"mel", s.maxExpectedLayer,
-		"mtls", s.maxTemporalLayerSeen,
-		"al", al,
-		"brs", brs,
-		"d", distance,
-	)	// REMOVE
 
 	return float64(distance) / float64(s.maxTemporalLayerSeen+1)
 }
@@ -586,7 +577,6 @@ func (s *StreamTrackerManager) bitrateReporter() {
 
 		case <-ticker.C:
 			al, brs := s.GetLayeredBitrate()
-			s.logger.Infow("RAJA measured bitrates", "al", al, "brs", brs)	// REMOVE
 			s.updateMaxTemporalLayerSeen(brs)
 
 			if listener := s.getListener(); listener != nil {

--- a/pkg/sfu/streamtrackermanager.go
+++ b/pkg/sfu/streamtrackermanager.go
@@ -242,7 +242,6 @@ func (s *StreamTrackerManager) IsPaused() bool {
 }
 
 func (s *StreamTrackerManager) SetMaxExpectedSpatialLayer(layer int32) int32 {
-	s.logger.Infow("RAJA setting max expected layer", "layer", layer) // REMOVE
 	s.lock.Lock()
 	prev := s.maxExpectedLayer
 	if layer <= s.maxExpectedLayer {
@@ -291,7 +290,7 @@ func (s *StreamTrackerManager) DistanceToDesired() float64 {
 		return 0
 	}
 
-	al, brs := s.getLayeredBitrateLocked()
+	_, brs := s.getLayeredBitrateLocked()
 
 	maxLayers := InvalidLayers
 done:
@@ -307,7 +306,6 @@ done:
 		}
 	}
 
-	// RAJA-TODO: need to take available layers into account
 	adjustedMaxLayers := maxLayers
 	if !maxLayers.IsValid() {
 		adjustedMaxLayers = VideoLayers{Spatial: 0, Temporal: 0}


### PR DESCRIPTION
With layer based quality, when all layers are switched off due to dynacast, there was no indication to the scorer that layers should not be expected. That resulted in scorer declaring `POOR` quality (scorer expected packets, but got 0 packets)