### PR TITLE
Detect client short ice connection

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -793,7 +793,7 @@ func (p *ParticipantImpl) ICERestart(iceConfig *livekit.ICEConfig, reason liveki
 		t.(types.LocalMediaTrack).Restart()
 	}
 
-	p.TransportManager.ICERestart(iceConfig, reason == livekit.ReconnectReason_RR_PUBLISHER_FAILED || reason == livekit.ReconnectReason_RR_SUBSCRIBER_FAILED)
+	p.TransportManager.ICERestart(iceConfig, reason)
 }
 
 func (p *ParticipantImpl) OnICEConfigChanged(f func(participant types.LocalParticipant, iceConfig *livekit.ICEConfig)) {

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -495,7 +495,7 @@ func (t *PCTransport) resetShortConn() {
 	t.lock.Unlock()
 }
 
-func (t *PCTransport) isShortConnection(at time.Time) (bool, time.Duration) {
+func (t *PCTransport) IsShortConnection(at time.Time) (bool, time.Duration) {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 
@@ -568,7 +568,7 @@ func (t *PCTransport) handleConnectionFailed(forceShortConn bool) {
 	isShort := forceShortConn
 	if !isShort {
 		var duration time.Duration
-		isShort, duration = t.isShortConnection(time.Now())
+		isShort, duration = t.IsShortConnection(time.Now())
 		if isShort {
 			pair, err := t.getSelectedPair()
 			if err != nil {


### PR DESCRIPTION
Fix issue: When network is not stable, client might detects ice connection failure and send ice restart before server detects it, cause short ice can't be detected to switch candidate type. 