### PR TITLE
Don't close rtcpreader if downtrack will be resumed

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -836,7 +836,7 @@ func (d *DownTrack) CloseWithFlush(flush bool) {
 		d.logger.Debugw("closing sender", "kind", d.kind)
 		d.receiver.DeleteDownTrack(d.subscriberID)
 
-		if d.rtcpReader != nil {
+		if d.rtcpReader != nil && flush {
 			d.logger.Debugw("downtrack close rtcp reader")
 			d.rtcpReader.Close()
 			d.rtcpReader.OnPacket(nil)


### PR DESCRIPTION
If a downtrack close without flush (that means it will be resumed), we should not close the rtcp reader for it. Since the pion will continue holds the original rtcp reader in srtcp stream and write packets to it, if we close the old downtrack and rtcp reader, the resumed downtrack will create a new rtcp reader but can't get any packets from it