### PR TITLE
Delete down track from receiver in close always.

### DIFF
--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -103,6 +103,14 @@ func (r *WrappedReceiver) Codecs() []webrtc.RTPCodecParameters {
 	return codecs
 }
 
+func (r *WrappedReceiver) DeleteDownTrack(participantID livekit.ParticipantID) {
+	if r.TrackReceiver != nil {
+		r.TrackReceiver.DeleteDownTrack(participantID)
+	}
+}
+
+// --------------------------------------------
+
 type DummyReceiver struct {
 	receiver         atomic.Value
 	trackID          livekit.TrackID
@@ -167,42 +175,42 @@ func (d *DummyReceiver) StreamID() string {
 }
 
 func (d *DummyReceiver) Codec() webrtc.RTPCodecParameters {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.Codec()
 	}
 	return d.codec
 }
 
 func (d *DummyReceiver) HeaderExtensions() []webrtc.RTPHeaderExtensionParameter {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.HeaderExtensions()
 	}
 	return d.headerExtensions
 }
 
 func (d *DummyReceiver) ReadRTP(buf []byte, layer uint8, sn uint16) (int, error) {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.ReadRTP(buf, layer, sn)
 	}
 	return 0, errors.New("no receiver")
 }
 
 func (d *DummyReceiver) GetLayeredBitrate() ([]int32, sfu.Bitrates) {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.GetLayeredBitrate()
 	}
 	return nil, sfu.Bitrates{}
 }
 
 func (d *DummyReceiver) GetAudioLevel() (float64, bool) {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.GetAudioLevel()
 	}
 	return 0, false
 }
 
 func (d *DummyReceiver) SendPLI(layer int32, force bool) {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		r.SendPLI(layer, force)
 	}
 }
@@ -210,7 +218,7 @@ func (d *DummyReceiver) SendPLI(layer int32, force bool) {
 func (d *DummyReceiver) SetUpTrackPaused(paused bool) {
 	d.settingsLock.Lock()
 	defer d.settingsLock.Unlock()
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		d.pausedValid = false
 		r.SetUpTrackPaused(paused)
 	} else {
@@ -222,7 +230,7 @@ func (d *DummyReceiver) SetUpTrackPaused(paused bool) {
 func (d *DummyReceiver) SetMaxExpectedSpatialLayer(layer int32) {
 	d.settingsLock.Lock()
 	defer d.settingsLock.Unlock()
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		d.maxExpectedLayerValid = false
 		r.SetMaxExpectedSpatialLayer(layer)
 	} else {
@@ -234,7 +242,7 @@ func (d *DummyReceiver) SetMaxExpectedSpatialLayer(layer int32) {
 func (d *DummyReceiver) AddDownTrack(track sfu.TrackSender) error {
 	d.downtrackLock.Lock()
 	defer d.downtrackLock.Unlock()
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		r.AddDownTrack(track)
 	} else {
 		d.downtracks[track.SubscriberID()] = track
@@ -245,7 +253,7 @@ func (d *DummyReceiver) AddDownTrack(track sfu.TrackSender) error {
 func (d *DummyReceiver) DeleteDownTrack(participantID livekit.ParticipantID) {
 	d.downtrackLock.Lock()
 	defer d.downtrackLock.Unlock()
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		r.DeleteDownTrack(participantID)
 	} else {
 		delete(d.downtracks, participantID)
@@ -253,28 +261,28 @@ func (d *DummyReceiver) DeleteDownTrack(participantID livekit.ParticipantID) {
 }
 
 func (d *DummyReceiver) DebugInfo() map[string]interface{} {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.DebugInfo()
 	}
 	return nil
 }
 
 func (d *DummyReceiver) GetTemporalLayerFpsForSpatial(spatial int32) []float32 {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.GetTemporalLayerFpsForSpatial(spatial)
 	}
 	return nil
 }
 
 func (d *DummyReceiver) TrackInfo() *livekit.TrackInfo {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.TrackInfo()
 	}
 	return nil
 }
 
 func (d *DummyReceiver) IsClosed() bool {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.IsClosed()
 	}
 	return false
@@ -290,14 +298,14 @@ func (d *DummyReceiver) GetRedReceiver() sfu.TrackReceiver {
 }
 
 func (d *DummyReceiver) GetRTCPSenderReportData(layer int32) (*buffer.RTCPSenderReportData, *buffer.RTCPSenderReportData) {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.GetRTCPSenderReportData(layer)
 	}
 	return nil, nil
 }
 
 func (d *DummyReceiver) GetReferenceLayerRTPTimestamp(ts uint32, layer int32, referenceLayer int32) (uint32, error) {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.GetReferenceLayerRTPTimestamp(ts, layer, referenceLayer)
 	}
 	return 0, errors.New("receiver not available")

--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -167,42 +167,42 @@ func (d *DummyReceiver) StreamID() string {
 }
 
 func (d *DummyReceiver) Codec() webrtc.RTPCodecParameters {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
 		return r.Codec()
 	}
 	return d.codec
 }
 
 func (d *DummyReceiver) HeaderExtensions() []webrtc.RTPHeaderExtensionParameter {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
 		return r.HeaderExtensions()
 	}
 	return d.headerExtensions
 }
 
 func (d *DummyReceiver) ReadRTP(buf []byte, layer uint8, sn uint16) (int, error) {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
 		return r.ReadRTP(buf, layer, sn)
 	}
 	return 0, errors.New("no receiver")
 }
 
 func (d *DummyReceiver) GetLayeredBitrate() ([]int32, sfu.Bitrates) {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
 		return r.GetLayeredBitrate()
 	}
 	return nil, sfu.Bitrates{}
 }
 
 func (d *DummyReceiver) GetAudioLevel() (float64, bool) {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
 		return r.GetAudioLevel()
 	}
 	return 0, false
 }
 
 func (d *DummyReceiver) SendPLI(layer int32, force bool) {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
 		r.SendPLI(layer, force)
 	}
 }
@@ -210,7 +210,7 @@ func (d *DummyReceiver) SendPLI(layer int32, force bool) {
 func (d *DummyReceiver) SetUpTrackPaused(paused bool) {
 	d.settingsLock.Lock()
 	defer d.settingsLock.Unlock()
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
 		d.pausedValid = false
 		r.SetUpTrackPaused(paused)
 	} else {
@@ -222,7 +222,7 @@ func (d *DummyReceiver) SetUpTrackPaused(paused bool) {
 func (d *DummyReceiver) SetMaxExpectedSpatialLayer(layer int32) {
 	d.settingsLock.Lock()
 	defer d.settingsLock.Unlock()
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
 		d.maxExpectedLayerValid = false
 		r.SetMaxExpectedSpatialLayer(layer)
 	} else {
@@ -234,7 +234,7 @@ func (d *DummyReceiver) SetMaxExpectedSpatialLayer(layer int32) {
 func (d *DummyReceiver) AddDownTrack(track sfu.TrackSender) error {
 	d.downtrackLock.Lock()
 	defer d.downtrackLock.Unlock()
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
 		r.AddDownTrack(track)
 	} else {
 		d.downtracks[track.SubscriberID()] = track
@@ -245,7 +245,7 @@ func (d *DummyReceiver) AddDownTrack(track sfu.TrackSender) error {
 func (d *DummyReceiver) DeleteDownTrack(participantID livekit.ParticipantID) {
 	d.downtrackLock.Lock()
 	defer d.downtrackLock.Unlock()
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
 		r.DeleteDownTrack(participantID)
 	} else {
 		delete(d.downtracks, participantID)
@@ -253,28 +253,28 @@ func (d *DummyReceiver) DeleteDownTrack(participantID livekit.ParticipantID) {
 }
 
 func (d *DummyReceiver) DebugInfo() map[string]interface{} {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
 		return r.DebugInfo()
 	}
 	return nil
 }
 
 func (d *DummyReceiver) GetTemporalLayerFpsForSpatial(spatial int32) []float32 {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
 		return r.GetTemporalLayerFpsForSpatial(spatial)
 	}
 	return nil
 }
 
 func (d *DummyReceiver) TrackInfo() *livekit.TrackInfo {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
 		return r.TrackInfo()
 	}
 	return nil
 }
 
 func (d *DummyReceiver) IsClosed() bool {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
 		return r.IsClosed()
 	}
 	return false
@@ -290,14 +290,14 @@ func (d *DummyReceiver) GetRedReceiver() sfu.TrackReceiver {
 }
 
 func (d *DummyReceiver) GetRTCPSenderReportData(layer int32) (*buffer.RTCPSenderReportData, *buffer.RTCPSenderReportData) {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
 		return r.GetRTCPSenderReportData(layer)
 	}
 	return nil, nil
 }
 
 func (d *DummyReceiver) GetReferenceLayerRTPTimestamp(ts uint32, layer int32, referenceLayer int32) (uint32, error) {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok && r != nil {
 		return r.GetReferenceLayerRTPTimestamp(ts, layer, referenceLayer)
 	}
 	return 0, errors.New("receiver not available")

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -842,13 +842,13 @@ func (d *DownTrack) CloseWithFlush(flush bool) {
 
 		d.bound.Store(false)
 		d.logger.Debugw("closing sender", "kind", d.kind)
-		d.receiver.DeleteDownTrack(d.subscriberID)
+	}
+	d.receiver.DeleteDownTrack(d.subscriberID)
 
-		if d.rtcpReader != nil && flush {
-			d.logger.Debugw("downtrack close rtcp reader")
-			d.rtcpReader.Close()
-			d.rtcpReader.OnPacket(nil)
-		}
+	if d.rtcpReader != nil && flush {
+		d.logger.Debugw("downtrack close rtcp reader")
+		d.rtcpReader.Close()
+		d.rtcpReader.OnPacket(nil)
 	}
 
 	d.bindLock.Unlock()

--- a/test/singlenode_test.go
+++ b/test/singlenode_test.go
@@ -584,7 +584,6 @@ func TestSubscribeToCodecUnsupported(t *testing.T) {
 		for _, t := range tracks {
 			if strings.EqualFold(t.Codec().MimeType, "video/vp8") {
 				return ""
-
 			}
 		}
 		return "did not receive track with vp8"


### PR DESCRIPTION
I think with the parallel close in goroutines, it so happens that peer connection can get closed first and unbind the track.

The delete down track and RTCP reader close was inside if `bound` block. So, they were not running leaving a dangling down track in the receiver.