### PR TITLE
Ensure that RR is not received for a while before running scorer on nil

### DIFF
--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -869,7 +869,7 @@ func (r *RTPStats) DeltaInfo(snapshotId uint32) *RTPDeltaInfo {
 	}
 	if packetsExpected == 0 {
 		if r.params.IsReceiverReportDriven {
-			// not received RTCP RR
+			// not received RTCP RR (OR) publisher is not producing any data
 			return nil
 		}
 


### PR DESCRIPTION
data.

Without the check, it was getting tripped by publisher not publishing any data. Both conditions returned nil, but in one case, the receiver report should have been received, but no movement in number of packets.