### PR TITLE
Full reconnect on publication mismatch on resume.

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -526,6 +526,38 @@ func (r *Room) UpdateSubscriptions(
 }
 
 func (r *Room) SyncState(participant types.LocalParticipant, state *livekit.SyncState) error {
+	pLogger := participant.GetLogger()
+	pLogger.Infow("setting sync state", "state", state)
+
+	shouldReconnect := false
+	pubTracks := state.GetPublishTracks()
+	existingPubTracks := participant.GetPublishedTracks()
+	for _, pubTrack := range pubTracks {
+		// client may not have sent TrackInfo for each published track
+		ti := pubTrack.Track
+		if ti == nil {
+			pLogger.Warnw("TrackInfo not sent during resume", nil)
+			shouldReconnect = true
+			break
+		}
+
+		found := false
+		for _, existingPubTrack := range existingPubTracks {
+			if existingPubTrack.ID() == livekit.TrackID(ti.Sid) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			pLogger.Warnw("unknown track during resume", nil, "trackID", ti.Sid)
+			break
+		}
+	}
+	if shouldReconnect {
+		pLogger.Warnw("unable to resume due to missing published tracks, starting full reconnect", nil)
+		participant.IssueFullReconnect(types.ParticipantCloseReasonPublicationError)
+	}
+
 	return nil
 }
 

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -556,8 +556,15 @@ func (r *Room) SyncState(participant types.LocalParticipant, state *livekit.Sync
 	if shouldReconnect {
 		pLogger.Warnw("unable to resume due to missing published tracks, starting full reconnect", nil)
 		participant.IssueFullReconnect(types.ParticipantCloseReasonPublicationError)
+		return nil
 	}
 
+	r.UpdateSubscriptions(
+		participant,
+		livekit.StringsAsTrackIDs(state.Subscription.TrackSids),
+		state.Subscription.ParticipantTracks,
+		state.Subscription.Subscribe,
+	)
 	return nil
 }
 

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -550,6 +550,7 @@ func (r *Room) SyncState(participant types.LocalParticipant, state *livekit.Sync
 		}
 		if !found {
 			pLogger.Warnw("unknown track during resume", nil, "trackID", ti.Sid)
+			shouldReconnect = true
 			break
 		}
 	}


### PR DESCRIPTION
It is possible that publications mismatch on resume. An example sequence
- Client sends `AddTrack` for `trackA`
- Server never receives it due to signalling connection breakage.
- Client could do a resume (reconnect=1) noticing signalling connection breakage.
- Client's view thinks that `trackA` is known to server, but server does not know about it.
- A subsequence offer containing `trackA` triggers `trackInfo not available before track publish` and the track does not get published.

Detect the case of missing track and issue a full reconnect.