### PR TITLE
Pure code movement

### DIFF
--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -240,7 +240,7 @@ func (t *MediaTrackReceiver) SetLayerSsrc(mime string, rid string, ssrc uint32) 
 	defer t.lock.Unlock()
 
 	layer := buffer.RidToSpatialLayer(rid, t.params.TrackInfo)
-	if layer == sfu.InvalidLayerSpatial {
+	if layer == buffer.InvalidLayerSpatial {
 		// non-simulcast case will not have `rid`
 		layer = 0
 	}

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -24,6 +24,7 @@ import (
 	"github.com/livekit/livekit-server/pkg/sfu"
 	"github.com/livekit/livekit-server/pkg/sfu/buffer"
 	"github.com/livekit/livekit-server/pkg/sfu/connectionquality"
+	"github.com/livekit/livekit-server/pkg/sfu/streamallocator"
 	"github.com/livekit/livekit-server/pkg/telemetry"
 	"github.com/livekit/mediatransportutil/pkg/twcc"
 	"github.com/livekit/protocol/auth"
@@ -1338,7 +1339,7 @@ func (p *ParticipantImpl) subscriberRTCPWorker() {
 	}
 }
 
-func (p *ParticipantImpl) onStreamStateChange(update *sfu.StreamStateUpdate) error {
+func (p *ParticipantImpl) onStreamStateChange(update *streamallocator.StreamStateUpdate) error {
 	if len(update.StreamStates) == 0 {
 		return nil
 	}
@@ -1346,7 +1347,7 @@ func (p *ParticipantImpl) onStreamStateChange(update *sfu.StreamStateUpdate) err
 	streamStateUpdate := &livekit.StreamStateUpdate{}
 	for _, streamStateInfo := range update.StreamStates {
 		state := livekit.StreamState_ACTIVE
-		if streamStateInfo.State == sfu.StreamStatePaused {
+		if streamStateInfo.State == streamallocator.StreamStatePaused {
 			state = livekit.StreamState_PAUSED
 		}
 		streamStateUpdate.StreamStates = append(streamStateUpdate.StreamStates, &livekit.StreamStateInfo{

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -26,7 +26,7 @@ import (
 	"github.com/livekit/livekit-server/pkg/config"
 	serverlogger "github.com/livekit/livekit-server/pkg/logger"
 	"github.com/livekit/livekit-server/pkg/rtc/types"
-	"github.com/livekit/livekit-server/pkg/sfu"
+	"github.com/livekit/livekit-server/pkg/sfu/streamallocator"
 	"github.com/livekit/livekit-server/pkg/telemetry"
 	"github.com/livekit/livekit-server/pkg/telemetry/prometheus"
 )
@@ -182,7 +182,7 @@ type PCTransport struct {
 	onNegotiationFailed       func()
 
 	// stream allocator for subscriber PC
-	streamAllocator *sfu.StreamAllocator
+	streamAllocator *streamallocator.StreamAllocator
 
 	previousAnswer *webrtc.SessionDescription
 	// track id -> description map in previous offer sdp
@@ -366,7 +366,7 @@ func NewPCTransport(params TransportParams) (*PCTransport, error) {
 		canReuseTransceiver:      true,
 	}
 	if params.IsSendSide {
-		t.streamAllocator = sfu.NewStreamAllocator(sfu.StreamAllocatorParams{
+		t.streamAllocator = streamallocator.NewStreamAllocator(streamallocator.StreamAllocatorParams{
 			Config: params.CongestionControlConfig,
 			Logger: params.Logger,
 		})
@@ -1085,7 +1085,7 @@ func (t *PCTransport) ResetShortConnOnICERestart() {
 	t.resetShortConnOnICERestart.Store(true)
 }
 
-func (t *PCTransport) OnStreamStateChange(f func(update *sfu.StreamStateUpdate) error) {
+func (t *PCTransport) OnStreamStateChange(f func(update *streamallocator.StreamStateUpdate) error) {
 	if t.streamAllocator == nil {
 		return
 	}
@@ -1098,7 +1098,7 @@ func (t *PCTransport) AddTrackToStreamAllocator(subTrack types.SubscribedTrack) 
 		return
 	}
 
-	t.streamAllocator.AddTrack(subTrack.DownTrack(), sfu.AddTrackParams{
+	t.streamAllocator.AddTrack(subTrack.DownTrack(), streamallocator.AddTrackParams{
 		Source:      subTrack.MediaTrack().Source(),
 		IsSimulcast: subTrack.MediaTrack().IsSimulcast(),
 		PublisherID: subTrack.MediaTrack().PublisherID(),

--- a/pkg/rtc/transportmanager.go
+++ b/pkg/rtc/transportmanager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/livekit/livekit-server/pkg/config"
 	"github.com/livekit/livekit-server/pkg/rtc/types"
 	"github.com/livekit/livekit-server/pkg/sfu"
+	"github.com/livekit/livekit-server/pkg/sfu/streamallocator"
 	"github.com/livekit/livekit-server/pkg/telemetry"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
@@ -243,7 +244,7 @@ func (t *TransportManager) OnSubscriberInitialConnected(f func()) {
 	t.onSubscriberInitialConnected = f
 }
 
-func (t *TransportManager) OnSubscriberStreamStateChange(f func(update *sfu.StreamStateUpdate) error) {
+func (t *TransportManager) OnSubscriberStreamStateChange(f func(update *streamallocator.StreamStateUpdate) error) {
 	t.subscriber.OnStreamStateChange(f)
 }
 

--- a/pkg/sfu/buffer/videolayer.go
+++ b/pkg/sfu/buffer/videolayer.go
@@ -15,6 +15,11 @@ var (
 		Spatial:  InvalidLayerSpatial,
 		Temporal: InvalidLayerTemporal,
 	}
+
+	DefaultMaxLayers = VideoLayer{
+		Spatial:  DefaultMaxLayerSpatial,
+		Temporal: DefaultMaxLayerTemporal,
+	}
 )
 
 type VideoLayer struct {

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -631,9 +631,6 @@ func (d *DownTrack) WriteRTP(extPkt *buffer.ExtPacket, layer int32) error {
 	}
 
 	d.rtpStats.Update(hdr, len(payload), 0, time.Now().UnixNano())
-	if d.kind == webrtc.RTPCodecTypeAudio {
-		d.logger.Infow("RAJA forwarding audio", "isn", extPkt.Packet.SequenceNumber, "its", extPkt.Packet.Timestamp, "osn", hdr.SequenceNumber, "ots", hdr.Timestamp)
-	}
 	return nil
 }
 
@@ -1174,9 +1171,6 @@ func (d *DownTrack) writeBlankFrameRTP(duration float32, generation uint32) chan
 					d.logger.Warnw("could not write blank frame", err)
 					close(done)
 					return
-				}
-				if d.kind == webrtc.RTPCodecTypeAudio {
-					d.logger.Infow("RAJA audio blank", "osn", hdr.SequenceNumber, "ots", hdr.Timestamp)
 				}
 
 				d.streamAllocatorBytesCounter.Add(uint32(pktSize))

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -141,7 +141,7 @@ type DownTrackStreamAllocatorListener interface {
 	OnSubscriptionChanged(dt *DownTrack)
 
 	// subscribed max video layer changed
-	OnSubscribedLayersChanged(dt *DownTrack, layers VideoLayers)
+	OnSubscribedLayersChanged(dt *DownTrack, layers buffer.VideoLayer)
 
 	// target video layer reached
 	OnTargetLayerReached(dt *DownTrack)
@@ -508,7 +508,7 @@ func (d *DownTrack) stopKeyFrameRequester() {
 }
 
 func (d *DownTrack) keyFrameRequester(generation uint32, layer int32) {
-	if d.IsClosed() || layer == InvalidLayerSpatial {
+	if d.IsClosed() || layer == buffer.InvalidLayerSpatial {
 		return
 	}
 	interval := 2 * d.rtpStats.GetRtt()
@@ -631,6 +631,9 @@ func (d *DownTrack) WriteRTP(extPkt *buffer.ExtPacket, layer int32) error {
 	}
 
 	d.rtpStats.Update(hdr, len(payload), 0, time.Now().UnixNano())
+	if d.kind == webrtc.RTPCodecTypeAudio {
+		d.logger.Infow("RAJA forwarding audio", "isn", extPkt.Packet.SequenceNumber, "its", extPkt.Packet.Timestamp, "osn", hdr.SequenceNumber, "ots", hdr.Timestamp)
+	}
 	return nil
 }
 
@@ -739,7 +742,7 @@ func (d *DownTrack) PubMute(pubMuted bool) {
 	d.handleMute(pubMuted, true, changed, maxLayers)
 }
 
-func (d *DownTrack) handleMute(muted bool, isPub bool, changed bool, maxLayers VideoLayers) {
+func (d *DownTrack) handleMute(muted bool, isPub bool, changed bool, maxLayers buffer.VideoLayer) {
 	if !changed {
 		return
 	}
@@ -767,7 +770,7 @@ func (d *DownTrack) handleMute(muted bool, isPub bool, changed bool, maxLayers V
 	// and that could turn on/off layers on publisher side.
 	//
 	if !isPub && d.onMaxSubscribedLayerChanged != nil && d.kind == webrtc.RTPCodecTypeVideo {
-		notifyLayer := InvalidLayerSpatial
+		notifyLayer := buffer.InvalidLayerSpatial
 		if !muted {
 			//
 			// When unmuting, don't wait for layer lock as
@@ -861,7 +864,7 @@ func (d *DownTrack) CloseWithFlush(flush bool) {
 	d.logger.Infow("rtp stats", "direction", "downstream", "mime", d.mime, "ssrc", d.ssrc, "stats", d.rtpStats.ToString())
 
 	if d.onMaxSubscribedLayerChanged != nil && d.kind == webrtc.RTPCodecTypeVideo {
-		d.onMaxSubscribedLayerChanged(d, InvalidLayerSpatial)
+		d.onMaxSubscribedLayerChanged(d, buffer.InvalidLayerSpatial)
 	}
 
 	if d.onCloseHandler != nil {
@@ -905,7 +908,7 @@ func (d *DownTrack) SetMaxTemporalLayer(temporalLayer int32) {
 	}
 }
 
-func (d *DownTrack) MaxLayers() VideoLayers {
+func (d *DownTrack) MaxLayers() buffer.VideoLayer {
 	return d.forwarder.MaxLayers()
 }
 
@@ -1008,7 +1011,7 @@ func (d *DownTrack) AllocateOptimal(allowOvershoot bool) VideoAllocation {
 	al, brs := d.receiver.GetLayeredBitrate()
 	allocation := d.forwarder.AllocateOptimal(al, brs, allowOvershoot)
 	d.maybeStartKeyFrameRequester()
-	d.maybeAddTransition(allocation.bandwidthNeeded, allocation.distanceToDesired)
+	d.maybeAddTransition(allocation.BandwidthNeeded, allocation.DistanceToDesired)
 	return allocation
 }
 
@@ -1017,7 +1020,7 @@ func (d *DownTrack) ProvisionalAllocatePrepare() {
 	d.forwarder.ProvisionalAllocatePrepare(al, brs)
 }
 
-func (d *DownTrack) ProvisionalAllocate(availableChannelCapacity int64, layers VideoLayers, allowPause bool, allowOvershoot bool) int64 {
+func (d *DownTrack) ProvisionalAllocate(availableChannelCapacity int64, layers buffer.VideoLayer, allowPause bool, allowOvershoot bool) int64 {
 	return d.forwarder.ProvisionalAllocate(availableChannelCapacity, layers, allowPause, allowOvershoot)
 }
 
@@ -1036,7 +1039,7 @@ func (d *DownTrack) ProvisionalAllocateGetBestWeightedTransition() VideoTransiti
 func (d *DownTrack) ProvisionalAllocateCommit() VideoAllocation {
 	allocation := d.forwarder.ProvisionalAllocateCommit()
 	d.maybeStartKeyFrameRequester()
-	d.maybeAddTransition(allocation.bandwidthNeeded, allocation.distanceToDesired)
+	d.maybeAddTransition(allocation.BandwidthNeeded, allocation.DistanceToDesired)
 	return allocation
 }
 
@@ -1044,7 +1047,7 @@ func (d *DownTrack) AllocateNextHigher(availableChannelCapacity int64, allowOver
 	al, brs := d.receiver.GetLayeredBitrate()
 	allocation, available := d.forwarder.AllocateNextHigher(availableChannelCapacity, al, brs, allowOvershoot)
 	d.maybeStartKeyFrameRequester()
-	d.maybeAddTransition(allocation.bandwidthNeeded, allocation.distanceToDesired)
+	d.maybeAddTransition(allocation.BandwidthNeeded, allocation.DistanceToDesired)
 	return allocation, available
 }
 
@@ -1059,7 +1062,7 @@ func (d *DownTrack) Pause() VideoAllocation {
 	al, brs := d.receiver.GetLayeredBitrate()
 	allocation := d.forwarder.Pause(al, brs)
 	d.maybeStartKeyFrameRequester()
-	d.maybeAddTransition(allocation.bandwidthNeeded, allocation.distanceToDesired)
+	d.maybeAddTransition(allocation.BandwidthNeeded, allocation.DistanceToDesired)
 	return allocation
 }
 
@@ -1172,6 +1175,9 @@ func (d *DownTrack) writeBlankFrameRTP(duration float32, generation uint32) chan
 					close(done)
 					return
 				}
+				if d.kind == webrtc.RTPCodecTypeAudio {
+					d.logger.Infow("RAJA audio blank", "osn", hdr.SequenceNumber, "ots", hdr.Timestamp)
+				}
 
 				d.streamAllocatorBytesCounter.Add(uint32(pktSize))
 
@@ -1278,7 +1284,7 @@ func (d *DownTrack) handleRTCP(bytes []byte) {
 	sendPliOnce := func() {
 		if pliOnce {
 			_, layer := d.forwarder.CheckSync()
-			if layer != InvalidLayerSpatial && !d.forwarder.IsAnyMuted() {
+			if layer != buffer.InvalidLayerSpatial && !d.forwarder.IsAnyMuted() {
 				d.logger.Debugw("sending PLI RTCP", "layer", layer)
 				d.receiver.SendPLI(layer, false)
 				d.isNACKThrottled.Store(true)
@@ -1637,7 +1643,7 @@ func (d *DownTrack) onBindAndConnected() {
 	if d.connected.Load() && d.bound.Load() && !d.bindAndConnectedOnce.Swap(true) {
 		if d.kind == webrtc.RTPCodecTypeVideo {
 			_, layer := d.forwarder.CheckSync()
-			if layer != InvalidLayerSpatial {
+			if layer != buffer.InvalidLayerSpatial {
 				d.receiver.SendPLI(layer, true)
 			}
 		}

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func disable(f *Forwarder) {
-	f.currentLayers = InvalidLayers
-	f.targetLayers = InvalidLayers
+	f.currentLayers = buffer.InvalidLayers
+	f.targetLayers = buffer.InvalidLayers
 }
 
 func newForwarder(codec webrtc.RTPCodecCapability, kind webrtc.RTPCodecType) *Forwarder {
@@ -40,74 +40,74 @@ func TestForwarderMute(t *testing.T) {
 func TestForwarderLayersAudio(t *testing.T) {
 	f := newForwarder(testutils.TestOpusCodec, webrtc.RTPCodecTypeAudio)
 
-	require.Equal(t, InvalidLayers, f.MaxLayers())
+	require.Equal(t, buffer.InvalidLayers, f.MaxLayers())
 
-	require.Equal(t, InvalidLayers, f.CurrentLayers())
-	require.Equal(t, InvalidLayers, f.TargetLayers())
+	require.Equal(t, buffer.InvalidLayers, f.CurrentLayers())
+	require.Equal(t, buffer.InvalidLayers, f.TargetLayers())
 
 	changed, maxLayers, currentLayers := f.SetMaxSpatialLayer(1)
 	require.False(t, changed)
-	require.Equal(t, InvalidLayers, maxLayers)
-	require.Equal(t, InvalidLayers, currentLayers)
+	require.Equal(t, buffer.InvalidLayers, maxLayers)
+	require.Equal(t, buffer.InvalidLayers, currentLayers)
 
 	changed, maxLayers, currentLayers = f.SetMaxTemporalLayer(1)
 	require.False(t, changed)
-	require.Equal(t, InvalidLayers, maxLayers)
-	require.Equal(t, InvalidLayers, currentLayers)
+	require.Equal(t, buffer.InvalidLayers, maxLayers)
+	require.Equal(t, buffer.InvalidLayers, currentLayers)
 
-	require.Equal(t, InvalidLayers, f.MaxLayers())
+	require.Equal(t, buffer.InvalidLayers, f.MaxLayers())
 }
 
 func TestForwarderLayersVideo(t *testing.T) {
 	f := newForwarder(testutils.TestVP8Codec, webrtc.RTPCodecTypeVideo)
 
 	maxLayers := f.MaxLayers()
-	expectedLayers := VideoLayers{Spatial: InvalidLayerSpatial, Temporal: DefaultMaxLayerTemporal}
+	expectedLayers := buffer.VideoLayer{Spatial: buffer.InvalidLayerSpatial, Temporal: buffer.DefaultMaxLayerTemporal}
 	require.Equal(t, expectedLayers, maxLayers)
 
-	require.Equal(t, InvalidLayers, f.CurrentLayers())
-	require.Equal(t, InvalidLayers, f.TargetLayers())
+	require.Equal(t, buffer.InvalidLayers, f.CurrentLayers())
+	require.Equal(t, buffer.InvalidLayers, f.TargetLayers())
 
-	expectedLayers = VideoLayers{
-		Spatial:  DefaultMaxLayerSpatial,
-		Temporal: DefaultMaxLayerTemporal,
+	expectedLayers = buffer.VideoLayer{
+		Spatial:  buffer.DefaultMaxLayerSpatial,
+		Temporal: buffer.DefaultMaxLayerTemporal,
 	}
-	changed, maxLayers, currentLayers := f.SetMaxSpatialLayer(DefaultMaxLayerSpatial)
+	changed, maxLayers, currentLayers := f.SetMaxSpatialLayer(buffer.DefaultMaxLayerSpatial)
 	require.True(t, changed)
 	require.Equal(t, expectedLayers, maxLayers)
-	require.Equal(t, InvalidLayers, currentLayers)
+	require.Equal(t, buffer.InvalidLayers, currentLayers)
 
-	changed, maxLayers, currentLayers = f.SetMaxSpatialLayer(DefaultMaxLayerSpatial - 1)
+	changed, maxLayers, currentLayers = f.SetMaxSpatialLayer(buffer.DefaultMaxLayerSpatial - 1)
 	require.True(t, changed)
-	expectedLayers = VideoLayers{
-		Spatial:  DefaultMaxLayerSpatial - 1,
-		Temporal: DefaultMaxLayerTemporal,
+	expectedLayers = buffer.VideoLayer{
+		Spatial:  buffer.DefaultMaxLayerSpatial - 1,
+		Temporal: buffer.DefaultMaxLayerTemporal,
 	}
 	require.Equal(t, expectedLayers, maxLayers)
 	require.Equal(t, expectedLayers, f.MaxLayers())
-	require.Equal(t, InvalidLayers, currentLayers)
+	require.Equal(t, buffer.InvalidLayers, currentLayers)
 
-	f.currentLayers = VideoLayers{Spatial: 0, Temporal: 1}
-	changed, maxLayers, currentLayers = f.SetMaxSpatialLayer(DefaultMaxLayerSpatial - 1)
+	f.currentLayers = buffer.VideoLayer{Spatial: 0, Temporal: 1}
+	changed, maxLayers, currentLayers = f.SetMaxSpatialLayer(buffer.DefaultMaxLayerSpatial - 1)
 	require.False(t, changed)
 	require.Equal(t, expectedLayers, maxLayers)
 	require.Equal(t, expectedLayers, f.MaxLayers())
-	require.Equal(t, VideoLayers{Spatial: 0, Temporal: 1}, currentLayers)
+	require.Equal(t, buffer.VideoLayer{Spatial: 0, Temporal: 1}, currentLayers)
 
-	changed, maxLayers, currentLayers = f.SetMaxTemporalLayer(DefaultMaxLayerTemporal)
+	changed, maxLayers, currentLayers = f.SetMaxTemporalLayer(buffer.DefaultMaxLayerTemporal)
 	require.False(t, changed)
 	require.Equal(t, expectedLayers, maxLayers)
-	require.Equal(t, VideoLayers{Spatial: 0, Temporal: 1}, currentLayers)
+	require.Equal(t, buffer.VideoLayer{Spatial: 0, Temporal: 1}, currentLayers)
 
-	changed, maxLayers, currentLayers = f.SetMaxTemporalLayer(DefaultMaxLayerTemporal - 1)
+	changed, maxLayers, currentLayers = f.SetMaxTemporalLayer(buffer.DefaultMaxLayerTemporal - 1)
 	require.True(t, changed)
-	expectedLayers = VideoLayers{
-		Spatial:  DefaultMaxLayerSpatial - 1,
-		Temporal: DefaultMaxLayerTemporal - 1,
+	expectedLayers = buffer.VideoLayer{
+		Spatial:  buffer.DefaultMaxLayerSpatial - 1,
+		Temporal: buffer.DefaultMaxLayerTemporal - 1,
 	}
 	require.Equal(t, expectedLayers, maxLayers)
 	require.Equal(t, expectedLayers, f.MaxLayers())
-	require.Equal(t, VideoLayers{Spatial: 0, Temporal: 1}, currentLayers)
+	require.Equal(t, buffer.VideoLayer{Spatial: 0, Temporal: 1}, currentLayers)
 }
 
 func TestForwarderAllocateOptimal(t *testing.T) {
@@ -121,53 +121,53 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 	}
 
 	// invalid max layers
-	f.maxLayers = InvalidLayers
+	f.maxLayers = buffer.InvalidLayers
 	expectedResult := VideoAllocation{
-		pauseReason:         VideoPauseReasonFeedDry,
-		bandwidthRequested:  0,
-		bandwidthDelta:      0,
-		bitrates:            bitrates,
-		targetLayers:        InvalidLayers,
-		requestLayerSpatial: InvalidLayerSpatial,
-		maxLayers:           InvalidLayers,
-		distanceToDesired:   0,
+		PauseReason:         VideoPauseReasonFeedDry,
+		BandwidthRequested:  0,
+		BandwidthDelta:      0,
+		Bitrates:            bitrates,
+		TargetLayers:        buffer.InvalidLayers,
+		RequestLayerSpatial: buffer.InvalidLayerSpatial,
+		MaxLayers:           buffer.InvalidLayers,
+		DistanceToDesired:   0,
 	}
 	result := f.AllocateOptimal(nil, bitrates, true)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 
-	f.SetMaxSpatialLayer(DefaultMaxLayerSpatial)
-	f.SetMaxTemporalLayer(DefaultMaxLayerTemporal)
+	f.SetMaxSpatialLayer(buffer.DefaultMaxLayerSpatial)
+	f.SetMaxTemporalLayer(buffer.DefaultMaxLayerTemporal)
 
-	// should still have target at InvalidLayers until max publisher layer is available
+	// should still have target at buffer.InvalidLayers until max publisher layer is available
 	expectedResult = VideoAllocation{
-		pauseReason:         VideoPauseReasonFeedDry,
-		bandwidthRequested:  0,
-		bandwidthDelta:      0,
-		bitrates:            bitrates,
-		targetLayers:        InvalidLayers,
-		requestLayerSpatial: InvalidLayerSpatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0,
+		PauseReason:         VideoPauseReasonFeedDry,
+		BandwidthRequested:  0,
+		BandwidthDelta:      0,
+		Bitrates:            bitrates,
+		TargetLayers:        buffer.InvalidLayers,
+		RequestLayerSpatial: buffer.InvalidLayerSpatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   0,
 	}
 	result = f.AllocateOptimal(nil, bitrates, true)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 
-	f.SetMaxPublishedLayer(DefaultMaxLayerSpatial)
+	f.SetMaxPublishedLayer(buffer.DefaultMaxLayerSpatial)
 
 	// muted should not consume any bandwidth
 	f.Mute(true)
 	disable(f)
 	expectedResult = VideoAllocation{
-		pauseReason:         VideoPauseReasonMuted,
-		bandwidthRequested:  0,
-		bandwidthDelta:      0,
-		bitrates:            bitrates,
-		targetLayers:        InvalidLayers,
-		requestLayerSpatial: InvalidLayerSpatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0,
+		PauseReason:         VideoPauseReasonMuted,
+		BandwidthRequested:  0,
+		BandwidthDelta:      0,
+		Bitrates:            bitrates,
+		TargetLayers:        buffer.InvalidLayers,
+		RequestLayerSpatial: buffer.InvalidLayerSpatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   0,
 	}
 	result = f.AllocateOptimal(nil, bitrates, true)
 	require.Equal(t, expectedResult, result)
@@ -179,14 +179,14 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 	f.PubMute(true)
 	disable(f)
 	expectedResult = VideoAllocation{
-		pauseReason:         VideoPauseReasonPubMuted,
-		bandwidthRequested:  0,
-		bandwidthDelta:      0,
-		bitrates:            bitrates,
-		targetLayers:        InvalidLayers,
-		requestLayerSpatial: InvalidLayerSpatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0,
+		PauseReason:         VideoPauseReasonPubMuted,
+		BandwidthRequested:  0,
+		BandwidthDelta:      0,
+		Bitrates:            bitrates,
+		TargetLayers:        buffer.InvalidLayers,
+		RequestLayerSpatial: buffer.InvalidLayerSpatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   0,
 	}
 	result = f.AllocateOptimal(nil, bitrates, true)
 	require.Equal(t, expectedResult, result)
@@ -195,209 +195,209 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 	f.PubMute(false)
 
 	// when parked layers valid, should stay there
-	f.parkedLayers = VideoLayers{
+	f.parkedLayers = buffer.VideoLayer{
 		Spatial:  0,
 		Temporal: 1,
 	}
 	expectedResult = VideoAllocation{
-		pauseReason:         VideoPauseReasonFeedDry,
-		bandwidthRequested:  0,
-		bandwidthDelta:      0,
-		bitrates:            emptyBitrates,
-		targetLayers:        f.parkedLayers,
-		requestLayerSpatial: f.parkedLayers.Spatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0,
+		PauseReason:         VideoPauseReasonFeedDry,
+		BandwidthRequested:  0,
+		BandwidthDelta:      0,
+		Bitrates:            emptyBitrates,
+		TargetLayers:        f.parkedLayers,
+		RequestLayerSpatial: f.parkedLayers.Spatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   0,
 	}
 	result = f.AllocateOptimal(nil, emptyBitrates, true)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 	require.Equal(t, f.parkedLayers, f.TargetLayers())
-	f.parkedLayers = InvalidLayers
+	f.parkedLayers = buffer.InvalidLayers
 
 	// when max layers changes, target is opportunistic, but requested spatial layer should be at max
 	f.SetMaxTemporalLayerSeen(3)
-	f.maxLayers = VideoLayers{Spatial: 1, Temporal: 3}
+	f.maxLayers = buffer.VideoLayer{Spatial: 1, Temporal: 3}
 	expectedResult = VideoAllocation{
-		pauseReason:         VideoPauseReasonNone,
-		bandwidthRequested:  bitrates[1][3],
-		bandwidthDelta:      bitrates[1][3],
-		bandwidthNeeded:     bitrates[1][3],
-		bitrates:            bitrates,
-		targetLayers:        DefaultMaxLayers,
-		requestLayerSpatial: f.maxLayers.Spatial,
-		maxLayers:           f.maxLayers,
-		distanceToDesired:   -1,
+		PauseReason:         VideoPauseReasonNone,
+		BandwidthRequested:  bitrates[1][3],
+		BandwidthDelta:      bitrates[1][3],
+		BandwidthNeeded:     bitrates[1][3],
+		Bitrates:            bitrates,
+		TargetLayers:        buffer.DefaultMaxLayers,
+		RequestLayerSpatial: f.maxLayers.Spatial,
+		MaxLayers:           f.maxLayers,
+		DistanceToDesired:   -1,
 	}
 	result = f.AllocateOptimal(nil, bitrates, true)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
-	require.Equal(t, DefaultMaxLayers, f.TargetLayers())
+	require.Equal(t, buffer.DefaultMaxLayers, f.TargetLayers())
 
 	// reset max layers for rest of the tests below
-	f.maxLayers = DefaultMaxLayers
+	f.maxLayers = buffer.DefaultMaxLayers
 
 	// when feed is dry and current is not valid, should set up for opportunistic forwarding
 	// NOTE: feed is dry due to availableLayers = nil, some valid bitrates may be passed in here for testing purposes only
 	disable(f)
-	expectedTargetLayers := VideoLayers{
+	expectedTargetLayers := buffer.VideoLayer{
 		Spatial:  2,
-		Temporal: DefaultMaxLayerTemporal,
+		Temporal: buffer.DefaultMaxLayerTemporal,
 	}
 	expectedResult = VideoAllocation{
-		pauseReason:         VideoPauseReasonNone,
-		bandwidthRequested:  bitrates[2][1],
-		bandwidthDelta:      bitrates[2][1] - bitrates[1][3],
-		bandwidthNeeded:     bitrates[2][1],
-		bitrates:            bitrates,
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: expectedTargetLayers.Spatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   -0.5,
+		PauseReason:         VideoPauseReasonNone,
+		BandwidthRequested:  bitrates[2][1],
+		BandwidthDelta:      bitrates[2][1] - bitrates[1][3],
+		BandwidthNeeded:     bitrates[2][1],
+		Bitrates:            bitrates,
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: expectedTargetLayers.Spatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   -0.5,
 	}
 	result = f.AllocateOptimal(nil, bitrates, true)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 	require.Equal(t, expectedTargetLayers, f.TargetLayers())
 
-	f.targetLayers = VideoLayers{Spatial: 0, Temporal: 0}  // set to valid to trigger paths in tests below
-	f.currentLayers = VideoLayers{Spatial: 0, Temporal: 3} // set to valid to trigger paths in tests below
+	f.targetLayers = buffer.VideoLayer{Spatial: 0, Temporal: 0}  // set to valid to trigger paths in tests below
+	f.currentLayers = buffer.VideoLayer{Spatial: 0, Temporal: 3} // set to valid to trigger paths in tests below
 
 	// when feed is dry and current is valid, should stay at current
-	expectedTargetLayers = VideoLayers{
+	expectedTargetLayers = buffer.VideoLayer{
 		Spatial:  0,
 		Temporal: 3,
 	}
 	expectedResult = VideoAllocation{
-		pauseReason:         VideoPauseReasonFeedDry,
-		bandwidthRequested:  0,
-		bandwidthDelta:      0 - bitrates[2][1],
-		bitrates:            emptyBitrates,
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: expectedTargetLayers.Spatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   -0.75,
+		PauseReason:         VideoPauseReasonFeedDry,
+		BandwidthRequested:  0,
+		BandwidthDelta:      0 - bitrates[2][1],
+		Bitrates:            emptyBitrates,
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: expectedTargetLayers.Spatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   -0.75,
 	}
 	result = f.AllocateOptimal(nil, emptyBitrates, true)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 	require.Equal(t, expectedTargetLayers, f.TargetLayers())
 
-	f.currentLayers = InvalidLayers
+	f.currentLayers = buffer.InvalidLayers
 
 	// opportunistic target if feed is not dry and current is not valid, i. e. not forwarding
 	expectedResult = VideoAllocation{
-		pauseReason:         VideoPauseReasonNone,
-		bandwidthRequested:  bitrates[2][1],
-		bandwidthDelta:      bitrates[2][1],
-		bandwidthNeeded:     bitrates[2][1],
-		bitrates:            bitrates,
-		targetLayers:        DefaultMaxLayers,
-		requestLayerSpatial: 2,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   -0.5,
+		PauseReason:         VideoPauseReasonNone,
+		BandwidthRequested:  bitrates[2][1],
+		BandwidthDelta:      bitrates[2][1],
+		BandwidthNeeded:     bitrates[2][1],
+		Bitrates:            bitrates,
+		TargetLayers:        buffer.DefaultMaxLayers,
+		RequestLayerSpatial: 2,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   -0.5,
 	}
 	result = f.AllocateOptimal([]int32{0, 1}, bitrates, true)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
-	require.Equal(t, DefaultMaxLayers, f.TargetLayers())
+	require.Equal(t, buffer.DefaultMaxLayers, f.TargetLayers())
 
 	// if feed is not dry and current is not locked, should be opportunistic (with and without overshoot)
-	f.targetLayers = InvalidLayers
+	f.targetLayers = buffer.InvalidLayers
 	expectedResult = VideoAllocation{
-		pauseReason:         VideoPauseReasonFeedDry,
-		bandwidthRequested:  0,
-		bandwidthDelta:      0 - bitrates[2][1],
-		bitrates:            emptyBitrates,
-		targetLayers:        DefaultMaxLayers,
-		requestLayerSpatial: 2,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   -1.0,
+		PauseReason:         VideoPauseReasonFeedDry,
+		BandwidthRequested:  0,
+		BandwidthDelta:      0 - bitrates[2][1],
+		Bitrates:            emptyBitrates,
+		TargetLayers:        buffer.DefaultMaxLayers,
+		RequestLayerSpatial: 2,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   -1.0,
 	}
 	result = f.AllocateOptimal([]int32{0, 1}, emptyBitrates, false)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 
-	f.targetLayers = InvalidLayers
-	expectedTargetLayers = VideoLayers{
+	f.targetLayers = buffer.InvalidLayers
+	expectedTargetLayers = buffer.VideoLayer{
 		Spatial:  2,
-		Temporal: DefaultMaxLayerTemporal,
+		Temporal: buffer.DefaultMaxLayerTemporal,
 	}
 	expectedResult = VideoAllocation{
-		pauseReason:         VideoPauseReasonNone,
-		bandwidthRequested:  bitrates[2][1],
-		bandwidthDelta:      bitrates[2][1],
-		bandwidthNeeded:     bitrates[2][1],
-		bitrates:            bitrates,
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: 2,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   -0.5,
+		PauseReason:         VideoPauseReasonNone,
+		BandwidthRequested:  bitrates[2][1],
+		BandwidthDelta:      bitrates[2][1],
+		BandwidthNeeded:     bitrates[2][1],
+		Bitrates:            bitrates,
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: 2,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   -0.5,
 	}
 	result = f.AllocateOptimal([]int32{0, 1}, bitrates, true)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 
 	// switches to highest available if feed is not dry and current is valid and current is not available
-	f.currentLayers = VideoLayers{Spatial: 0, Temporal: 1}
-	expectedTargetLayers = VideoLayers{
+	f.currentLayers = buffer.VideoLayer{Spatial: 0, Temporal: 1}
+	expectedTargetLayers = buffer.VideoLayer{
 		Spatial:  1,
-		Temporal: DefaultMaxLayerTemporal,
+		Temporal: buffer.DefaultMaxLayerTemporal,
 	}
 	expectedResult = VideoAllocation{
-		pauseReason:         VideoPauseReasonNone,
-		bandwidthRequested:  bitrates[2][1],
-		bandwidthDelta:      0,
-		bandwidthNeeded:     bitrates[2][1],
-		bitrates:            bitrates,
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: 1,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0.5,
+		PauseReason:         VideoPauseReasonNone,
+		BandwidthRequested:  bitrates[2][1],
+		BandwidthDelta:      0,
+		BandwidthNeeded:     bitrates[2][1],
+		Bitrates:            bitrates,
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: 1,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   0.5,
 	}
 	result = f.AllocateOptimal([]int32{1}, bitrates, true)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 
 	// stays the same if feed is not dry and current is valid, available and locked
-	f.maxLayers = VideoLayers{Spatial: 0, Temporal: 1}
-	f.currentLayers = VideoLayers{Spatial: 0, Temporal: 1}
+	f.maxLayers = buffer.VideoLayer{Spatial: 0, Temporal: 1}
+	f.currentLayers = buffer.VideoLayer{Spatial: 0, Temporal: 1}
 	f.requestLayerSpatial = 0
-	expectedTargetLayers = VideoLayers{
+	expectedTargetLayers = buffer.VideoLayer{
 		Spatial:  0,
 		Temporal: 1,
 	}
 	expectedResult = VideoAllocation{
-		pauseReason:         VideoPauseReasonFeedDry,
-		bandwidthRequested:  0,
-		bandwidthDelta:      0 - bitrates[2][1],
-		bitrates:            emptyBitrates,
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: 0,
-		maxLayers:           f.maxLayers,
-		distanceToDesired:   0.0,
+		PauseReason:         VideoPauseReasonFeedDry,
+		BandwidthRequested:  0,
+		BandwidthDelta:      0 - bitrates[2][1],
+		Bitrates:            emptyBitrates,
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: 0,
+		MaxLayers:           f.maxLayers,
+		DistanceToDesired:   0.0,
 	}
 	result = f.AllocateOptimal([]int32{0, 1}, emptyBitrates, true)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 
 	// opportunistic if feed is not dry and current is valid, but request layer has changed
-	f.maxLayers = VideoLayers{Spatial: 2, Temporal: 1}
-	f.currentLayers = VideoLayers{Spatial: 0, Temporal: 1}
+	f.maxLayers = buffer.VideoLayer{Spatial: 2, Temporal: 1}
+	f.currentLayers = buffer.VideoLayer{Spatial: 0, Temporal: 1}
 	f.requestLayerSpatial = 0
-	expectedTargetLayers = VideoLayers{
+	expectedTargetLayers = buffer.VideoLayer{
 		Spatial:  2,
 		Temporal: 3,
 	}
 	expectedResult = VideoAllocation{
-		pauseReason:         VideoPauseReasonFeedDry,
-		bandwidthRequested:  0,
-		bandwidthDelta:      0,
-		bitrates:            emptyBitrates,
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: 2,
-		maxLayers:           f.maxLayers,
-		distanceToDesired:   -1.5,
+		PauseReason:         VideoPauseReasonFeedDry,
+		BandwidthRequested:  0,
+		BandwidthDelta:      0,
+		Bitrates:            emptyBitrates,
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: 2,
+		MaxLayers:           f.maxLayers,
+		DistanceToDesired:   -1.5,
 	}
 	result = f.AllocateOptimal([]int32{0, 1}, emptyBitrates, true)
 	require.Equal(t, expectedResult, result)
@@ -406,10 +406,10 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 
 func TestForwarderProvisionalAllocate(t *testing.T) {
 	f := newForwarder(testutils.TestVP8Codec, webrtc.RTPCodecTypeVideo)
-	f.SetMaxSpatialLayer(DefaultMaxLayerSpatial)
-	f.SetMaxTemporalLayer(DefaultMaxLayerTemporal)
-	f.SetMaxPublishedLayer(DefaultMaxLayerSpatial)
-	f.SetMaxTemporalLayerSeen(DefaultMaxLayerTemporal)
+	f.SetMaxSpatialLayer(buffer.DefaultMaxLayerSpatial)
+	f.SetMaxTemporalLayer(buffer.DefaultMaxLayerTemporal)
+	f.SetMaxPublishedLayer(buffer.DefaultMaxLayerSpatial)
+	f.SetMaxTemporalLayerSeen(buffer.DefaultMaxLayerTemporal)
 
 	bitrates := Bitrates{
 		{1, 2, 3, 4},
@@ -419,37 +419,37 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 
 	f.ProvisionalAllocatePrepare(nil, bitrates)
 
-	usedBitrate := f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 0}, true, false)
+	usedBitrate := f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 0, Temporal: 0}, true, false)
 	require.Equal(t, bitrates[0][0], usedBitrate)
 
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 2, Temporal: 3}, true, false)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 2, Temporal: 3}, true, false)
 	require.Equal(t, bitrates[2][3]-bitrates[0][0], usedBitrate)
 
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 3}, true, false)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 0, Temporal: 3}, true, false)
 	require.Equal(t, bitrates[0][3]-bitrates[2][3], usedBitrate)
 
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 1, Temporal: 2}, true, false)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 1, Temporal: 2}, true, false)
 	require.Equal(t, bitrates[1][2]-bitrates[0][3], usedBitrate)
 
 	// available not enough to reach (2, 2), allocating at (2, 2) should not succeed
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][2]-bitrates[1][2]-1, VideoLayers{Spatial: 2, Temporal: 2}, true, false)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][2]-bitrates[1][2]-1, buffer.VideoLayer{Spatial: 2, Temporal: 2}, true, false)
 	require.Equal(t, int64(0), usedBitrate)
 
 	// committing should set target to (1, 2)
-	expectedTargetLayers := VideoLayers{
+	expectedTargetLayers := buffer.VideoLayer{
 		Spatial:  1,
 		Temporal: 2,
 	}
 	expectedResult := VideoAllocation{
-		isDeficient:         true,
-		bandwidthRequested:  bitrates[1][2],
-		bandwidthDelta:      bitrates[1][2],
-		bandwidthNeeded:     bitrates[2][3],
-		bitrates:            bitrates,
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: expectedTargetLayers.Spatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   1.25,
+		IsDeficient:         true,
+		BandwidthRequested:  bitrates[1][2],
+		BandwidthDelta:      bitrates[1][2],
+		BandwidthNeeded:     bitrates[2][3],
+		Bitrates:            bitrates,
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: expectedTargetLayers.Spatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   1.25,
 	}
 	result := f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -457,26 +457,26 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 	require.Equal(t, expectedTargetLayers, f.TargetLayers())
 
 	// when nothing fits and pausing disallowed, should allocate (0, 0)
-	f.targetLayers = InvalidLayers
+	f.targetLayers = buffer.InvalidLayers
 	f.ProvisionalAllocatePrepare(nil, bitrates)
-	usedBitrate = f.ProvisionalAllocate(0, VideoLayers{Spatial: 0, Temporal: 0}, false, false)
+	usedBitrate = f.ProvisionalAllocate(0, buffer.VideoLayer{Spatial: 0, Temporal: 0}, false, false)
 	require.Equal(t, int64(1), usedBitrate)
 
 	// committing should set target to (0, 0)
-	expectedTargetLayers = VideoLayers{
+	expectedTargetLayers = buffer.VideoLayer{
 		Spatial:  0,
 		Temporal: 0,
 	}
 	expectedResult = VideoAllocation{
-		isDeficient:         true,
-		bandwidthRequested:  bitrates[0][0],
-		bandwidthDelta:      bitrates[0][0] - bitrates[1][2],
-		bandwidthNeeded:     bitrates[2][3],
-		bitrates:            bitrates,
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: expectedTargetLayers.Spatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   2.75,
+		IsDeficient:         true,
+		BandwidthRequested:  bitrates[0][0],
+		BandwidthDelta:      bitrates[0][0] - bitrates[1][2],
+		BandwidthNeeded:     bitrates[2][3],
+		Bitrates:            bitrates,
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: expectedTargetLayers.Spatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   2.75,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -496,34 +496,34 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 
 	f.ProvisionalAllocatePrepare(nil, bitrates)
 
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 0}, false, true)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 0, Temporal: 0}, false, true)
 	require.Equal(t, int64(0), usedBitrate)
 
 	// overshoot should succeed
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 2, Temporal: 3}, false, true)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 2, Temporal: 3}, false, true)
 	require.Equal(t, bitrates[2][3], usedBitrate)
 
 	// overshoot should succeed - this should win as this is lesser overshoot
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 1, Temporal: 3}, false, true)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 1, Temporal: 3}, false, true)
 	require.Equal(t, bitrates[1][3]-bitrates[2][3], usedBitrate)
 
 	// committing should set target to (1, 3)
-	expectedTargetLayers = VideoLayers{
+	expectedTargetLayers = buffer.VideoLayer{
 		Spatial:  1,
 		Temporal: 3,
 	}
-	expectedMaxLayers := VideoLayers{
+	expectedMaxLayers := buffer.VideoLayer{
 		Spatial:  0,
 		Temporal: 3,
 	}
 	expectedResult = VideoAllocation{
-		bandwidthRequested:  bitrates[1][3],
-		bandwidthDelta:      bitrates[1][3] - 1, // 1 is the last allocation bandwidth requested
-		bitrates:            bitrates,
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: expectedTargetLayers.Spatial,
-		maxLayers:           expectedMaxLayers,
-		distanceToDesired:   -1.75,
+		BandwidthRequested:  bitrates[1][3],
+		BandwidthDelta:      bitrates[1][3] - 1, // 1 is the last allocation bandwidth requested
+		Bitrates:            bitrates,
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: expectedTargetLayers.Spatial,
+		MaxLayers:           expectedMaxLayers,
+		DistanceToDesired:   -1.75,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -539,35 +539,35 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 		{0, 0, 0, 0},
 	}
 
-	f.currentLayers = VideoLayers{Spatial: 0, Temporal: 2}
+	f.currentLayers = buffer.VideoLayer{Spatial: 0, Temporal: 2}
 	f.ProvisionalAllocatePrepare(nil, bitrates)
 
 	// all the provisional allocations should not succeed because the feed is dry
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 0}, false, true)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 0, Temporal: 0}, false, true)
 	require.Equal(t, int64(0), usedBitrate)
 
 	// overshoot should not succeed
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 2, Temporal: 3}, false, true)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 2, Temporal: 3}, false, true)
 	require.Equal(t, int64(0), usedBitrate)
 
 	// overshoot should not succeed
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 1, Temporal: 3}, false, true)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 1, Temporal: 3}, false, true)
 	require.Equal(t, int64(0), usedBitrate)
 
 	// committing should set target to (0, 2), i. e. leave it at current for opportunistic forwarding
-	expectedTargetLayers = VideoLayers{
+	expectedTargetLayers = buffer.VideoLayer{
 		Spatial:  0,
 		Temporal: 2,
 	}
 	expectedResult = VideoAllocation{
-		pauseReason:         VideoPauseReasonFeedDry,
-		bandwidthRequested:  bitrates[0][2],
-		bandwidthDelta:      bitrates[0][2] - 8, // 8 is the last allocation bandwidth requested
-		bitrates:            bitrates,
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: expectedTargetLayers.Spatial,
-		maxLayers:           expectedMaxLayers,
-		distanceToDesired:   0.25,
+		PauseReason:         VideoPauseReasonFeedDry,
+		BandwidthRequested:  bitrates[0][2],
+		BandwidthDelta:      bitrates[0][2] - 8, // 8 is the last allocation bandwidth requested
+		Bitrates:            bitrates,
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: expectedTargetLayers.Spatial,
+		MaxLayers:           expectedMaxLayers,
+		DistanceToDesired:   0.25,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -577,42 +577,42 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 	//
 	// Same case as above, but current is above max, so target should go to invalid
 	//
-	f.currentLayers = VideoLayers{Spatial: 1, Temporal: 2}
+	f.currentLayers = buffer.VideoLayer{Spatial: 1, Temporal: 2}
 	f.ProvisionalAllocatePrepare(nil, bitrates)
 
 	// all the provisional allocations below should not succeed because the feed is dry
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 0}, false, true)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 0, Temporal: 0}, false, true)
 	require.Equal(t, int64(0), usedBitrate)
 
 	// overshoot should not succeed
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 2, Temporal: 3}, false, true)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 2, Temporal: 3}, false, true)
 	require.Equal(t, int64(0), usedBitrate)
 
 	// overshoot should not succeed
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 1, Temporal: 3}, false, true)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 1, Temporal: 3}, false, true)
 	require.Equal(t, int64(0), usedBitrate)
 
 	expectedResult = VideoAllocation{
-		pauseReason:         VideoPauseReasonFeedDry,
-		bandwidthRequested:  0,
-		bandwidthDelta:      0,
-		bitrates:            bitrates,
-		targetLayers:        InvalidLayers,
-		requestLayerSpatial: InvalidLayerSpatial,
-		maxLayers:           expectedMaxLayers,
-		distanceToDesired:   0.25,
+		PauseReason:         VideoPauseReasonFeedDry,
+		BandwidthRequested:  0,
+		BandwidthDelta:      0,
+		Bitrates:            bitrates,
+		TargetLayers:        buffer.InvalidLayers,
+		RequestLayerSpatial: buffer.InvalidLayerSpatial,
+		MaxLayers:           expectedMaxLayers,
+		DistanceToDesired:   0.25,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
-	require.Equal(t, InvalidLayers, f.TargetLayers())
-	require.Equal(t, InvalidLayers, f.CurrentLayers())
+	require.Equal(t, buffer.InvalidLayers, f.TargetLayers())
+	require.Equal(t, buffer.InvalidLayers, f.CurrentLayers())
 }
 
 func TestForwarderProvisionalAllocateMute(t *testing.T) {
 	f := newForwarder(testutils.TestVP8Codec, webrtc.RTPCodecTypeVideo)
-	f.SetMaxSpatialLayer(DefaultMaxLayerSpatial)
-	f.SetMaxTemporalLayer(DefaultMaxLayerTemporal)
+	f.SetMaxSpatialLayer(buffer.DefaultMaxLayerSpatial)
+	f.SetMaxTemporalLayer(buffer.DefaultMaxLayerTemporal)
 
 	bitrates := Bitrates{
 		{1, 2, 3, 4},
@@ -623,35 +623,35 @@ func TestForwarderProvisionalAllocateMute(t *testing.T) {
 	f.Mute(true)
 	f.ProvisionalAllocatePrepare(nil, bitrates)
 
-	usedBitrate := f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 0}, true, false)
+	usedBitrate := f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 0, Temporal: 0}, true, false)
 	require.Equal(t, int64(0), usedBitrate)
 
-	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 1, Temporal: 2}, true, true)
+	usedBitrate = f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 1, Temporal: 2}, true, true)
 	require.Equal(t, int64(0), usedBitrate)
 
-	// committing should set target to InvalidLayers as track is muted
+	// committing should set target to buffer.InvalidLayers as track is muted
 	expectedResult := VideoAllocation{
-		pauseReason:         VideoPauseReasonMuted,
-		bandwidthRequested:  0,
-		bandwidthDelta:      0,
-		bitrates:            bitrates,
-		targetLayers:        InvalidLayers,
-		requestLayerSpatial: InvalidLayerSpatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0,
+		PauseReason:         VideoPauseReasonMuted,
+		BandwidthRequested:  0,
+		BandwidthDelta:      0,
+		Bitrates:            bitrates,
+		TargetLayers:        buffer.InvalidLayers,
+		RequestLayerSpatial: buffer.InvalidLayerSpatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   0,
 	}
 	result := f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
-	require.Equal(t, InvalidLayers, f.TargetLayers())
+	require.Equal(t, buffer.InvalidLayers, f.TargetLayers())
 }
 
 func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 	f := newForwarder(testutils.TestVP8Codec, webrtc.RTPCodecTypeVideo)
-	f.SetMaxSpatialLayer(DefaultMaxLayerSpatial)
-	f.SetMaxTemporalLayer(DefaultMaxLayerTemporal)
-	f.SetMaxPublishedLayer(DefaultMaxLayerSpatial)
-	f.SetMaxTemporalLayerSeen(DefaultMaxLayerTemporal)
+	f.SetMaxSpatialLayer(buffer.DefaultMaxLayerSpatial)
+	f.SetMaxTemporalLayer(buffer.DefaultMaxLayerTemporal)
+	f.SetMaxPublishedLayer(buffer.DefaultMaxLayerSpatial)
+	f.SetMaxTemporalLayerSeen(buffer.DefaultMaxLayerTemporal)
 
 	bitrates := Bitrates{
 		{1, 2, 3, 4},
@@ -661,27 +661,27 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 
 	f.ProvisionalAllocatePrepare(nil, bitrates)
 
-	// from scratch (InvalidLayers) should give back layer (0, 0)
+	// from scratch (buffer.InvalidLayers) should give back layer (0, 0)
 	expectedTransition := VideoTransition{
-		from:           InvalidLayers,
-		to:             VideoLayers{Spatial: 0, Temporal: 0},
-		bandwidthDelta: 1,
+		From:           buffer.InvalidLayers,
+		To:             buffer.VideoLayer{Spatial: 0, Temporal: 0},
+		BandwidthDelta: 1,
 	}
 	transition := f.ProvisionalAllocateGetCooperativeTransition(false)
 	require.Equal(t, expectedTransition, transition)
 
 	// committing should set target to (0, 0)
-	expectedLayers := VideoLayers{Spatial: 0, Temporal: 0}
+	expectedLayers := buffer.VideoLayer{Spatial: 0, Temporal: 0}
 	expectedResult := VideoAllocation{
-		isDeficient:         true,
-		bandwidthRequested:  1,
-		bandwidthDelta:      1,
-		bandwidthNeeded:     bitrates[2][1],
-		bitrates:            bitrates,
-		targetLayers:        expectedLayers,
-		requestLayerSpatial: expectedLayers.Spatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   2.25,
+		IsDeficient:         true,
+		BandwidthRequested:  1,
+		BandwidthDelta:      1,
+		BandwidthNeeded:     bitrates[2][1],
+		Bitrates:            bitrates,
+		TargetLayers:        expectedLayers,
+		RequestLayerSpatial: expectedLayers.Spatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   2.25,
 	}
 	result := f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -689,28 +689,28 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 	require.Equal(t, expectedLayers, f.TargetLayers())
 
 	// a higher target that is already streaming, just maintain it
-	targetLayers := VideoLayers{Spatial: 2, Temporal: 1}
+	targetLayers := buffer.VideoLayer{Spatial: 2, Temporal: 1}
 	f.targetLayers = targetLayers
-	f.lastAllocation.bandwidthRequested = 10
+	f.lastAllocation.BandwidthRequested = 10
 	expectedTransition = VideoTransition{
-		from:           targetLayers,
-		to:             targetLayers,
-		bandwidthDelta: 0,
+		From:           targetLayers,
+		To:             targetLayers,
+		BandwidthDelta: 0,
 	}
 	transition = f.ProvisionalAllocateGetCooperativeTransition(false)
 	require.Equal(t, expectedTransition, transition)
 
 	// committing should set target to (2, 1)
-	expectedLayers = VideoLayers{Spatial: 2, Temporal: 1}
+	expectedLayers = buffer.VideoLayer{Spatial: 2, Temporal: 1}
 	expectedResult = VideoAllocation{
-		bandwidthRequested:  10,
-		bandwidthDelta:      0,
-		bitrates:            bitrates,
-		bandwidthNeeded:     bitrates[2][1],
-		targetLayers:        expectedLayers,
-		requestLayerSpatial: expectedLayers.Spatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0.0,
+		BandwidthRequested:  10,
+		BandwidthDelta:      0,
+		Bitrates:            bitrates,
+		BandwidthNeeded:     bitrates[2][1],
+		TargetLayers:        expectedLayers,
+		RequestLayerSpatial: expectedLayers.Spatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   0.0,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -718,12 +718,12 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 	require.Equal(t, expectedLayers, f.TargetLayers())
 
 	// from a target that has become unavailable, should switch to lower available layer
-	targetLayers = VideoLayers{Spatial: 2, Temporal: 2}
+	targetLayers = buffer.VideoLayer{Spatial: 2, Temporal: 2}
 	f.targetLayers = targetLayers
 	expectedTransition = VideoTransition{
-		from:           targetLayers,
-		to:             VideoLayers{Spatial: 2, Temporal: 1},
-		bandwidthDelta: 0,
+		From:           targetLayers,
+		To:             buffer.VideoLayer{Spatial: 2, Temporal: 1},
+		BandwidthDelta: 0,
 	}
 	transition = f.ProvisionalAllocateGetCooperativeTransition(false)
 	require.Equal(t, expectedTransition, transition)
@@ -734,11 +734,11 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 	f.Mute(true)
 	f.ProvisionalAllocatePrepare(nil, bitrates)
 
-	// mute should send target to InvalidLayers
+	// mute should send target to buffer.InvalidLayers
 	expectedTransition = VideoTransition{
-		from:           VideoLayers{Spatial: 2, Temporal: 1},
-		to:             InvalidLayers,
-		bandwidthDelta: -10,
+		From:           buffer.VideoLayer{Spatial: 2, Temporal: 1},
+		To:             buffer.InvalidLayers,
+		BandwidthDelta: -10,
 	}
 	transition = f.ProvisionalAllocateGetCooperativeTransition(false)
 	require.Equal(t, expectedTransition, transition)
@@ -757,29 +757,29 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 		{9, 10, 0, 0},
 	}
 
-	f.targetLayers = InvalidLayers
+	f.targetLayers = buffer.InvalidLayers
 	f.ProvisionalAllocatePrepare(nil, bitrates)
 
-	// from scratch (InvalidLayers) should go to a layer past maximum as overshoot is allowed
+	// from scratch (buffer.InvalidLayers) should go to a layer past maximum as overshoot is allowed
 	expectedTransition = VideoTransition{
-		from:           InvalidLayers,
-		to:             VideoLayers{Spatial: 1, Temporal: 0},
-		bandwidthDelta: 5,
+		From:           buffer.InvalidLayers,
+		To:             buffer.VideoLayer{Spatial: 1, Temporal: 0},
+		BandwidthDelta: 5,
 	}
 	transition = f.ProvisionalAllocateGetCooperativeTransition(true)
 	require.Equal(t, expectedTransition, transition)
 
 	// committing should set target to (1, 0)
-	expectedLayers = VideoLayers{Spatial: 1, Temporal: 0}
-	expectedMaxLayers := VideoLayers{Spatial: 0, Temporal: DefaultMaxLayerTemporal}
+	expectedLayers = buffer.VideoLayer{Spatial: 1, Temporal: 0}
+	expectedMaxLayers := buffer.VideoLayer{Spatial: 0, Temporal: buffer.DefaultMaxLayerTemporal}
 	expectedResult = VideoAllocation{
-		bandwidthRequested:  5,
-		bandwidthDelta:      5,
-		bitrates:            bitrates,
-		targetLayers:        expectedLayers,
-		requestLayerSpatial: expectedLayers.Spatial,
-		maxLayers:           expectedMaxLayers,
-		distanceToDesired:   -1.0,
+		BandwidthRequested:  5,
+		BandwidthDelta:      5,
+		Bitrates:            bitrates,
+		TargetLayers:        expectedLayers,
+		RequestLayerSpatial: expectedLayers.Spatial,
+		MaxLayers:           expectedMaxLayers,
+		DistanceToDesired:   -1.0,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -795,30 +795,30 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 		{0, 0, 0, 0},
 	}
 
-	f.currentLayers = VideoLayers{Spatial: 0, Temporal: 2}
-	f.targetLayers = InvalidLayers
+	f.currentLayers = buffer.VideoLayer{Spatial: 0, Temporal: 2}
+	f.targetLayers = buffer.InvalidLayers
 	f.ProvisionalAllocatePrepare(nil, bitrates)
 
-	// from scratch (InvalidLayers) should go to current layer
-	// NOTE: targetLayer is set to InvalidLayers for testing, but in practice current layers valid and target layers invalid should not happen
+	// from scratch (buffer.InvalidLayers) should go to current layer
+	// NOTE: targetLayer is set to buffer.InvalidLayers for testing, but in practice current layers valid and target layers invalid should not happen
 	expectedTransition = VideoTransition{
-		from:           InvalidLayers,
-		to:             VideoLayers{Spatial: 0, Temporal: 2},
-		bandwidthDelta: -5, // 5 was the bandwidth needed for the last allocation
+		From:           buffer.InvalidLayers,
+		To:             buffer.VideoLayer{Spatial: 0, Temporal: 2},
+		BandwidthDelta: -5, // 5 was the bandwidth needed for the last allocation
 	}
 	transition = f.ProvisionalAllocateGetCooperativeTransition(true)
 	require.Equal(t, expectedTransition, transition)
 
 	// committing should set target to (0, 2)
-	expectedLayers = VideoLayers{Spatial: 0, Temporal: 2}
+	expectedLayers = buffer.VideoLayer{Spatial: 0, Temporal: 2}
 	expectedResult = VideoAllocation{
-		bandwidthRequested:  0,
-		bandwidthDelta:      -5,
-		bitrates:            bitrates,
-		targetLayers:        expectedLayers,
-		requestLayerSpatial: expectedLayers.Spatial,
-		maxLayers:           expectedMaxLayers,
-		distanceToDesired:   -0.5,
+		BandwidthRequested:  0,
+		BandwidthDelta:      -5,
+		Bitrates:            bitrates,
+		TargetLayers:        expectedLayers,
+		RequestLayerSpatial: expectedLayers.Spatial,
+		MaxLayers:           expectedMaxLayers,
+		DistanceToDesired:   -0.5,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -827,13 +827,13 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 
 	// committing should set target to current layers to enable opportunistic forwarding
 	expectedResult = VideoAllocation{
-		bandwidthRequested:  0,
-		bandwidthDelta:      0,
-		bitrates:            bitrates,
-		targetLayers:        expectedLayers,
-		requestLayerSpatial: expectedLayers.Spatial,
-		maxLayers:           expectedMaxLayers,
-		distanceToDesired:   -0.5,
+		BandwidthRequested:  0,
+		BandwidthDelta:      0,
+		Bitrates:            bitrates,
+		TargetLayers:        expectedLayers,
+		RequestLayerSpatial: expectedLayers.Spatial,
+		MaxLayers:           expectedMaxLayers,
+		DistanceToDesired:   -0.5,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -843,8 +843,8 @@ func TestForwarderProvisionalAllocateGetCooperativeTransition(t *testing.T) {
 
 func TestForwarderProvisionalAllocateGetBestWeightedTransition(t *testing.T) {
 	f := newForwarder(testutils.TestVP8Codec, webrtc.RTPCodecTypeVideo)
-	f.SetMaxSpatialLayer(DefaultMaxLayerSpatial)
-	f.SetMaxTemporalLayer(DefaultMaxLayerTemporal)
+	f.SetMaxSpatialLayer(buffer.DefaultMaxLayerSpatial)
+	f.SetMaxTemporalLayer(buffer.DefaultMaxLayerTemporal)
 
 	bitrates := Bitrates{
 		{1, 2, 3, 4},
@@ -854,12 +854,12 @@ func TestForwarderProvisionalAllocateGetBestWeightedTransition(t *testing.T) {
 
 	f.ProvisionalAllocatePrepare(nil, bitrates)
 
-	f.targetLayers = VideoLayers{Spatial: 2, Temporal: 2}
-	f.lastAllocation.bandwidthRequested = bitrates[2][2]
+	f.targetLayers = buffer.VideoLayer{Spatial: 2, Temporal: 2}
+	f.lastAllocation.BandwidthRequested = bitrates[2][2]
 	expectedTransition := VideoTransition{
-		from:           f.targetLayers,
-		to:             VideoLayers{Spatial: 2, Temporal: 0},
-		bandwidthDelta: 2,
+		From:           f.targetLayers,
+		To:             buffer.VideoLayer{Spatial: 2, Temporal: 0},
+		BandwidthDelta: 2,
 	}
 	transition := f.ProvisionalAllocateGetBestWeightedTransition()
 	require.Equal(t, expectedTransition, transition)
@@ -867,9 +867,9 @@ func TestForwarderProvisionalAllocateGetBestWeightedTransition(t *testing.T) {
 
 func TestForwarderAllocateNextHigher(t *testing.T) {
 	f := newForwarder(testutils.TestOpusCodec, webrtc.RTPCodecTypeAudio)
-	f.SetMaxSpatialLayer(DefaultMaxLayerSpatial)
-	f.SetMaxTemporalLayer(DefaultMaxLayerTemporal)
-	f.SetMaxPublishedLayer(DefaultMaxLayerSpatial)
+	f.SetMaxSpatialLayer(buffer.DefaultMaxLayerSpatial)
+	f.SetMaxTemporalLayer(buffer.DefaultMaxLayerTemporal)
+	f.SetMaxPublishedLayer(buffer.DefaultMaxLayerSpatial)
 
 	emptyBitrates := Bitrates{}
 	bitrates := Bitrates{
@@ -878,81 +878,81 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 		{0, 7, 0, 0},
 	}
 
-	result, boosted := f.AllocateNextHigher(ChannelCapacityInfinity, nil, bitrates, false)
+	result, boosted := f.AllocateNextHigher(100_000_000, nil, bitrates, false)
 	require.Equal(t, VideoAllocationDefault, result) // no layer for audio
 	require.False(t, boosted)
 
 	f = newForwarder(testutils.TestVP8Codec, webrtc.RTPCodecTypeVideo)
-	f.SetMaxSpatialLayer(DefaultMaxLayerSpatial)
-	f.SetMaxTemporalLayer(DefaultMaxLayerTemporal)
-	f.SetMaxPublishedLayer(DefaultMaxLayerSpatial)
-	f.SetMaxTemporalLayerSeen(DefaultMaxLayerTemporal)
+	f.SetMaxSpatialLayer(buffer.DefaultMaxLayerSpatial)
+	f.SetMaxTemporalLayer(buffer.DefaultMaxLayerTemporal)
+	f.SetMaxPublishedLayer(buffer.DefaultMaxLayerSpatial)
+	f.SetMaxTemporalLayerSeen(buffer.DefaultMaxLayerTemporal)
 
 	// when not in deficient state, does not boost
-	result, boosted = f.AllocateNextHigher(ChannelCapacityInfinity, nil, bitrates, false)
+	result, boosted = f.AllocateNextHigher(100_000_000, nil, bitrates, false)
 	require.Equal(t, VideoAllocationDefault, result)
 	require.False(t, boosted)
 
 	// if layers have not caught up, should not allocate next layer even if deficient
-	f.targetLayers = VideoLayers{
+	f.targetLayers = buffer.VideoLayer{
 		Spatial:  0,
 		Temporal: 0,
 	}
-	result, boosted = f.AllocateNextHigher(ChannelCapacityInfinity, nil, bitrates, false)
+	result, boosted = f.AllocateNextHigher(100_000_000, nil, bitrates, false)
 	require.Equal(t, VideoAllocationDefault, result)
 	require.False(t, boosted)
 
-	f.lastAllocation.isDeficient = true
-	f.currentLayers = VideoLayers{
+	f.lastAllocation.IsDeficient = true
+	f.currentLayers = buffer.VideoLayer{
 		Spatial:  0,
 		Temporal: 0,
 	}
 
 	// move from (0, 0) -> (0, 1), i.e. a higher temporal layer is available in the same spatial layer
-	expectedTargetLayers := VideoLayers{
+	expectedTargetLayers := buffer.VideoLayer{
 		Spatial:  0,
 		Temporal: 1,
 	}
 	expectedResult := VideoAllocation{
-		isDeficient:         true,
-		bandwidthRequested:  3,
-		bandwidthDelta:      1,
-		bandwidthNeeded:     bitrates[2][1],
-		bitrates:            bitrates,
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: expectedTargetLayers.Spatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   2.0,
+		IsDeficient:         true,
+		BandwidthRequested:  3,
+		BandwidthDelta:      1,
+		BandwidthNeeded:     bitrates[2][1],
+		Bitrates:            bitrates,
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: expectedTargetLayers.Spatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   2.0,
 	}
-	result, boosted = f.AllocateNextHigher(ChannelCapacityInfinity, nil, bitrates, false)
+	result, boosted = f.AllocateNextHigher(100_000_000, nil, bitrates, false)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 	require.Equal(t, expectedTargetLayers, f.TargetLayers())
 	require.True(t, boosted)
 
 	// empty bitrates cannot increase layer, i. e. last allocation is left unchanged
-	result, boosted = f.AllocateNextHigher(ChannelCapacityInfinity, nil, emptyBitrates, false)
+	result, boosted = f.AllocateNextHigher(100_000_000, nil, emptyBitrates, false)
 	require.Equal(t, expectedResult, result)
 	require.False(t, boosted)
 
 	// move from (0, 1) -> (1, 0), i.e. a higher spatial layer is available
 	f.currentLayers.Temporal = 1
-	expectedTargetLayers = VideoLayers{
+	expectedTargetLayers = buffer.VideoLayer{
 		Spatial:  1,
 		Temporal: 0,
 	}
 	expectedResult = VideoAllocation{
-		isDeficient:         true,
-		bandwidthRequested:  4,
-		bandwidthDelta:      1,
-		bandwidthNeeded:     bitrates[2][1],
-		bitrates:            bitrates,
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: expectedTargetLayers.Spatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   1.25,
+		IsDeficient:         true,
+		BandwidthRequested:  4,
+		BandwidthDelta:      1,
+		BandwidthNeeded:     bitrates[2][1],
+		Bitrates:            bitrates,
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: expectedTargetLayers.Spatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   1.25,
 	}
-	result, boosted = f.AllocateNextHigher(ChannelCapacityInfinity, nil, bitrates, false)
+	result, boosted = f.AllocateNextHigher(100_000_000, nil, bitrates, false)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 	require.Equal(t, expectedTargetLayers, f.TargetLayers())
@@ -961,22 +961,22 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 	// next higher, move from (1, 0) -> (1, 3), still deficient though
 	f.currentLayers.Spatial = 1
 	f.currentLayers.Temporal = 0
-	expectedTargetLayers = VideoLayers{
+	expectedTargetLayers = buffer.VideoLayer{
 		Spatial:  1,
 		Temporal: 3,
 	}
 	expectedResult = VideoAllocation{
-		isDeficient:         true,
-		bandwidthRequested:  5,
-		bandwidthDelta:      1,
-		bandwidthNeeded:     bitrates[2][1],
-		bitrates:            bitrates,
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: expectedTargetLayers.Spatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0.5,
+		IsDeficient:         true,
+		BandwidthRequested:  5,
+		BandwidthDelta:      1,
+		BandwidthNeeded:     bitrates[2][1],
+		Bitrates:            bitrates,
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: expectedTargetLayers.Spatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   0.5,
 	}
-	result, boosted = f.AllocateNextHigher(ChannelCapacityInfinity, nil, bitrates, false)
+	result, boosted = f.AllocateNextHigher(100_000_000, nil, bitrates, false)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 	require.Equal(t, expectedTargetLayers, f.TargetLayers())
@@ -984,21 +984,21 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 
 	// next higher, move from (1, 3) -> (2, 1), optimal allocation
 	f.currentLayers.Temporal = 3
-	expectedTargetLayers = VideoLayers{
+	expectedTargetLayers = buffer.VideoLayer{
 		Spatial:  2,
 		Temporal: 1,
 	}
 	expectedResult = VideoAllocation{
-		bandwidthRequested:  7,
-		bandwidthDelta:      2,
-		bitrates:            bitrates,
-		bandwidthNeeded:     bitrates[2][1],
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: expectedTargetLayers.Spatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0.0,
+		BandwidthRequested:  7,
+		BandwidthDelta:      2,
+		Bitrates:            bitrates,
+		BandwidthNeeded:     bitrates[2][1],
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: expectedTargetLayers.Spatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   0.0,
 	}
-	result, boosted = f.AllocateNextHigher(ChannelCapacityInfinity, nil, bitrates, false)
+	result, boosted = f.AllocateNextHigher(100_000_000, nil, bitrates, false)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 	require.Equal(t, expectedTargetLayers, f.TargetLayers())
@@ -1007,7 +1007,7 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 	// ask again, should return not boosted as there is no room to go higher
 	f.currentLayers.Spatial = 2
 	f.currentLayers.Temporal = 1
-	result, boosted = f.AllocateNextHigher(ChannelCapacityInfinity, nil, bitrates, false)
+	result, boosted = f.AllocateNextHigher(100_000_000, nil, bitrates, false)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 	require.Equal(t, expectedTargetLayers, f.TargetLayers())
@@ -1015,25 +1015,25 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 
 	// turn off everything, allocating next layer should result in streaming lowest layers
 	disable(f)
-	f.lastAllocation.isDeficient = true
-	f.lastAllocation.bandwidthRequested = 0
+	f.lastAllocation.IsDeficient = true
+	f.lastAllocation.BandwidthRequested = 0
 
-	expectedTargetLayers = VideoLayers{
+	expectedTargetLayers = buffer.VideoLayer{
 		Spatial:  0,
 		Temporal: 0,
 	}
 	expectedResult = VideoAllocation{
-		isDeficient:         true,
-		bandwidthRequested:  2,
-		bandwidthDelta:      2,
-		bandwidthNeeded:     bitrates[2][1],
-		bitrates:            bitrates,
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: expectedTargetLayers.Spatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   2.25,
+		IsDeficient:         true,
+		BandwidthRequested:  2,
+		BandwidthDelta:      2,
+		BandwidthNeeded:     bitrates[2][1],
+		Bitrates:            bitrates,
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: expectedTargetLayers.Spatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   2.25,
 	}
-	result, boosted = f.AllocateNextHigher(ChannelCapacityInfinity, nil, bitrates, false)
+	result, boosted = f.AllocateNextHigher(100_000_000, nil, bitrates, false)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 	require.Equal(t, expectedTargetLayers, f.TargetLayers())
@@ -1041,15 +1041,15 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 
 	// no new available capacity cannot bump up layer
 	expectedResult = VideoAllocation{
-		isDeficient:         true,
-		bandwidthRequested:  2,
-		bandwidthDelta:      2,
-		bandwidthNeeded:     bitrates[2][1],
-		bitrates:            bitrates,
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: expectedTargetLayers.Spatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   2.25,
+		IsDeficient:         true,
+		BandwidthRequested:  2,
+		BandwidthDelta:      2,
+		BandwidthNeeded:     bitrates[2][1],
+		Bitrates:            bitrates,
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: expectedTargetLayers.Spatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   2.25,
 	}
 	result, boosted = f.AllocateNextHigher(0, nil, bitrates, false)
 	require.Equal(t, expectedResult, result)
@@ -1068,22 +1068,22 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 
 	f.currentLayers = f.targetLayers
 
-	expectedTargetLayers = VideoLayers{
+	expectedTargetLayers = buffer.VideoLayer{
 		Spatial:  1,
 		Temporal: 0,
 	}
-	expectedMaxLayers := VideoLayers{
+	expectedMaxLayers := buffer.VideoLayer{
 		Spatial:  0,
-		Temporal: DefaultMaxLayerTemporal,
+		Temporal: buffer.DefaultMaxLayerTemporal,
 	}
 	expectedResult = VideoAllocation{
-		bandwidthRequested:  bitrates[1][0],
-		bandwidthDelta:      bitrates[1][0],
-		bitrates:            bitrates,
-		targetLayers:        expectedTargetLayers,
-		requestLayerSpatial: expectedTargetLayers.Spatial,
-		maxLayers:           expectedMaxLayers,
-		distanceToDesired:   -1.0,
+		BandwidthRequested:  bitrates[1][0],
+		BandwidthDelta:      bitrates[1][0],
+		Bitrates:            bitrates,
+		TargetLayers:        expectedTargetLayers,
+		RequestLayerSpatial: expectedTargetLayers.Spatial,
+		MaxLayers:           expectedMaxLayers,
+		DistanceToDesired:   -1.0,
 	}
 	// overshoot should return (1, 0) even if there is not enough capacity
 	result, boosted = f.AllocateNextHigher(bitrates[1][0]-1, nil, bitrates, true)
@@ -1095,10 +1095,10 @@ func TestForwarderAllocateNextHigher(t *testing.T) {
 
 func TestForwarderPause(t *testing.T) {
 	f := newForwarder(testutils.TestVP8Codec, webrtc.RTPCodecTypeVideo)
-	f.SetMaxSpatialLayer(DefaultMaxLayerSpatial)
-	f.SetMaxTemporalLayer(DefaultMaxLayerTemporal)
-	f.SetMaxPublishedLayer(DefaultMaxLayerSpatial)
-	f.SetMaxTemporalLayerSeen(DefaultMaxLayerTemporal)
+	f.SetMaxSpatialLayer(buffer.DefaultMaxLayerSpatial)
+	f.SetMaxTemporalLayer(buffer.DefaultMaxLayerTemporal)
+	f.SetMaxPublishedLayer(buffer.DefaultMaxLayerSpatial)
+	f.SetMaxTemporalLayerSeen(buffer.DefaultMaxLayerTemporal)
 
 	bitrates := Bitrates{
 		{1, 2, 3, 4},
@@ -1107,33 +1107,33 @@ func TestForwarderPause(t *testing.T) {
 	}
 
 	f.ProvisionalAllocatePrepare(nil, bitrates)
-	f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 0}, true, false)
+	f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 0, Temporal: 0}, true, false)
 	// should have set target at (0, 0)
 	f.ProvisionalAllocateCommit()
 
 	expectedResult := VideoAllocation{
-		pauseReason:         VideoPauseReasonBandwidth,
-		isDeficient:         true,
-		bandwidthRequested:  0,
-		bandwidthDelta:      0 - bitrates[0][0],
-		bandwidthNeeded:     bitrates[2][3],
-		bitrates:            bitrates,
-		targetLayers:        InvalidLayers,
-		requestLayerSpatial: InvalidLayerSpatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   3,
+		PauseReason:         VideoPauseReasonBandwidth,
+		IsDeficient:         true,
+		BandwidthRequested:  0,
+		BandwidthDelta:      0 - bitrates[0][0],
+		BandwidthNeeded:     bitrates[2][3],
+		Bitrates:            bitrates,
+		TargetLayers:        buffer.InvalidLayers,
+		RequestLayerSpatial: buffer.InvalidLayerSpatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   3,
 	}
 	result := f.Pause(nil, bitrates)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
-	require.Equal(t, InvalidLayers, f.TargetLayers())
+	require.Equal(t, buffer.InvalidLayers, f.TargetLayers())
 }
 
 func TestForwarderPauseMute(t *testing.T) {
 	f := newForwarder(testutils.TestVP8Codec, webrtc.RTPCodecTypeVideo)
-	f.SetMaxSpatialLayer(DefaultMaxLayerSpatial)
-	f.SetMaxTemporalLayer(DefaultMaxLayerTemporal)
-	f.SetMaxPublishedLayer(DefaultMaxLayerSpatial)
+	f.SetMaxSpatialLayer(buffer.DefaultMaxLayerSpatial)
+	f.SetMaxTemporalLayer(buffer.DefaultMaxLayerTemporal)
+	f.SetMaxPublishedLayer(buffer.DefaultMaxLayerSpatial)
 
 	bitrates := Bitrates{
 		{1, 2, 3, 4},
@@ -1142,25 +1142,25 @@ func TestForwarderPauseMute(t *testing.T) {
 	}
 
 	f.ProvisionalAllocatePrepare(nil, bitrates)
-	f.ProvisionalAllocate(bitrates[2][3], VideoLayers{Spatial: 0, Temporal: 0}, true, true)
+	f.ProvisionalAllocate(bitrates[2][3], buffer.VideoLayer{Spatial: 0, Temporal: 0}, true, true)
 	// should have set target at (0, 0)
 	f.ProvisionalAllocateCommit()
 
 	f.Mute(true)
 	expectedResult := VideoAllocation{
-		pauseReason:         VideoPauseReasonMuted,
-		bandwidthRequested:  0,
-		bandwidthDelta:      0 - bitrates[0][0],
-		bitrates:            bitrates,
-		targetLayers:        InvalidLayers,
-		requestLayerSpatial: InvalidLayerSpatial,
-		maxLayers:           DefaultMaxLayers,
-		distanceToDesired:   0,
+		PauseReason:         VideoPauseReasonMuted,
+		BandwidthRequested:  0,
+		BandwidthDelta:      0 - bitrates[0][0],
+		Bitrates:            bitrates,
+		TargetLayers:        buffer.InvalidLayers,
+		RequestLayerSpatial: buffer.InvalidLayerSpatial,
+		MaxLayers:           buffer.DefaultMaxLayers,
+		DistanceToDesired:   0,
 	}
 	result := f.Pause(nil, bitrates)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
-	require.Equal(t, InvalidLayers, f.TargetLayers())
+	require.Equal(t, buffer.InvalidLayers, f.TargetLayers())
 }
 
 func TestForwarderGetTranslationParamsMuted(t *testing.T) {
@@ -1365,7 +1365,7 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 	require.Equal(t, expectedTP, *actualTP)
 
 	// although target layer matches, not a key frame, so should drop
-	f.targetLayers = VideoLayers{
+	f.targetLayers = buffer.VideoLayer{
 		Spatial:  0,
 		Temporal: 1,
 	}
@@ -1620,7 +1620,7 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 
 	// switching SSRC (happens for new layer or new track source)
 	// should lock onto the new source, but sequence number should be contiguous
-	f.targetLayers = VideoLayers{
+	f.targetLayers = buffer.VideoLayer{
 		Spatial:  1,
 		Temporal: 1,
 	}
@@ -1706,11 +1706,11 @@ func TestForwardGetSnTsForPadding(t *testing.T) {
 	}
 	extPkt, _ := testutils.GetTestExtPacketVP8(params, vp8)
 
-	f.targetLayers = VideoLayers{
+	f.targetLayers = buffer.VideoLayer{
 		Spatial:  0,
 		Temporal: 1,
 	}
-	f.currentLayers = InvalidLayers
+	f.currentLayers = buffer.InvalidLayers
 
 	// send it through so that forwarder locks onto stream
 	_, _ = f.GetTranslationParams(extPkt, 0)
@@ -1773,11 +1773,11 @@ func TestForwardGetSnTsForBlankFrames(t *testing.T) {
 	}
 	extPkt, _ := testutils.GetTestExtPacketVP8(params, vp8)
 
-	f.targetLayers = VideoLayers{
+	f.targetLayers = buffer.VideoLayer{
 		Spatial:  0,
 		Temporal: 1,
 	}
-	f.currentLayers = InvalidLayers
+	f.currentLayers = buffer.InvalidLayers
 
 	// send it through so that forwarder locks onto stream
 	_, _ = f.GetTranslationParams(extPkt, 0)
@@ -1843,11 +1843,11 @@ func TestForwardGetPaddingVP8(t *testing.T) {
 	}
 	extPkt, _ := testutils.GetTestExtPacketVP8(params, vp8)
 
-	f.targetLayers = VideoLayers{
+	f.targetLayers = buffer.VideoLayer{
 		Spatial:  0,
 		Temporal: 1,
 	}
-	f.currentLayers = InvalidLayers
+	f.currentLayers = buffer.InvalidLayers
 
 	// send it through so that forwarder locks onto stream
 	_, _ = f.GetTranslationParams(extPkt, 0)

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -30,7 +30,7 @@ var (
 
 type AudioLevelHandle func(level uint8, duration uint32)
 
-type Bitrates [DefaultMaxLayerSpatial + 1][DefaultMaxLayerTemporal + 1]int64
+type Bitrates [buffer.DefaultMaxLayerSpatial + 1][buffer.DefaultMaxLayerTemporal + 1]int64
 
 // TrackReceiver defines an interface receive media from remote peer
 type TrackReceiver interface {
@@ -94,11 +94,11 @@ type WebRTCReceiver struct {
 	twcc *twcc.Responder
 
 	bufferMu sync.RWMutex
-	buffers  [DefaultMaxLayerSpatial + 1]*buffer.Buffer
+	buffers  [buffer.DefaultMaxLayerSpatial + 1]*buffer.Buffer
 	rtt      uint32
 
 	upTrackMu sync.RWMutex
-	upTracks  [DefaultMaxLayerSpatial + 1]*webrtc.TrackRemote
+	upTracks  [buffer.DefaultMaxLayerSpatial + 1]*webrtc.TrackRemote
 
 	lbThreshold int
 
@@ -391,7 +391,7 @@ func (w *WebRTCReceiver) SetMaxExpectedSpatialLayer(layer int32) {
 	w.streamTrackerManager.SetMaxExpectedSpatialLayer(layer)
 
 	now := time.Now()
-	if layer == InvalidLayerSpatial {
+	if layer == buffer.InvalidLayerSpatial {
 		w.connectionStats.UpdateLayerMute(true, now)
 	} else {
 		w.connectionStats.UpdateLayerMute(false, now)

--- a/pkg/sfu/streamallocator/channelobserver.go
+++ b/pkg/sfu/streamallocator/channelobserver.go
@@ -1,0 +1,181 @@
+package streamallocator
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/livekit/protocol/logger"
+)
+
+// ------------------------------------------------
+
+type ChannelTrend int
+
+const (
+	ChannelTrendNeutral ChannelTrend = iota
+	ChannelTrendClearing
+	ChannelTrendCongesting
+)
+
+func (c ChannelTrend) String() string {
+	switch c {
+	case ChannelTrendNeutral:
+		return "NEUTRAL"
+	case ChannelTrendClearing:
+		return "CLEARING"
+	case ChannelTrendCongesting:
+		return "CONGESTING"
+	default:
+		return fmt.Sprintf("%d", int(c))
+	}
+}
+
+// ------------------------------------------------
+
+type ChannelCongestionReason int
+
+const (
+	ChannelCongestionReasonNone ChannelCongestionReason = iota
+	ChannelCongestionReasonEstimate
+	ChannelCongestionReasonLoss
+)
+
+func (c ChannelCongestionReason) String() string {
+	switch c {
+	case ChannelCongestionReasonNone:
+		return "NONE"
+	case ChannelCongestionReasonEstimate:
+		return "ESTIMATE"
+	case ChannelCongestionReasonLoss:
+		return "LOSS"
+	default:
+		return fmt.Sprintf("%d", int(c))
+	}
+}
+
+// ------------------------------------------------
+
+type ChannelObserverParams struct {
+	Name                           string
+	EstimateRequiredSamples        int
+	EstimateDownwardTrendThreshold float64
+	EstimateCollapseValues         bool
+	NackWindowMinDuration          time.Duration
+	NackWindowMaxDuration          time.Duration
+	NackRatioThreshold             float64
+}
+
+type ChannelObserver struct {
+	params ChannelObserverParams
+	logger logger.Logger
+
+	estimateTrend *TrendDetector
+
+	nackWindowStartTime time.Time
+	packets             uint32
+	repeatedNacks       uint32
+}
+
+func NewChannelObserver(params ChannelObserverParams, logger logger.Logger) *ChannelObserver {
+	return &ChannelObserver{
+		params: params,
+		logger: logger,
+		estimateTrend: NewTrendDetector(TrendDetectorParams{
+			Name:                   params.Name + "-estimate",
+			Logger:                 logger,
+			RequiredSamples:        params.EstimateRequiredSamples,
+			DownwardTrendThreshold: params.EstimateDownwardTrendThreshold,
+			CollapseValues:         params.EstimateCollapseValues,
+		}),
+	}
+}
+
+func (c *ChannelObserver) SeedEstimate(estimate int64) {
+	c.estimateTrend.Seed(estimate)
+}
+
+func (c *ChannelObserver) SeedNack(packets uint32, repeatedNacks uint32) {
+	c.packets = packets
+	c.repeatedNacks = repeatedNacks
+}
+
+func (c *ChannelObserver) AddEstimate(estimate int64) {
+	c.estimateTrend.AddValue(estimate)
+}
+
+func (c *ChannelObserver) AddNack(packets uint32, repeatedNacks uint32) {
+	if c.params.NackWindowMaxDuration != 0 && !c.nackWindowStartTime.IsZero() && time.Since(c.nackWindowStartTime) > c.params.NackWindowMaxDuration {
+		c.nackWindowStartTime = time.Time{}
+		c.packets = 0
+		c.repeatedNacks = 0
+	}
+
+	//
+	// Start NACK monitoring window only when a repeated NACK happens.
+	// This allows locking tightly to when NACKs start happening and
+	// check if the NACKs keep adding up (potentially a sign of congestion)
+	// or isolated losses
+	//
+	if c.repeatedNacks == 0 && repeatedNacks != 0 {
+		c.nackWindowStartTime = time.Now()
+	}
+
+	if !c.nackWindowStartTime.IsZero() {
+		c.packets += packets
+		c.repeatedNacks += repeatedNacks
+	}
+}
+
+func (c *ChannelObserver) GetLowestEstimate() int64 {
+	return c.estimateTrend.GetLowest()
+}
+
+func (c *ChannelObserver) GetHighestEstimate() int64 {
+	return c.estimateTrend.GetHighest()
+}
+
+func (c *ChannelObserver) GetNackRatio() (uint32, uint32, float64) {
+	ratio := 0.0
+	if c.packets != 0 {
+		ratio = float64(c.repeatedNacks) / float64(c.packets)
+		if ratio > 1.0 {
+			ratio = 1.0
+		}
+	}
+
+	return c.packets, c.repeatedNacks, ratio
+}
+
+func (c *ChannelObserver) GetTrend() (ChannelTrend, ChannelCongestionReason) {
+	estimateDirection := c.estimateTrend.GetDirection()
+	packets, repeatedNacks, nackRatio := c.GetNackRatio()
+
+	switch {
+	case estimateDirection == TrendDirectionDownward:
+		c.logger.Debugw(
+			"stream allocator: channel observer: estimate is trending downward",
+			"name", c.params.Name,
+			"estimate", c.estimateTrend.ToString(),
+			"packets", packets,
+			"repeatedNacks", repeatedNacks,
+			"ratio", nackRatio,
+		)
+		return ChannelTrendCongesting, ChannelCongestionReasonEstimate
+	case c.params.NackWindowMinDuration != 0 && !c.nackWindowStartTime.IsZero() && time.Since(c.nackWindowStartTime) > c.params.NackWindowMinDuration && nackRatio > c.params.NackRatioThreshold:
+		c.logger.Debugw(
+			"stream allocator: channel observer: high rate of repeated NACKs",
+			"name", c.params.Name,
+			"estimate", c.estimateTrend.ToString(),
+			"packets", packets,
+			"repeatedNacks", repeatedNacks,
+			"ratio", nackRatio,
+		)
+		return ChannelTrendCongesting, ChannelCongestionReasonLoss
+	case estimateDirection == TrendDirectionUpward:
+		return ChannelTrendClearing, ChannelCongestionReasonNone
+	}
+
+	return ChannelTrendNeutral, ChannelCongestionReasonNone
+}
+
+// ------------------------------------------------

--- a/pkg/sfu/streamallocator/prober.go
+++ b/pkg/sfu/streamallocator/prober.go
@@ -103,7 +103,7 @@
 //     window being long(ish). But, RTT should be much shorter especially if
 //     the subscriber peer connection of the client is able to connect to
 //     the nearest data center.
-package sfu
+package streamallocator
 
 import (
 	"fmt"

--- a/pkg/sfu/streamallocator/streamstateupdate.go
+++ b/pkg/sfu/streamallocator/streamstateupdate.go
@@ -1,0 +1,63 @@
+package streamallocator
+
+import (
+	"github.com/livekit/protocol/livekit"
+)
+
+// ------------------------------------------------
+
+type StreamState int
+
+const (
+	StreamStateActive StreamState = iota
+	StreamStatePaused
+)
+
+func (s StreamState) String() string {
+	switch s {
+	case StreamStateActive:
+		return "active"
+	case StreamStatePaused:
+		return "paused"
+	default:
+		return "unknown"
+	}
+}
+
+// ------------------------------------------------
+
+type StreamStateInfo struct {
+	ParticipantID livekit.ParticipantID
+	TrackID       livekit.TrackID
+	State         StreamState
+}
+
+type StreamStateUpdate struct {
+	StreamStates []*StreamStateInfo
+}
+
+func NewStreamStateUpdate() *StreamStateUpdate {
+	return &StreamStateUpdate{}
+}
+
+func (s *StreamStateUpdate) HandleStreamingChange(isPaused bool, track *Track) {
+	if isPaused {
+		s.StreamStates = append(s.StreamStates, &StreamStateInfo{
+			ParticipantID: track.PublisherID(),
+			TrackID:       track.ID(),
+			State:         StreamStatePaused,
+		})
+	} else {
+		s.StreamStates = append(s.StreamStates, &StreamStateInfo{
+			ParticipantID: track.PublisherID(),
+			TrackID:       track.ID(),
+			State:         StreamStateActive,
+		})
+	}
+}
+
+func (s *StreamStateUpdate) Empty() bool {
+	return len(s.StreamStates) == 0
+}
+
+// ------------------------------------------------

--- a/pkg/sfu/streamallocator/track.go
+++ b/pkg/sfu/streamallocator/track.go
@@ -1,0 +1,255 @@
+package streamallocator
+
+import (
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/logger"
+
+	"github.com/livekit/livekit-server/pkg/sfu"
+	"github.com/livekit/livekit-server/pkg/sfu/buffer"
+)
+
+type Track struct {
+	downTrack   *sfu.DownTrack
+	source      livekit.TrackSource
+	isSimulcast bool
+	priority    uint8
+	publisherID livekit.ParticipantID
+	logger      logger.Logger
+
+	maxLayers buffer.VideoLayer
+
+	totalPackets       uint32
+	totalRepeatedNacks uint32
+
+	isDirty bool
+
+	isPaused bool
+}
+
+func NewTrack(
+	downTrack *sfu.DownTrack,
+	source livekit.TrackSource,
+	isSimulcast bool,
+	publisherID livekit.ParticipantID,
+	logger logger.Logger,
+) *Track {
+	t := &Track{
+		downTrack:   downTrack,
+		source:      source,
+		isSimulcast: isSimulcast,
+		publisherID: publisherID,
+		logger:      logger,
+		isPaused:    true,
+	}
+	t.SetPriority(0)
+	t.SetMaxLayers(downTrack.MaxLayers())
+
+	return t
+}
+
+func (t *Track) SetDirty(isDirty bool) bool {
+	if t.isDirty == isDirty {
+		return false
+	}
+
+	t.isDirty = isDirty
+	return true
+}
+
+func (t *Track) SetPaused(isPaused bool) bool {
+	if t.isPaused == isPaused {
+		return false
+	}
+
+	t.isPaused = isPaused
+	return true
+}
+
+func (t *Track) SetPriority(priority uint8) bool {
+	if priority == 0 {
+		switch t.source {
+		case livekit.TrackSource_SCREEN_SHARE:
+			priority = PriorityDefaultScreenshare
+		default:
+			priority = PriorityDefaultVideo
+		}
+	}
+
+	if t.priority == priority {
+		return false
+	}
+
+	t.priority = priority
+	return true
+}
+
+func (t *Track) Priority() uint8 {
+	return t.priority
+}
+
+func (t *Track) DownTrack() *sfu.DownTrack {
+	return t.downTrack
+}
+
+func (t *Track) IsManaged() bool {
+	return t.source != livekit.TrackSource_SCREEN_SHARE || t.isSimulcast
+}
+
+func (t *Track) ID() livekit.TrackID {
+	return livekit.TrackID(t.downTrack.ID())
+}
+
+func (t *Track) PublisherID() livekit.ParticipantID {
+	return t.publisherID
+}
+
+func (t *Track) SetMaxLayers(layers buffer.VideoLayer) bool {
+	if t.maxLayers == layers {
+		return false
+	}
+
+	t.maxLayers = layers
+	return true
+}
+
+func (t *Track) WritePaddingRTP(bytesToSend int) int {
+	return t.downTrack.WritePaddingRTP(bytesToSend, false)
+}
+
+func (t *Track) AllocateOptimal(allowOvershoot bool) sfu.VideoAllocation {
+	return t.downTrack.AllocateOptimal(allowOvershoot)
+}
+
+func (t *Track) ProvisionalAllocatePrepare() {
+	t.downTrack.ProvisionalAllocatePrepare()
+}
+
+func (t *Track) ProvisionalAllocate(availableChannelCapacity int64, layers buffer.VideoLayer, allowPause bool, allowOvershoot bool) int64 {
+	return t.downTrack.ProvisionalAllocate(availableChannelCapacity, layers, allowPause, allowOvershoot)
+}
+
+func (t *Track) ProvisionalAllocateGetCooperativeTransition(allowOvershoot bool) sfu.VideoTransition {
+	return t.downTrack.ProvisionalAllocateGetCooperativeTransition(allowOvershoot)
+}
+
+func (t *Track) ProvisionalAllocateGetBestWeightedTransition() sfu.VideoTransition {
+	return t.downTrack.ProvisionalAllocateGetBestWeightedTransition()
+}
+
+func (t *Track) ProvisionalAllocateCommit() sfu.VideoAllocation {
+	return t.downTrack.ProvisionalAllocateCommit()
+}
+
+func (t *Track) AllocateNextHigher(availableChannelCapacity int64, allowOvershoot bool) (sfu.VideoAllocation, bool) {
+	return t.downTrack.AllocateNextHigher(availableChannelCapacity, allowOvershoot)
+}
+
+func (t *Track) GetNextHigherTransition(allowOvershoot bool) (sfu.VideoTransition, bool) {
+	return t.downTrack.GetNextHigherTransition(allowOvershoot)
+}
+
+func (t *Track) Pause() sfu.VideoAllocation {
+	return t.downTrack.Pause()
+}
+
+func (t *Track) IsDeficient() bool {
+	return t.downTrack.IsDeficient()
+}
+
+func (t *Track) BandwidthRequested() int64 {
+	return t.downTrack.BandwidthRequested()
+}
+
+func (t *Track) DistanceToDesired() float64 {
+	return t.downTrack.DistanceToDesired()
+}
+
+func (t *Track) GetNackDelta() (uint32, uint32) {
+	totalPackets, totalRepeatedNacks := t.downTrack.GetNackStats()
+
+	packetDelta := totalPackets - t.totalPackets
+	t.totalPackets = totalPackets
+
+	nackDelta := totalRepeatedNacks - t.totalRepeatedNacks
+	t.totalRepeatedNacks = totalRepeatedNacks
+
+	return packetDelta, nackDelta
+}
+
+// ------------------------------------------------
+
+type TrackSorter []*Track
+
+func (t TrackSorter) Len() int {
+	return len(t)
+}
+
+func (t TrackSorter) Swap(i, j int) {
+	t[i], t[j] = t[j], t[i]
+}
+
+func (t TrackSorter) Less(i, j int) bool {
+	//
+	// TrackSorter is used to allocate layer-by-layer.
+	// So, higher priority track should come earlier so that it gets an earlier shot at each layer
+	//
+	if t[i].priority != t[j].priority {
+		return t[i].priority > t[j].priority
+	}
+
+	if t[i].maxLayers.Spatial != t[j].maxLayers.Spatial {
+		return t[i].maxLayers.Spatial > t[j].maxLayers.Spatial
+	}
+
+	return t[i].maxLayers.Temporal > t[j].maxLayers.Temporal
+}
+
+// ------------------------------------------------
+
+type MaxDistanceSorter []*Track
+
+func (m MaxDistanceSorter) Len() int {
+	return len(m)
+}
+
+func (m MaxDistanceSorter) Swap(i, j int) {
+	m[i], m[j] = m[j], m[i]
+}
+
+func (m MaxDistanceSorter) Less(i, j int) bool {
+	//
+	// MaxDistanceSorter is used to find a deficient track to use for probing during recovery from congestion.
+	// So, higher priority track should come earlier so that they have a chance to recover sooner.
+	//
+	if m[i].priority != m[j].priority {
+		return m[i].priority > m[j].priority
+	}
+
+	return m[i].DistanceToDesired() > m[j].DistanceToDesired()
+}
+
+// ------------------------------------------------
+
+type MinDistanceSorter []*Track
+
+func (m MinDistanceSorter) Len() int {
+	return len(m)
+}
+
+func (m MinDistanceSorter) Swap(i, j int) {
+	m[i], m[j] = m[j], m[i]
+}
+
+func (m MinDistanceSorter) Less(i, j int) bool {
+	//
+	// MinDistanceSorter is used to find excess bandwidth in cooperative allocation.
+	// So, lower priority track should come earlier so that they contribute bandwidth to higher priority tracks.
+	//
+	if m[i].priority != m[j].priority {
+		return m[i].priority < m[j].priority
+	}
+
+	return m[i].DistanceToDesired() < m[j].DistanceToDesired()
+}
+
+// ------------------------------------------------

--- a/pkg/sfu/streamallocator/trenddetector.go
+++ b/pkg/sfu/streamallocator/trenddetector.go
@@ -1,0 +1,157 @@
+package streamallocator
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/livekit/protocol/logger"
+)
+
+// ------------------------------------------------
+
+type TrendDirection int
+
+const (
+	TrendDirectionNeutral TrendDirection = iota
+	TrendDirectionUpward
+	TrendDirectionDownward
+)
+
+func (t TrendDirection) String() string {
+	switch t {
+	case TrendDirectionNeutral:
+		return "NEUTRAL"
+	case TrendDirectionUpward:
+		return "UPWARD"
+	case TrendDirectionDownward:
+		return "DOWNWARD"
+	default:
+		return fmt.Sprintf("%d", int(t))
+	}
+}
+
+// ------------------------------------------------
+
+type TrendDetectorParams struct {
+	Name                   string
+	Logger                 logger.Logger
+	RequiredSamples        int
+	DownwardTrendThreshold float64
+	CollapseValues         bool
+}
+
+type TrendDetector struct {
+	params TrendDetectorParams
+
+	startTime    time.Time
+	numSamples   int
+	values       []int64
+	lowestValue  int64
+	highestValue int64
+
+	direction TrendDirection
+}
+
+func NewTrendDetector(params TrendDetectorParams) *TrendDetector {
+	return &TrendDetector{
+		params:    params,
+		startTime: time.Now(),
+		direction: TrendDirectionNeutral,
+	}
+}
+
+func (t *TrendDetector) Seed(value int64) {
+	if len(t.values) != 0 {
+		return
+	}
+
+	t.values = append(t.values, value)
+}
+
+func (t *TrendDetector) AddValue(value int64) {
+	t.numSamples++
+	if t.lowestValue == 0 || value < t.lowestValue {
+		t.lowestValue = value
+	}
+	if value > t.highestValue {
+		t.highestValue = value
+	}
+
+	// ignore duplicate values
+	if t.params.CollapseValues && len(t.values) != 0 && t.values[len(t.values)-1] == value {
+		return
+	}
+
+	if len(t.values) == t.params.RequiredSamples {
+		t.values = t.values[1:]
+	}
+	t.values = append(t.values, value)
+
+	t.updateDirection()
+}
+
+func (t *TrendDetector) GetLowest() int64 {
+	return t.lowestValue
+}
+
+func (t *TrendDetector) GetHighest() int64 {
+	return t.highestValue
+}
+
+func (t *TrendDetector) GetValues() []int64 {
+	return t.values
+}
+
+func (t *TrendDetector) GetDirection() TrendDirection {
+	return t.direction
+}
+
+func (t *TrendDetector) ToString() string {
+	now := time.Now()
+	elapsed := now.Sub(t.startTime).Seconds()
+	str := fmt.Sprintf("n: %s", t.params.Name)
+	str += fmt.Sprintf(", t: %+v|%+v|%.2fs", t.startTime.Format(time.UnixDate), now.Format(time.UnixDate), elapsed)
+	str += fmt.Sprintf(", v: %d|%d|%d|%+v|%.2f", t.numSamples, t.lowestValue, t.highestValue, t.values, kendallsTau(t.values))
+	return str
+}
+
+func (t *TrendDetector) updateDirection() {
+	if len(t.values) < t.params.RequiredSamples {
+		t.direction = TrendDirectionNeutral
+		return
+	}
+
+	// using Kendall's Tau to find trend
+	kt := kendallsTau(t.values)
+
+	t.direction = TrendDirectionNeutral
+	switch {
+	case kt > 0:
+		t.direction = TrendDirectionUpward
+	case kt < t.params.DownwardTrendThreshold:
+		t.direction = TrendDirectionDownward
+	}
+}
+
+// ------------------------------------------------
+
+func kendallsTau(values []int64) float64 {
+	concordantPairs := 0
+	discordantPairs := 0
+
+	for i := 0; i < len(values)-1; i++ {
+		for j := i + 1; j < len(values); j++ {
+			if values[i] < values[j] {
+				concordantPairs++
+			} else if values[i] > values[j] {
+				discordantPairs++
+			}
+		}
+	}
+
+	if (concordantPairs + discordantPairs) == 0 {
+		return 0.0
+	}
+
+	return (float64(concordantPairs) - float64(discordantPairs)) / (float64(concordantPairs) + float64(discordantPairs))
+}

--- a/pkg/sfu/videolayerselector.go
+++ b/pkg/sfu/videolayerselector.go
@@ -11,7 +11,7 @@ import (
 
 type targetLayer struct {
 	Target int
-	Layer  VideoLayers
+	Layer  buffer.VideoLayer
 }
 
 type DDVideoLayerSelector struct {
@@ -22,7 +22,7 @@ type DDVideoLayerSelector struct {
 	// expectKeyFrame      bool
 
 	decodeTargetLayer          []targetLayer
-	layer                      VideoLayers
+	layer                      buffer.VideoLayer
 	activeDecodeTargetsBitmask *uint32
 	structure                  *dd.FrameDependencyStructure
 }
@@ -30,7 +30,7 @@ type DDVideoLayerSelector struct {
 func NewDDVideoLayerSelector(logger logger.Logger) *DDVideoLayerSelector {
 	return &DDVideoLayerSelector{
 		logger: logger,
-		layer:  VideoLayers{Spatial: 2, Temporal: 2},
+		layer:  buffer.VideoLayer{Spatial: 2, Temporal: 2},
 	}
 }
 
@@ -48,7 +48,7 @@ func (s *DDVideoLayerSelector) Select(expPkt *buffer.ExtPacket, tp *TranslationP
 	}
 
 	// forward all packets before locking
-	if s.layer == InvalidLayers {
+	if s.layer == buffer.InvalidLayers {
 		return true
 	}
 
@@ -122,8 +122,8 @@ func (s *DDVideoLayerSelector) Select(expPkt *buffer.ExtPacket, tp *TranslationP
 	return true
 }
 
-func (s *DDVideoLayerSelector) SelectLayer(layer VideoLayers) {
-	// layer = VideoLayers{1, 1}
+func (s *DDVideoLayerSelector) SelectLayer(layer buffer.VideoLayer) {
+	// layer = buffer.VideoLayer{1, 1}
 	s.layer = layer
 	activeBitMask := uint32(0)
 	var maxSpatial, maxTemporal int32
@@ -152,7 +152,7 @@ func (s *DDVideoLayerSelector) updateDependencyStructure(structure *dd.FrameDepe
 	s.decodeTargetLayer = s.decodeTargetLayer[:0]
 
 	for target := 0; target < structure.NumDecodeTargets; target++ {
-		layer := VideoLayers{Spatial: 0, Temporal: 0}
+		layer := buffer.VideoLayer{Spatial: 0, Temporal: 0}
 		for _, t := range structure.Templates {
 			if t.DecodeTargetIndications[target] != dd.DecodeTargetNotPresent {
 				if layer.Spatial < int32(t.SpatialId) {


### PR DESCRIPTION
Splitting out StreamAllocator into its own directory and splitting some structs from inside the old streamallocator.go to their own files. Will be cleaner to read/do some changes in the future.

Because of the namespace move, a bunch of other things got affected, but no functionality change at all.

Also removed variable/type proxying happening in forwarder.