### PR TITLE
Dependent RTT/jitter control.

### DIFF
--- a/pkg/sfu/connectionquality/connectionstats.go
+++ b/pkg/sfu/connectionquality/connectionstats.go
@@ -21,11 +21,13 @@ const (
 )
 
 type ConnectionStatsParams struct {
-	UpdateInterval time.Duration
-	MimeType       string
-	IsFECEnabled   bool
-	GetDeltaStats  func() map[uint32]*buffer.StreamStatsWithLayers
-	Logger         logger.Logger
+	UpdateInterval    time.Duration
+	MimeType          string
+	IsFECEnabled      bool
+	IsDependentRTT    bool
+	IsDependentJitter bool
+	GetDeltaStats     func() map[uint32]*buffer.StreamStatsWithLayers
+	Logger            logger.Logger
 }
 
 type ConnectionStats struct {
@@ -49,8 +51,10 @@ func NewConnectionStats(params ConnectionStatsParams) *ConnectionStats {
 	return &ConnectionStats{
 		params: params,
 		scorer: newQualityScorer(qualityScorerParams{
-			PacketLossWeight: getPacketLossWeight(params.MimeType, params.IsFECEnabled), // LK-TODO: have to notify codec change?
-			Logger:           params.Logger,
+			PacketLossWeight:  getPacketLossWeight(params.MimeType, params.IsFECEnabled), // LK-TODO: have to notify codec change?
+			IsDependentRTT:    params.IsDependentRTT,
+			IsDependentJitter: params.IsDependentJitter,
+			Logger:            params.Logger,
 		}),
 		done: core.NewFuse(),
 	}

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -271,10 +271,11 @@ func NewDownTrack(
 	})
 
 	d.connectionStats = connectionquality.NewConnectionStats(connectionquality.ConnectionStatsParams{
-		MimeType:      codecs[0].MimeType, // LK-TODO have to notify on codec change
-		IsFECEnabled:  strings.EqualFold(codecs[0].MimeType, webrtc.MimeTypeOpus) && strings.Contains(strings.ToLower(codecs[0].SDPFmtpLine), "fec"),
-		GetDeltaStats: d.getDeltaStats,
-		Logger:        d.logger,
+		MimeType:          codecs[0].MimeType, // LK-TODO have to notify on codec change
+		IsFECEnabled:      strings.EqualFold(codecs[0].MimeType, webrtc.MimeTypeOpus) && strings.Contains(strings.ToLower(codecs[0].SDPFmtpLine), "fec"),
+		IsDependentJitter: true,
+		GetDeltaStats:     d.getDeltaStats,
+		Logger:            d.logger.WithValues("direction", "down"),
 	})
 	d.connectionStats.OnStatsUpdate(func(_cs *connectionquality.ConnectionStats, stat *livekit.AnalyticsStat) {
 		if d.onStatsUpdate != nil {

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -204,10 +204,11 @@ func NewWebRTCReceiver(
 	})
 
 	w.connectionStats = connectionquality.NewConnectionStats(connectionquality.ConnectionStatsParams{
-		MimeType:      w.codec.MimeType,
-		IsFECEnabled:  strings.EqualFold(w.codec.MimeType, webrtc.MimeTypeOpus) && strings.Contains(strings.ToLower(w.codec.SDPFmtpLine), "fec"),
-		GetDeltaStats: w.getDeltaStats,
-		Logger:        w.logger,
+		MimeType:       w.codec.MimeType,
+		IsFECEnabled:   strings.EqualFold(w.codec.MimeType, webrtc.MimeTypeOpus) && strings.Contains(strings.ToLower(w.codec.SDPFmtpLine), "fec"),
+		IsDependentRTT: true,
+		GetDeltaStats:  w.getDeltaStats,
+		Logger:         w.logger.WithValues("direction", "up"),
 	})
 	w.connectionStats.OnStatsUpdate(func(_cs *connectionquality.ConnectionStats, stat *livekit.AnalyticsStat) {
 		if w.onStatsUpdate != nil {


### PR DESCRIPTION
Provide levers to ignore/include RTT/jitter in scoring. In certain cases, some data is not available. For example, up stream tracks do not have RTT unless using RTCP-XR. Down stream RTT is used as proxy. But, RTT increase due to down stream congestion penalizing an up stream track is not desirable.

Similarly down stream tracks are affected by up stream jitter as SFU is purely forwarding media.