### PR TITLE
Small stream allocator tweaks.

### DIFF
--- a/pkg/sfu/streamallocator/probe_controller.go
+++ b/pkg/sfu/streamallocator/probe_controller.go
@@ -86,7 +86,7 @@ func (p *ProbeController) ProbeClusterDone(info ProbeClusterInfo, lowestEstimate
 	if queueWait > ProbeSettleWaitMax {
 		queueWait = ProbeSettleWaitMax
 	}
-	p.probeEndTime = p.lastProbeStartTime.Add(queueWait)
+	p.probeEndTime = p.lastProbeStartTime.Add(queueWait + info.Duration)
 	p.params.Logger.Infow(
 		"setting probe end time",
 		"probeClusterId", p.probeClusterId,


### PR DESCRIPTION
1. Probe end time needs to include the probe cluster running time also.
2. Apply collapse window only within the sliding window. This is to prevent cases of some old data declaring congestion. For example, an estimate could have fallen 15 seconds ago and there might have been a bunch of estimates at that fallen value. And the whole sliding window could have that value at some point. But, a further drop may trigger congestion detection. But, that might be acting too fast, i. e. on one instance of value fall. Change it so that we detect if there is a fall within the sliding window and apply collapse based on that.