### PR TITLE
A couple of stream allocator tweaks 

### DIFF
--- a/pkg/sfu/streamallocator/channelobserver.go
+++ b/pkg/sfu/streamallocator/channelobserver.go
@@ -59,7 +59,7 @@ type ChannelObserverParams struct {
 	Name                           string
 	EstimateRequiredSamples        int
 	EstimateDownwardTrendThreshold float64
-	EstimateCollapseValues         bool
+	EstimateCollapseThreshold      time.Duration
 	NackWindowMinDuration          time.Duration
 	NackWindowMaxDuration          time.Duration
 	NackRatioThreshold             float64
@@ -86,7 +86,7 @@ func NewChannelObserver(params ChannelObserverParams, logger logger.Logger) *Cha
 			Logger:                 logger,
 			RequiredSamples:        params.EstimateRequiredSamples,
 			DownwardTrendThreshold: params.EstimateDownwardTrendThreshold,
-			CollapseValues:         params.EstimateCollapseValues,
+			CollapseThreshold:      params.EstimateCollapseThreshold,
 		}),
 		nackTracker: NewNackTracker(NackTrackerParams{
 			Name:              params.Name + "-estimate",

--- a/pkg/sfu/streamallocator/prober.go
+++ b/pkg/sfu/streamallocator/prober.go
@@ -488,7 +488,7 @@ func (c *Cluster) Process(pl ProberListener) {
 		pl.OnSendProbe(bytesShortFall)
 	}
 
-	// LK-TODO look at adapting sleep time based on how many bytes and how much time is left
+	// STREAM-ALLOCATOR-TODO look at adapting sleep time based on how many bytes and how much time is left
 }
 
 func (c *Cluster) String() string {

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -79,8 +79,8 @@ func getProbeMax(value int64) int64 {
 		if idx == 0 {
 			ratio = pmr.Ratio
 		} else {
-			ratio = float64(value - ProbeMaxRatio[idx-1].Upper) / float64(pmr.Upper - ProbeMaxRatio[idx-1].Upper)
-			ratio = ratio * pmr.Ratio + (1.0 - ratio) * ProbeMaxRatio[idx-1].Ratio
+			ratio = float64(value-ProbeMaxRatio[idx-1].Upper) / float64(pmr.Upper-ProbeMaxRatio[idx-1].Upper)
+			ratio = ratio*pmr.Ratio + (1.0-ratio)*ProbeMaxRatio[idx-1].Ratio
 		}
 		break
 	}
@@ -1210,7 +1210,7 @@ func (s *StreamAllocator) initProbe(probeRateBps int64) {
 		)
 	}
 
-	maxProbeRateBps := getProbeMax(s.committedChannelCapacity)
+	maxProbeRateBps := getProbeMax(int64(math.Max(float64(s.committedChannelCapacity), float64(expectedBandwidthUsage))))
 	if probeRateBps > maxProbeRateBps {
 		probeRateBps = maxProbeRateBps
 	}
@@ -1237,6 +1237,10 @@ func (s *StreamAllocator) initProbe(probeRateBps int64) {
 	// current expected bandwidth usage, i. e. when that condition triggers, the committed channel capacity
 	// is set to a certain % of the previous expected bandwidth usage and then a re-allocation done.
 	// That re-allocation will push the expected lower than committed.
+	//
+	// Another case of this is a probe succeeding, but the resulting channel capacity is not enough to
+	// boost a deficient track. It would take one or more probe clusters starting at the committed channel
+	// caacity and going up before deficient tracks could be boosted.
 	//
 	// STREAM-ALLOCATOR-TODO: See note above about possibly skipping probe when expected usage is
 	// (much) higher than committed chnanle capacity.

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -45,7 +45,7 @@ const (
 	FlagAllowOvershootWhileDeficient            = false
 	FlagAllowOvershootExemptTrackWhileDeficient = true
 	FlagAllowOvershootInProbe                   = true
-	FlagAllowOvershootInCatchup                 = true
+	FlagAllowOvershootInCatchup                 = false
 )
 
 // ---------------------------------------------------------------------------
@@ -55,7 +55,7 @@ var (
 		Name:                           "probe",
 		EstimateRequiredSamples:        3,
 		EstimateDownwardTrendThreshold: 0.0,
-		EstimateCollapseValues:         false,
+		EstimateCollapseThreshold:      0,
 		NackWindowMinDuration:          500 * time.Millisecond,
 		NackWindowMaxDuration:          1 * time.Second,
 		NackRatioThreshold:             0.04,
@@ -65,7 +65,7 @@ var (
 		Name:                           "non-probe",
 		EstimateRequiredSamples:        8,
 		EstimateDownwardTrendThreshold: -0.5,
-		EstimateCollapseValues:         true,
+		EstimateCollapseThreshold:      500 * time.Millisecond,
 		NackWindowMinDuration:          1 * time.Second,
 		NackWindowMaxDuration:          2 * time.Second,
 		NackRatioThreshold:             0.08,

--- a/pkg/sfu/streamallocator/trenddetector.go
+++ b/pkg/sfu/streamallocator/trenddetector.go
@@ -37,7 +37,7 @@ type TrendDetectorParams struct {
 	Logger                 logger.Logger
 	RequiredSamples        int
 	DownwardTrendThreshold float64
-	CollapseValues         bool
+	CollapseThreshold      time.Duration
 }
 
 type TrendDetector struct {
@@ -48,6 +48,9 @@ type TrendDetector struct {
 	values       []int64
 	lowestValue  int64
 	highestValue int64
+
+	hasFallen    bool
+	lastSampleAt time.Time
 
 	direction TrendDirection
 }
@@ -66,6 +69,8 @@ func (t *TrendDetector) Seed(value int64) {
 	}
 
 	t.values = append(t.values, value)
+	t.lastSampleAt = time.Now()
+	t.hasFallen = false
 }
 
 func (t *TrendDetector) AddValue(value int64) {
@@ -77,10 +82,28 @@ func (t *TrendDetector) AddValue(value int64) {
 		t.highestValue = value
 	}
 
-	// ignore duplicate values
-	if t.params.CollapseValues && len(t.values) != 0 && t.values[len(t.values)-1] == value {
-		return
+	// Ignore duplicate values in collapse window.
+	//
+	// Bandwidth estimate is received periodically. If the estimate does not change, it will be repeated.
+	// When there is congestion, there are several estimates received with decreasing values.
+	//
+	// Using a sliding window, collapsing repeated values and waiting for falling trend is to ensure that
+	// the reaction is not too fast, i. e. reacting to falling values too quick could mean a lot of re-allocation
+	// resulting in layer switches, key frames and more congestion.
+	//
+	// But, on the flip side, estimate could fall once or twice withing a sliding window and stay there.
+	// In those cases, using a collapse window to record value even if it is duplicate. By doing that,
+	// a trend could be detected eventually. If will be delayed, but that is fine with slow changing estimates.
+	if len(t.values) != 0 && t.values[len(t.values)-1] == value && t.params.CollapseThreshold > 0 {
+		if !t.hasFallen || (!t.lastSampleAt.IsZero() && time.Since(t.lastSampleAt) < t.params.CollapseThreshold) {
+			return
+		}
 	}
+
+	if len(t.values) != 0 && t.values[len(t.values)-1] > value {
+		t.hasFallen = true
+	}
+	t.lastSampleAt = time.Now()
 
 	if len(t.values) == t.params.RequiredSamples {
 		t.values = t.values[1:]

--- a/pkg/sfu/streamallocator/trenddetector.go
+++ b/pkg/sfu/streamallocator/trenddetector.go
@@ -94,13 +94,17 @@ func (t *TrendDetector) AddValue(value int64) {
 	// But, on the flip side, estimate could fall once or twice withing a sliding window and stay there.
 	// In those cases, using a collapse window to record value even if it is duplicate. By doing that,
 	// a trend could be detected eventually. If will be delayed, but that is fine with slow changing estimates.
-	if len(t.values) != 0 && t.values[len(t.values)-1] == value && t.params.CollapseThreshold > 0 {
+	lastValue := int64(0)
+	if len(t.values) != 0 {
+		lastValue = t.values[len(t.values)-1]
+	}
+	if lastValue == value && t.params.CollapseThreshold > 0 {
 		if !t.hasFallen || (!t.lastSampleAt.IsZero() && time.Since(t.lastSampleAt) < t.params.CollapseThreshold) {
 			return
 		}
 	}
 
-	if len(t.values) != 0 && t.values[len(t.values)-1] > value {
+	if lastValue > value {
 		t.hasFallen = true
 	}
 	t.lastSampleAt = time.Now()


### PR DESCRIPTION
- Do not overshoot on catch up. It so happens that during probe
  the next higher layer is at some bit rate which is much lower
  than normal bit rate for that layer. But, by the time the probe
  ends, publisher has climbed up to normal bit rate.
  So, the probe goal although achieved is not enough.
  Allowing overshoot latches on the next layer which might be more
  than the channel capacity.
- Use a collapse window to record values in case of a only one
  or two changes in an evaluation window. Some times it happens
  that the estimate falls once or twice and stays there. By collapsing
  repeated values, it could be a long time before that fall in estimate
  is processed. Introduce a collapse window and record duplicate value
  if a value was not recorded for collapse window duration. This allows
  delayed processing of those isolated falls in estimate.
- Some other clean up.