### PR TITLE
Do not process events after participant close.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -538,6 +538,10 @@ func (p *ParticipantImpl) HandleAnswer(answer webrtc.SessionDescription) {
 }
 
 func (p *ParticipantImpl) onPublisherAnswer(answer webrtc.SessionDescription) error {
+	if p.IsClosed() || p.IsDisconnected() {
+		return nil
+	}
+
 	p.params.Logger.Debugw("sending answer", "transport", livekit.SignalTarget_PUBLISHER)
 	answer = p.configurePublisherAnswer(answer)
 	if err := p.writeMessage(&livekit.SignalResponse{
@@ -1290,7 +1294,7 @@ func (p *ParticipantImpl) onDataMessage(kind livekit.DataPacket_Kind, data []byt
 }
 
 func (p *ParticipantImpl) onICECandidate(c *webrtc.ICECandidate, target livekit.SignalTarget) error {
-	if c == nil || p.IsDisconnected() {
+	if c == nil || p.IsDisconnected() || p.IsClosed() {
 		return nil
 	}
 

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -1370,6 +1370,11 @@ func (t *PCTransport) postEvent(event event) {
 
 func (t *PCTransport) processEvents() {
 	for event := range t.eventCh {
+		if t.isClosed.Load() {
+			// just drain the channel with processing events
+			continue
+		}
+
 		err := t.handleEvent(&event)
 		if err != nil {
 			t.params.Logger.Errorw("error handling event", err, "event", event.String())

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -1371,7 +1371,7 @@ func (t *PCTransport) postEvent(event event) {
 func (t *PCTransport) processEvents() {
 	for event := range t.eventCh {
 		if t.isClosed.Load() {
-			// just drain the channel with processing events
+			// just drain the channel without processing events
 			continue
 		}
 


### PR DESCRIPTION
Avoid processing transport events after participant/transport close. It causes error logs which are not really errors, but distracting noise.