### PR TITLE
Avoid reference in closure to reduce life span of objects.

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -1610,6 +1610,13 @@ func (t *PCTransport) setupSignalStateCheckTimer() {
 		failed := t.negotiationState != NegotiationStateNone
 
 		if t.negotiateCounter.Load() == negotiateVersion && failed {
+			t.params.Logger.Infow(
+				"negotiation timed out",
+				"localCurrent", t.pc.CurrentLocalDescription(),
+				"localPending", t.pc.PendingLocalDescription(),
+				"remoteCurrent", t.pc.CurrentRemoteDescription(),
+				"remotePending", t.pc.PendingRemoteDescription(),
+			)
 			if onNegotiationFailed := t.getOnNegotiationFailed(); onNegotiationFailed != nil {
 				onNegotiationFailed()
 			}


### PR DESCRIPTION
A subscription in subscription manager could live till the source track goes away even though the participant with that subscription is long gone due to closure on source track removal. Handle it by using trackID to look up on source track removal.

Also, logging SDPs when a negotiation failure happens to check if there are any mismatches.