### PR TITLE
Log additional details when updating participant permissions

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -370,6 +370,8 @@ func (p *ParticipantImpl) SetPermission(permission *livekit.ParticipantPermissio
 		return false
 	}
 
+	p.GetLogger().Infow("updating participant permission", "permission", permission)
+
 	video.UpdateFromPermission(permission)
 	p.dirty.Store(true)
 


### PR DESCRIPTION
To help track down sporadic updateParticipant failures