### PR TITLE
Set potential codecs for tracks without simulcast codecs.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1707,6 +1707,24 @@ func (p *ParticipantImpl) addMigrateMutedTrack(cid string, ti *livekit.TrackInfo
 			}
 		}
 	}
+	// check for mime_type for tracks that do not have simulcast_codecs set
+	if ti.MimeType != "" {
+		for _, nc := range parameters.Codecs {
+			if strings.EqualFold(nc.MimeType, ti.MimeType) {
+				alreadyAdded := false
+				for _, pc := range potentialCodecs {
+					if strings.EqualFold(pc.MimeType, ti.MimeType) {
+						alreadyAdded = true
+						break
+					}
+				}
+				if !alreadyAdded {
+					potentialCodecs = append(potentialCodecs, nc)
+				}
+				break
+			}
+		}
+	}
 	mt.SetPotentialCodecs(potentialCodecs, parameters.HeaderExtensions)
 
 	for _, codec := range ti.Codecs {


### PR DESCRIPTION
When migrating muted track, need to set potential codecs. For audio, there may not be `simulcast_codecs` in `AddTrack`. Hence when migrating a muted track, the potential codecs are not set. That results in no receivers in relay up track (because all this could happen before the audio track is unmuted).

So, look at MimeType in TrackInfo (this will be set in OnTrack) and use that as potential codec.