### PR TITLE
Fixed hidden participant update

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -625,14 +625,13 @@ func (p *ParticipantImpl) removeMutedTrackNotFired(mt *MediaTrack) {
 // AddTrack is called when client intends to publish track.
 // records track details and lets client know it's ok to proceed
 func (p *ParticipantImpl) AddTrack(req *livekit.AddTrackRequest) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	if !p.grants.Video.GetCanPublishSource(req.Source) {
+	if !p.CanPublishSource(req.Source) {
 		p.params.Logger.Warnw("no permission to publish track", nil)
 		return
 	}
 
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	ti := p.addPendingTrackLocked(req)
 	if ti == nil {
 		return

--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -86,6 +86,10 @@ func (p *ParticipantImpl) SendParticipantUpdate(participantsToUpdate []*livekit.
 				isValid = false
 			}
 		}
+		if pi.Permission != nil && pi.Permission.Hidden && pi.Sid != string(p.params.SID) {
+			p.params.Logger.Debugw("skipping hidden participant update", "otherParticipant", pi.Identity)
+			isValid = false
+		}
 		if isValid {
 			p.updateCache.Add(pID, participantUpdateInfo{version: pi.Version, state: pi.State, updatedAt: time.Now()})
 			validUpdates = append(validUpdates, pi)


### PR DESCRIPTION
Skip hidden participant updates. Previously these were sent if a hidden participant had published a track