### PR TITLE
Honor bind address passed as `--bind` also for RTC ports

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -211,6 +211,9 @@ func getConfig(c *cli.Context) (*config.Config, error) {
 					"::1",
 				}
 			}
+			for _, bindAddr := range conf.BindAddresses {
+				conf.RTC.IPs.Includes = append(conf.RTC.IPs.Includes, bindAddr + "/24")
+			}
 		}
 	}
 	return conf, nil

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -208,7 +208,7 @@ func getConfig(c *cli.Context) (*config.Config, error) {
 			if conf.BindAddresses == nil {
 				conf.BindAddresses = []string{
 					"127.0.0.1",
-					"[::1]",
+					"::1",
 				}
 			}
 		}

--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -10,6 +10,7 @@ import (
 	_ "net/http/pprof"
 	"runtime"
 	"runtime/pprof"
+	"strconv"
 	"time"
 
 	"github.com/pion/turn/v2"
@@ -177,14 +178,14 @@ func (s *LivekitServer) Start() error {
 	listeners := make([]net.Listener, 0)
 	promListeners := make([]net.Listener, 0)
 	for _, addr := range addresses {
-		ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", addr, s.config.Port))
+		ln, err := net.Listen("tcp", net.JoinHostPort(addr, strconv.Itoa(int(s.config.Port))))
 		if err != nil {
 			return err
 		}
 		listeners = append(listeners, ln)
 
 		if s.promServer != nil {
-			ln, err = net.Listen("tcp", fmt.Sprintf("%s:%d", addr, s.config.PrometheusPort))
+			ln, err = net.Listen("tcp", net.JoinHostPort(addr, strconv.Itoa(int(s.config.PrometheusPort))))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR attempts to solve an issue that happened on a machine with IPv6 enabled, and livekit-server failing to bind RTP ports on the wrong interface, even though `--dev --bind 127.0.0.1` had been passed. The value of the `--bind` flag is used for the WebSocket port binding, but it's ignored for the RTP port bindings, which is arguably not the user's intention when using `--dev --bind`.

Note the following local addresses present in the system, and the `livekit-server` command output:

```
$ ip addr
[...]
7: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default
    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0
    inet6 2001:db8:1::1/64 scope global tentative
    inet6 fe80::1/64 scope link tentative
```

```
$ livekit-server --dev --bind 127.0.0.1
2023-06-21T13:44:50.354+0200    INFO    livekit server/main.go:197      starting in development mode
2023-06-21T13:44:50.355+0200    INFO    livekit server/main.go:200      no keys provided, using placeholder keys        {"API Key": "devkey", "API Secret": "secret"}
2023-06-21T13:44:50.355+0200    INFO    livekit routing/interfaces.go:113       using single-node routing
listen udp [2001:db8:1::1]:7882: bind: cannot assign requested address
```

The error comes from here:
https://github.com/livekit/mediatransportutil/blob/d5299b9561353a93bb8f3cba1af438cc38b6eda6/pkg/rtcconfig/webrtc_config.go#L104
> ```go
> if ipFilter != nil {
> 	opts = append(opts, ice.UDPMuxFromPortWithIPFilter(ipFilter))
> }
> [...]
> udpMux, err := ice.NewMultiUDPMuxFromPort(int(rtcConf.UDPPort), opts...)
> ```
because `ipFilter` is empty.


There are 2 distinct changes in this PR:

## Use net.JoinHostPort to build "host:port" strings for net.Listen

net.JoinHostPort provides a unified way of building strings of the form "Host:Port", abstracting the particular syntax requirements of some methods in the `net` package (namely, that IPv4 addresses can be given as-is to `net.Listen`, but IPv6 addresses must be given enclosed in square brackets).

This change makes sense because an address such as `[::1]` is *not* a valid IPv6 address; the square brackets are just a detail particular to the Go `net` library. As such, this syntax shouldn't be exposed to the user, and configuration should just accept valid IPv6 addresses and convert them as needed for usage within the code.

This change is needed in order to build valid CIDR strings that can be set into `conf.RTC.IPs.Includes` in the next change:


## Use '--bind' CLI flag to also filter RTC bind address

The local address passed to a command such as

    livekit-server --dev --bind 127.0.0.1

was being used as binding address for the TCP WebSocket port, but was being ignored for RTC connections.

With `--dev`, the conf.RTC.UDPPort config is set to 7882, which enables "UDP muxing" mechanism. Without interface or address filtering, Pion would try to bind to port 7882 on *all* interfaces.

This was failing on a system with IPv6 enabled, when trying to bind to an IPv6 address of the `docker0` interface. It seems to make sense that the user-passed bind addresses are also honored for the RTC port bindings.