### PR TITLE
Unify the forwarder between dependency descriptor and no DD case.

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -1277,10 +1277,10 @@ func (d *DownTrack) handleRTCP(bytes []byte) {
 	pliOnce := true
 	sendPliOnce := func() {
 		if pliOnce {
-			targetLayers := d.forwarder.TargetLayers()
-			if targetLayers != InvalidLayers && !d.forwarder.IsAnyMuted() {
-				d.logger.Debugw("sending PLI RTCP", "layer", targetLayers.Spatial)
-				d.receiver.SendPLI(targetLayers.Spatial, false)
+			_, layer := d.forwarder.CheckSync()
+			if layer != InvalidLayerSpatial && !d.forwarder.IsAnyMuted() {
+				d.logger.Debugw("sending PLI RTCP", "layer", layer)
+				d.receiver.SendPLI(layer, false)
 				d.isNACKThrottled.Store(true)
 				d.rtpStats.UpdatePliTime()
 				pliOnce = false

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -298,11 +298,6 @@ func (w *WebRTCReceiver) AddUpTrack(track *webrtc.TrackRemote, buff *buffer.Buff
 	}
 
 	layer := int32(0)
-	// for svc codecs, use layer full quality instead.
-	// we only have buffer for full quality
-	if w.isSVC {
-		layer = int32(len(w.buffers)) - 1
-	}
 	if w.Kind() == webrtc.RTPCodecTypeVideo && !w.isSVC {
 		layer = buffer.RidToSpatialLayer(track.RID(), w.trackInfo)
 	}
@@ -510,10 +505,10 @@ func (w *WebRTCReceiver) getBuffer(layer int32) *buffer.Buffer {
 }
 
 func (w *WebRTCReceiver) getBufferLocked(layer int32) *buffer.Buffer {
-	// for svc codecs, use layer full quality instead.
-	// we only have buffer for full quality
+	// for svc codecs, use layer = 0 always.
+	// spatial layers are in-built and handled by single buffer
 	if w.isSVC {
-		layer = int32(len(w.buffers)) - 1
+		layer = 0
 	}
 
 	if int(layer) >= len(w.buffers) {


### PR DESCRIPTION
Had the two paths different while moving to opportunistic forwarding for a couple of reasons (did not want to affect the DD path and did not want to get slowed down by not a fully released feature).

Unifying the paths now. But, this is not quite working well for DD case.

Seeing a few things that needs investigation/more work
- Receive stream start up takes longer - looks like forwarding starts early but decoder is not able to decode/render. Unclear why.
- The decode side goes through several resolution steps (spaced about 10 seconds apart). With JS sample app default, the receive side should end up with a adaptive stream resolution which should pick layer 1. But, before adaptive stream kicks in, server starts with LOW, then switches to HIGH and then eventually comes to layer 1. Subscribed resolutions go from 160x90 -> 240x135 -> one more in between -> 640x360 which is the target for layer 1.
- When it finally settles at 640x360 on subscriber side, the publisher side bit rate shows 1.8 Mbps. JS sample app console logs say that layer 2 is disabled which is the correct dynacast behaviour. Unclear what is driving the bitrate on publisher side to be that high.

Also switching receiver side to consistently use layer 0(buffer0) for SVC.

Testing:
--------
Sanity check that video is received for camera/screen share when using AV1 or VP8 or H264. (with AV1 issues above which need further investigation).