### PR TITLE
Fix node stats updates on Windows

### DIFF
--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof"
+	"runtime"
 	"runtime/pprof"
 	"time"
 
@@ -217,6 +218,9 @@ func (s *LivekitServer) Start() error {
 		values = append(values, "region", s.config.Region)
 	}
 	logger.Infow("starting LiveKit server", values...)
+	if runtime.GOOS == "windows" {
+		logger.Infow("Windows detected, capacity management is unavailable")
+	}
 
 	for _, promLn := range promListeners {
 		go s.promServer.Serve(promLn)

--- a/pkg/telemetry/prometheus/node.go
+++ b/pkg/telemetry/prometheus/node.go
@@ -3,7 +3,6 @@ package prometheus
 import (
 	"time"
 
-	"github.com/mackerelio/go-osstat/loadavg"
 	"github.com/mackerelio/go-osstat/memory"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
@@ -100,7 +99,7 @@ func Init(nodeID string, nodeType livekit.NodeType, env string) {
 }
 
 func GetUpdatedNodeStats(prev *livekit.NodeStats, prevAverage *livekit.NodeStats) (*livekit.NodeStats, bool, error) {
-	loadAvg, err := loadavg.Get()
+	loadAvg, err := getLoadAvg()
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/telemetry/prometheus/node_linux.go
+++ b/pkg/telemetry/prometheus/node_linux.go
@@ -5,36 +5,9 @@ package prometheus
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/florianl/go-tc"
-	"github.com/mackerelio/go-osstat/cpu"
 )
-
-var (
-	cpuStatsLock              sync.RWMutex
-	lastCPUTotal, lastCPUIdle uint64
-)
-
-func getCPUStats() (cpuLoad float32, numCPUs uint32, err error) {
-	cpuInfo, err := cpu.Get()
-	if err != nil {
-		return
-	}
-
-	cpuStatsLock.Lock()
-	if lastCPUTotal > 0 && lastCPUTotal < cpuInfo.Total {
-		cpuLoad = 1 - float32(cpuInfo.Idle-lastCPUIdle)/float32(cpuInfo.Total-lastCPUTotal)
-	}
-
-	lastCPUTotal = cpuInfo.Total
-	lastCPUIdle = cpuInfo.Idle // + cpu.Iowait
-	cpuStatsLock.Unlock()
-
-	numCPUs = uint32(cpuInfo.CPUCount)
-
-	return
-}
 
 func getTCStats() (packets, drops uint32, err error) {
 	rtnl, err := tc.Open(&tc.Config{})

--- a/pkg/telemetry/prometheus/node_nonlinux.go
+++ b/pkg/telemetry/prometheus/node_nonlinux.go
@@ -2,38 +2,6 @@
 
 package prometheus
 
-import (
-	"runtime"
-	"sync"
-
-	"github.com/mackerelio/go-osstat/cpu"
-)
-
-var (
-	cpuStatsLock              sync.RWMutex
-	lastCPUTotal, lastCPUIdle uint64
-)
-
-func getCPUStats() (cpuLoad float32, numCPUs uint32, err error) {
-	cpuInfo, err := cpu.Get()
-	if err != nil {
-		return
-	}
-
-	cpuStatsLock.Lock()
-	if lastCPUTotal > 0 && lastCPUTotal < cpuInfo.Total {
-		cpuLoad = 1 - float32(cpuInfo.Idle-lastCPUIdle)/float32(cpuInfo.Total-lastCPUTotal)
-	}
-
-	lastCPUTotal = cpuInfo.Total
-	lastCPUIdle = cpuInfo.Idle
-	cpuStatsLock.Unlock()
-
-	numCPUs = uint32(runtime.NumCPU())
-
-	return
-}
-
 func getTCStats() (packets, drops uint32, err error) {
 	// linux only
 	return

--- a/pkg/telemetry/prometheus/node_nonwindows.go
+++ b/pkg/telemetry/prometheus/node_nonwindows.go
@@ -1,0 +1,56 @@
+//go:build !windows
+
+/*
+ * Copyright 2023 LiveKit, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus
+
+import (
+	"runtime"
+	"sync"
+
+	"github.com/mackerelio/go-osstat/cpu"
+	"github.com/mackerelio/go-osstat/loadavg"
+)
+
+var (
+	cpuStatsLock              sync.RWMutex
+	lastCPUTotal, lastCPUIdle uint64
+)
+
+func getLoadAvg() (*loadavg.Stats, error) {
+	return loadavg.Get()
+}
+
+func getCPUStats() (cpuLoad float32, numCPUs uint32, err error) {
+	cpuInfo, err := cpu.Get()
+	if err != nil {
+		return
+	}
+
+	cpuStatsLock.Lock()
+	if lastCPUTotal > 0 && lastCPUTotal < cpuInfo.Total {
+		cpuLoad = 1 - float32(cpuInfo.Idle-lastCPUIdle)/float32(cpuInfo.Total-lastCPUTotal)
+	}
+
+	lastCPUTotal = cpuInfo.Total
+	lastCPUIdle = cpuInfo.Idle
+	cpuStatsLock.Unlock()
+
+	numCPUs = uint32(runtime.NumCPU())
+
+	return
+}

--- a/pkg/telemetry/prometheus/node_windows.go
+++ b/pkg/telemetry/prometheus/node_windows.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+/*
+ * Copyright 2023 LiveKit, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus
+
+func getLoadAvg() (*loadavg.Stats, error) {
+	return &loadavg.Stats{}, nil
+}
+
+func getCPUStats() (cpuLoad float32, numCPUs uint32, err error) {
+	return 1, 1, nil
+}

--- a/pkg/telemetry/prometheus/node_windows.go
+++ b/pkg/telemetry/prometheus/node_windows.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build windows
 
 /*
  * Copyright 2023 LiveKit, Inc


### PR DESCRIPTION
Because we aren't able to get CPU count/load info on Windows, they are stubbed out to return placeholders. This restores compatibility to run on Windows.

Closes #1175