### PR TITLE
Ignore receiver reports that have a sequence number before first packet.

### DIFF
--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -540,6 +540,8 @@ func (r *RTPStats) UpdateFromReceiverReport(rr rtcp.ReceptionReport) (rtt uint32
 	defer r.lock.Unlock()
 
 	if !r.endTime.IsZero() || !r.params.IsReceiverReportDriven || rr.LastSequenceNumber < r.extStartSN {
+		// it is possible that the `LastSequenceNumber` in the receiver report is before the starting
+		// sequence number when dummy packets are used to trigger Pion's OnTrack path.
 		return
 	}
 

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -539,7 +539,7 @@ func (r *RTPStats) UpdateFromReceiverReport(rr rtcp.ReceptionReport) (rtt uint32
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	if !r.endTime.IsZero() || !r.params.IsReceiverReportDriven {
+	if !r.endTime.IsZero() || !r.params.IsReceiverReportDriven || rr.LastSequenceNumber < r.extStartSN {
 		return
 	}
 
@@ -1107,7 +1107,7 @@ func (r *RTPStats) DeltaInfoOverridden(snapshotId uint32) *RTPDeltaInfo {
 	packetsExpected := now.extStartSNOverridden - then.extStartSNOverridden
 	if packetsExpected > NumSequenceNumbers {
 		r.logger.Warnw(
-			"too many packets expected in delta",
+			"too many packets expected in delta (overridden)",
 			fmt.Errorf("start: %d, end: %d, expected: %d", then.extStartSNOverridden, now.extStartSNOverridden, packetsExpected),
 		)
 		return nil
@@ -1558,7 +1558,7 @@ func (r *RTPStats) updateGapHistogram(gap int) {
 }
 
 func (r *RTPStats) getAndResetSnapshot(snapshotId uint32, override bool) (*Snapshot, *Snapshot) {
-	if !r.initialized || (r.params.IsReceiverReportDriven && r.lastRRTime.IsZero()) {
+	if !r.initialized || (override && r.lastRRTime.IsZero()) {
 		return nil, nil
 	}
 
@@ -1573,7 +1573,7 @@ func (r *RTPStats) getAndResetSnapshot(snapshotId uint32, override bool) (*Snaps
 	}
 
 	var startTime time.Time
-	if override && r.params.IsReceiverReportDriven {
+	if override {
 		startTime = r.lastRRTime
 	} else {
 		startTime = time.Now()

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1649,7 +1649,7 @@ func (f *Forwarder) maybeStart() {
 	f.firstTS = extPkt.Packet.Timestamp
 }
 
-func (f *Forwarder) GetSnTsForPadding(num int) ([]SnTs, error) {
+func (f *Forwarder) GetSnTsForPadding(num int, forceMarker bool) ([]SnTs, error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -1660,7 +1660,6 @@ func (f *Forwarder) GetSnTsForPadding(num int) ([]SnTs, error) {
 	// not get out-of-sync. But, when a stream is paused,
 	// force a frame marker as a restart of the stream will
 	// start with a key frame which will reset the decoder.
-	forceMarker := false
 	if !f.vls.GetTarget().IsValid() {
 		forceMarker = true
 	}

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -1770,7 +1770,7 @@ func TestForwardGetSnTsForPadding(t *testing.T) {
 	disable(f)
 
 	// should get back frame end needed as the last packet did not have RTP marker set
-	snts, err := f.GetSnTsForPadding(5)
+	snts, err := f.GetSnTsForPadding(5, false)
 	require.NoError(t, err)
 
 	numPadding := 5
@@ -1786,7 +1786,7 @@ func TestForwardGetSnTsForPadding(t *testing.T) {
 	require.Equal(t, sntsExpected, snts)
 
 	// now that there is a marker, timestamp should jump on first padding when asked again
-	snts, err = f.GetSnTsForPadding(numPadding)
+	snts, err = f.GetSnTsForPadding(numPadding, false)
 	require.NoError(t, err)
 
 	for i := 0; i < numPadding; i++ {

--- a/pkg/sfu/streamallocator/track.go
+++ b/pkg/sfu/streamallocator/track.go
@@ -135,7 +135,7 @@ func (t *Track) SetMaxLayer(layer buffer.VideoLayer) bool {
 }
 
 func (t *Track) WritePaddingRTP(bytesToSend int) int {
-	return t.downTrack.WritePaddingRTP(bytesToSend, false)
+	return t.downTrack.WritePaddingRTP(bytesToSend, false, false)
 }
 
 func (t *Track) AllocateOptimal(allowOvershoot bool) sfu.VideoAllocation {


### PR DESCRIPTION
When using Go SDK client, SFU sends padding/blank frames at the start so that Pion can detect track and fire OnTrack. Those packats are not recorded in RTPStats by design. But, a receiver report could have the sequence number from the padding/blank frames. Using that to take snap shots has trouble because of sequence numbers moving back. Prevent that by ignoring receiver report with sequence number  before start sequence number.

There are cases where a sequence number of 1 is received. Not sure what is causing that exactly. Need more data to debug.

Also passing in `forceMarker` from the padding path. Cannot rely on checking target layer as it could be set to valid with opportunistic forwarding when we want to sent padding initially.