### PR TITLE
Attempt to reduce disruption due to probe.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -286,7 +286,7 @@ func NewConfig(confString string, strictMode bool, c *cli.Context, baseFlags []c
 			},
 			CongestionControl: CongestionControlConfig{
 				Enabled:    true,
-				AllowPause: true,
+				AllowPause: false,
 				ProbeMode:  CongestionControlProbeModePadding,
 				ProbeConfig: CongestionControlProbeConfig{
 					BaseInterval:  3 * time.Second,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -632,6 +632,13 @@ func GenerateCLIFlags(existingFlags []cli.Flag, hidden bool) ([]cli.Flag, error)
 				Usage:   generatedCLIFlagUsage,
 				Hidden:  hidden,
 			}
+		case reflect.Float64:
+			flag = &cli.Float64Flag{
+				Name:    name,
+				EnvVars: []string{envVar},
+				Usage:   generatedCLIFlagUsage,
+				Hidden:  hidden,
+			}
 		case reflect.Slice:
 			// TODO
 			continue
@@ -682,6 +689,8 @@ func (conf *Config) updateFromCLI(c *cli.Context, baseFlags []cli.Flag) error {
 		case reflect.Uint8, reflect.Uint16, reflect.Uint32:
 			configValue.SetUint(c.Uint64(flagName))
 		case reflect.Float32:
+			configValue.SetFloat(c.Float64(flagName))
+		case reflect.Float64:
 			configValue.SetFloat(c.Float64(flagName))
 		// case reflect.Slice:
 		// 	// TODO

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -115,12 +115,12 @@ type CongestionControlProbeConfig struct {
 
 	TrendWait time.Duration `yaml:"trend_wait,omitempty"`
 
-	OveragePct  int64         `yaml:"overage_pct,omitempty"`
-	MinBps      int64         `yaml:"min_bps,omitempty"`
-	MinDuration time.Duration `yaml:"min_duration,omitempty"`
-	MaxDuration time.Duration `yaml:"max_duration,omitempty"`
-	DurationOverflowFactor float64 `yaml:"duration_overflow_factor,omitempty"`
-	DurationIncreaseFactor float64 `yaml:"duration_increase_factor,omitempty"`
+	OveragePct             int64         `yaml:"overage_pct,omitempty"`
+	MinBps                 int64         `yaml:"min_bps,omitempty"`
+	MinDuration            time.Duration `yaml:"min_duration,omitempty"`
+	MaxDuration            time.Duration `yaml:"max_duration,omitempty"`
+	DurationOverflowFactor float64       `yaml:"duration_overflow_factor,omitempty"`
+	DurationIncreaseFactor float64       `yaml:"duration_increase_factor,omitempty"`
 }
 
 type CongestionControlConfig struct {
@@ -298,10 +298,10 @@ func NewConfig(confString string, strictMode bool, c *cli.Context, baseFlags []c
 
 					TrendWait: 2 * time.Second,
 
-					OveragePct:  120,
-					MinBps:      200_000,
-					MinDuration: 200 * time.Millisecond,
-					MaxDuration: 20 * time.Second,
+					OveragePct:             120,
+					MinBps:                 200_000,
+					MinDuration:            200 * time.Millisecond,
+					MaxDuration:            20 * time.Second,
 					DurationOverflowFactor: 1.25,
 					DurationIncreaseFactor: 1.5,
 				},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -105,12 +105,29 @@ type PLIThrottleConfig struct {
 	HighQuality time.Duration `yaml:"high_quality,omitempty"`
 }
 
+type CongestionControlProbeConfig struct {
+	BaseInterval  time.Duration `yaml:"base_interval,omitempty"`
+	BackoffFactor float64       `yaml:"backoff_factor,omitempty"`
+	MaxInterval   time.Duration `yaml:"max_interval,omitempty"`
+
+	SettleWait    time.Duration `yaml:"settle_wait,omitempty"`
+	SettleWaitMax time.Duration `yaml:"settle_wait_max,omitempty"`
+
+	TrendWait time.Duration `yaml:"trend_wait,omitempty"`
+
+	OveragePct  int64         `yaml:"overage_pct,omitempty"`
+	MinBps      int64         `yaml:"min_bps,omitempty"`
+	MinDuration time.Duration `yaml:"min_duration,omitempty"`
+	MaxDuration time.Duration `yaml:"max_duration,omitempty"`
+}
+
 type CongestionControlConfig struct {
-	Enabled            bool                       `yaml:"enabled"`
-	AllowPause         bool                       `yaml:"allow_pause"`
-	UseSendSideBWE     bool                       `yaml:"send_side_bandwidth_estimation,omitempty"`
-	ProbeMode          CongestionControlProbeMode `yaml:"padding_mode,omitempty"`
-	MinChannelCapacity int64                      `yaml:"min_channel_capacity,omitempty"`
+	Enabled            bool                         `yaml:"enabled"`
+	AllowPause         bool                         `yaml:"allow_pause"`
+	UseSendSideBWE     bool                         `yaml:"send_side_bandwidth_estimation,omitempty"`
+	ProbeMode          CongestionControlProbeMode   `yaml:"padding_mode,omitempty"`
+	MinChannelCapacity int64                        `yaml:"min_channel_capacity,omitempty"`
+	ProbeConfig        CongestionControlProbeConfig `yaml:"probe_config,omitempty"`
 }
 
 type AudioConfig struct {
@@ -267,8 +284,23 @@ func NewConfig(confString string, strictMode bool, c *cli.Context, baseFlags []c
 			},
 			CongestionControl: CongestionControlConfig{
 				Enabled:    true,
-				AllowPause: false,
+				AllowPause: true,
 				ProbeMode:  CongestionControlProbeModePadding,
+				ProbeConfig: CongestionControlProbeConfig{
+					BaseInterval:  5 * time.Second,
+					BackoffFactor: 1.5,
+					MaxInterval:   2 * time.Minute,
+
+					SettleWait:    250 * time.Millisecond,
+					SettleWaitMax: 10 * time.Second,
+
+					TrendWait: 2 * time.Second,
+
+					OveragePct:  120,
+					MinBps:      200_000,
+					MinDuration: 200 * time.Millisecond,
+					MaxDuration: 300 * time.Millisecond,
+				},
 			},
 		},
 		Audio: AudioConfig{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -119,6 +119,8 @@ type CongestionControlProbeConfig struct {
 	MinBps      int64         `yaml:"min_bps,omitempty"`
 	MinDuration time.Duration `yaml:"min_duration,omitempty"`
 	MaxDuration time.Duration `yaml:"max_duration,omitempty"`
+	DurationOverflowFactor float64 `yaml:"duration_overflow_factor,omitempty"`
+	DurationIncreaseFactor float64 `yaml:"duration_increase_factor,omitempty"`
 }
 
 type CongestionControlConfig struct {
@@ -287,7 +289,7 @@ func NewConfig(confString string, strictMode bool, c *cli.Context, baseFlags []c
 				AllowPause: true,
 				ProbeMode:  CongestionControlProbeModePadding,
 				ProbeConfig: CongestionControlProbeConfig{
-					BaseInterval:  5 * time.Second,
+					BaseInterval:  3 * time.Second,
 					BackoffFactor: 1.5,
 					MaxInterval:   2 * time.Minute,
 
@@ -299,7 +301,9 @@ func NewConfig(confString string, strictMode bool, c *cli.Context, baseFlags []c
 					OveragePct:  120,
 					MinBps:      200_000,
 					MinDuration: 200 * time.Millisecond,
-					MaxDuration: 300 * time.Millisecond,
+					MaxDuration: 20 * time.Second,
+					DurationOverflowFactor: 1.25,
+					DurationIncreaseFactor: 1.5,
 				},
 			},
 		},

--- a/pkg/sfu/sequencer.go
+++ b/pkg/sfu/sequencer.go
@@ -11,6 +11,7 @@ import (
 const (
 	defaultRtt           = 70
 	ignoreRetransmission = 100 // Ignore packet retransmission after ignoreRetransmission milliseconds
+	maxAck               = 3
 )
 
 func btoi(b bool) int {
@@ -187,7 +188,7 @@ func (s *sequencer) getPacketsMeta(seqNo []uint16) []packetMeta {
 			continue
 		}
 
-		if seq.lastNack == 0 || refTime-seq.lastNack > uint32(math.Min(float64(ignoreRetransmission), float64(2*s.rtt))) {
+		if (seq.lastNack == 0 || refTime-seq.lastNack > uint32(math.Min(float64(ignoreRetransmission), float64(2*s.rtt)))) && seq.nacked < maxAck {
 			seq.nacked++
 			seq.lastNack = refTime
 

--- a/pkg/sfu/streamallocator/channelobserver.go
+++ b/pkg/sfu/streamallocator/channelobserver.go
@@ -120,6 +120,10 @@ func (c *ChannelObserver) GetHighestEstimate() int64 {
 	return c.estimateTrend.GetHighest()
 }
 
+func (c *ChannelObserver) HasEnoughEstimateSamples() bool {
+	return c.estimateTrend.HasEnoughSamples()
+}
+
 func (c *ChannelObserver) GetNackRatio() float64 {
 	return c.nackTracker.GetRatio()
 }

--- a/pkg/sfu/streamallocator/probe_controller.go
+++ b/pkg/sfu/streamallocator/probe_controller.go
@@ -177,7 +177,7 @@ func (p *ProbeController) finalizeProbeLocked(trend ChannelTrend) (isNotFailing 
 		return false
 	}
 
-	// reset probe interval and increase probe duration on a non-failing probe
+	// reset probe interval and increase probe duration on a upward trending probe
 	p.resetProbeIntervalLocked()
 	if trend == ChannelTrendClearing {
 		p.increaseProbeDurationLocked()

--- a/pkg/sfu/streamallocator/probe_controller.go
+++ b/pkg/sfu/streamallocator/probe_controller.go
@@ -19,22 +19,22 @@ type ProbeControllerParams struct {
 type ProbeController struct {
 	params ProbeControllerParams
 
-	lock                  sync.RWMutex
-	probeInterval         time.Duration
-	lastProbeStartTime    time.Time
-	probeGoalBps          int64
-	probeClusterId        ProbeClusterId
-	doneProbeClusterInfo  ProbeClusterInfo
-	abortedProbeClusterId ProbeClusterId
+	lock                      sync.RWMutex
+	probeInterval             time.Duration
+	lastProbeStartTime        time.Time
+	probeGoalBps              int64
+	probeClusterId            ProbeClusterId
+	doneProbeClusterInfo      ProbeClusterInfo
+	abortedProbeClusterId     ProbeClusterId
 	goalReachedProbeClusterId ProbeClusterId
-	probeTrendObserved    bool
-	probeEndTime          time.Time
-	probeDuration time.Duration
+	probeTrendObserved        bool
+	probeEndTime              time.Time
+	probeDuration             time.Duration
 }
 
 func NewProbeController(params ProbeControllerParams) *ProbeController {
 	p := &ProbeController{
-		params: params,
+		params:        params,
 		probeDuration: params.Config.MinDuration,
 	}
 
@@ -211,7 +211,7 @@ func (p *ProbeController) InitProbe(probeGoalDeltaBps int64, expectedBandwidthUs
 		int(p.probeGoalBps),
 		int(expectedBandwidthUsage),
 		p.probeDuration,
-		time.Duration(float64(p.probeDuration.Milliseconds()) * p.params.Config.DurationOverflowFactor) * time.Millisecond,
+		time.Duration(float64(p.probeDuration.Milliseconds())*p.params.Config.DurationOverflowFactor)*time.Millisecond,
 	)
 
 	return p.probeClusterId, p.probeGoalBps
@@ -240,7 +240,7 @@ func (p *ProbeController) resetProbeDurationLocked() {
 }
 
 func (p *ProbeController) increaseProbeDurationLocked() {
-	p.probeDuration = time.Duration(float64(p.probeDuration.Milliseconds()) * p.params.Config.DurationIncreaseFactor) * time.Millisecond
+	p.probeDuration = time.Duration(float64(p.probeDuration.Milliseconds())*p.params.Config.DurationIncreaseFactor) * time.Millisecond
 	if p.probeDuration > p.params.Config.MaxDuration {
 		p.probeDuration = p.params.Config.MaxDuration
 	}

--- a/pkg/sfu/streamallocator/probe_controller.go
+++ b/pkg/sfu/streamallocator/probe_controller.go
@@ -115,7 +115,7 @@ func (p *ProbeController) MaybeFinalizeProbe(
 	}
 
 	if isComplete && p.probeEndTime.IsZero() && p.doneProbeClusterInfo.Id != ProbeClusterIdInvalid && p.doneProbeClusterInfo.Id == p.probeClusterId {
-		p.params.Logger.Infow("RAJA estimates", "lowest", lowestEstimate, "highest", highestEstimate)	// REMOVE
+		p.params.Logger.Infow("RAJA estimates", "lowest", lowestEstimate, "highest", highestEstimate) // REMOVE
 		// ensure any queueing due to probing is flushed
 		// STREAM-ALLOCATOR-TODO: CongestionControlProbeConfig.SettleWait should actually be a certain number of RTTs.
 		expectedDuration := float64(9.0)

--- a/pkg/sfu/streamallocator/prober.go
+++ b/pkg/sfu/streamallocator/prober.go
@@ -176,6 +176,7 @@ func (p *Prober) Reset() {
 	p.clustersMu.Lock()
 	if p.activeCluster != nil {
 		p.logger.Infow("prober: resetting active cluster", "cluster", p.activeCluster.String())
+		p.logger.Errorw("prober: resetting active cluster", nil, "cluster", p.activeCluster.String())	// REMOVE
 		reset = true
 		info = p.activeCluster.GetInfo()
 	}

--- a/pkg/sfu/streamallocator/prober.go
+++ b/pkg/sfu/streamallocator/prober.go
@@ -176,7 +176,6 @@ func (p *Prober) Reset() {
 	p.clustersMu.Lock()
 	if p.activeCluster != nil {
 		p.logger.Infow("prober: resetting active cluster", "cluster", p.activeCluster.String())
-		p.logger.Errorw("prober: resetting active cluster", nil, "cluster", p.activeCluster.String())	// REMOVE
 		reset = true
 		info = p.activeCluster.GetInfo()
 	}

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -629,6 +629,7 @@ func (s *StreamAllocator) handleSignalAdjustState(event *Event) {
 func (s *StreamAllocator) handleSignalEstimate(event *Event) {
 	receivedEstimate, _ := event.Data.(int64)
 	s.lastReceivedEstimate = receivedEstimate
+	s.params.Logger.Infow("RAJA new estimate", "estimate", receivedEstimate)	// REMOVE
 	s.monitorRate(receivedEstimate)
 
 	// while probing, maintain estimate separately to enable keeping current committed estimate if probe fails

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -199,6 +199,7 @@ func NewStreamAllocator(params StreamAllocatorParams) *StreamAllocator {
 	}
 
 	s.probeController = NewProbeController(ProbeControllerParams{
+		Config: s.params.Config.ProbeConfig,
 		Prober: s.prober,
 		Logger: params.Logger,
 	})

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -629,7 +629,7 @@ func (s *StreamAllocator) handleSignalAdjustState(event *Event) {
 func (s *StreamAllocator) handleSignalEstimate(event *Event) {
 	receivedEstimate, _ := event.Data.(int64)
 	s.lastReceivedEstimate = receivedEstimate
-	s.params.Logger.Infow("RAJA new estimate", "estimate", receivedEstimate)	// REMOVE
+	s.params.Logger.Infow("RAJA new estimate", "estimate", receivedEstimate) // REMOVE
 	s.monitorRate(receivedEstimate)
 
 	// while probing, maintain estimate separately to enable keeping current committed estimate if probe fails

--- a/pkg/sfu/streamallocator/trenddetector.go
+++ b/pkg/sfu/streamallocator/trenddetector.go
@@ -74,9 +74,6 @@ func (t *TrendDetector) Seed(value int64) {
 	}
 
 	t.samples = append(t.samples, trendDetectorSample{value: value, at: time.Now()})
-	t.numSamples = 1
-	t.lowestValue = value
-	t.highestValue = value
 }
 
 func (t *TrendDetector) AddValue(value int64) {

--- a/pkg/sfu/streamallocator/trenddetector.go
+++ b/pkg/sfu/streamallocator/trenddetector.go
@@ -75,6 +75,8 @@ func (t *TrendDetector) Seed(value int64) {
 
 	t.samples = append(t.samples, trendDetectorSample{value: value, at: time.Now()})
 	t.numSamples = 1
+	t.lowestValue = value
+	t.highestValue = value
 }
 
 func (t *TrendDetector) AddValue(value int64) {

--- a/pkg/sfu/streamallocator/trenddetector.go
+++ b/pkg/sfu/streamallocator/trenddetector.go
@@ -74,6 +74,7 @@ func (t *TrendDetector) Seed(value int64) {
 	}
 
 	t.samples = append(t.samples, trendDetectorSample{value: value, at: time.Now()})
+	t.numSamples = 1
 }
 
 func (t *TrendDetector) AddValue(value int64) {
@@ -120,6 +121,10 @@ func (t *TrendDetector) GetHighest() int64 {
 
 func (t *TrendDetector) GetDirection() TrendDirection {
 	return t.direction
+}
+
+func (t *TrendDetector) HasEnoughSamples() bool {
+	return t.numSamples >= t.params.RequiredSamples
 }
 
 func (t *TrendDetector) ToString() string {


### PR DESCRIPTION
With REMB, getting a higher estimate requires probing for a while. But, when congested, although the code does stop probing immediately on detecting any congestion, it does seem to take a bit of time to get a congestion signal and that affects media.

This is an attempt to reduce that disruption some. Change include
1. Make config of all probing parameters.
2. Limiting number of times a packet is acked to three. This is a bit of drive by as too many retransmissions affect congestion. Although there are already several rules in place to restrict retransmissions, this is yet another tool for that. Anything more than three times is probably not useful anyway.
3. Introduce growing probes. The idea is to keep the probes short to begin with. This limits the amount of disruption. When congested, these probes are expected to not provide a signal that things are clearing up. So, the probe duration remains the same. But, if there is a signal that channel is clearing up, probe increase in duration exponentially till the goal is reached. Any time, the probe detects congestion, it falls back to min duration and starts over again. There are more strategies to play around here (i. e. things like ramping back down the probe duration rather than jumping back to min duration on a single failure)
4. While this limits disruption, the ramp back up is slower.

In some testing, this has performed better in low bandwidth conditions (for example running using 500 kbps down stream bandwidth with two clients running on the same machine, i. e. the remote video of both clients are piped through the same 500 kbps congested pipe). But, requires more testing.

Especially important would be to check if the stream can get stuck, i. e. not able to probe back up to desired quality.