### PR TITLE
Return max spatial layer from selectors.

### DIFF
--- a/pkg/rtc/room_test.go
+++ b/pkg/rtc/room_test.go
@@ -140,7 +140,9 @@ func TestRoomJoin(t *testing.T) {
 
 	t.Run("cannot exceed max participants", func(t *testing.T) {
 		rm := newRoomWithParticipants(t, testRoomOpts{num: 1})
+		rm.lock.Lock()
 		rm.protoRoom.MaxParticipants = 1
+		rm.lock.Unlock()
 		p := newMockParticipant("second", types.ProtocolVersion(0), false, false)
 
 		err := rm.Join(p, nil, nil, iceServersForRoom)
@@ -347,8 +349,10 @@ func TestRoomClosure(t *testing.T) {
 			isClosed = true
 		})
 		p := rm.GetParticipants()[0]
+		rm.lock.Lock()
 		// allows immediate close after
 		rm.protoRoom.EmptyTimeout = 0
+		rm.lock.Unlock()
 		rm.RemoveParticipant(p.Identity(), p.ID(), types.ParticipantCloseReasonClientRequestLeave)
 
 		time.Sleep(time.Duration(RoomDepartureGrace)*time.Second + defaultDelay)
@@ -377,7 +381,9 @@ func TestRoomClosure(t *testing.T) {
 		rm.OnClose(func() {
 			isClosed = true
 		})
+		rm.lock.Lock()
 		rm.protoRoom.EmptyTimeout = 1
+		rm.lock.Unlock()
 
 		time.Sleep(1010 * time.Millisecond)
 		rm.CloseIfEmpty()

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -624,7 +624,7 @@ func (d *DownTrack) WriteRTP(extPkt *buffer.ExtPacket, layer int32) error {
 	d.bytesSent.Add(uint32(hdr.MarshalSize() + len(payload)))
 
 	if tp.isSwitchingToMaxSpatial && d.onMaxSubscribedLayerChanged != nil && d.kind == webrtc.RTPCodecTypeVideo {
-		d.onMaxSubscribedLayerChanged(d, d.forwarder.MaxLayer().Spatial)
+		d.onMaxSubscribedLayerChanged(d, tp.maxSpatialLayer)
 	}
 
 	if extPkt.KeyFrame {

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -129,6 +129,7 @@ type TranslationParams struct {
 	isResuming                  bool
 	isSwitchingToRequestSpatial bool
 	isSwitchingToMaxSpatial     bool
+	maxSpatialLayer             int32
 	rtp                         *TranslationParamsRTP
 	codecBytes                  []byte
 	ddBytes                     []byte
@@ -1570,6 +1571,7 @@ func (f *Forwarder) getTranslationParamsVideo(extPkt *buffer.ExtPacket, layer in
 	tp.isResuming = result.IsResuming
 	tp.isSwitchingToRequestSpatial = result.IsSwitchingToRequestSpatial
 	tp.isSwitchingToMaxSpatial = result.IsSwitchingToMaxSpatial
+	tp.maxSpatialLayer = result.MaxSpatialLayer
 	tp.ddBytes = result.DependencyDescriptorExtension
 	tp.marker = result.RTPMarker
 

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -1717,6 +1717,7 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 	require.NoError(t, err)
 	expectedTP = TranslationParams{
 		isSwitchingToMaxSpatial: true,
+		maxSpatialLayer:         1,
 		rtp: &TranslationParamsRTP{
 			snOrdering:     SequenceNumberOrderingContiguous,
 			sequenceNumber: 23339,

--- a/pkg/sfu/videolayerselector/dependencydescriptor.go
+++ b/pkg/sfu/videolayerselector/dependencydescriptor.go
@@ -230,6 +230,7 @@ func (d *DependencyDescriptor) Select(extPkt *buffer.ExtPacket, _layer int32) (r
 		}
 		if d.currentLayer.Spatial == d.maxLayer.Spatial {
 			result.IsSwitchingToMaxSpatial = true
+			result.MaxSpatialLayer = d.currentLayer.Spatial
 			d.logger.Infow(
 				"reached max layer",
 				"current", d.currentLayer,

--- a/pkg/sfu/videolayerselector/simulcast.go
+++ b/pkg/sfu/videolayerselector/simulcast.go
@@ -98,6 +98,7 @@ func (s *Simulcast) Select(extPkt *buffer.ExtPacket, layer int32) (result VideoL
 
 			if s.currentLayer.Spatial >= s.maxLayer.Spatial {
 				result.IsSwitchingToMaxSpatial = true
+				result.MaxSpatialLayer = s.currentLayer.Spatial
 				s.logger.Infow(
 					"reached max layer",
 					"current", s.currentLayer,
@@ -136,6 +137,7 @@ func (s *Simulcast) Select(extPkt *buffer.ExtPacket, layer int32) (result VideoL
 
 		if s.currentLayer.Spatial >= s.maxLayer.Spatial {
 			result.IsSwitchingToMaxSpatial = true
+			result.MaxSpatialLayer = s.currentLayer.Spatial
 		}
 
 		if s.currentLayer.Spatial >= s.maxLayer.Spatial || s.currentLayer.Spatial == s.maxSeenLayer.Spatial {

--- a/pkg/sfu/videolayerselector/videolayerselector.go
+++ b/pkg/sfu/videolayerselector/videolayerselector.go
@@ -11,6 +11,7 @@ type VideoLayerSelectorResult struct {
 	IsResuming                    bool
 	IsSwitchingToRequestSpatial   bool
 	IsSwitchingToMaxSpatial       bool
+	MaxSpatialLayer               int32
 	RTPMarker                     bool
 	DependencyDescriptorExtension []byte
 }

--- a/pkg/sfu/videolayerselector/vp9.go
+++ b/pkg/sfu/videolayerselector/vp9.go
@@ -85,6 +85,7 @@ func (v *VP9) Select(extPkt *buffer.ExtPacket, _layer int32) (result VideoLayerS
 
 			if v.currentLayer.Spatial != v.maxLayer.Spatial && updatedLayer.Spatial == v.maxLayer.Spatial {
 				result.IsSwitchingToMaxSpatial = true
+				result.MaxSpatialLayer = updatedLayer.Spatial
 				v.logger.Infow(
 					"reached max layer",
 					"current", v.currentLayer,


### PR DESCRIPTION
With differing requirements of SVC and allowing overshoot in Simulcast, selectors are best placed to indicate what is the max spatial layer when they indicate a switch to max spatial layer.