### PR TITLE
 Push track quality to poor on a bandwidth constrained pause.

### DIFF
--- a/pkg/sfu/connectionquality/connectionstats.go
+++ b/pkg/sfu/connectionquality/connectionstats.go
@@ -139,6 +139,22 @@ func (cs *ConnectionStats) UpdateLayerMute(isMuted bool) {
 	cs.scorer.UpdateLayerMute(isMuted)
 }
 
+func (cs *ConnectionStats) UpdatePauseAt(isPaused bool, at time.Time) {
+	if cs.done.IsBroken() {
+		return
+	}
+
+	cs.scorer.UpdatePauseAt(isPaused, at)
+}
+
+func (cs *ConnectionStats) UpdatePause(isPaused bool) {
+	if cs.done.IsBroken() {
+		return
+	}
+
+	cs.scorer.UpdatePause(isPaused)
+}
+
 func (cs *ConnectionStats) AddLayerTransitionAt(distance float64, at time.Time) {
 	if cs.done.IsBroken() {
 		return

--- a/pkg/sfu/connectionquality/scorer.go
+++ b/pkg/sfu/connectionquality/scorer.go
@@ -162,7 +162,7 @@ type qualityScorer struct {
 	layerMutedAt   time.Time
 	layerUnmutedAt time.Time
 
-	pausedAt   time.Time
+	pausedAt  time.Time
 	resumedAt time.Time
 
 	maxPPS float64

--- a/pkg/sfu/connectionquality/scorer.go
+++ b/pkg/sfu/connectionquality/scorer.go
@@ -162,6 +162,9 @@ type qualityScorer struct {
 	layerMutedAt   time.Time
 	layerUnmutedAt time.Time
 
+	pausedAt   time.Time
+	resumedAt time.Time
+
 	maxPPS float64
 
 	aggregateBitrate *utils.TimedAggregator[int64]
@@ -224,17 +227,6 @@ func (q *qualityScorer) UpdateMute(isMuted bool) {
 
 func (q *qualityScorer) addBitrateTransitionAtLocked(bitrate int64, at time.Time) {
 	q.aggregateBitrate.AddSampleAt(bitrate, at)
-
-	if bitrate == 0 {
-		if !q.isLayerMuted() {
-			q.layerMutedAt = at
-			q.score = maxScore
-		}
-	} else {
-		if q.isLayerMuted() {
-			q.layerUnmutedAt = at
-		}
-	}
 }
 
 func (q *qualityScorer) AddBitrateTransitionAt(bitrate int64, at time.Time) {
@@ -254,8 +246,9 @@ func (q *qualityScorer) AddBitrateTransition(bitrate int64) {
 func (q *qualityScorer) updateLayerMuteAtLocked(isMuted bool, at time.Time) {
 	if isMuted {
 		if !q.isLayerMuted() {
-			q.aggregateBitrate.AddSampleAt(0, at)
-			q.layerDistance.AddSampleAt(0, at)
+			q.aggregateBitrate.Reset()
+			q.layerDistance.Reset()
+
 			q.layerMutedAt = at
 			q.score = maxScore
 		}
@@ -278,6 +271,36 @@ func (q *qualityScorer) UpdateLayerMute(isMuted bool) {
 	defer q.lock.Unlock()
 
 	q.updateLayerMuteAtLocked(isMuted, time.Now())
+}
+
+func (q *qualityScorer) updatePauseAtLocked(isPaused bool, at time.Time) {
+	if isPaused {
+		if !q.isPaused() {
+			q.aggregateBitrate.Reset()
+			q.layerDistance.Reset()
+
+			q.pausedAt = at
+			q.score = poorScore
+		}
+	} else {
+		if q.isPaused() {
+			q.resumedAt = at
+		}
+	}
+}
+
+func (q *qualityScorer) UpdatePauseAt(isPaused bool, at time.Time) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	q.updatePauseAtLocked(isPaused, at)
+}
+
+func (q *qualityScorer) UpdatePause(isPaused bool) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	q.updatePauseAtLocked(isPaused, time.Now())
 }
 
 func (q *qualityScorer) addLayerTransitionAtLocked(distance float64, at time.Time) {
@@ -311,11 +334,14 @@ func (q *qualityScorer) updateAtLocked(stat *windowStat, at time.Time) {
 
 	// nothing to do when muted or not unmuted for long enough
 	// NOTE: it is possible that unmute -> mute -> unmute transition happens in the
-	//       same analysis window. On a transition to mute, state immediately moves
-	//       to stable and quality EXCELLENT for responsiveness. On an unmute, the
-	//       entire window data is considered (as long as enough time has passed since
-	//       unmute) including the data before mute.
-	if q.isMuted() || !q.isUnmutedEnough(at) || q.isLayerMuted() {
+	//       same analysis window. On a transition to mute, quality is immediately moved
+	//       EXCELLENT for responsiveness. On an unmute, the entire window data is
+	//       considered (as long as enough time has passed since unmute).
+	//
+	//       Similarly, when paused (possibly due to congestion), score is immediately
+	//       set to poorScore for responsiveness. The layer transision is reest.
+	//       On a resume, quality climbs back up using normal operation.
+	if q.isMuted() || !q.isUnmutedEnough(at) || q.isLayerMuted() || q.isPaused() {
 		q.lastUpdateAt = at
 		return
 	}
@@ -428,6 +454,10 @@ func (q *qualityScorer) isUnmutedEnough(at time.Time) bool {
 
 func (q *qualityScorer) isLayerMuted() bool {
 	return !q.layerMutedAt.IsZero() && (q.layerUnmutedAt.IsZero() || q.layerMutedAt.After(q.layerUnmutedAt))
+}
+
+func (q *qualityScorer) isPaused() bool {
+	return !q.pausedAt.IsZero() && (q.resumedAt.IsZero() || q.pausedAt.After(q.resumedAt))
 }
 
 func (q *qualityScorer) getPacketLossWeight(stat *windowStat) float64 {

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -950,18 +950,24 @@ func (d *DownTrack) UpTrackMaxTemporalLayerSeenChange(maxTemporalLayerSeen int32
 	}
 }
 
-func (d *DownTrack) maybeAddTransition(_bitrate int64, distance float64) {
+func (d *DownTrack) maybeAddTransition(_bitrate int64, distance float64, pauseReason VideoPauseReason) {
 	if d.kind == webrtc.RTPCodecTypeAudio {
 		return
 	}
 
-	d.connectionStats.AddLayerTransition(distance)
+	if pauseReason == VideoPauseReasonBandwidth {
+		d.connectionStats.UpdatePause(true)
+	} else {
+		d.connectionStats.UpdatePause(false)
+		d.connectionStats.AddLayerTransition(distance)
+	}
 }
 
 func (d *DownTrack) UpTrackBitrateReport(availableLayers []int32, bitrates Bitrates) {
 	d.maybeAddTransition(
 		d.forwarder.GetOptimalBandwidthNeeded(bitrates),
 		d.forwarder.DistanceToDesired(availableLayers, bitrates),
+		d.forwarder.PauseReason(),
 	)
 }
 
@@ -1011,7 +1017,7 @@ func (d *DownTrack) AllocateOptimal(allowOvershoot bool) VideoAllocation {
 	al, brs := d.receiver.GetLayeredBitrate()
 	allocation := d.forwarder.AllocateOptimal(al, brs, allowOvershoot)
 	d.maybeStartKeyFrameRequester()
-	d.maybeAddTransition(allocation.BandwidthNeeded, allocation.DistanceToDesired)
+	d.maybeAddTransition(allocation.BandwidthNeeded, allocation.DistanceToDesired, allocation.PauseReason)
 	return allocation
 }
 
@@ -1039,7 +1045,7 @@ func (d *DownTrack) ProvisionalAllocateGetBestWeightedTransition() VideoTransiti
 func (d *DownTrack) ProvisionalAllocateCommit() VideoAllocation {
 	allocation := d.forwarder.ProvisionalAllocateCommit()
 	d.maybeStartKeyFrameRequester()
-	d.maybeAddTransition(allocation.BandwidthNeeded, allocation.DistanceToDesired)
+	d.maybeAddTransition(allocation.BandwidthNeeded, allocation.DistanceToDesired, allocation.PauseReason)
 	return allocation
 }
 
@@ -1047,7 +1053,7 @@ func (d *DownTrack) AllocateNextHigher(availableChannelCapacity int64, allowOver
 	al, brs := d.receiver.GetLayeredBitrate()
 	allocation, available := d.forwarder.AllocateNextHigher(availableChannelCapacity, al, brs, allowOvershoot)
 	d.maybeStartKeyFrameRequester()
-	d.maybeAddTransition(allocation.BandwidthNeeded, allocation.DistanceToDesired)
+	d.maybeAddTransition(allocation.BandwidthNeeded, allocation.DistanceToDesired, allocation.PauseReason)
 	return allocation, available
 }
 
@@ -1062,7 +1068,7 @@ func (d *DownTrack) Pause() VideoAllocation {
 	al, brs := d.receiver.GetLayeredBitrate()
 	allocation := d.forwarder.Pause(al, brs)
 	d.maybeStartKeyFrameRequester()
-	d.maybeAddTransition(allocation.BandwidthNeeded, allocation.DistanceToDesired)
+	d.maybeAddTransition(allocation.BandwidthNeeded, allocation.DistanceToDesired, allocation.PauseReason)
 	return allocation
 }
 

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -526,6 +526,13 @@ func (f *Forwarder) IsDeficient() bool {
 	return f.isDeficientLocked()
 }
 
+func (f *Forwarder) PauseReason() VideoPauseReason {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+
+	return f.lastAllocation.PauseReason
+}
+
 func (f *Forwarder) BandwidthRequested(brs Bitrates) int64 {
 	f.lock.RLock()
 	defer f.lock.RUnlock()

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1872,7 +1872,7 @@ done:
 		((adjustedMaxLayer.Spatial - adjustedTargetLayer.Spatial) * (maxSeenLayer.Temporal + 1)) +
 			(adjustedMaxLayer.Temporal - adjustedTargetLayer.Temporal)
 	if !targetLayer.IsValid() {
-		distance++
+		distance += (maxSeenLayer.Temporal + 1)
 	}
 
 	return float64(distance) / float64(maxSeenLayer.Temporal+1)

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -562,7 +562,7 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 		TargetLayer:         expectedTargetLayer,
 		RequestLayerSpatial: expectedTargetLayer.Spatial,
 		MaxLayer:            expectedMaxLayer,
-		DistanceToDesired:   0.25,
+		DistanceToDesired:   1.0,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -595,7 +595,7 @@ func TestForwarderProvisionalAllocate(t *testing.T) {
 		TargetLayer:         buffer.InvalidLayer,
 		RequestLayerSpatial: buffer.InvalidLayerSpatial,
 		MaxLayer:            expectedMaxLayer,
-		DistanceToDesired:   0.25,
+		DistanceToDesired:   1.0,
 	}
 	result = f.ProvisionalAllocateCommit()
 	require.Equal(t, expectedResult, result)
@@ -1114,7 +1114,7 @@ func TestForwarderPause(t *testing.T) {
 		TargetLayer:         buffer.InvalidLayer,
 		RequestLayerSpatial: buffer.InvalidLayerSpatial,
 		MaxLayer:            buffer.DefaultMaxLayer,
-		DistanceToDesired:   3,
+		DistanceToDesired:   3.75,
 	}
 	result := f.Pause(nil, bitrates)
 	require.Equal(t, expectedResult, result)

--- a/test/singlenode_test.go
+++ b/test/singlenode_test.go
@@ -620,7 +620,7 @@ func TestSubscribeToCodecUnsupported(t *testing.T) {
 		require.Equal(t, h264TrackID, sr.TrackSid)
 		require.Equal(t, livekit.SubscriptionError_SE_CODEC_UNSUPPORTED, sr.Err)
 		return true
-	}, time.Second, 10*time.Millisecond, "did not receive subscription response")
+	}, 5*time.Second, 10*time.Millisecond, "did not receive subscription response")
 
 	// publish another vp8 track again, ensure the transport recovered by sfu and c2 can receive it
 	t4, err := c1.AddStaticTrack("video/vp8", "video2", "webcam2")


### PR DESCRIPTION
A few different ways to handle this, but settled on an explicit notification into scorer about pause/resume. I considered the following and may need to do at least the first one if things change later.
1. As participant level score is minimum of track scores, track level score being set to `POOR` will be reflected at participant level. But, if participant level score moves to average or median, will need to add a participant level check for any track being paused due to congestion and force a poor quality.
2. Was thinking of adding a high distance penalty in the `DistanceToDesired` method, but decided against it for a couple of reasons
    i. That meant the `DistanceToDesired` method has knowledge of scorer and sets up penalty to force poor quality. Introduces unnecessary coupling.
    ii. The scorer update is not happening (or happening much more infrequently) when streams are paused. So, there may not be a chance to update score. The explicit notification sets the score immediately. Even if update does not run, getting the score would return poor quality as long as track is paused.

Also, removing some automatic setting/unsetting in scorer as there are a bunch of cases and it was getting confusing. Will make a note in place. Now, callers should notify changes.