### PR TITLE
Avoid divide-by-zero and NaN

### DIFF
--- a/pkg/sfu/connectionquality/scorer.go
+++ b/pkg/sfu/connectionquality/scorer.go
@@ -349,7 +349,7 @@ func (q *qualityScorer) isLayerMuted() bool {
 }
 
 func (q *qualityScorer) getPacketLossWeight(stat *windowStat) float64 {
-	if stat == nil {
+	if stat == nil || stat.duration == 0 {
 		return q.params.PacketLossWeight
 	}
 


### PR DESCRIPTION
Does not affect functionality as the usage of this returned value happens only when the scoring window has data, but just cleaning it up.