### PR TITLE
Limit to max temporal layer seen to avoid negative distance

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -540,7 +540,7 @@ func (f *Forwarder) AllocateOptimal(availableLayers []int32, brs Bitrates, allow
 		}
 		alloc.targetLayers = VideoLayers{
 			Spatial:  int32(math.Min(float64(f.maxPublishedLayer), float64(maxSpatial))),
-			Temporal: DefaultMaxLayerTemporal,
+			Temporal: f.maxTemporalLayerSeen,
 		}
 	}
 


### PR DESCRIPTION
unnecessarily.

Not a big deal, but good to have it not show negative unnecessarily.