### PR TITLE
Give proper grace period when recorder is still in the room

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	DefaultEmptyTimeout       = 5 * 60 // 5m
-	DefaultRoomDepartureGrace = 20
+	RoomDepartureGrace        = 20
 	AudioLevelQuantization    = 8 // ideally power of 2 to minimize float decimal
 	invAudioLevelQuantization = 1.0 / AudioLevelQuantization
 	subscriberUpdateInterval  = 3 * time.Second
@@ -464,6 +464,11 @@ func (r *Room) RemoveParticipant(identity livekit.ParticipantIdentity, pID livek
 	// send broadcast only if it's not already closed
 	sendUpdates := !p.IsDisconnected()
 
+	// remove all published tracks
+	for _, t := range p.GetPublishedTracks() {
+		r.trackManager.RemoveTrack(t)
+	}
+
 	p.OnTrackUpdated(nil)
 	p.OnTrackPublished(nil)
 	p.OnTrackUnpublished(nil)
@@ -476,11 +481,7 @@ func (r *Room) RemoveParticipant(identity livekit.ParticipantIdentity, pID livek
 	r.Logger.Debugw("closing participant for removal", "pID", p.ID(), "participant", p.Identity())
 	_ = p.Close(true, reason)
 
-	r.lock.RLock()
-	if len(r.participants) == 0 {
-		r.leftAt.Store(time.Now().Unix())
-	}
-	r.lock.RUnlock()
+	r.leftAt.Store(time.Now().Unix())
 
 	if sendUpdates {
 		if r.onParticipantChanged != nil {
@@ -597,16 +598,16 @@ func (r *Room) CloseIfEmpty() {
 		}
 	}
 
-	timeout := r.protoRoom.EmptyTimeout
+	var timeout uint32
 	var elapsed int64
-	if r.FirstJoinedAt() > 0 {
+	if r.FirstJoinedAt() > 0 && r.LastLeftAt() > 0 {
 		// exit 20s after
 		elapsed = time.Now().Unix() - r.LastLeftAt()
-		if timeout > DefaultRoomDepartureGrace {
-			timeout = DefaultRoomDepartureGrace
-		}
+		// need to give time in case participant is reconnecting
+		timeout = RoomDepartureGrace
 	} else {
 		elapsed = time.Now().Unix() - r.protoRoom.CreationTime
+		timeout = r.protoRoom.EmptyTimeout
 	}
 	r.lock.Unlock()
 

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -27,12 +27,16 @@ import (
 
 const (
 	DefaultEmptyTimeout       = 5 * 60 // 5m
-	RoomDepartureGrace        = 20
-	AudioLevelQuantization    = 8 // ideally power of 2 to minimize float decimal
+	AudioLevelQuantization    = 8      // ideally power of 2 to minimize float decimal
 	invAudioLevelQuantization = 1.0 / AudioLevelQuantization
 	subscriberUpdateInterval  = 3 * time.Second
 
 	dataForwardLoadBalanceThreshold = 20
+)
+
+var (
+	// var to allow unit test override
+	RoomDepartureGrace uint32 = 20
 )
 
 type broadcastOptions struct {
@@ -601,7 +605,6 @@ func (r *Room) CloseIfEmpty() {
 	var timeout uint32
 	var elapsed int64
 	if r.FirstJoinedAt() > 0 && r.LastLeftAt() > 0 {
-		// exit 20s after
 		elapsed = time.Now().Unix() - r.LastLeftAt()
 		// need to give time in case participant is reconnecting
 		timeout = RoomDepartureGrace

--- a/pkg/rtc/room_test.go
+++ b/pkg/rtc/room_test.go
@@ -59,11 +59,11 @@ func TestJoinedState(t *testing.T) {
 		require.LessOrEqual(t, s, rm.LastLeftAt())
 	})
 
-	t.Run("LastLeftAt should not be set when there are still participants in the room", func(t *testing.T) {
+	t.Run("LastLeftAt should be set when there are still participants in the room", func(t *testing.T) {
 		rm := newRoomWithParticipants(t, testRoomOpts{num: 2})
 		p0 := rm.GetParticipants()[0]
 		rm.RemoveParticipant(p0.Identity(), p0.ID(), types.ParticipantCloseReasonClientRequestLeave)
-		require.EqualValues(t, 0, rm.LastLeftAt())
+		require.Greater(t, rm.LastLeftAt(), int64(0))
 	})
 }
 

--- a/pkg/rtc/room_test.go
+++ b/pkg/rtc/room_test.go
@@ -33,6 +33,8 @@ func init() {
 	serverlogger.InitFromConfig(config.LoggingConfig{
 		Config: logger.Config{Level: "debug"},
 	})
+	// allow immediate closure in testing
+	RoomDepartureGrace = 0
 }
 
 var iceServersForRoom = []*livekit.ICEServer{{Urls: []string{"stun:stun.l.google.com:19302"}}}

--- a/pkg/rtc/room_test.go
+++ b/pkg/rtc/room_test.go
@@ -34,7 +34,7 @@ func init() {
 		Config: logger.Config{Level: "debug"},
 	})
 	// allow immediate closure in testing
-	RoomDepartureGrace = 0
+	RoomDepartureGrace = 1
 }
 
 var iceServersForRoom = []*livekit.ICEServer{{Urls: []string{"stun:stun.l.google.com:19302"}}}
@@ -351,7 +351,7 @@ func TestRoomClosure(t *testing.T) {
 		rm.protoRoom.EmptyTimeout = 0
 		rm.RemoveParticipant(p.Identity(), p.ID(), types.ParticipantCloseReasonClientRequestLeave)
 
-		time.Sleep(defaultDelay)
+		time.Sleep(time.Duration(RoomDepartureGrace)*time.Second + defaultDelay)
 
 		rm.CloseIfEmpty()
 		require.Len(t, rm.GetParticipants(), 0)


### PR DESCRIPTION
When a recorder is in the room, we would skip grace period due to a bug with how LastLeftAt was set. This would cause RoomComposite templates to exit immediately if the last participant in the room reconnects.