### PR TITLE
Return chosen codec for simulcast codecs

### DIFF
--- a/pkg/rtc/mediaengine.go
+++ b/pkg/rtc/mediaengine.go
@@ -16,7 +16,7 @@ func registerCodecs(me *webrtc.MediaEngine, codecs []*livekit.Codec, rtcpFeedbac
 	opusCodec := opusCodecCapability
 	opusCodec.RTCPFeedback = rtcpFeedback.Audio
 	var opusPayload webrtc.PayloadType
-	if isCodecEnabled(codecs, opusCodec) {
+	if IsCodecEnabled(codecs, opusCodec) {
 		opusPayload = 111
 		if err := me.RegisterCodec(webrtc.RTPCodecParameters{
 			RTPCodecCapability: opusCodec,
@@ -25,7 +25,7 @@ func registerCodecs(me *webrtc.MediaEngine, codecs []*livekit.Codec, rtcpFeedbac
 			return err
 		}
 
-		if isCodecEnabled(codecs, redCodecCapability) {
+		if IsCodecEnabled(codecs, redCodecCapability) {
 			if err := me.RegisterCodec(webrtc.RTPCodecParameters{
 				RTPCodecCapability: redCodecCapability,
 				PayloadType:        63,
@@ -65,7 +65,7 @@ func registerCodecs(me *webrtc.MediaEngine, codecs []*livekit.Codec, rtcpFeedbac
 			PayloadType:        35,
 		},
 	} {
-		if isCodecEnabled(codecs, codec.RTPCodecCapability) {
+		if IsCodecEnabled(codecs, codec.RTPCodecCapability) {
 			if err := me.RegisterCodec(codec, webrtc.RTPCodecTypeVideo); err != nil {
 				return err
 			}
@@ -103,7 +103,7 @@ func createMediaEngine(codecs []*livekit.Codec, config DirectionConfig) (*webrtc
 	return me, nil
 }
 
-func isCodecEnabled(codecs []*livekit.Codec, cap webrtc.RTPCodecCapability) bool {
+func IsCodecEnabled(codecs []*livekit.Codec, cap webrtc.RTPCodecCapability) bool {
 	for _, codec := range codecs {
 		if !strings.EqualFold(codec.Mime, cap.MimeType) {
 			continue

--- a/pkg/rtc/mediaengine_test.go
+++ b/pkg/rtc/mediaengine_test.go
@@ -12,15 +12,15 @@ import (
 func TestIsCodecEnabled(t *testing.T) {
 	t.Run("empty fmtp requirement should match all", func(t *testing.T) {
 		enabledCodecs := []*livekit.Codec{{Mime: "video/h264"}}
-		require.True(t, isCodecEnabled(enabledCodecs, webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeH264, SDPFmtpLine: "special"}))
-		require.True(t, isCodecEnabled(enabledCodecs, webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeH264}))
-		require.False(t, isCodecEnabled(enabledCodecs, webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeVP8}))
+		require.True(t, IsCodecEnabled(enabledCodecs, webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeH264, SDPFmtpLine: "special"}))
+		require.True(t, IsCodecEnabled(enabledCodecs, webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeH264}))
+		require.False(t, IsCodecEnabled(enabledCodecs, webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeVP8}))
 	})
 
 	t.Run("when fmtp is provided, require match", func(t *testing.T) {
 		enabledCodecs := []*livekit.Codec{{Mime: "video/h264", FmtpLine: "special"}}
-		require.True(t, isCodecEnabled(enabledCodecs, webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeH264, SDPFmtpLine: "special"}))
-		require.False(t, isCodecEnabled(enabledCodecs, webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeH264}))
-		require.False(t, isCodecEnabled(enabledCodecs, webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeVP8}))
+		require.True(t, IsCodecEnabled(enabledCodecs, webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeH264, SDPFmtpLine: "special"}))
+		require.False(t, IsCodecEnabled(enabledCodecs, webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeH264}))
+		require.False(t, IsCodecEnabled(enabledCodecs, webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeVP8}))
 	})
 }

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1461,10 +1461,12 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 		} else if req.Type == livekit.TrackType_AUDIO && !strings.HasPrefix(mime, "audio/") {
 			mime = "audio/" + mime
 		}
-		ti.Codecs = append(ti.Codecs, &livekit.SimulcastCodecInfo{
-			MimeType: mime,
-			Cid:      codec.Cid,
-		})
+		if IsCodecEnabled(p.params.EnabledCodecs, webrtc.RTPCodecCapability{MimeType: mime}) {
+			ti.Codecs = append(ti.Codecs, &livekit.SimulcastCodecInfo{
+				MimeType: mime,
+				Cid:      codec.Cid,
+			})
+		}
 	}
 
 	p.params.Telemetry.TrackPublishRequested(context.Background(), p.ID(), p.Identity(), ti)

--- a/pkg/rtc/subscriptionmanager_test.go
+++ b/pkg/rtc/subscriptionmanager_test.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 const (
-	subSettleTimeout = 300 * time.Millisecond
+	subSettleTimeout = 600 * time.Millisecond
 	subCheckInterval = 10 * time.Millisecond
 )
 


### PR DESCRIPTION
Sfu will remove unsupported codec from simulcast codecs in `AddTrackRequest`, so that clients can fallback to backup codec correctly in this case.