### PR TITLE
unlock room with uncancellable context

### DIFF
--- a/pkg/service/roomallocator.go
+++ b/pkg/service/roomallocator.go
@@ -42,7 +42,12 @@ func (r *StandardRoomAllocator) CreateRoom(ctx context.Context, req *livekit.Cre
 		return nil, err
 	}
 	defer func() {
-		_ = r.roomStore.UnlockRoom(ctx, livekit.RoomName(req.Name), token)
+		timeoutContext, cancelFunc := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancelFunc()
+		err = r.roomStore.UnlockRoom(timeoutContext, livekit.RoomName(req.Name), token)
+		if err != nil {
+			logger.Infow("failed to unlock room", "error", err, "room", req.Name)
+		}
 	}()
 
 	// find existing room and update it


### PR DESCRIPTION
When participant is joining via browser or composite egress: 
if too many participants are joining the same room locking procedure can fall out of specified duration. 
if websocket connection gets interrupted - context is getting cancelled. therefore if lock has happened but unlock didn't - cancelled context is not allowing to perform unlock due to "context cancelled" error. 
it causes a cascade failures on all of these many participants.

change is making sure that Unlock is called always and is not cancelled via existing ctx 