### PR TITLE
Simulate muted audio track publish on migration.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -569,7 +569,7 @@ func (p *ParticipantImpl) handleMigrateMutedTrack() {
 		}
 
 		ti := pti.trackInfos[0]
-		if ti.Muted && ti.Type == livekit.TrackType_VIDEO {
+		if ti.Muted {
 			mt := p.addMigrateMutedTrack(cid, ti)
 			if mt != nil {
 				addedTracks = append(addedTracks, mt)


### PR DESCRIPTION
Till now only video was using simulated publish when migrating on mute. But, with `pauseUpstream() + replaceTrack(null)`, it is possible that client does not send any data when muted.

I do not think there is a problem to do this (even when client is actually using mute which sends silence frames).
When migrate info is handle (when sync state is set), muted tracks will be aded to published tracks and onTrackPublished fired. If the audio track is indeed muted (and not replaced with a null track), when silence packets are received, OnTrack will fire, but a new media track will not be added as it as was already added when handling muted track.