### PR TITLE
Promote switch logs to Infow.

### DIFF
--- a/pkg/sfu/streamtrackermanager.go
+++ b/pkg/sfu/streamtrackermanager.go
@@ -577,7 +577,7 @@ func (s *StreamTrackerManager) GetReferenceLayerRTPTimestamp(ts uint32, layer in
 	ntpDiff := srRef.NTPTimestamp.Time().Sub(srLayer.NTPTimestamp.Time())
 	rtpDiff := ntpDiff.Nanoseconds() * int64(s.clockRate) / 1e9
 	normalizedTS := srLayer.RTPTimestamp + uint32(rtpDiff)
-	s.logger.Debugw(
+	s.logger.Infow(
 		"getting reference timestamp",
 		"layer", layer,
 		"referenceLayer", referenceLayer,


### PR DESCRIPTION
Seeing cases of Egress having PTS move backward.
That is caused by some combination of
1. Starting with padding packets to enable Pion to fire OnTrack
2. Switching layers
3. Not having sender report for a layer when switching to that layer
4. Potentially client re-basing time stamps?

The problem happens when reference time stamp is too far ahead of last send time stamp on a switch. It is unclear how that could happen unless client is sending reports with that shift.

Enabling more logs at Infow to get a better view into the issue if and when it happens again.

Also, setting `minTS` to default of -1 in uint64 consistently.