### PR TITLE
Ensure sequence number continuity

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -630,6 +630,9 @@ func (d *DownTrack) WriteRTP(extPkt *buffer.ExtPacket, layer int32) error {
 		}
 	}
 
+	if d.kind == webrtc.RTPCodecTypeAudio {
+		d.logger.Infow("sending audio frame", "sn", hdr.SequenceNumber, "ts", hdr.Timestamp, "isn", extPkt.Packet.SequenceNumber, "its", extPkt.Packet.Timestamp) // REMOVE
+	}
 	d.rtpStats.Update(hdr, len(payload), 0, time.Now().UnixNano())
 	return nil
 }
@@ -1711,6 +1714,7 @@ func (d *DownTrack) sendSilentFrameOnMuteForOpus() {
 				d.logger.Warnw("could not write blank frame", err)
 				return
 			}
+			d.logger.Infow("sending audio frame silence", "sn", hdr.SequenceNumber, "ts", hdr.Timestamp) // REMOVE
 		}
 
 		numFrames--

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -630,9 +630,6 @@ func (d *DownTrack) WriteRTP(extPkt *buffer.ExtPacket, layer int32) error {
 		}
 	}
 
-	if d.kind == webrtc.RTPCodecTypeAudio {
-		d.logger.Infow("sending audio frame", "sn", hdr.SequenceNumber, "ts", hdr.Timestamp, "isn", extPkt.Packet.SequenceNumber, "its", extPkt.Packet.Timestamp) // REMOVE
-	}
 	d.rtpStats.Update(hdr, len(payload), 0, time.Now().UnixNano())
 	return nil
 }
@@ -1714,7 +1711,6 @@ func (d *DownTrack) sendSilentFrameOnMuteForOpus() {
 				d.logger.Warnw("could not write blank frame", err)
 				return
 			}
-			d.logger.Infow("sending audio frame silence", "sn", hdr.SequenceNumber, "ts", hdr.Timestamp) // REMOVE
 		}
 
 		numFrames--


### PR DESCRIPTION
When using Go SDK (livekit-cli or egress) as a client, SFU sends blank frames when audio track is muted to ensure that Pion OnTrack fires on GoSDK side. That resulted in a huge sequence number/time stamp jump when the real stream started.

Ensure continuity by creating random sequence number/time stamp when starting with a blank frames. And when sequence number/time stamp is initialized using SetLastSnTs, continue sequence if it was already initialized.