### PR TITLE
Start moving forwarding pipeline to extended range.

### DIFF
--- a/pkg/sfu/buffer/buffer_test.go
+++ b/pkg/sfu/buffer/buffer_test.go
@@ -198,8 +198,8 @@ func TestNewBuffer(t *testing.T) {
 				buf, _ := p.Marshal()
 				_, _ = buff.Write(buf)
 			}
-			require.Equal(t, uint16(1), buff.rtpStats.cycles)
-			require.Equal(t, uint16(2), buff.rtpStats.highestSN)
+			require.Equal(t, uint16(2), buff.rtpStats.sequenceNumber.GetHighest())
+			require.Equal(t, uint32((1<<16)+2), buff.rtpStats.sequenceNumber.GetExtendedHighest())
 		})
 	}
 }

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -322,7 +322,7 @@ func (r *RTPStats) Update(rtph *rtp.Header, payloadSize int, paddingSize int, pa
 		r.resyncOnNextPacket = false
 
 		if r.initialized {
-			r.sequenceNumber.ResetHighest(rtph.SequenceNumber)
+			r.sequenceNumber.ResetHighest(rtph.SequenceNumber - 1)
 			r.timestamp.ResetHighest(rtph.Timestamp)
 			r.highestTime = packetTime
 		}

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -181,8 +181,8 @@ func NewRTPStats(params RTPStatsParams) *RTPStats {
 	return &RTPStats{
 		params:         params,
 		logger:         params.Logger,
-		sequenceNumber: NewWrapAround[uint16, uint32](1 << 16),
-		timestamp:      NewWrapAround[uint32, uint64](1 << 32),
+		sequenceNumber: NewWrapAround[uint16, uint32](),
+		timestamp:      NewWrapAround[uint32, uint64](),
 		nextSnapshotId: FirstSnapshotId,
 		snapshots:      make(map[uint32]*Snapshot),
 	}

--- a/pkg/sfu/buffer/wraparound.go
+++ b/pkg/sfu/buffer/wraparound.go
@@ -1,5 +1,9 @@
 package buffer
 
+import (
+	"unsafe"
+)
+
 type number interface {
 	uint16 | uint32
 }
@@ -17,9 +21,10 @@ type WrapAround[T number, ET extendedNumber] struct {
 	cycles      int
 }
 
-func NewWrapAround[T number, ET extendedNumber](fullRange ET) *WrapAround[T, ET] {
+func NewWrapAround[T number, ET extendedNumber]() *WrapAround[T, ET] {
+	var t T
 	return &WrapAround[T, ET]{
-		fullRange: fullRange,
+		fullRange: 1 << (unsafe.Sizeof(t) * 8),
 	}
 }
 

--- a/pkg/sfu/buffer/wraparound.go
+++ b/pkg/sfu/buffer/wraparound.go
@@ -1,0 +1,116 @@
+package buffer
+
+type number interface {
+	uint16 | uint32
+}
+
+type extendedNumber interface {
+	uint32 | uint64
+}
+
+type WrapAround[T number, ET extendedNumber] struct {
+	fullRange ET
+
+	initialized bool
+	start       T
+	highest     T
+	cycles      int
+}
+
+func NewWrapAround[T number, ET extendedNumber](fullRange ET) *WrapAround[T, ET] {
+	return &WrapAround[T, ET]{
+		fullRange: fullRange,
+	}
+}
+
+func (w *WrapAround[T, ET]) Seed(from *WrapAround[T, ET]) {
+	w.initialized = from.initialized
+	w.highest = from.highest
+	w.cycles = from.cycles
+}
+
+type wrapAroundUpdateResult[ET extendedNumber] struct {
+	isRestart          bool
+	preExtendedStart   ET // valid only if isRestart = true
+	preExtendedHighest ET
+	extendedVal        ET
+}
+
+func (w *WrapAround[T, ET]) Update(val T) (result wrapAroundUpdateResult[ET]) {
+	if !w.initialized {
+		result.preExtendedHighest = ET(val) - 1
+		result.extendedVal = ET(val)
+
+		w.start = val
+		w.highest = val
+		w.initialized = true
+		return
+	}
+
+	result.preExtendedHighest = w.GetExtendedHighest()
+
+	gap := val - w.highest
+	if gap == 0 || gap > T(w.fullRange>>1) {
+		// duplicate OR out-of-order
+		result.isRestart, result.preExtendedStart, result.extendedVal = w.maybeAdjustStart(val)
+		return
+	}
+
+	// in-order
+	if val < w.highest {
+		w.cycles++
+	}
+	w.highest = val
+
+	result.extendedVal = ET(w.cycles)*w.fullRange + ET(val)
+	return
+}
+
+func (w *WrapAround[T, ET]) ResetHighest(val T) {
+	// TODO: what about cycles?
+	w.highest = val
+}
+
+func (w *WrapAround[T, ET]) GetStart() T {
+	return w.start
+}
+
+func (w *WrapAround[T, ET]) GetExtendedStart() ET {
+	return ET(w.start)
+}
+
+func (w *WrapAround[T, ET]) GetHighest() T {
+	return w.highest
+}
+
+func (w *WrapAround[T, ET]) GetExtendedHighest() ET {
+	return ET(w.cycles)*w.fullRange + ET(w.highest)
+}
+
+func (w *WrapAround[T, ET]) maybeAdjustStart(val T) (isRestart bool, preExtendedStart ET, extendedVal ET) {
+	// re-adjust start if necessary. The conditions are
+	// 1. Not seen more than half the range yet
+	// 1. wrap around compared to start and not completed a half cycle, sequences like (10, 65530) in uint16 space
+	// 2. no wrap around, but out-of-order compared to start and not completed a half cycle , sequences like (10, 9), (65530, 65528) in uint16 space
+	totalNum := w.GetExtendedHighest() - w.GetExtendedStart() + 1
+	if totalNum > (w.fullRange >> 1) {
+		extendedVal = ET(w.cycles)*w.fullRange + ET(val)
+		return
+	}
+
+	cycles := w.cycles
+	if val-w.start > T(w.fullRange>>1) {
+		// out-of-order with existing start => a new start
+		isRestart = true
+		preExtendedStart = w.GetExtendedStart()
+
+		if val > w.highest {
+			// wrap around
+			w.cycles = 1
+			cycles = 0
+		}
+		w.start = val
+	}
+	extendedVal = ET(cycles)*w.fullRange + ET(val)
+	return
+}

--- a/pkg/sfu/buffer/wraparound.go
+++ b/pkg/sfu/buffer/wraparound.go
@@ -72,7 +72,6 @@ func (w *WrapAround[T, ET]) Update(val T) (result wrapAroundUpdateResult[ET]) {
 }
 
 func (w *WrapAround[T, ET]) ResetHighest(val T) {
-	// TODO: what about cycles?
 	w.highest = val
 }
 

--- a/pkg/sfu/buffer/wraparound_test.go
+++ b/pkg/sfu/buffer/wraparound_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestWrapAroundUint16(t *testing.T) {
-	w := NewWrapAround[uint16, uint32](uint32(1 << 16))
+	w := NewWrapAround[uint16, uint32]()
 	testCases := []struct {
 		name            string
 		input           uint16
@@ -151,7 +151,7 @@ func TestWrapAroundUint16(t *testing.T) {
 }
 
 func TestWrapAroundUint32(t *testing.T) {
-	w := NewWrapAround[uint32, uint64](uint64(1 << 32))
+	w := NewWrapAround[uint32, uint64]()
 	testCases := []struct {
 		name            string
 		input           uint32

--- a/pkg/sfu/buffer/wraparound_test.go
+++ b/pkg/sfu/buffer/wraparound_test.go
@@ -1,0 +1,295 @@
+package buffer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapAroundUint16(t *testing.T) {
+	w := NewWrapAround[uint16, uint32](uint32(1 << 16))
+	testCases := []struct {
+		name            string
+		input           uint16
+		updated         wrapAroundUpdateResult[uint32]
+		start           uint16
+		extendedStart   uint32
+		highest         uint16
+		extendedHighest uint32
+	}{
+		// initialize
+		{
+			name:  "initialize",
+			input: 10,
+			updated: wrapAroundUpdateResult[uint32]{
+				isRestart:          false,
+				preExtendedStart:   0,
+				preExtendedHighest: 9,
+				extendedVal:        10,
+			},
+			start:           10,
+			extendedStart:   10,
+			highest:         10,
+			extendedHighest: 10,
+		},
+		// an older number without wrap around should reset start point
+		{
+			name:  "reset start no wrap around",
+			input: 8,
+			updated: wrapAroundUpdateResult[uint32]{
+				isRestart:          true,
+				preExtendedStart:   10,
+				preExtendedHighest: 10,
+				extendedVal:        8,
+			},
+			start:           8,
+			extendedStart:   8,
+			highest:         10,
+			extendedHighest: 10,
+		},
+		// an older number with wrap around should reset start point
+		{
+			name:  "reset start wrap around",
+			input: (1 << 16) - 6,
+			updated: wrapAroundUpdateResult[uint32]{
+				isRestart:          true,
+				preExtendedStart:   8,
+				preExtendedHighest: 10,
+				extendedVal:        (1 << 16) - 6,
+			},
+			start:           (1 << 16) - 6,
+			extendedStart:   (1 << 16) - 6,
+			highest:         10,
+			extendedHighest: (1 << 16) + 10,
+		},
+		// an older number with wrap around should reset start point again
+		{
+			name:  "reset start again",
+			input: (1 << 16) - 12,
+			updated: wrapAroundUpdateResult[uint32]{
+				isRestart:          true,
+				preExtendedStart:   (1 << 16) - 6,
+				preExtendedHighest: (1 << 16) + 10,
+				extendedVal:        (1 << 16) - 12,
+			},
+			start:           (1 << 16) - 12,
+			extendedStart:   (1 << 16) - 12,
+			highest:         10,
+			extendedHighest: (1 << 16) + 10,
+		},
+		// duplicate should return same as highest
+		{
+			name:  "duplicate",
+			input: 10,
+			updated: wrapAroundUpdateResult[uint32]{
+				isRestart:          false,
+				preExtendedStart:   0,
+				preExtendedHighest: (1 << 16) + 10,
+				extendedVal:        (1 << 16) + 10,
+			},
+			start:           (1 << 16) - 12,
+			extendedStart:   (1 << 16) - 12,
+			highest:         10,
+			extendedHighest: (1 << 16) + 10,
+		},
+		// a significant jump in order should not reset start
+		{
+			name:  "big in-order jump",
+			input: 1 << 15,
+			updated: wrapAroundUpdateResult[uint32]{
+				isRestart:          false,
+				preExtendedStart:   0,
+				preExtendedHighest: (1 << 16) + 10,
+				extendedVal:        (1 << 16) + (1 << 15),
+			},
+			start:           (1 << 16) - 12,
+			extendedStart:   (1 << 16) - 12,
+			highest:         1 << 15,
+			extendedHighest: (1 << 16) + (1 << 15),
+		},
+		// now out-of-order should not reset start as half the range has been seen
+		{
+			name:  "out-of-order after half range",
+			input: (1 << 15) - 1,
+			updated: wrapAroundUpdateResult[uint32]{
+				isRestart:          false,
+				preExtendedStart:   0,
+				preExtendedHighest: (1 << 16) + (1 << 15),
+				extendedVal:        (1 << 16) + (1 << 15) - 1,
+			},
+			start:           (1 << 16) - 12,
+			extendedStart:   (1 << 16) - 12,
+			highest:         1 << 15,
+			extendedHighest: (1 << 16) + (1 << 15),
+		},
+		// in-order, should update highest
+		{
+			name:  "in-order",
+			input: (1 << 15) + 3,
+			updated: wrapAroundUpdateResult[uint32]{
+				isRestart:          false,
+				preExtendedStart:   0,
+				preExtendedHighest: (1 << 16) + (1 << 15),
+				extendedVal:        (1 << 16) + (1 << 15) + 3,
+			},
+			start:           (1 << 16) - 12,
+			extendedStart:   (1 << 16) - 12,
+			highest:         (1 << 15) + 3,
+			extendedHighest: (1 << 16) + (1 << 15) + 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.updated, w.Update(tc.input))
+			require.Equal(t, tc.start, w.GetStart())
+			require.Equal(t, tc.extendedStart, w.GetExtendedStart())
+			require.Equal(t, tc.highest, w.GetHighest())
+			require.Equal(t, tc.extendedHighest, w.GetExtendedHighest())
+		})
+	}
+}
+
+func TestWrapAroundUint32(t *testing.T) {
+	w := NewWrapAround[uint32, uint64](uint64(1 << 32))
+	testCases := []struct {
+		name            string
+		input           uint32
+		updated         wrapAroundUpdateResult[uint64]
+		start           uint32
+		extendedStart   uint64
+		highest         uint32
+		extendedHighest uint64
+	}{
+		// initialize
+		{
+			name:  "initialize",
+			input: 10,
+			updated: wrapAroundUpdateResult[uint64]{
+				isRestart:          false,
+				preExtendedStart:   0,
+				preExtendedHighest: 9,
+				extendedVal:        10,
+			},
+			start:           10,
+			extendedStart:   10,
+			highest:         10,
+			extendedHighest: 10,
+		},
+		// an older number without wrap around should reset start point
+		{
+			name:  "reset start no wrap around",
+			input: 8,
+			updated: wrapAroundUpdateResult[uint64]{
+				isRestart:          true,
+				preExtendedStart:   10,
+				preExtendedHighest: 10,
+				extendedVal:        8,
+			},
+			start:           8,
+			extendedStart:   8,
+			highest:         10,
+			extendedHighest: 10,
+		},
+		// an older number with wrap around should reset start point
+		{
+			name:  "reset start wrap around",
+			input: (1 << 32) - 6,
+			updated: wrapAroundUpdateResult[uint64]{
+				isRestart:          true,
+				preExtendedStart:   8,
+				preExtendedHighest: 10,
+				extendedVal:        (1 << 32) - 6,
+			},
+			start:           (1 << 32) - 6,
+			extendedStart:   (1 << 32) - 6,
+			highest:         10,
+			extendedHighest: (1 << 32) + 10,
+		},
+		// an older number with wrap around should reset start point again
+		{
+			name:  "reset start again",
+			input: (1 << 32) - 12,
+			updated: wrapAroundUpdateResult[uint64]{
+				isRestart:          true,
+				preExtendedStart:   (1 << 32) - 6,
+				preExtendedHighest: (1 << 32) + 10,
+				extendedVal:        (1 << 32) - 12,
+			},
+			start:           (1 << 32) - 12,
+			extendedStart:   (1 << 32) - 12,
+			highest:         10,
+			extendedHighest: (1 << 32) + 10,
+		},
+		// duplicate should return same as highest
+		{
+			name:  "duplicate",
+			input: 10,
+			updated: wrapAroundUpdateResult[uint64]{
+				isRestart:          false,
+				preExtendedStart:   0,
+				preExtendedHighest: (1 << 32) + 10,
+				extendedVal:        (1 << 32) + 10,
+			},
+			start:           (1 << 32) - 12,
+			extendedStart:   (1 << 32) - 12,
+			highest:         10,
+			extendedHighest: (1 << 32) + 10,
+		},
+		// a significant jump in order should not reset start
+		{
+			name:  "big in-order jump",
+			input: 1 << 31,
+			updated: wrapAroundUpdateResult[uint64]{
+				isRestart:          false,
+				preExtendedStart:   0,
+				preExtendedHighest: (1 << 32) + 10,
+				extendedVal:        (1 << 32) + (1 << 31),
+			},
+			start:           (1 << 32) - 12,
+			extendedStart:   (1 << 32) - 12,
+			highest:         1 << 31,
+			extendedHighest: (1 << 32) + (1 << 31),
+		},
+		// now out-of-order should not reset start as half the range has been seen
+		{
+			name:  "out-of-order after half range",
+			input: (1 << 31) - 1,
+			updated: wrapAroundUpdateResult[uint64]{
+				isRestart:          false,
+				preExtendedStart:   0,
+				preExtendedHighest: (1 << 32) + (1 << 31),
+				extendedVal:        (1 << 32) + (1 << 31) - 1,
+			},
+			start:           (1 << 32) - 12,
+			extendedStart:   (1 << 32) - 12,
+			highest:         1 << 31,
+			extendedHighest: (1 << 32) + (1 << 31),
+		},
+		// in-order, should update highest
+		{
+			name:  "in-order",
+			input: (1 << 31) + 3,
+			updated: wrapAroundUpdateResult[uint64]{
+				isRestart:          false,
+				preExtendedStart:   0,
+				preExtendedHighest: (1 << 32) + (1 << 31),
+				extendedVal:        (1 << 32) + (1 << 31) + 3,
+			},
+			start:           (1 << 32) - 12,
+			extendedStart:   (1 << 32) - 12,
+			highest:         (1 << 31) + 3,
+			extendedHighest: (1 << 32) + (1 << 31) + 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.updated, w.Update(tc.input))
+			require.Equal(t, tc.start, w.GetStart())
+			require.Equal(t, tc.extendedStart, w.GetExtendedStart())
+			require.Equal(t, tc.highest, w.GetHighest())
+			require.Equal(t, tc.extendedHighest, w.GetExtendedHighest())
+		})
+	}
+}


### PR DESCRIPTION
When publisher is muted for audio, there are no packets forwarded. So, subscriber could be a large jump in sequence number and time stamp. Although the range for wrap around is quite high (> 13h for video clock rate and > 24h for 48 KHz audio clock rate), a safer option is to exten the range.

Will do it multiple steps. First part here.
- Use extended range inside RTPStats module.
- What RTPStats exports remains the same so that this PR can be kept small(ish).

Over time, RTP stats will export extended range and other parts of the pipeline will use extended range too.