### PR TITLE
Use bandwidth requested from last allocation.

### DIFF
--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -469,7 +469,7 @@ func TestPreferVideoCodecForPublisher(t *testing.T) {
 		participant.SetResponseSink(sink)
 		var answer webrtc.SessionDescription
 		var answerReceived atomic.Bool
-		sink.WriteMessageStub = func(msg proto.Message) error {
+		sink.WriteMessageCalls(func(msg proto.Message) error {
 			if res, ok := msg.(*livekit.SignalResponse); ok {
 				if res.GetAnswer() != nil {
 					answer = FromProtoSessionDescription(res.GetAnswer())
@@ -478,7 +478,7 @@ func TestPreferVideoCodecForPublisher(t *testing.T) {
 				}
 			}
 			return nil
-		}
+		})
 		participant.HandleOffer(sdp)
 
 		require.Eventually(t, func() bool { return answerReceived.Load() }, 5*time.Second, 10*time.Millisecond)

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -995,8 +995,7 @@ func (d *DownTrack) IsDeficient() bool {
 }
 
 func (d *DownTrack) BandwidthRequested() int64 {
-	_, brs := d.receiver.GetLayeredBitrate()
-	return d.forwarder.BandwidthRequested(brs)
+	return d.forwarder.BandwidthRequested()
 }
 
 func (d *DownTrack) DistanceToDesired() float64 {

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -456,25 +456,11 @@ func (f *Forwarder) IsDeficient() bool {
 	return f.isDeficientLocked()
 }
 
-func (f *Forwarder) BandwidthRequested(brs Bitrates) int64 {
+func (f *Forwarder) BandwidthRequested() int64 {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 
-	if !f.targetLayers.IsValid() {
-		if f.targetLayers != buffer.InvalidLayers {
-			f.logger.Warnw(
-				"unexpected target layers", nil,
-				"target", f.targetLayers,
-				"current", f.currentLayers,
-				"parked", f.parkedLayers,
-				"max", f.maxLayers,
-				"lastAllocation", f.lastAllocation,
-			)
-		}
-		return 0
-	}
-
-	return brs[f.targetLayers.Spatial][f.targetLayers.Temporal]
+	return f.lastAllocation.BandwidthRequested
 }
 
 func (f *Forwarder) DistanceToDesired(availableLayers []int32, brs Bitrates) float64 {


### PR DESCRIPTION
With overshoot/opportunistic forwarding, It is possible that bitrate at target layers is 0. So, use bandwidth requested from last allocation which shouold have a correct value.

Still need to think about using the latest bit rates to get the requested bandwidth. It is possible that bitrates have changed since last allocation. That was the idea behind using the latest bitrates, but it could return 0. Accounting for it runs into a few scenarios. Last allocation has number from last allocation and is a good indicator of the need.