### PR TITLE
Check for desired before clean up.

### DIFF
--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -369,6 +369,7 @@ func (m *SubscriptionManager) reconcileSubscription(s *trackSubscription) {
 			// successfully unsubscribed, remove from map
 			m.lock.Lock()
 			if !s.isDesired() {
+				s.logger.Debugw("unsubscribe removing subscription")
 				delete(m.subscriptions, s.trackID)
 			}
 			m.lock.Unlock()
@@ -389,7 +390,10 @@ func (m *SubscriptionManager) reconcileSubscription(s *trackSubscription) {
 
 	if s.needsCleanup() {
 		m.lock.Lock()
-		delete(m.subscriptions, s.trackID)
+		if !s.isDesired() {
+			s.logger.Debugw("cleanup removing subscription")
+			delete(m.subscriptions, s.trackID)
+		}
 		m.lock.Unlock()
 	}
 }


### PR DESCRIPTION
Fix a potential race between needsCleanup checking and a re-subscribe setting desired back to true.