### PR TITLE
Disable active TCP

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -1484,8 +1484,7 @@ func (t *PCTransport) handleLocalICECandidate(e *event) error {
 			t.params.Logger.Debugw("filtering out local candidate", "candidate", cstr)
 			t.filteredLocalCandidates = append(t.filteredLocalCandidates, cstr)
 			filtered = true
-		}
-		if c.Protocol == webrtc.ICEProtocolTCP && c.TCPType == ice.TCPTypeActive.String() {
+		} else if c.Protocol == webrtc.ICEProtocolTCP && c.TCPType == ice.TCPTypeActive.String() {
 			// SFU should not support TCP active candidates. clients should connect to us
 			filtered = true
 		}


### PR DESCRIPTION
Active TCP was added in pion/ice v2.3.4. This is causing a couple of issues for us.

1. Active TCP does not make sense for an SFU. Clients are expected to be behind NAT and we should not be dialing them. Instead, LiveKit exposes a TCP port so clients could dial in
2. Active TCP is causing all iOS clients to become disconnected immediately. This is impacting all version of libwebrtc-based iOS clients (tested from M104 to M111)