### PR TITLE
Simplify probe done handling.

### DIFF
--- a/pkg/sfu/streamallocator/probe_controller.go
+++ b/pkg/sfu/streamallocator/probe_controller.go
@@ -38,8 +38,6 @@ type ProbeController struct {
 	abortedProbeClusterId ProbeClusterId
 	probeTrendObserved    bool
 	probeEndTime          time.Time
-
-	onProbeDone func(isSuccessful bool)
 }
 
 func NewProbeController(params ProbeControllerParams) *ProbeController {
@@ -49,13 +47,6 @@ func NewProbeController(params ProbeControllerParams) *ProbeController {
 
 	p.Reset()
 	return p
-}
-
-func (p *ProbeController) OnProbeDone(f func(isSuccessful bool)) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	p.onProbeDone = f
 }
 
 func (p *ProbeController) Reset() {
@@ -69,23 +60,17 @@ func (p *ProbeController) Reset() {
 	p.clearProbeLocked()
 }
 
-func (p *ProbeController) ProbeClusterDone(info ProbeClusterInfo, lowestEstimate int64) {
+func (p *ProbeController) ProbeClusterDone(info ProbeClusterInfo, lowestEstimate int64) bool {
 	p.lock.Lock()
+	defer p.lock.Unlock()
+
 	if p.probeClusterId != info.Id {
-		p.lock.Unlock()
-		return
+		return false
 	}
 
 	if p.abortedProbeClusterId == ProbeClusterIdInvalid {
 		// successful probe, finalize
-		isSuccessful := p.finalizeProbeLocked()
-		onProbeDone := p.onProbeDone
-		p.lock.Unlock()
-
-		if onProbeDone != nil {
-			onProbeDone(isSuccessful)
-		}
-		return
+		return p.finalizeProbeLocked()
 	}
 
 	// ensure probe queue is flushed
@@ -97,7 +82,7 @@ func (p *ProbeController) ProbeClusterDone(info ProbeClusterInfo, lowestEstimate
 	}
 	queueWait := time.Duration(queueTime+float64(ProbeSettleWait)) * time.Millisecond
 	p.probeEndTime = p.lastProbeStartTime.Add(queueWait)
-	p.lock.Unlock()
+	return false
 }
 
 func (p *ProbeController) CheckProbe(trend ChannelTrend, highestEstimate int64) {
@@ -139,19 +124,15 @@ func (p *ProbeController) CheckProbe(trend ChannelTrend, highestEstimate int64) 
 	}
 }
 
-func (p *ProbeController) MaybeFinalizeProbe() {
+func (p *ProbeController) MaybeFinalizeProbe() (isHandled bool, isSuccessful bool) {
 	p.lock.Lock()
-	var onProbeDone func(bool)
-	isSuccessful := false
-	if p.isInProbeLocked() && !p.probeEndTime.IsZero() && time.Now().After(p.probeEndTime) {
-		isSuccessful = p.finalizeProbeLocked()
-		onProbeDone = p.onProbeDone
-	}
-	p.lock.Unlock()
+	defer p.lock.Unlock()
 
-	if onProbeDone != nil {
-		onProbeDone(isSuccessful)
+	if p.isInProbeLocked() && (p.probeEndTime.IsZero() || time.Now().After(p.probeEndTime)) {
+		return true, p.finalizeProbeLocked()
 	}
+
+	return false, false
 }
 
 func (p *ProbeController) DoesProbeNeedFinalize() bool {

--- a/pkg/sfu/streamallocator/prober.go
+++ b/pkg/sfu/streamallocator/prober.go
@@ -175,7 +175,7 @@ func (p *Prober) Reset() {
 
 	p.clustersMu.Lock()
 	if p.activeCluster != nil {
-		p.logger.Debugw("resetting active cluster", "cluster", p.activeCluster.String())
+		p.logger.Infow("prober: resetting active cluster", "cluster", p.activeCluster.String())
 		reset = true
 		info = p.activeCluster.GetInfo()
 	}


### PR DESCRIPTION
Seeing a case where the channel observer is not re-created after an aborted probe. Simplifying probe done (no callbacks, making it synchronous). And logging some more.

Not able to see how probe done did not re-create a non-probe channel observer. Hopefully, logging will help if it happens again.