### PR TITLE
Experimental flag to try time stamp adjustment to control drift.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -107,6 +107,9 @@ type RTCConfig struct {
 
 	// force a reconnect on a subscription error
 	ReconnectOnSubscriptionError *bool `yaml:"reconnect_on_subscription_error,omitempty"`
+
+	// allow time stamp adjust to keep drift low, this is experimental
+	AllowTimestampAdjustment *bool `yaml:"allow_timestamp_adjustment,omitempty"`
 }
 
 type TURNServer struct {

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -104,6 +104,7 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 		sub.GetBufferFactory(),
 		subscriberID,
 		t.params.ReceiverConfig.PacketBufferSize,
+		sub.GetAllowTimestampAdjustment(),
 		LoggerWithTrack(sub.GetLogger(), trackID, t.params.IsRelayed),
 	)
 	if err != nil {

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -92,6 +92,7 @@ type ParticipantParams struct {
 	SubscriberAllowPause         bool
 	SubscriptionLimitAudio       int32
 	SubscriptionLimitVideo       int32
+	AllowTimestampAdjustment     bool
 }
 
 type ParticipantImpl struct {
@@ -226,6 +227,10 @@ func (p *ParticipantImpl) GetLogger() logger.Logger {
 
 func (p *ParticipantImpl) GetAdaptiveStream() bool {
 	return p.params.AdaptiveStream
+}
+
+func (p *ParticipantImpl) GetAllowTimestampAdjustment() bool {
+	return p.params.AllowTimestampAdjustment
 }
 
 func (p *ParticipantImpl) ID() livekit.ParticipantID {

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -341,6 +341,8 @@ type LocalParticipant interface {
 	// down stream bandwidth management
 	SetSubscriberAllowPause(allowPause bool)
 	SetSubscriberChannelCapacity(channelCapacity int64)
+
+	GetAllowTimestampAdjustment() bool
 }
 
 // Room is a container of participants, and can provide room-level actions

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -165,6 +165,16 @@ type FakeLocalParticipant struct {
 	getAdaptiveStreamReturnsOnCall map[int]struct {
 		result1 bool
 	}
+	GetAllowTimestampAdjustmentStub        func() bool
+	getAllowTimestampAdjustmentMutex       sync.RWMutex
+	getAllowTimestampAdjustmentArgsForCall []struct {
+	}
+	getAllowTimestampAdjustmentReturns struct {
+		result1 bool
+	}
+	getAllowTimestampAdjustmentReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	GetAudioLevelStub        func() (float64, bool)
 	getAudioLevelMutex       sync.RWMutex
 	getAudioLevelArgsForCall []struct {
@@ -1608,6 +1618,59 @@ func (fake *FakeLocalParticipant) GetAdaptiveStreamReturnsOnCall(i int, result1 
 		})
 	}
 	fake.getAdaptiveStreamReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeLocalParticipant) GetAllowTimestampAdjustment() bool {
+	fake.getAllowTimestampAdjustmentMutex.Lock()
+	ret, specificReturn := fake.getAllowTimestampAdjustmentReturnsOnCall[len(fake.getAllowTimestampAdjustmentArgsForCall)]
+	fake.getAllowTimestampAdjustmentArgsForCall = append(fake.getAllowTimestampAdjustmentArgsForCall, struct {
+	}{})
+	stub := fake.GetAllowTimestampAdjustmentStub
+	fakeReturns := fake.getAllowTimestampAdjustmentReturns
+	fake.recordInvocation("GetAllowTimestampAdjustment", []interface{}{})
+	fake.getAllowTimestampAdjustmentMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLocalParticipant) GetAllowTimestampAdjustmentCallCount() int {
+	fake.getAllowTimestampAdjustmentMutex.RLock()
+	defer fake.getAllowTimestampAdjustmentMutex.RUnlock()
+	return len(fake.getAllowTimestampAdjustmentArgsForCall)
+}
+
+func (fake *FakeLocalParticipant) GetAllowTimestampAdjustmentCalls(stub func() bool) {
+	fake.getAllowTimestampAdjustmentMutex.Lock()
+	defer fake.getAllowTimestampAdjustmentMutex.Unlock()
+	fake.GetAllowTimestampAdjustmentStub = stub
+}
+
+func (fake *FakeLocalParticipant) GetAllowTimestampAdjustmentReturns(result1 bool) {
+	fake.getAllowTimestampAdjustmentMutex.Lock()
+	defer fake.getAllowTimestampAdjustmentMutex.Unlock()
+	fake.GetAllowTimestampAdjustmentStub = nil
+	fake.getAllowTimestampAdjustmentReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeLocalParticipant) GetAllowTimestampAdjustmentReturnsOnCall(i int, result1 bool) {
+	fake.getAllowTimestampAdjustmentMutex.Lock()
+	defer fake.getAllowTimestampAdjustmentMutex.Unlock()
+	fake.GetAllowTimestampAdjustmentStub = nil
+	if fake.getAllowTimestampAdjustmentReturnsOnCall == nil {
+		fake.getAllowTimestampAdjustmentReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.getAllowTimestampAdjustmentReturnsOnCall[i] = struct {
 		result1 bool
 	}{result1}
 }
@@ -5456,6 +5519,8 @@ func (fake *FakeLocalParticipant) Invocations() map[string][][]interface{} {
 	defer fake.debugInfoMutex.RUnlock()
 	fake.getAdaptiveStreamMutex.RLock()
 	defer fake.getAdaptiveStreamMutex.RUnlock()
+	fake.getAllowTimestampAdjustmentMutex.RLock()
+	defer fake.getAllowTimestampAdjustmentMutex.RUnlock()
 	fake.getAudioLevelMutex.RLock()
 	defer fake.getAudioLevelMutex.RUnlock()
 	fake.getBufferFactoryMutex.RLock()

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -309,6 +309,11 @@ func (r *RoomManager) StartSession(
 	if pi.SubscriberAllowPause != nil {
 		subscriberAllowPause = *pi.SubscriberAllowPause
 	}
+	// default do not allow timestamp adjustment
+	allowTimestampAdjustment := false
+	if r.config.RTC.AllowTimestampAdjustment != nil {
+		allowTimestampAdjustment = *r.config.RTC.AllowTimestampAdjustment
+	}
 	participant, err = rtc.NewParticipant(rtc.ParticipantParams{
 		Identity:                pi.Identity,
 		Name:                    pi.Name,
@@ -343,6 +348,7 @@ func (r *RoomManager) StartSession(
 		SubscriberAllowPause:         subscriberAllowPause,
 		SubscriptionLimitAudio:       r.config.Limit.SubscriptionLimitAudio,
 		SubscriptionLimitVideo:       r.config.Limit.SubscriptionLimitVideo,
+		AllowTimestampAdjustment:     allowTimestampAdjustment,
 	})
 	if err != nil {
 		return err

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -738,37 +738,35 @@ func (r *RTPStats) SetRtcpSenderReportData(srData *RTCPSenderReportData) {
 	}
 
 	// TODO-REMOVE-AFTER-DEBUG-START
-	if r.params.ClockRate != 90000 { // log only for audio as it is less frequent
-		ntpTime := srData.NTPTimestamp.Time()
+	ntpTime := srData.NTPTimestamp.Time()
 
-		var ntpDiffSinceLast, arrivalDiffSinceLast time.Duration
-		var rtpDiffSinceLast uint32
-		if r.srData != nil {
-			ntpDiffSinceLast = ntpTime.Sub(r.srData.NTPTimestamp.Time())
-			rtpDiffSinceLast = srData.RTPTimestamp - r.srData.RTPTimestamp
-			arrivalDiffSinceLast = srData.ArrivalTime.Sub(r.srData.ArrivalTime)
-		}
-
-		timeSinceFirst := time.Since(r.firstTime) // ideally should use NTP time from SR, but that is a different time base, now is a resonable approximation
-		rtpDiffSinceFirst := getExtTS(srData.RTPTimestamp, r.tsCycles) - r.extStartTS
-		drift := int64(uint64(timeSinceFirst.Nanoseconds()*int64(r.params.ClockRate)/1e9) - rtpDiffSinceFirst)
-		driftMs := (float64(drift) * 1000) / float64(r.params.ClockRate)
-
-		r.logger.Debugw(
-			"received sender report",
-			"ntp", ntpTime,
-			"rtp", srData.RTPTimestamp,
-			"arrival", srData.ArrivalTime,
-			"ntpDiff", ntpDiffSinceLast,
-			"rtpDiff", rtpDiffSinceLast,
-			"arrivalDiff", arrivalDiffSinceLast,
-			"expectedTimeDiff", float64(rtpDiffSinceLast)/float64(r.params.ClockRate),
-			"timeSinceFirst", timeSinceFirst,
-			"rtpDiffSinceFirst", rtpDiffSinceFirst,
-			"drift", drift,
-			"driftMs", driftMs,
-		)
+	var ntpDiffSinceLast, arrivalDiffSinceLast time.Duration
+	var rtpDiffSinceLast uint32
+	if r.srData != nil {
+		ntpDiffSinceLast = ntpTime.Sub(r.srData.NTPTimestamp.Time())
+		rtpDiffSinceLast = srData.RTPTimestamp - r.srData.RTPTimestamp
+		arrivalDiffSinceLast = srData.ArrivalTime.Sub(r.srData.ArrivalTime)
 	}
+
+	timeSinceFirst := time.Since(r.firstTime) // ideally should use NTP time from SR, but that is a different time base, now is a resonable approximation
+	rtpDiffSinceFirst := getExtTS(srData.RTPTimestamp, r.tsCycles) - r.extStartTS
+	drift := int64(uint64(timeSinceFirst.Nanoseconds()*int64(r.params.ClockRate)/1e9) - rtpDiffSinceFirst)
+	driftMs := (float64(drift) * 1000) / float64(r.params.ClockRate)
+
+	r.logger.Debugw(
+		"received sender report",
+		"ntp", ntpTime,
+		"rtp", srData.RTPTimestamp,
+		"arrival", srData.ArrivalTime,
+		"ntpDiff", ntpDiffSinceLast,
+		"rtpDiff", rtpDiffSinceLast,
+		"arrivalDiff", arrivalDiffSinceLast,
+		"expectedTimeDiff", float64(rtpDiffSinceLast)/float64(r.params.ClockRate),
+		"timeSinceFirst", timeSinceFirst,
+		"rtpDiffSinceFirst", rtpDiffSinceFirst,
+		"drift", drift,
+		"driftMs", driftMs,
+	)
 	// TODO-REMOVE-AFTER-DEBUG-END
 
 	srDataCopy := *srData

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -177,7 +177,6 @@ type RTPStats struct {
 	srData        *RTCPSenderReportData
 	lastSRTime    time.Time
 	lastSRNTP     mediatransportutil.NtpTime
-	lastSRRTP     uint32
 	pidController *PIDController
 
 	nextSnapshotId uint32
@@ -285,7 +284,6 @@ func (r *RTPStats) Seed(from *RTPStats) {
 	}
 	r.lastSRTime = from.lastSRTime
 	r.lastSRNTP = from.lastSRNTP
-	r.lastSRRTP = from.lastSRRTP
 
 	r.nextSnapshotId = from.nextSnapshotId
 	for id, ss := range from.snapshots {
@@ -892,7 +890,6 @@ func (r *RTPStats) GetRtcpSenderReport(ssrc uint32) (*rtcp.SenderReport, float64
 
 	r.lastSRTime = now
 	r.lastSRNTP = nowNTP
-	r.lastSRRTP = nowRTP
 
 	return &rtcp.SenderReport{
 		SSRC:        ssrc,

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -174,21 +174,29 @@ type RTPStats struct {
 	rtt    uint32
 	maxRtt uint32
 
-	srData     *RTCPSenderReportData
-	lastSRTime time.Time
-	lastSRNTP  mediatransportutil.NtpTime
+	srData        *RTCPSenderReportData
+	lastSRTime    time.Time
+	lastSRNTP     mediatransportutil.NtpTime
+	lastSRRTP     uint32
+	pidController *PIDController
 
 	nextSnapshotId uint32
 	snapshots      map[uint32]*Snapshot
 }
 
 func NewRTPStats(params RTPStatsParams) *RTPStats {
-	return &RTPStats{
+	r := &RTPStats{
 		params:         params,
 		logger:         params.Logger,
 		nextSnapshotId: FirstSnapshotId,
 		snapshots:      make(map[uint32]*Snapshot),
+		pidController:  NewPIDController(),
 	}
+
+	r.pidController.SetGains(2.0, 0.5, 0.25)
+	r.pidController.SetDerivativeLPF(0.02)
+	r.pidController.SetOutputLimits(-0.025*float64(params.ClockRate), 0.025*float64(params.ClockRate))
+	return r
 }
 
 func (r *RTPStats) Seed(from *RTPStats) {
@@ -277,6 +285,7 @@ func (r *RTPStats) Seed(from *RTPStats) {
 	}
 	r.lastSRTime = from.lastSRTime
 	r.lastSRNTP = from.lastSRNTP
+	r.lastSRRTP = from.lastSRRTP
 
 	r.nextSnapshotId = from.nextSnapshotId
 	for id, ss := range from.snapshots {
@@ -742,7 +751,7 @@ func (r *RTPStats) SetRtcpSenderReportData(srData *RTCPSenderReportData) {
 			arrivalDiffSinceLast = srData.ArrivalTime.Sub(r.srData.ArrivalTime)
 		}
 
-		timeSinceFirst := srData.NTPTimestamp.Time().Sub(r.firstTime)
+		timeSinceFirst := time.Since(r.firstTime) // ideally should use NTP time from SR, but that is a different time base, now is a resonable approximation
 		rtpDiffSinceFirst := getExtTS(srData.RTPTimestamp, r.tsCycles) - r.extStartTS
 		drift := int64(uint64(timeSinceFirst.Nanoseconds()*int64(r.params.ClockRate)/1e9) - rtpDiffSinceFirst)
 		driftMs := (float64(drift) * 1000) / float64(r.params.ClockRate)
@@ -806,12 +815,12 @@ func (r *RTPStats) GetExpectedRTPTimestamp(at time.Time) (uint32, error) {
 	return uint32(expectedExtRTP), nil
 }
 
-func (r *RTPStats) GetRtcpSenderReport(ssrc uint32) *rtcp.SenderReport {
+func (r *RTPStats) GetRtcpSenderReport(ssrc uint32) (*rtcp.SenderReport, float64) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
 	if !r.initialized {
-		return nil
+		return nil, 0.0
 	}
 
 	// construct current time based on monotonic clock
@@ -837,14 +846,29 @@ func (r *RTPStats) GetRtcpSenderReport(ssrc uint32) *rtcp.SenderReport {
 	nowRTP := r.highestTS + uint32(timeSinceHighest.Nanoseconds()*int64(r.params.ClockRate)/1e9)
 
 	// TODO-REMOVE-AFTER-DEBUG-START
+	timeSinceFirst = nowNTP.Time().Sub(r.firstTime)
+	rtpDiffSinceFirst := getExtTS(nowRTP, r.tsCycles) - r.extStartTS
+	measurement := float64(rtpDiffSinceFirst) / timeSinceFirst.Seconds()
+	pidOutput := r.pidController.Update(
+		float64(r.params.ClockRate),
+		measurement,
+		now,
+	)
+	r.logger.Debugw(
+		"pid controller output",
+		"measurement", measurement,
+		"errorTerm", float64(r.params.ClockRate)-measurement,
+		"pidOutput", pidOutput,
+	)
+	// TODO-REMOVE-AFTER-DEBUG-STOP
+
+	// TODO-REMOVE-AFTER-DEBUG-START
 	ntpTime := nowNTP.Time()
 
 	ntpDiffLocal := ntpTime.Sub(r.highestTime)
 	rtpDiffLocal := int32(nowRTP - r.highestTS)
 	rtpOffsetLocal := int32(nowRTP - r.highestTS - uint32(ntpDiffLocal.Nanoseconds()*int64(r.params.ClockRate)/1e9))
 
-	timeSinceFirst = nowNTP.Time().Sub(r.firstTime)
-	rtpDiffSinceFirst := getExtTS(nowRTP, r.tsCycles) - r.extStartTS
 	drift := int64(uint64(timeSinceFirst.Nanoseconds()*int64(r.params.ClockRate)/1e9) - rtpDiffSinceFirst)
 	driftMs := (float64(drift) * 1000) / float64(r.params.ClockRate)
 
@@ -853,6 +877,7 @@ func (r *RTPStats) GetRtcpSenderReport(ssrc uint32) *rtcp.SenderReport {
 		"highestTS", r.highestTS,
 		"highestTime", r.highestTime.String(),
 		"reportTS", nowRTP,
+		"expectedTS", uint32(expectedExtRTP),
 		"reportTime", ntpTime.String(),
 		"rtpDiffLocal", rtpDiffLocal,
 		"ntpDiffLocal", ntpDiffLocal,
@@ -861,11 +886,13 @@ func (r *RTPStats) GetRtcpSenderReport(ssrc uint32) *rtcp.SenderReport {
 		"rtpDiffSinceFirst", rtpDiffSinceFirst,
 		"drift", drift,
 		"driftMs", driftMs,
+		"rate", measurement,
 	)
 	// TODO-REMOVE-AFTER-DEBUG-END
 
 	r.lastSRTime = now
 	r.lastSRNTP = nowNTP
+	r.lastSRRTP = nowRTP
 
 	return &rtcp.SenderReport{
 		SSRC:        ssrc,
@@ -873,7 +900,7 @@ func (r *RTPStats) GetRtcpSenderReport(ssrc uint32) *rtcp.SenderReport {
 		RTPTime:     nowRTP,
 		PacketCount: r.getTotalPacketsPrimary() + r.packetsDuplicate + r.packetsPadding,
 		OctetCount:  uint32(r.bytes + r.bytesDuplicate + r.bytesPadding),
-	}
+	}, pidOutput
 }
 
 func (r *RTPStats) SnapshotRtcpReceptionReport(ssrc uint32, proxyFracLost uint8, snapshotId uint32) *rtcp.ReceptionReport {
@@ -1747,3 +1774,90 @@ func AggregateRTPDeltaInfo(deltaInfoList []*RTPDeltaInfo) *RTPDeltaInfo {
 		Firs:                 firs,
 	}
 }
+
+// -------------------------------------------------------------------
+
+type PIDController struct {
+	kp, ki, kd float64
+
+	tau float64 // low pass filter of D, time constant
+
+	outMin, outMax float64
+	isOutLimitsSet bool
+
+	iMin, iMax   float64
+	isILimitsSet bool
+
+	iVal, dVal float64
+
+	prevError, prevMeasurement float64
+	prevMeasurementTime        time.Time
+}
+
+func NewPIDController() *PIDController {
+	return &PIDController{}
+}
+
+func (p *PIDController) SetGains(kp, ki, kd float64) {
+	p.kp = kp
+	p.ki = ki
+	p.kd = kd
+}
+
+func (p *PIDController) SetDerivativeLPF(tau float64) {
+	p.tau = tau
+}
+
+func (p *PIDController) SetOutputLimits(min, max float64) {
+	p.outMin = min
+	p.outMax = max
+	p.isOutLimitsSet = true
+}
+
+func (p *PIDController) SetIntegralLimits(min, max float64) {
+	p.iMin = min
+	p.iMax = max
+	p.isILimitsSet = true
+}
+
+func (p *PIDController) Update(setpoint, measurement float64, at time.Time) float64 {
+	diff := setpoint - measurement
+	if p.prevMeasurementTime.IsZero() {
+		p.prevError = diff
+		p.prevMeasurement = measurement
+		p.prevMeasurementTime = at
+		return 0
+	}
+
+	proportional := p.kp * diff
+
+	duration := at.Sub(p.prevMeasurementTime).Seconds()
+	p.iVal = p.iVal + (0.5 * p.ki * duration * (diff + p.prevError))
+	if p.isILimitsSet {
+		if p.iVal > p.iMax {
+			p.iVal = p.iMax
+		}
+		if p.iVal < p.iMin {
+			p.iVal = p.iMin
+		}
+	}
+
+	p.dVal = (-2.0 * p.kd * (measurement - p.prevMeasurement)) + (((2.0*p.tau - duration) * p.dVal) / (2.0*p.tau + duration))
+
+	output := proportional + p.iVal + p.dVal
+	if p.isOutLimitsSet {
+		if output > p.outMax {
+			output = p.outMax
+		}
+		if output < p.outMin {
+			output = p.outMin
+		}
+	}
+
+	p.prevError = diff
+	p.prevMeasurement = measurement
+	p.prevMeasurementTime = at
+	return output
+}
+
+// -------------------------------------------------------------------

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1630,6 +1630,13 @@ func (f *Forwarder) GetRTPMungerParams() RTPMungerParams {
 	return f.rtpMunger.GetParams()
 }
 
+func (f *Forwarder) AdjustTimestamp(tsAdjust float64) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	f.rtpMunger.UpdateTsOffset(uint32(tsAdjust))
+}
+
 // -----------------------------------------------------------------------------
 
 func getOptimalBandwidthNeeded(muted bool, pubMuted bool, maxPublishedLayer int32, brs Bitrates, maxLayer buffer.VideoLayer) int64 {


### PR DESCRIPTION
There is a config to enable this.

Using a PID controller to try and keep the sample rate at expected value. Need to be seen if this works well. Adjustment are limited to 25 ms max at a time to ensure there are no large jumps. And it is applied when doing RTCP sender report which happens once in 5 seconds currently for both audio and video tracks.

A nice introduction to PID controllers - https://alphaville.github.io/qub/pid-101/#/ 
Implementation borrowed from - https://github.com/pms67/PID

A few things TODO
1. PID controller tuning is a process. Have picked values from test from that implementation above. May not be the best. Need to try.
2. Can potentially run this more often. Rather than running it only when running RTCP sender report (which is once in 5 seconds now), can potentially run it every second and limit the amount of change to something like 10 ms max.