### PR TITLE
Run quality scorer when there are no streams.

### DIFF
--- a/pkg/sfu/connectionquality/connectionstats.go
+++ b/pkg/sfu/connectionquality/connectionstats.go
@@ -190,6 +190,7 @@ func (cs *ConnectionStats) getStat(at time.Time) {
 	streams := cs.params.GetDeltaStats()
 	if len(streams) == 0 {
 		if cs.isTooLongSinceLastStats() {
+			cs.updateLastStatsAt(at)
 			cs.updateScore(streams, at)
 		}
 		cs.clearInProcess()

--- a/pkg/sfu/connectionquality/connectionstats.go
+++ b/pkg/sfu/connectionquality/connectionstats.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	UpdateInterval   = 5 * time.Second
-	processThreshold = 0.95
+	UpdateInterval           = 5 * time.Second
+	processThreshold         = 0.95
+	noStatsTooLongMultiplier = 2
 )
 
 type ConnectionStatsParams struct {
@@ -158,6 +159,17 @@ func (cs *ConnectionStats) updateLastStatsAt(at time.Time) {
 	cs.lastStatsAt = at
 }
 
+func (cs *ConnectionStats) isTooLongSinceLastStats() bool {
+	cs.lock.Lock()
+	defer cs.lock.Unlock()
+
+	interval := cs.params.UpdateInterval
+	if interval == 0 {
+		interval = UpdateInterval
+	}
+	return !cs.lastStatsAt.IsZero() && time.Since(cs.lastStatsAt) > interval*noStatsTooLongMultiplier
+}
+
 func (cs *ConnectionStats) clearInProcess() {
 	cs.lock.Lock()
 	defer cs.lock.Unlock()
@@ -177,6 +189,9 @@ func (cs *ConnectionStats) getStat(at time.Time) {
 
 	streams := cs.params.GetDeltaStats()
 	if len(streams) == 0 {
+		if cs.isTooLongSinceLastStats() {
+			cs.updateScore(streams, at)
+		}
 		cs.clearInProcess()
 		return
 	}

--- a/pkg/sfu/connectionquality/scorer.go
+++ b/pkg/sfu/connectionquality/scorer.go
@@ -363,6 +363,10 @@ func (q *qualityScorer) getPacketLossWeight(stat *windowStat) float64 {
 		q.maxPPS = pps
 	}
 
+	if q.maxPPS == 0 {
+		return q.params.PacketLossWeight
+	}
+
 	return math.Sqrt(pps/q.maxPPS) * q.params.PacketLossWeight
 }
 


### PR DESCRIPTION
In the down stream direction, receiver report is used for scoring. If there are no receiver reports, it should go to `dry` state and report poor quality.

Update scorer on dry condition only when update score has not happened for longer than some multiple of update interval. Cannot update on every interval when there are no streams as receiver report might be just missed. Waiting for longer to ensure that report is definitely not received.