### PR TITLE
Close subscriptions promptly

### DIFF
--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -104,6 +104,7 @@ func (m *SubscriptionManager) Close(willBeResumed bool) {
 	subTracks := m.GetSubscribedTracks()
 	downTracksToClose := make([]*sfu.DownTrack, 0, len(subTracks))
 	for _, st := range subTracks {
+		m.setDesired(st.ID(), false)
 		dt := st.DownTrack()
 		// nil check exists primarily for tests
 		if dt != nil {
@@ -133,17 +134,18 @@ func (m *SubscriptionManager) isClosed() bool {
 }
 
 func (m *SubscriptionManager) SubscribeToTrack(trackID livekit.TrackID) {
-	m.lock.Lock()
-	sub, ok := m.subscriptions[trackID]
-	if !ok {
+	sub, desireChanged := m.setDesired(trackID, true)
+	if sub == nil {
 		sLogger := m.params.Logger.WithValues(
 			"trackID", trackID,
 		)
-		sub = newTrackSubscription(m.params.Participant.ID(), trackID, sLogger)
+		sub := newTrackSubscription(m.params.Participant.ID(), trackID, sLogger)
+
+		m.lock.Lock()
 		m.subscriptions[trackID] = sub
+		m.lock.Unlock()
 	}
-	desireChanged := sub.setDesired(true)
-	m.lock.Unlock()
+	sub, desireChanged = m.setDesired(trackID, true)
 	if desireChanged {
 		sub.logger.Infow("subscribing to track")
 	}
@@ -153,17 +155,13 @@ func (m *SubscriptionManager) SubscribeToTrack(trackID livekit.TrackID) {
 }
 
 func (m *SubscriptionManager) UnsubscribeFromTrack(trackID livekit.TrackID) {
-	m.lock.Lock()
-	sub, ok := m.subscriptions[trackID]
-	m.lock.Unlock()
-	if !ok {
+	sub, desireChanged := m.setDesired(trackID, false)
+	if sub == nil || !desireChanged {
 		return
 	}
 
-	if sub.setDesired(false) {
-		sub.logger.Infow("unsubscribing from track")
-		m.queueReconcile(trackID)
-	}
+	sub.logger.Infow("unsubscribing from track")
+	m.queueReconcile(trackID)
 }
 
 func (m *SubscriptionManager) GetSubscribedTracks() []types.SubscribedTrack {
@@ -255,6 +253,18 @@ func (m *SubscriptionManager) WaitUntilSubscribed(timeout time.Duration) error {
 	return context.DeadlineExceeded
 }
 
+func (m *SubscriptionManager) setDesired(trackID livekit.TrackID, desired bool) (*trackSubscription, bool) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	sub, ok := m.subscriptions[trackID]
+	if !ok {
+		return nil, false
+	}
+
+	return sub, sub.setDesired(desired)
+}
+
 func (m *SubscriptionManager) canReconcile() bool {
 	p := m.params.Participant
 	if m.isClosed() || p.IsClosed() || p.IsDisconnected() {
@@ -267,7 +277,7 @@ func (m *SubscriptionManager) reconcileSubscriptions() {
 	var needsToReconcile []*trackSubscription
 	m.lock.RLock()
 	for _, sub := range m.subscriptions {
-		if sub.needsSubscribe() || sub.needsUnsubscribe() || sub.needsBind() {
+		if sub.needsSubscribe() || sub.needsUnsubscribe() || sub.needsBind() || sub.needsCleanup() {
 			needsToReconcile = append(needsToReconcile, sub)
 		}
 	}
@@ -374,6 +384,12 @@ func (m *SubscriptionManager) reconcileSubscription(s *trackSubscription) {
 			s.maybeRecordError(m.params.Telemetry, m.params.Participant.ID(), ErrTrackNotBound, false)
 			m.params.OnSubscriptionError(s.trackID, true, ErrTrackNotBound)
 		}
+	}
+
+	if s.needsCleanup() {
+		m.lock.Lock()
+		delete(m.subscriptions, s.trackID)
+		m.lock.Unlock()
 	}
 }
 
@@ -837,7 +853,6 @@ func (s *trackSubscription) setRemovedNotifier(notifier types.ChangeNotifier) bo
 
 func (s *trackSubscription) setRemovedNotifierLocked(notifier types.ChangeNotifier) bool {
 	if s.removedNotifier == notifier {
-
 		return false
 	}
 
@@ -962,4 +977,10 @@ func (s *trackSubscription) needsBind() bool {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	return s.desired && s.subscribedTrack != nil && !s.bound
+}
+
+func (s *trackSubscription) needsCleanup() bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return !s.desired && s.subscribedTrack == nil
 }

--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -139,13 +139,14 @@ func (m *SubscriptionManager) SubscribeToTrack(trackID livekit.TrackID) {
 		sLogger := m.params.Logger.WithValues(
 			"trackID", trackID,
 		)
-		sub := newTrackSubscription(m.params.Participant.ID(), trackID, sLogger)
+		sub = newTrackSubscription(m.params.Participant.ID(), trackID, sLogger)
 
 		m.lock.Lock()
 		m.subscriptions[trackID] = sub
 		m.lock.Unlock()
+
+		sub, desireChanged = m.setDesired(trackID, true)
 	}
-	sub, desireChanged = m.setDesired(trackID, true)
 	if desireChanged {
 		sub.logger.Infow("subscribing to track")
 	}


### PR DESCRIPTION
Two things:
-----------
1. Because the desired is not changed, the notifiers are not notified that the subscription is not observing any more. So, that holds a refernce to the subscription manager.

Address the above by setting `setDesired` to false on all subscriptions when subscription manager closes. That will remove observer from the notifiers.

2. When subscription manager is closed, the down track close is invoked which flows back (with onClose callback of downtrack) to subscription manager "handleSubscribedTrackClose". That callback handler sets the subscribed track to nil for that subscription.

A couple of scenarios here
a. Without the above change, desired could have been true and it would have looked that the track needs to try subscription again because `needsSubscribe == true` (desired == true && subscribedTrack == nil)

b. Even with the change above, there is a new condition of `desired == false && subscribedTrack == nil` and there was no handler for that condition in the reconciler.

Address this by adding a `needsCleanup` function and delete subscription from the map. Note that the reconciler may not be running to execute this action as subscription manager would have closed the `closeCh`, but doing the code in the interest of proper clean up.