### PR TITLE
Adjust sender report time stamp for slow publishers.

### DIFF
--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/livekit/protocol/logger"
 
 	"github.com/livekit/livekit-server/pkg/sfu"
+	"github.com/livekit/livekit-server/pkg/sfu/buffer"
 )
 
 // wrapper around WebRTC receiver, overriding its ID
@@ -286,6 +287,13 @@ func (d *DummyReceiver) GetPrimaryReceiverForRed() sfu.TrackReceiver {
 
 func (d *DummyReceiver) GetRedReceiver() sfu.TrackReceiver {
 	return d
+}
+
+func (d *DummyReceiver) GetRTCPSenderReportData(layer int32) (*buffer.RTCPSenderReportData, *buffer.RTCPSenderReportData) {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+		return r.GetRTCPSenderReportData(layer)
+	}
+	return nil, nil
 }
 
 func (d *DummyReceiver) GetReferenceLayerRTPTimestamp(ts uint32, layer int32, referenceLayer int32) (uint32, error) {

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -654,7 +654,7 @@ func (b *Buffer) SetSenderReportData(rtpTime uint32, ntpTime uint64) {
 	srData := &RTCPSenderReportData{
 		RTPTimestamp: rtpTime,
 		NTPTimestamp: mediatransportutil.NtpTime(ntpTime),
-		ArrivalTime:  time.Now(),
+		At:           time.Now(),
 	}
 
 	b.RLock()
@@ -668,7 +668,7 @@ func (b *Buffer) SetSenderReportData(rtpTime uint32, ntpTime uint64) {
 	}
 }
 
-func (b *Buffer) GetSenderReportData() *RTCPSenderReportData {
+func (b *Buffer) GetSenderReportData() (*RTCPSenderReportData, *RTCPSenderReportData) {
 	b.RLock()
 	defer b.RUnlock()
 
@@ -676,7 +676,7 @@ func (b *Buffer) GetSenderReportData() *RTCPSenderReportData {
 		return b.rtpStats.GetRtcpSenderReportData()
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (b *Buffer) SetLastFractionLostReport(lost uint8) {

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -1116,7 +1116,8 @@ func (d *DownTrack) CreateSenderReport() *rtcp.SenderReport {
 		return nil
 	}
 
-	sr, tsAdjust := d.rtpStats.GetRtcpSenderReport(d.ssrc)
+	srFirst, srNewest := d.receiver.GetRTCPSenderReportData(d.forwarder.GetReferenceLayerSpatial())
+	sr, tsAdjust := d.rtpStats.GetRtcpSenderReport(d.ssrc, srFirst, srNewest)
 	if d.allowTimestampAdjustment {
 		d.forwarder.AdjustTimestamp(tsAdjust)
 	}
@@ -1636,7 +1637,7 @@ func (d *DownTrack) DebugInfo() map[string]interface{} {
 	}
 }
 
-func (d *DownTrack) getExpectedRTPTimestamp(at time.Time) (uint32, uint32, error) {
+func (d *DownTrack) getExpectedRTPTimestamp(at time.Time) (uint32, uint64, error) {
 	return d.rtpStats.GetExpectedRTPTimestamp(at)
 }
 

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -65,6 +65,7 @@ type TrackReceiver interface {
 
 	GetTemporalLayerFpsForSpatial(layer int32) []float32
 
+	GetRTCPSenderReportData(layer int32) (*buffer.RTCPSenderReportData, *buffer.RTCPSenderReportData)
 	GetReferenceLayerRTPTimestamp(ts uint32, layer int32, referenceLayer int32) (uint32, error)
 }
 
@@ -309,7 +310,8 @@ func (w *WebRTCReceiver) AddUpTrack(track *webrtc.TrackRemote, buff *buffer.Buff
 	})
 	buff.OnRtcpFeedback(w.sendRTCP)
 	buff.OnRtcpSenderReport(func(srData *buffer.RTCPSenderReportData) {
-		w.streamTrackerManager.SetRTCPSenderReportData(layer, buff.GetSenderReportData())
+		srFirst, srNewest := buff.GetSenderReportData()
+		w.streamTrackerManager.SetRTCPSenderReportData(layer, srFirst, srNewest)
 
 		w.downTrackSpreader.Broadcast(func(dt TrackSender) {
 			_ = dt.HandleRTCPSenderReportData(w.codec.PayloadType, layer, srData)
@@ -742,6 +744,10 @@ func (w *WebRTCReceiver) GetTemporalLayerFpsForSpatial(layer int32) []float32 {
 	}
 
 	return b.GetTemporalLayerFpsForSpatial(layer)
+}
+
+func (w *WebRTCReceiver) GetRTCPSenderReportData(layer int32) (*buffer.RTCPSenderReportData, *buffer.RTCPSenderReportData) {
+	return w.streamTrackerManager.GetRTCPSenderReportData(layer)
 }
 
 func (w *WebRTCReceiver) GetReferenceLayerRTPTimestamp(ts uint32, layer int32, referenceLayer int32) (uint32, error) {


### PR DESCRIPTION
It is possible that publisher paces the media.
So, RTCP sender report from publisher could be ahead of what is being fowarded by a good amount (have seen up to 2 seconds ahead). Using the forwarded time stamp for RTCP sender report in the down stream leads to jumps back and forth in the down track RTCP sender report.

So, look at the publisher's RTCP sender report to check for it being ahead and use the publisher rate as a guide.