### PR TITLE
Filter another expected error.

### DIFF
--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -518,7 +518,7 @@ func (r *RTPStats) UpdateFromReceiverReport(rr rtcp.ReceptionReport) (rtt uint32
 	if err == nil {
 		isRttChanged = rtt != r.rtt
 	} else {
-		if !errors.Is(err, mediatransportutil.ErrRttNotLastSenderReport) {
+		if !errors.Is(err, mediatransportutil.ErrRttNotLastSenderReport) && !errors.Is(err, mediatransportutil.ErrRttNoLastSenderReport) {
 			r.logger.Warnw("error getting rtt", err)
 		}
 	}


### PR DESCRIPTION
Actually, was not filtering the not last sender report error before. Previous PR did that. This PR restores the old no last sender report filter. Both are filterable errors.