### PR TITLE
More scoring tweaks

### DIFF
--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -1896,18 +1896,20 @@ func (p *PIDController) Update(setpoint, measurement float64, at time.Time) floa
 	p.prevError = errorTerm
 	p.prevMeasurement = measurement
 	p.prevMeasurementTime = at
-	p.logger.Debugw(
-		"pid controller",
-		"setpoint", setpoint,
-		"measurement", measurement,
-		"errorTerm", errorTerm,
-		"proportional", proportional,
-		"integral", iVal,
-		"integralLimited", boundIVal,
-		"derivative", p.dVal,
-		"output", output,
-		"outputLimited", boundOutput,
-	)
+	/*
+		p.logger.Debugw(
+			"pid controller",
+			"setpoint", setpoint,
+			"measurement", measurement,
+			"errorTerm", errorTerm,
+			"proportional", proportional,
+			"integral", iVal,
+			"integralLimited", boundIVal,
+			"derivative", p.dVal,
+			"output", output,
+			"outputLimited", boundOutput,
+		)
+	*/
 	return boundOutput
 }
 

--- a/pkg/sfu/connectionquality/connectionstats.go
+++ b/pkg/sfu/connectionquality/connectionstats.go
@@ -25,8 +25,8 @@ type ConnectionStatsParams struct {
 	UpdateInterval            time.Duration
 	MimeType                  string
 	IsFECEnabled              bool
-	IsDependentRTT            bool
-	IsDependentJitter         bool
+	IncludeRTT                bool
+	IncludeJitter             bool
 	GetDeltaStats             func() map[uint32]*buffer.StreamStatsWithLayers
 	GetDeltaStatsOverridden   func() map[uint32]*buffer.StreamStatsWithLayers
 	GetLastReceiverReportTime func() time.Time
@@ -53,10 +53,10 @@ func NewConnectionStats(params ConnectionStatsParams) *ConnectionStats {
 	return &ConnectionStats{
 		params: params,
 		scorer: newQualityScorer(qualityScorerParams{
-			PacketLossWeight:  getPacketLossWeight(params.MimeType, params.IsFECEnabled), // LK-TODO: have to notify codec change?
-			IsDependentRTT:    params.IsDependentRTT,
-			IsDependentJitter: params.IsDependentJitter,
-			Logger:            params.Logger,
+			PacketLossWeight: getPacketLossWeight(params.MimeType, params.IsFECEnabled), // LK-TODO: have to notify codec change?
+			IncludeRTT:       params.IncludeRTT,
+			IncludeJitter:    params.IncludeJitter,
+			Logger:           params.Logger,
 		}),
 		done: core.NewFuse(),
 	}
@@ -293,10 +293,10 @@ func getPacketLossWeight(mimeType string, isFecEnabled bool) float64 {
 		}
 
 	case strings.EqualFold(mimeType, "audio/red"):
-		// 6.66%: fall to GOOD, 20.0%: fall to POOR
-		plw = 3.0
+		// 10%: fall to GOOD, 30.0%: fall to POOR
+		plw = 2.0
 		if isFecEnabled {
-			// 10%: fall to GOOD, 30.0%: fall to POOR
+			// 15%: fall to GOOD, 45.0%: fall to POOR
 			plw /= 1.5
 		}
 

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -303,7 +303,6 @@ func NewDownTrack(
 	d.connectionStats = connectionquality.NewConnectionStats(connectionquality.ConnectionStatsParams{
 		MimeType:                  codecs[0].MimeType, // LK-TODO have to notify on codec change
 		IsFECEnabled:              strings.EqualFold(codecs[0].MimeType, webrtc.MimeTypeOpus) && strings.Contains(strings.ToLower(codecs[0].SDPFmtpLine), "fec"),
-		IsDependentJitter:         true,
 		GetDeltaStats:             d.getDeltaStats,
 		GetDeltaStatsOverridden:   d.getDeltaStatsOverridden,
 		GetLastReceiverReportTime: func() time.Time { return d.rtpStats.LastReceiverReport() },

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -203,11 +203,10 @@ func NewWebRTCReceiver(
 	})
 
 	w.connectionStats = connectionquality.NewConnectionStats(connectionquality.ConnectionStatsParams{
-		MimeType:       w.codec.MimeType,
-		IsFECEnabled:   strings.EqualFold(w.codec.MimeType, webrtc.MimeTypeOpus) && strings.Contains(strings.ToLower(w.codec.SDPFmtpLine), "fec"),
-		IsDependentRTT: true,
-		GetDeltaStats:  w.getDeltaStats,
-		Logger:         w.logger.WithValues("direction", "up"),
+		MimeType:      w.codec.MimeType,
+		IsFECEnabled:  strings.EqualFold(w.codec.MimeType, webrtc.MimeTypeOpus) && strings.Contains(strings.ToLower(w.codec.SDPFmtpLine), "fec"),
+		GetDeltaStats: w.getDeltaStats,
+		Logger:        w.logger.WithValues("direction", "up"),
 	})
 	w.connectionStats.OnStatsUpdate(func(_cs *connectionquality.ConnectionStats, stat *livekit.AnalyticsStat) {
 		if w.onStatsUpdate != nil {


### PR DESCRIPTION
1. Completely removing RTT and jitter from score calculation. Need to do more work there.
    a) Jitter is slow moving (RFC 3550 formula is designed that way). But, we still get high values at times. Ideally, that should penalise the score, but due to jitter buffer, effect may not be too bad.
    b) Need to smooth RTT. It is based on receiver report and if one sample causes a high number, score could be penalised (this was being used in down track direction only). One option is to smooth it like the jitter formula above and try using it. But, for now, disabling that also.
    Having done this, high RTT and jitter are indicators of lesser quality, but it has been hard to get it all right to satisfy everybody and not confuse people.

2. When receiving lesser number of packets (for example DTX), reduce the weight of packet loss with a quadratic relationship to packet loss ratio. Previously, was using a square root and it was potentially weighting it too high. For example, if only 5 packets were received due to DTX instead of 50, we were still giving 30% weight (sqrt(0.1)). Now, it gets 1% weight. So, if one of those 5 packets were lost (20% packet loss ratio), it still does not get much weight as the number of packets is low.,

3. Slightly slower decrease when score is moving down (in EWMA).

4. When using RED, increase packet loss weight thresholds to be able to take more loss before penalising score.