### PR TITLE
Fix sequence number offset on packet drop

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -560,8 +560,6 @@ func (d *DownTrack) WriteRTP(extPkt *buffer.ExtPacket, layer int32) error {
 		return err
 	}
 
-	incomingPictureId := uint16(0)	// REMOVE
-	outgoingPictureId := uint16(0)	// REMOVE
 	payload := extPkt.Packet.Payload
 	if tp.vp8 != nil {
 		incomingVP8, _ := extPkt.Payload.(buffer.VP8)
@@ -572,8 +570,6 @@ func (d *DownTrack) WriteRTP(extPkt *buffer.ExtPacket, layer int32) error {
 			d.logger.Errorw("write rtp packet failed", err)
 			return err
 		}
-		incomingPictureId = incomingVP8.PictureID
-		outgoingPictureId = tp.vp8.Header.PictureID
 	}
 
 	var meta *packetMeta
@@ -635,9 +631,6 @@ func (d *DownTrack) WriteRTP(extPkt *buffer.ExtPacket, layer int32) error {
 	}
 
 	d.rtpStats.Update(hdr, len(payload), 0, time.Now().UnixNano())
-	if d.kind == webrtc.RTPCodecTypeVideo {
-		d.logger.Infow("RAJA forwarding video", "isn", extPkt.Packet.SequenceNumber, "its", extPkt.Packet.Timestamp, "im", extPkt.Packet.Marker, "osn", hdr.SequenceNumber, "ots", hdr.Timestamp, "om", hdr.Marker, "ipid", incomingPictureId, "opid", outgoingPictureId)	// REMOVE
-	}
 	return nil
 }
 
@@ -714,7 +707,6 @@ func (d *DownTrack) WritePaddingRTP(bytesToSend int, paddingOnMute bool) int {
 		if err != nil {
 			return bytesSent
 		}
-		d.logger.Infow("RAJA writing padding", "osn", hdr.SequenceNumber, "ots", hdr.Timestamp, "om", hdr.Marker)	// REMOVE
 
 		if !paddingOnMute {
 			d.rtpStats.Update(&hdr, 0, len(payload), time.Now().UnixNano())
@@ -1452,8 +1444,6 @@ func (d *DownTrack) retransmitPackets(nacks []uint16) {
 		pkt.Header.SSRC = d.ssrc
 		pkt.Header.PayloadType = d.payloadType
 
-		incomingPictureId := uint16(0)	// REMOVE
-		outgoingPictureId := uint16(0)	// REMOVE
 		payload := pkt.Payload
 		if d.mime == "video/vp8" && len(pkt.Payload) > 0 {
 			var incomingVP8 buffer.VP8
@@ -1469,8 +1459,6 @@ func (d *DownTrack) retransmitPackets(nacks []uint16) {
 				d.logger.Errorw("translating VP8 packet err", err)
 				continue
 			}
-			incomingPictureId = incomingVP8.PictureID
-			outgoingPictureId = translatedVP8.PictureID
 		}
 
 		var extraExtensions []extensionData
@@ -1493,7 +1481,6 @@ func (d *DownTrack) retransmitPackets(nacks []uint16) {
 
 			d.rtpStats.Update(&pkt.Header, len(payload), 0, time.Now().UnixNano())
 		}
-		d.logger.Infow("RAJA re-forwarding video", "isn", meta.sourceSeqNo, "osn", pkt.Header.SequenceNumber, "ots", pkt.Header.Timestamp, "om", pkt.Header.Marker, "ipid", incomingPictureId, "opid", outgoingPictureId)	// REMOVE
 	}
 
 	d.statsLock.Lock()

--- a/pkg/sfu/rtpmunger.go
+++ b/pkg/sfu/rtpmunger.go
@@ -136,14 +136,6 @@ func (r *RTPMunger) PacketDropped(extPkt *buffer.ExtPacket) {
 	}
 	r.snOffset++
 	r.lastSN = extPkt.Packet.SequenceNumber - r.snOffset
-
-	/* RAJA-REMOVE
-	r.snOffsetsWritePtr = (r.snOffsetsWritePtr - 1) & SnOffsetCacheMask
-	r.snOffsetsOccupancy--
-	if r.snOffsetsOccupancy < 0 {
-		r.logger.Warnw("sequence number offset cache is invalid", nil, "occupancy", r.snOffsetsOccupancy)
-	}
-	*/
 }
 
 func (r *RTPMunger) UpdateAndGetSnTs(extPkt *buffer.ExtPacket) (*TranslationParamsRTP, error) {

--- a/pkg/sfu/rtpmunger.go
+++ b/pkg/sfu/rtpmunger.go
@@ -137,11 +137,13 @@ func (r *RTPMunger) PacketDropped(extPkt *buffer.ExtPacket) {
 	r.snOffset++
 	r.lastSN = extPkt.Packet.SequenceNumber - r.snOffset
 
+	/* RAJA-REMOVE
 	r.snOffsetsWritePtr = (r.snOffsetsWritePtr - 1) & SnOffsetCacheMask
 	r.snOffsetsOccupancy--
 	if r.snOffsetsOccupancy < 0 {
 		r.logger.Warnw("sequence number offset cache is invalid", nil, "occupancy", r.snOffsetsOccupancy)
 	}
+	*/
 }
 
 func (r *RTPMunger) UpdateAndGetSnTs(extPkt *buffer.ExtPacket) (*TranslationParamsRTP, error) {

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -1094,12 +1094,6 @@ func (s *StreamAllocator) initProbe(probeRateBps int64) {
 	s.channelObserver = s.newChannelObserverProbe()
 	s.channelObserver.SeedEstimate(s.lastReceivedEstimate)
 
-	// RAJA-TODO: this probably should only look at probe goal which is always driven expected usage, some time committed is much higher
-	// RAJA-TODO: i guess this was done as expected based goal could be lower than currently commited because NACKs could have triggered a congestion
-	// RAJA-TODO: maybe check if goal is less than last received estimate and only used the last received if that is lower than the goal?
-	// RAJA-TODO: also potentially use "last received" and not "committed" as last received is the latest state.
-	// RAJA-TODO: but last received could be quite low if channel was over driven a lot and it just kept congesting for a long time
-	// RAJA-TODO: at a minimum add a comment here as to why desired is chosen like this
 	desiredRateBps := int(probeRateBps) + int(math.Max(float64(s.committedChannelCapacity), float64(expectedBandwidthUsage)))
 	s.probeClusterId = s.prober.AddCluster(
 		desiredRateBps,

--- a/pkg/sfu/vp8munger.go
+++ b/pkg/sfu/vp8munger.go
@@ -184,10 +184,9 @@ func (v *VP8Munger) UpdateAndGet(extPkt *buffer.ExtPacket, ordering SequenceNumb
 			IsKeyFrame:       vp8.IsKeyFrame,
 			HeaderSize:       vp8.HeaderSize + buffer.VP8PictureIdSizeDiff(mungedPictureId > 127, vp8.MBit),
 		}
-		translated := &TranslationParamsVP8{
+		return &TranslationParamsVP8{
 			Header: vp8Packet,
-		}
-		return translated, nil
+		}, nil
 	}
 
 	prevMaxPictureId := v.pictureIdWrapHandler.MaxPictureId()
@@ -290,10 +289,9 @@ func (v *VP8Munger) UpdateAndGet(extPkt *buffer.ExtPacket, ordering SequenceNumb
 		IsKeyFrame:       vp8.IsKeyFrame,
 		HeaderSize:       vp8.HeaderSize + buffer.VP8PictureIdSizeDiff(mungedPictureId > 127, vp8.MBit),
 	}
-	translated := &TranslationParamsVP8{
+	return &TranslationParamsVP8{
 		Header: vp8Packet,
-	}
-	return translated, nil
+	}, nil
 }
 
 func (v *VP8Munger) UpdateAndGetPadding(newPicture bool) *buffer.VP8 {

--- a/pkg/sfu/vp8munger.go
+++ b/pkg/sfu/vp8munger.go
@@ -207,7 +207,7 @@ func (v *VP8Munger) UpdateAndGet(extPkt *buffer.ExtPacket, ordering SequenceNumb
 	// the gap is larger.
 	if ordering == SequenceNumberOrderingGap {
 		for lostPictureId := prevMaxPictureId; lostPictureId <= extPictureId; lostPictureId++ {
-			// Quque up only if picture id was not dropped. This is to avoid a subsequent packet of dropped frame going through.
+			// Record missing only if picture id was not dropped. This is to avoid a subsequent packet of dropped frame going through.
 			// A sequence like this
 			//   o Packet 10 - Picture 11 - TID that should be dropped
 			//   o Packet 11 - missing - belongs to Picture 11 still

--- a/pkg/sfu/vp8munger_test.go
+++ b/pkg/sfu/vp8munger_test.go
@@ -65,17 +65,16 @@ func TestSetLast(t *testing.T) {
 				totalWrap:    0,
 				lastWrap:     0,
 			},
-			extLastPictureId:     13467,
-			pictureIdOffset:      0,
-			pictureIdUsed:        1,
-			lastTl0PicIdx:        233,
-			tl0PicIdxOffset:      0,
-			tl0PicIdxUsed:        1,
-			tidUsed:              1,
-			lastKeyIdx:           23,
-			keyIdxOffset:         0,
-			keyIdxUsed:           1,
-			lastDroppedPictureId: -1,
+			extLastPictureId: 13467,
+			pictureIdOffset:  0,
+			pictureIdUsed:    1,
+			lastTl0PicIdx:    233,
+			tl0PicIdxOffset:  0,
+			tl0PicIdxUsed:    1,
+			tidUsed:          1,
+			lastKeyIdx:       23,
+			keyIdxOffset:     0,
+			keyIdxUsed:       1,
 		},
 	}
 
@@ -140,17 +139,16 @@ func TestUpdateOffsets(t *testing.T) {
 				totalWrap:    0,
 				lastWrap:     0,
 			},
-			extLastPictureId:     13467,
-			pictureIdOffset:      345 - 13467 - 1,
-			pictureIdUsed:        1,
-			lastTl0PicIdx:        233,
-			tl0PicIdxOffset:      (12 - 233 - 1) & 0xff,
-			tl0PicIdxUsed:        1,
-			tidUsed:              1,
-			lastKeyIdx:           23,
-			keyIdxOffset:         (4 - 23 - 1) & 0x1f,
-			keyIdxUsed:           1,
-			lastDroppedPictureId: -1,
+			extLastPictureId: 13467,
+			pictureIdOffset:  345 - 13467 - 1,
+			pictureIdUsed:    1,
+			lastTl0PicIdx:    233,
+			tl0PicIdxOffset:  (12 - 233 - 1) & 0xff,
+			tl0PicIdxUsed:    1,
+			tidUsed:          1,
+			lastKeyIdx:       23,
+			keyIdxOffset:     (4 - 23 - 1) & 0x1f,
+			keyIdxUsed:       1,
 		},
 	}
 	require.True(t, compare(&expectedVP8Munger, v))
@@ -289,7 +287,8 @@ func TestTemporalLayerFiltering(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrFilteredVP8TemporalLayer)
 	require.Nil(t, tp)
-	require.EqualValues(t, 13467, v.lastDroppedPictureId)
+	dropped, _ := v.droppedPictureIds.Get(13467)
+	require.True(t, dropped)
 	require.EqualValues(t, 1, v.pictureIdOffset)
 
 	// another packet with the same picture id.
@@ -301,7 +300,8 @@ func TestTemporalLayerFiltering(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrFilteredVP8TemporalLayer)
 	require.Nil(t, tp)
-	require.EqualValues(t, 13467, v.lastDroppedPictureId)
+	dropped, _ = v.droppedPictureIds.Get(13467)
+	require.True(t, dropped)
 	require.EqualValues(t, 1, v.pictureIdOffset)
 
 	// another packet with the same picture id, but a gap in sequence number.
@@ -313,7 +313,8 @@ func TestTemporalLayerFiltering(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrFilteredVP8TemporalLayer)
 	require.Nil(t, tp)
-	require.EqualValues(t, 13467, v.lastDroppedPictureId)
+	dropped, _ = v.droppedPictureIds.Get(13467)
+	require.True(t, dropped)
 	require.EqualValues(t, 1, v.pictureIdOffset)
 }
 


### PR DESCRIPTION
All sequence numbers are stored in sequence number offset array. So, the offset write ptr should not be adjusted on packet drop. This was causing sequence numbers to get out of whack in lossy network + congestion case. And that caused PLIs to be generated.
NOTE: Still not able to reproduce the glut of PLIs, but this is one reason for PLIs.

Also made the VP8 munger under loss more resilient. Comments in code.

Enhanced RTPMunger UT to check for more sequence number offsets/write pointer.