### PR TITLE
Increase sequence number cache to handle high rate tracks.

### DIFF
--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -19,7 +19,7 @@ const (
 	GapHistogramNumBins = 101
 	NumSequenceNumbers  = 65536
 	FirstSnapshotId     = 1
-	SnInfoSize          = 2048
+	SnInfoSize          = 8192
 	SnInfoMask          = SnInfoSize - 1
 	TooLargeOWDDelta    = 400 * time.Millisecond
 )


### PR DESCRIPTION
Hopefully temporary while we can find a better solution. Adds 36 KB per SSRC. So, if a node can handle 10K SSRCs (roughly 10K tracks), that will be 360 MB of extra memory.