### PR TITLE
Logging more to understand layer transition leak better.

### DIFF
--- a/pkg/sfu/connectionquality/connectionstats.go
+++ b/pkg/sfu/connectionquality/connectionstats.go
@@ -81,33 +81,41 @@ func (cs *ConnectionStats) OnStatsUpdate(fn func(cs *ConnectionStats, stat *live
 }
 
 func (cs *ConnectionStats) UpdateMute(isMuted bool, at time.Time) {
+	/* TODO-RESTORE
 	if cs.done.IsBroken() {
 		return
 	}
+	*/
 
 	cs.scorer.UpdateMute(isMuted, at)
 }
 
 func (cs *ConnectionStats) AddBitrateTransition(bitrate int64, at time.Time) {
+	/* TODO-RESTORE
 	if cs.done.IsBroken() {
 		return
 	}
+	*/
 
 	cs.scorer.AddBitrateTransition(bitrate, at)
 }
 
 func (cs *ConnectionStats) UpdateLayerMute(isMuted bool, at time.Time) {
+	/* TODO-RESTORE
 	if cs.done.IsBroken() {
 		return
 	}
+	*/
 
 	cs.scorer.UpdateLayerMute(isMuted, at)
 }
 
 func (cs *ConnectionStats) AddLayerTransition(distance float64, at time.Time) {
+	/* TODO-RESTORE
 	if cs.done.IsBroken() {
 		return
 	}
+	*/
 
 	cs.scorer.AddLayerTransition(distance, at)
 }

--- a/pkg/sfu/connectionquality/connectionstats.go
+++ b/pkg/sfu/connectionquality/connectionstats.go
@@ -81,18 +81,34 @@ func (cs *ConnectionStats) OnStatsUpdate(fn func(cs *ConnectionStats, stat *live
 }
 
 func (cs *ConnectionStats) UpdateMute(isMuted bool, at time.Time) {
+	if cs.done.IsBroken() {
+		return
+	}
+
 	cs.scorer.UpdateMute(isMuted, at)
 }
 
 func (cs *ConnectionStats) AddBitrateTransition(bitrate int64, at time.Time) {
+	if cs.done.IsBroken() {
+		return
+	}
+
 	cs.scorer.AddBitrateTransition(bitrate, at)
 }
 
 func (cs *ConnectionStats) UpdateLayerMute(isMuted bool, at time.Time) {
+	if cs.done.IsBroken() {
+		return
+	}
+
 	cs.scorer.UpdateLayerMute(isMuted, at)
 }
 
 func (cs *ConnectionStats) AddLayerTransition(distance float64, at time.Time) {
+	if cs.done.IsBroken() {
+		return
+	}
+
 	cs.scorer.AddLayerTransition(distance, at)
 }
 
@@ -253,10 +269,9 @@ func (cs *ConnectionStats) updateStatsWorker() {
 	tk := time.NewTicker(interval)
 	defer tk.Stop()
 
-	done := cs.done.Watch()
 	for {
 		select {
-		case <-done:
+		case <-cs.done.Watch():
 			return
 
 		case <-tk.C:

--- a/pkg/sfu/connectionquality/scorer.go
+++ b/pkg/sfu/connectionquality/scorer.go
@@ -253,7 +253,7 @@ func (q *qualityScorer) AddLayerTransition(distance float64, at time.Time) {
 	defer q.lock.Unlock()
 
 	// TODO-REMOVE-AFTER-DEBUG
-	q.params.Logger.Debugw("adding layer transitions", "at", at, "distance", distance)
+	q.params.Logger.Debugw("adding layer transition", "at", at, "distance", distance)
 	q.layerTransitions = append(q.layerTransitions, layerTransition{
 		startedAt: at,
 		distance:  distance,

--- a/pkg/sfu/connectionquality/scorer.go
+++ b/pkg/sfu/connectionquality/scorer.go
@@ -252,6 +252,8 @@ func (q *qualityScorer) AddLayerTransition(distance float64, at time.Time) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
+	// TODO-REMOVE-AFTER-DEBUG
+	q.params.Logger.Debugw("adding layer transitions", "at", at, "distance", distance)
 	q.layerTransitions = append(q.layerTransitions, layerTransition{
 		startedAt: at,
 		distance:  distance,
@@ -261,6 +263,9 @@ func (q *qualityScorer) AddLayerTransition(distance float64, at time.Time) {
 func (q *qualityScorer) Update(stat *windowStat, at time.Time) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
+
+	// TODO-REMOVE-AFTER-DEBUG
+	q.params.Logger.Debugw("running update", "at", at, "stat", stat)
 
 	// always update transitions
 	expectedBitrate := q.getExpectedBitsAndUpdateTransitions(at)


### PR DESCRIPTION
Seems like layer transition leak happens in the down track path.
Update should be called periodically and cleaning up the transitions.
Wondering if this is due to some life cycle issue where down track
could be adding a bunch of transitions even after it is closed.

@paulwe analysed the code and noted that scorer can use online
aggregation and does not need to keep slices. Will look at that change
after understanding the leak better. Functionally does not look like
there should be a leak. So, want to understand that better and
potentially fix other issues.