### PR TITLE
Add ability to roll back video layer selection.

### DIFF
--- a/pkg/sfu/videolayerselector/base.go
+++ b/pkg/sfu/videolayerselector/base.go
@@ -142,12 +142,16 @@ func (b *Base) Rollback() {
 	b.targetLayer = b.previousTargetLayer
 }
 
-func (b *Base) SelectTemporal(extPkt *buffer.ExtPacket) int32 {
+func (b *Base) SelectTemporal(extPkt *buffer.ExtPacket) (int32, bool) {
 	if b.tls != nil {
+		isSwitching := false
 		this, next := b.tls.Select(extPkt, b.currentLayer.Temporal, b.targetLayer.Temporal)
 		if next != b.currentLayer.Temporal {
+			isSwitching = true
+
 			b.previousLayer = b.currentLayer
 			b.currentLayer.Temporal = next
+
 			b.logger.Infow(
 				"updating temporal layer",
 				"previous", b.previousLayer,
@@ -161,8 +165,8 @@ func (b *Base) SelectTemporal(extPkt *buffer.ExtPacket) int32 {
 				"maxSeen", b.maxSeenLayer,
 			)
 		}
-		return this
+		return this, isSwitching
 	}
 
-	return b.currentLayer.Temporal
+	return b.currentLayer.Temporal, false
 }

--- a/pkg/sfu/videolayerselector/videolayerselector.go
+++ b/pkg/sfu/videolayerselector/videolayerselector.go
@@ -47,6 +47,6 @@ type VideoLayerSelector interface {
 	GetCurrent() buffer.VideoLayer
 
 	Select(extPkt *buffer.ExtPacket, layer int32) VideoLayerSelectorResult
-	SelectTemporal(extPkt *buffer.ExtPacket) int32
+	SelectTemporal(extPkt *buffer.ExtPacket) (int32, bool)
 	Rollback()
 }

--- a/pkg/sfu/videolayerselector/videolayerselector.go
+++ b/pkg/sfu/videolayerselector/videolayerselector.go
@@ -8,6 +8,7 @@ import (
 type VideoLayerSelectorResult struct {
 	IsSelected                    bool
 	IsRelevant                    bool
+	IsSwitching                   bool
 	IsResuming                    bool
 	IsSwitchingToRequestSpatial   bool
 	IsSwitchingToMaxSpatial       bool
@@ -47,4 +48,5 @@ type VideoLayerSelector interface {
 
 	Select(extPkt *buffer.ExtPacket, layer int32) VideoLayerSelectorResult
 	SelectTemporal(extPkt *buffer.ExtPacket) int32
+	Rollback()
 }

--- a/pkg/sfu/videolayerselector/vp9.go
+++ b/pkg/sfu/videolayerselector/vp9.go
@@ -75,6 +75,7 @@ func (v *VP9) Select(extPkt *buffer.ExtPacket, _layer int32) (result VideoLayerS
 		}
 
 		if updatedLayer != v.currentLayer {
+			result.IsSwitching = true
 			if !v.currentLayer.IsValid() && updatedLayer.IsValid() {
 				result.IsResuming = true
 			}
@@ -89,6 +90,7 @@ func (v *VP9) Select(extPkt *buffer.ExtPacket, _layer int32) (result VideoLayerS
 				v.logger.Infow(
 					"reached max layer",
 					"current", v.currentLayer,
+					"updated", updatedLayer,
 					"target", v.targetLayer,
 					"max", v.maxLayer,
 					"layer", extPkt.VideoLayer.Spatial,
@@ -98,6 +100,7 @@ func (v *VP9) Select(extPkt *buffer.ExtPacket, _layer int32) (result VideoLayerS
 				)
 			}
 
+			v.previousLayer = v.currentLayer
 			v.currentLayer = updatedLayer
 		}
 	}


### PR DESCRIPTION
Not currently useful, but it is possible to do things like not applying a layer switch if the switch point time stamp is too far back.

Add ability to roll back a layer switch and invoke rollback if a packet was selected for forwarding, but a subsequent error or decision to drop the packet can rollback layer switch if that was the switching packet.

In current code, the paths where a packet can be dropped after selection does not happen at switch points. So, it was okay to apply the selection unconditionally. But, adding the call to rollback in the current code also in all paths where packet is dropped after selection for consistent code flow.