### PR TITLE
Do not let request layer overshoot available.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -578,59 +578,35 @@ func (f *Forwarder) AllocateOptimal(availableLayers []int32, brs Bitrates, allow
 		alloc.TargetLayer = parkedLayer
 		alloc.RequestLayerSpatial = alloc.TargetLayer.Spatial
 
-	case len(availableLayers) == 0:
-		// feed may be dry
-		if currentLayer.IsValid() {
-			// let it continue at current layer if valid.
-			// Covers the cases of
+	default:
+		requestLayerSpatial := buffer.InvalidLayerSpatial
+		for _, al := range availableLayers {
+			if al > requestLayerSpatial {
+				requestLayerSpatial = al
+			}
+		}
+		maxLayerSpatialLimit := int32(math.Min(float64(maxLayer.Spatial), float64(maxSeenLayer.Spatial)))
+		if requestLayerSpatial > maxLayerSpatialLimit {
+			requestLayerSpatial = maxLayerSpatialLimit
+		}
+		if currentLayer.IsValid() && ((requestLayerSpatial == requestSpatial && currentLayer.Spatial == requestSpatial) || requestLayerSpatial == buffer.InvalidLayerSpatial) {
+			// 1. current is locked to desired, stay there
+			// OR
+			// 2. feed may be dry, let it continue at current layer if valid.
+			// covers the cases of
 			//   1. mis-detection of layer stop - can continue streaming
 			//   2. current layer resuming - can latch on when it starts
-			alloc.TargetLayer = currentLayer
+			alloc.TargetLayer = buffer.VideoLayer{
+				Spatial:  currentLayer.Spatial,
+				Temporal: getMaxTemporal(),
+			}
 			alloc.RequestLayerSpatial = alloc.TargetLayer.Spatial
 		} else {
 			// opportunistically latch on to anything
 			opportunisticAlloc()
-			alloc.RequestLayerSpatial = int32(math.Min(float64(maxLayer.Spatial), float64(maxSeenLayer.Spatial)))
-		}
-
-	default:
-		isCurrentLayerAvailable := false
-		if currentLayer.IsValid() {
-			for _, l := range availableLayers {
-				if l == currentLayer.Spatial {
-					isCurrentLayerAvailable = true
-					break
-				}
-			}
-		}
-
-		if !isCurrentLayerAvailable && currentLayer.IsValid() {
-			// current layer maybe stopped, move to highest available
-			for _, l := range availableLayers {
-				if l > alloc.TargetLayer.Spatial {
-					alloc.TargetLayer.Spatial = l
-				}
-			}
-			alloc.TargetLayer.Temporal = getMaxTemporal()
-
-			alloc.RequestLayerSpatial = alloc.TargetLayer.Spatial
-		} else {
-			requestLayerSpatial := int32(0)
-			for _, al := range availableLayers {
-				if al > requestLayerSpatial {
-					requestLayerSpatial = al
-				}
-			}
-			if currentLayer.IsValid() && requestLayerSpatial == requestSpatial && currentLayer.Spatial == requestSpatial {
-				// current is locked to desired, stay there
-				alloc.TargetLayer = buffer.VideoLayer{
-					Spatial:  requestSpatial,
-					Temporal: getMaxTemporal(),
-				}
-				alloc.RequestLayerSpatial = requestSpatial
+			if requestLayerSpatial == buffer.InvalidLayerSpatial {
+				alloc.RequestLayerSpatial = maxLayerSpatialLimit
 			} else {
-				// opportunistically latch on to anything
-				opportunisticAlloc()
 				alloc.RequestLayerSpatial = requestLayerSpatial
 			}
 		}

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -615,7 +615,12 @@ func (f *Forwarder) AllocateOptimal(availableLayers []int32, brs Bitrates, allow
 
 			alloc.RequestLayerSpatial = alloc.TargetLayer.Spatial
 		} else {
-			requestLayerSpatial := int32(math.Min(float64(maxLayer.Spatial), float64(maxSeenLayer.Spatial)))
+			requestLayerSpatial := int32(0)
+			for _, al := range availableLayers {
+				if al > requestLayerSpatial {
+					requestLayerSpatial = al
+				}
+			}
 			if currentLayer.IsValid() && requestLayerSpatial == requestSpatial && currentLayer.Spatial == requestSpatial {
 				// current is locked to desired, stay there
 				alloc.TargetLayer = buffer.VideoLayer{

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -293,7 +293,7 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 		BandwidthNeeded:     bitrates[2][1],
 		Bitrates:            bitrates,
 		TargetLayer:         buffer.DefaultMaxLayer,
-		RequestLayerSpatial: 2,
+		RequestLayerSpatial: 1,
 		MaxLayer:            buffer.DefaultMaxLayer,
 		DistanceToDesired:   -0.5,
 	}
@@ -310,7 +310,7 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 		BandwidthDelta:      0 - bitrates[2][1],
 		Bitrates:            emptyBitrates,
 		TargetLayer:         buffer.DefaultMaxLayer,
-		RequestLayerSpatial: 2,
+		RequestLayerSpatial: 1,
 		MaxLayer:            buffer.DefaultMaxLayer,
 		DistanceToDesired:   -1.0,
 	}
@@ -330,7 +330,7 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 		BandwidthNeeded:     bitrates[2][1],
 		Bitrates:            bitrates,
 		TargetLayer:         expectedTargetLayer,
-		RequestLayerSpatial: 2,
+		RequestLayerSpatial: 1,
 		MaxLayer:            buffer.DefaultMaxLayer,
 		DistanceToDesired:   -0.5,
 	}
@@ -377,7 +377,7 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 		MaxLayer:            f.vls.GetMax(),
 		DistanceToDesired:   0.0,
 	}
-	result = f.AllocateOptimal([]int32{0, 1}, emptyBitrates, true)
+	result = f.AllocateOptimal([]int32{0}, emptyBitrates, true)
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 
@@ -395,7 +395,7 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 		BandwidthDelta:      0,
 		Bitrates:            emptyBitrates,
 		TargetLayer:         expectedTargetLayer,
-		RequestLayerSpatial: 2,
+		RequestLayerSpatial: 1,
 		MaxLayer:            f.vls.GetMax(),
 		DistanceToDesired:   -1,
 	}

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -338,10 +338,10 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 	require.Equal(t, expectedResult, result)
 	require.Equal(t, expectedResult, f.lastAllocation)
 
-	// switches to highest available if feed is not dry and current is valid and current is not available
+	// switches request layer to highest available if feed is not dry and current is valid and current is not available
 	f.vls.SetCurrent(buffer.VideoLayer{Spatial: 0, Temporal: 1})
 	expectedTargetLayer = buffer.VideoLayer{
-		Spatial:  1,
+		Spatial:  2,
 		Temporal: buffer.DefaultMaxLayerTemporal,
 	}
 	expectedResult = VideoAllocation{
@@ -353,7 +353,7 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 		TargetLayer:         expectedTargetLayer,
 		RequestLayerSpatial: 1,
 		MaxLayer:            buffer.DefaultMaxLayer,
-		DistanceToDesired:   0.5,
+		DistanceToDesired:   -0.5,
 	}
 	result = f.AllocateOptimal([]int32{1}, bitrates, true)
 	require.Equal(t, expectedResult, result)


### PR DESCRIPTION
After a layer stopped on publisher side, an optimal allocation side while initially adjusted to not request the stopped layer, a subsequent allocation went back to the higher layer although it was stopped. Prevent that.