### PR TITLE
DownTrack scoring when RR is not received.

### DIFF
--- a/pkg/sfu/connectionquality/scorer.go
+++ b/pkg/sfu/connectionquality/scorer.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	MaxMOS = float32(4.5)
+	MinMOS = float32(1.0)
 
 	maxScore  = float64(100.0)
 	poorScore = float64(30.0)
@@ -242,6 +243,8 @@ func (q *qualityScorer) Update(stat *windowStat, at time.Time) {
 	expectedBitrate := q.getExpectedBitsAndUpdateTransitions(at)
 	expectedDistance := q.getExpectedDistanceAndUpdateTransitions(at)
 
+	q.params.Logger.Debugw("incoming stat", "stat", stat, "isMuted", q.isMuted(), "isUnmuted", q.isUnmutedEnough(at), "layerMuted", q.isLayerMuted()) // REMOVE
+
 	// nothing to do when muted or not unmuted for long enough
 	// NOTE: it is possible that unmute -> mute -> unmute transition happens in the
 	//       same analysis window. On a transition to mute, state immediately moves
@@ -362,6 +365,7 @@ func (q *qualityScorer) getPacketLossWeight(stat *windowStat) float64 {
 	pps := float64(stat.packetsExpected) / stat.duration.Seconds()
 	if pps > q.maxPPS {
 		q.maxPPS = pps
+		q.params.Logger.Debugw("updating maxPPS", "expected", stat.packetsExpected, "duration", stat.duration.Seconds(), "pps", pps)
 	}
 
 	if q.maxPPS == 0 {

--- a/pkg/sfu/connectionquality/scorer.go
+++ b/pkg/sfu/connectionquality/scorer.go
@@ -243,8 +243,6 @@ func (q *qualityScorer) Update(stat *windowStat, at time.Time) {
 	expectedBitrate := q.getExpectedBitsAndUpdateTransitions(at)
 	expectedDistance := q.getExpectedDistanceAndUpdateTransitions(at)
 
-	q.params.Logger.Debugw("incoming stat", "stat", stat, "isMuted", q.isMuted(), "isUnmuted", q.isUnmutedEnough(at), "layerMuted", q.isLayerMuted()) // REMOVE
-
 	// nothing to do when muted or not unmuted for long enough
 	// NOTE: it is possible that unmute -> mute -> unmute transition happens in the
 	//       same analysis window. On a transition to mute, state immediately moves

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -107,9 +107,10 @@ var (
 // -------------------------------------------------------------------
 
 type DownTrackState struct {
-	RTPStats             *buffer.RTPStats
-	DeltaStatsSnapshotId uint32
-	ForwarderState       ForwarderState
+	RTPStats                       *buffer.RTPStats
+	DeltaStatsSnapshotId           uint32
+	DeltaStatsOverriddenSnapshotId uint32
+	ForwarderState                 ForwarderState
 }
 
 func (d DownTrackState) String() string {
@@ -216,8 +217,9 @@ type DownTrack struct {
 
 	blankFramesGeneration atomic.Uint32
 
-	connectionStats      *connectionquality.ConnectionStats
-	deltaStatsSnapshotId uint32
+	connectionStats                *connectionquality.ConnectionStats
+	deltaStatsSnapshotId           uint32
+	deltaStatsOverriddenSnapshotId uint32
 
 	// for throttling error logs
 	writeIOErrors atomic.Uint32
@@ -281,25 +283,28 @@ func NewDownTrack(
 		}
 	})
 
-	d.connectionStats = connectionquality.NewConnectionStats(connectionquality.ConnectionStatsParams{
-		MimeType:          codecs[0].MimeType, // LK-TODO have to notify on codec change
-		IsFECEnabled:      strings.EqualFold(codecs[0].MimeType, webrtc.MimeTypeOpus) && strings.Contains(strings.ToLower(codecs[0].SDPFmtpLine), "fec"),
-		IsDependentJitter: true,
-		GetDeltaStats:     d.getDeltaStats,
-		Logger:            d.logger.WithValues("direction", "down"),
-	})
-	d.connectionStats.OnStatsUpdate(func(_cs *connectionquality.ConnectionStats, stat *livekit.AnalyticsStat) {
-		if d.onStatsUpdate != nil {
-			d.onStatsUpdate(d, stat)
-		}
-	})
-
 	d.rtpStats = buffer.NewRTPStats(buffer.RTPStatsParams{
 		ClockRate:              d.codec.ClockRate,
 		IsReceiverReportDriven: true,
 		Logger:                 d.logger,
 	})
 	d.deltaStatsSnapshotId = d.rtpStats.NewSnapshotId()
+	d.deltaStatsOverriddenSnapshotId = d.rtpStats.NewSnapshotId()
+
+	d.connectionStats = connectionquality.NewConnectionStats(connectionquality.ConnectionStatsParams{
+		MimeType:                  codecs[0].MimeType, // LK-TODO have to notify on codec change
+		IsFECEnabled:              strings.EqualFold(codecs[0].MimeType, webrtc.MimeTypeOpus) && strings.Contains(strings.ToLower(codecs[0].SDPFmtpLine), "fec"),
+		IsDependentJitter:         true,
+		GetDeltaStats:             d.getDeltaStats,
+		GetDeltaStatsOverridden:   d.getDeltaStatsOverridden,
+		GetLastReceiverReportTime: func() time.Time { return d.rtpStats.LastReceiverReport() },
+		Logger:                    d.logger.WithValues("direction", "down"),
+	})
+	d.connectionStats.OnStatsUpdate(func(_cs *connectionquality.ConnectionStats, stat *livekit.AnalyticsStat) {
+		if d.onStatsUpdate != nil {
+			d.onStatsUpdate(d, stat)
+		}
+	})
 
 	return d, nil
 }
@@ -851,7 +856,8 @@ func (d *DownTrack) CloseWithFlush(flush bool) {
 		d.logger.Debugw("closing sender", "kind", d.kind)
 		d.receiver.DeleteDownTrack(d.subscriberID)
 
-		if d.rtcpReader != nil && flush {
+		// RAJA-RESTORE if d.rtcpReader != nil && flush {
+		if d.rtcpReader != nil {
 			d.logger.Debugw("downtrack close rtcp reader")
 			d.rtcpReader.Close()
 			d.rtcpReader.OnPacket(nil)
@@ -913,16 +919,19 @@ func (d *DownTrack) MaxLayer() buffer.VideoLayer {
 }
 
 func (d *DownTrack) GetState() DownTrackState {
-	return DownTrackState{
-		RTPStats:             d.rtpStats,
-		DeltaStatsSnapshotId: d.deltaStatsSnapshotId,
-		ForwarderState:       d.forwarder.GetState(),
+	dts := DownTrackState{
+		RTPStats:                       d.rtpStats,
+		DeltaStatsSnapshotId:           d.deltaStatsSnapshotId,
+		DeltaStatsOverriddenSnapshotId: d.deltaStatsOverriddenSnapshotId,
+		ForwarderState:                 d.forwarder.GetState(),
 	}
+	return dts
 }
 
 func (d *DownTrack) SeedState(state DownTrackState) {
 	d.rtpStats.Seed(state.RTPStats)
 	d.deltaStatsSnapshotId = state.DeltaStatsSnapshotId
+	d.deltaStatsOverriddenSnapshotId = state.DeltaStatsOverriddenSnapshotId
 	d.forwarder.SeedState(state.ForwarderState)
 }
 
@@ -1341,8 +1350,6 @@ func (d *DownTrack) handleRTCP(bytes []byte) {
 					l(d, rr)
 				}
 				d.listenerLock.RUnlock()
-
-				d.connectionStats.ReceiverReportReceived(time.Now())
 			}
 
 		case *rtcp.TransportLayerNack:
@@ -1626,22 +1633,28 @@ func (d *DownTrack) GetTrackStats() *livekit.RTPStats {
 	return d.rtpStats.ToProto()
 }
 
-func (d *DownTrack) getDeltaStats() map[uint32]*buffer.StreamStatsWithLayers {
-	streamStats := make(map[uint32]*buffer.StreamStatsWithLayers, 1)
-
-	deltaStats := d.rtpStats.DeltaInfo(d.deltaStatsSnapshotId)
-	if deltaStats == nil {
+func (d *DownTrack) deltaStats(ds *buffer.RTPDeltaInfo) map[uint32]*buffer.StreamStatsWithLayers {
+	if ds == nil {
 		return nil
 	}
 
+	streamStats := make(map[uint32]*buffer.StreamStatsWithLayers, 1)
 	streamStats[d.ssrc] = &buffer.StreamStatsWithLayers{
-		RTPStats: deltaStats,
+		RTPStats: ds,
 		Layers: map[int32]*buffer.RTPDeltaInfo{
-			0: deltaStats,
+			0: ds,
 		},
 	}
 
 	return streamStats
+}
+
+func (d *DownTrack) getDeltaStats() map[uint32]*buffer.StreamStatsWithLayers {
+	return d.deltaStats(d.rtpStats.DeltaInfo(d.deltaStatsSnapshotId))
+}
+
+func (d *DownTrack) getDeltaStatsOverridden() map[uint32]*buffer.StreamStatsWithLayers {
+	return d.deltaStats(d.rtpStats.DeltaInfoOverridden(d.deltaStatsOverriddenSnapshotId))
 }
 
 func (d *DownTrack) GetNackStats() (totalPackets uint32, totalRepeatedNACKs uint32) {

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -856,8 +856,7 @@ func (d *DownTrack) CloseWithFlush(flush bool) {
 		d.logger.Debugw("closing sender", "kind", d.kind)
 		d.receiver.DeleteDownTrack(d.subscriberID)
 
-		// RAJA-RESTORE if d.rtcpReader != nil && flush {
-		if d.rtcpReader != nil {
+		if d.rtcpReader != nil && flush {
 			d.logger.Debugw("downtrack close rtcp reader")
 			d.rtcpReader.Close()
 			d.rtcpReader.OnPacket(nil)


### PR DESCRIPTION
Got more complicated than I would like, but the main challenge is distinguishing between publisher traffic stopping vs subscriber not sendint RTCP Receiver Report.

Split out the send and receiver report snapshot on down track. This is directionally okay. As we want to report what we are sending to analytics. Till now, what is reported to analytics also depended on what was reported in receiver report.

Once that is split out, can check for streaming.
If publisher has run dry, we will not be sending anything.

If we are sending data, then look for long interval without receiver report and treat it like no report and score it poor. Scoring runs on receiver report based snap shot purely.

Also, increase the no receiver report interval to 30 seconds to give enough headroom.