### PR TITLE
Avoid reconnect loop for unsupported downtrack

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1
 	github.com/livekit/mediatransportutil v0.0.0-20230523035537-27577c4e1646
-	github.com/livekit/protocol v1.5.7
+	github.com/livekit/protocol v1.5.8-0.20230531030840-2a4d1a607ba3
 	github.com/livekit/psrpc v0.3.1-0.20230528083849-53d664c6d912
 	github.com/mackerelio/go-osstat v0.2.4
 	github.com/magefile/mage v1.15.0
@@ -102,5 +102,3 @@ require (
 	google.golang.org/grpc v1.55.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace github.com/livekit/protocol => ../protocol

--- a/go.mod
+++ b/go.mod
@@ -102,3 +102,5 @@ require (
 	google.golang.org/grpc v1.55.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/livekit/protocol => ../protocol

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkD
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20230523035537-27577c4e1646 h1:acGSGkWJdut7TUWozCDheHu4dwWFDqqRzv+SBbIY9Xo=
 github.com/livekit/mediatransportutil v0.0.0-20230523035537-27577c4e1646/go.mod h1:MRc0zSOSzXuFt0X218SgabzlaKevkvCckPgBEoHYc34=
-github.com/livekit/protocol v1.5.7 h1:jZeFQEmLuIhFblXDGPRCBbfjVJHb+YU7AsO+SMoXF70=
-github.com/livekit/protocol v1.5.7/go.mod h1:ZaOnsvP+JS4s7vI1UO+JVdBagvvLp/lBXDAl2hkDS0I=
+github.com/livekit/protocol v1.5.8-0.20230531030840-2a4d1a607ba3 h1:UtySLPpOMgT9D/t0MOOxHShAyQQ2WsGKrUJ0XZCJlcI=
+github.com/livekit/protocol v1.5.8-0.20230531030840-2a4d1a607ba3/go.mod h1:ZaOnsvP+JS4s7vI1UO+JVdBagvvLp/lBXDAl2hkDS0I=
 github.com/livekit/psrpc v0.3.1-0.20230528083849-53d664c6d912 h1:q6i7ptxK6yZ220eyCWx5l1ZsUMQNyuYZ5feG91sM8EI=
 github.com/livekit/psrpc v0.3.1-0.20230528083849-53d664c6d912/go.mod h1:n6JntEg+zT6Ji8InoyTpV7wusPNwGqqtxmHlkNhDN0U=
 github.com/mackerelio/go-osstat v0.2.4 h1:qxGbdPkFo65PXOb/F/nhDKpF2nGmGaCFDLXoZjJTtUs=

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -128,7 +128,11 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 	// Bind callback can happen from replaceTrack, so set it up early
 	var reusingTransceiver atomic.Bool
 	var dtState sfu.DownTrackState
-	downTrack.OnBinding(func() {
+	downTrack.OnBinding(func(err error) {
+		if err != nil {
+			go subTrack.Bound(err)
+			return
+		}
 		wr.DetermineReceiver(downTrack.Codec())
 		if reusingTransceiver.Load() {
 			downTrack.SeedState(dtState)
@@ -142,7 +146,7 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 			)
 		}
 
-		go subTrack.Bound()
+		go subTrack.Bound(nil)
 
 		subTrack.SetPublisherMuted(t.params.MediaTrack.IsMuted())
 	})

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2088,13 +2088,16 @@ func (p *ParticipantImpl) onPublicationError(trackID livekit.TrackID) {
 
 func (p *ParticipantImpl) onSubscriptionError(trackID livekit.TrackID, fatal bool, err error) {
 	signalErr := livekit.SubscriptionError_SE_UNKOWN
-	if errors.Is(err, webrtc.ErrUnsupportedCodec) {
+	switch {
+	case errors.Is(err, webrtc.ErrUnsupportedCodec):
 		signalErr = livekit.SubscriptionError_SE_CODEC_UNSUPPORTED
+	case errors.Is(err, ErrTrackNotFound):
+		signalErr = livekit.SubscriptionError_SE_TRACK_NOTFOUND
 	}
 
 	_ = p.writeMessage(&livekit.SignalResponse{
-		Message: &livekit.SignalResponse_SubscribptionResponse{
-			SubscribptionResponse: &livekit.SubscriptionResponse{
+		Message: &livekit.SignalResponse_SubscriptionResponse{
+			SubscriptionResponse: &livekit.SubscriptionResponse{
 				TrackSid: string(trackID),
 				Err:      signalErr,
 			},

--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -309,6 +309,7 @@ func (m *SubscriptionManager) reconcileSubscription(s *trackSubscription) {
 					s.logger.Infow("unsubscribing from track after notFoundTimeout", "error", err)
 					s.setDesired(false)
 					m.queueReconcile(s.trackID)
+					m.params.OnSubscriptionError(s.trackID, false, err)
 				}
 			default:
 				// all other errors

--- a/pkg/rtc/subscriptionmanager_test.go
+++ b/pkg/rtc/subscriptionmanager_test.go
@@ -54,7 +54,7 @@ func TestSubscribe(t *testing.T) {
 		sm.params.OnTrackSubscribed = func(subTrack types.SubscribedTrack) {
 			subCount.Add(1)
 		}
-		sm.params.OnSubscriptionError = func(trackID livekit.TrackID) {
+		sm.params.OnSubscriptionError = func(trackID livekit.TrackID, fatal bool, err error) {
 			failed.Store(true)
 		}
 		numParticipantSubscribed := atomic.Int32{}
@@ -123,7 +123,7 @@ func TestSubscribe(t *testing.T) {
 		resolver := newTestResolver(false, true, "pub", "pubID")
 		sm.params.TrackResolver = resolver.Resolve
 		failed := atomic.Bool{}
-		sm.params.OnSubscriptionError = func(trackID livekit.TrackID) {
+		sm.params.OnSubscriptionError = func(trackID livekit.TrackID, fatal bool, err error) {
 			failed.Store(true)
 		}
 
@@ -164,7 +164,7 @@ func TestSubscribe(t *testing.T) {
 		resolver := newTestResolver(true, true, "pub", "pubID")
 		sm.params.TrackResolver = resolver.Resolve
 		failed := atomic.Bool{}
-		sm.params.OnSubscriptionError = func(trackID livekit.TrackID) {
+		sm.params.OnSubscriptionError = func(trackID livekit.TrackID, fatal bool, err error) {
 			failed.Store(true)
 		}
 
@@ -360,7 +360,7 @@ func TestSubscriptionLimits(t *testing.T) {
 	sm.params.OnTrackSubscribed = func(subTrack types.SubscribedTrack) {
 		subCount.Add(1)
 	}
-	sm.params.OnSubscriptionError = func(trackID livekit.TrackID) {
+	sm.params.OnSubscriptionError = func(trackID livekit.TrackID, fatal bool, err error) {
 		failed.Store(true)
 	}
 	numParticipantSubscribed := atomic.Int32{}
@@ -463,7 +463,7 @@ func newTestSubscriptionManagerWithParams(t *testing.T, params testSubscriptionP
 		Logger:              logger.GetLogger(),
 		OnTrackSubscribed:   func(subTrack types.SubscribedTrack) {},
 		OnTrackUnsubscribed: func(subTrack types.SubscribedTrack) {},
-		OnSubscriptionError: func(trackID livekit.TrackID) {},
+		OnSubscriptionError: func(trackID livekit.TrackID, fatal bool, err error) {},
 		TrackResolver: func(identity livekit.ParticipantIdentity, trackID livekit.TrackID) types.MediaResolverResult {
 			return types.MediaResolverResult{}
 		},
@@ -526,7 +526,7 @@ func setTestSubscribedTrackBound(t *testing.T, st types.SubscribedTrack) {
 	require.True(t, ok)
 
 	for i := 0; i < fst.AddOnBindCallCount(); i++ {
-		fst.AddOnBindArgsForCall(i)()
+		fst.AddOnBindArgsForCall(i)(nil)
 	}
 }
 

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -427,7 +427,7 @@ type LocalMediaTrack interface {
 
 //counterfeiter:generate . SubscribedTrack
 type SubscribedTrack interface {
-	AddOnBind(f func())
+	AddOnBind(f func(error))
 	IsBound() bool
 	Close(willBeResumed bool)
 	OnClose(f func(willBeResumed bool))

--- a/pkg/rtc/types/typesfakes/fake_subscribed_track.go
+++ b/pkg/rtc/types/typesfakes/fake_subscribed_track.go
@@ -11,10 +11,10 @@ import (
 )
 
 type FakeSubscribedTrack struct {
-	AddOnBindStub        func(func())
+	AddOnBindStub        func(func(error))
 	addOnBindMutex       sync.RWMutex
 	addOnBindArgsForCall []struct {
-		arg1 func()
+		arg1 func(error)
 	}
 	CloseStub        func(bool)
 	closeMutex       sync.RWMutex
@@ -174,10 +174,10 @@ type FakeSubscribedTrack struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeSubscribedTrack) AddOnBind(arg1 func()) {
+func (fake *FakeSubscribedTrack) AddOnBind(arg1 func(error)) {
 	fake.addOnBindMutex.Lock()
 	fake.addOnBindArgsForCall = append(fake.addOnBindArgsForCall, struct {
-		arg1 func()
+		arg1 func(error)
 	}{arg1})
 	stub := fake.AddOnBindStub
 	fake.recordInvocation("AddOnBind", []interface{}{arg1})
@@ -193,13 +193,13 @@ func (fake *FakeSubscribedTrack) AddOnBindCallCount() int {
 	return len(fake.addOnBindArgsForCall)
 }
 
-func (fake *FakeSubscribedTrack) AddOnBindCalls(stub func(func())) {
+func (fake *FakeSubscribedTrack) AddOnBindCalls(stub func(func(error))) {
 	fake.addOnBindMutex.Lock()
 	defer fake.addOnBindMutex.Unlock()
 	fake.AddOnBindStub = stub
 }
 
-func (fake *FakeSubscribedTrack) AddOnBindArgsForCall(i int) func() {
+func (fake *FakeSubscribedTrack) AddOnBindArgsForCall(i int) func(error) {
 	fake.addOnBindMutex.RLock()
 	defer fake.addOnBindMutex.RUnlock()
 	argsForCall := fake.addOnBindArgsForCall[i]

--- a/test/client/client.go
+++ b/test/client/client.go
@@ -367,8 +367,8 @@ func (c *RTCClient) Run() error {
 			c.lock.Unlock()
 		case *livekit.SignalResponse_Pong:
 			c.pongReceivedAt.Store(msg.Pong)
-		case *livekit.SignalResponse_SubscribptionResponse:
-			c.subscriptionResponse.Store(msg.SubscribptionResponse)
+		case *livekit.SignalResponse_SubscriptionResponse:
+			c.subscriptionResponse.Store(msg.SubscriptionResponse)
 		}
 	}
 }

--- a/test/client/client.go
+++ b/test/client/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -61,6 +62,8 @@ type RTCClient struct {
 	// map of livekit.ParticipantID and last packet
 	lastPackets   map[livekit.ParticipantID]*rtp.Packet
 	bytesReceived map[livekit.ParticipantID]uint64
+
+	subscriptionResponse atomic.Pointer[livekit.SubscriptionResponse]
 }
 
 var (
@@ -80,9 +83,10 @@ var (
 )
 
 type Options struct {
-	AutoSubscribe bool
-	Publish       string
-	ClientInfo    *livekit.ClientInfo
+	AutoSubscribe  bool
+	Publish        string
+	ClientInfo     *livekit.ClientInfo
+	DisabledCodecs []webrtc.RTPCodecCapability
 }
 
 func NewWebSocketConn(host, token string, opts *Options) (*websocket.Conn, error) {
@@ -116,7 +120,7 @@ func SetAuthorizationToken(header http.Header, token string) {
 	header.Set("Authorization", "Bearer "+token)
 }
 
-func NewRTCClient(conn *websocket.Conn) (*RTCClient, error) {
+func NewRTCClient(conn *websocket.Conn, opts *Options) (*RTCClient, error) {
 	var err error
 
 	c := &RTCClient{
@@ -139,7 +143,8 @@ func NewRTCClient(conn *websocket.Conn) (*RTCClient, error) {
 	}
 	conf.SettingEngine.SetLite(false)
 	conf.SettingEngine.SetAnsweringDTLSRole(webrtc.DTLSRoleClient)
-	codecs := []*livekit.Codec{
+	var codecs []*livekit.Codec
+	for _, codec := range []*livekit.Codec{
 		{
 			Mime: "audio/opus",
 		},
@@ -149,7 +154,21 @@ func NewRTCClient(conn *websocket.Conn) (*RTCClient, error) {
 		{
 			Mime: "video/h264",
 		},
+	} {
+		var disabled bool
+		if opts != nil {
+			for _, dc := range opts.DisabledCodecs {
+				if strings.EqualFold(dc.MimeType, codec.Mime) && (dc.SDPFmtpLine == "" || dc.SDPFmtpLine == codec.FmtpLine) {
+					disabled = true
+					break
+				}
+			}
+		}
+		if !disabled {
+			codecs = append(codecs, codec)
+		}
 	}
+
 	//
 	// The signal targets are from point of view of server.
 	// From client side, they are flipped,
@@ -348,6 +367,8 @@ func (c *RTCClient) Run() error {
 			c.lock.Unlock()
 		case *livekit.SignalResponse_Pong:
 			c.pongReceivedAt.Store(msg.Pong)
+		case *livekit.SignalResponse_SubscribptionResponse:
+			c.subscriptionResponse.Store(msg.SubscribptionResponse)
 		}
 	}
 }
@@ -450,6 +471,10 @@ func (c *RTCClient) RefreshToken() string {
 
 func (c *RTCClient) PongReceivedAt() int64 {
 	return c.pongReceivedAt.Load()
+}
+
+func (c *RTCClient) GetSubscriptionResponseAndClear() *livekit.SubscriptionResponse {
+	return c.subscriptionResponse.Swap(nil)
 }
 
 func (c *RTCClient) SendPing() error {

--- a/test/integration_helpers.go
+++ b/test/integration_helpers.go
@@ -196,7 +196,7 @@ func createRTCClient(name string, port int, opts *testclient.Options) *testclien
 		panic(err)
 	}
 
-	c, err := testclient.NewRTCClient(ws)
+	c, err := testclient.NewRTCClient(ws, opts)
 	if err != nil {
 		panic(err)
 	}
@@ -213,7 +213,7 @@ func createRTCClientWithToken(token string, port int, opts *testclient.Options) 
 		panic(err)
 	}
 
-	c, err := testclient.NewRTCClient(ws)
+	c, err := testclient.NewRTCClient(ws, opts)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
When the client subscribes to a track which codec is unsupported by the client, sfu will trigger negotiation failed and issue a full reconnect after received client answer. If the client try to subscribe that track then it will get full reconnect again. That will cause a infinite reconnect loop until the client don't subscribe that track. This PR will unsubscribe the error track for the client and send a SubscriptionResponse that contain the reason to indicates the track's codec is not supported to avoid the reconnect loop.