### PR TITLE
Time stamp adjustments v2 (I think)

### DIFF
--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -12,7 +12,6 @@ import (
 	"github.com/livekit/protocol/logger"
 
 	"github.com/livekit/livekit-server/pkg/sfu"
-	"github.com/livekit/livekit-server/pkg/sfu/buffer"
 )
 
 // wrapper around WebRTC receiver, overriding its ID
@@ -297,11 +296,11 @@ func (d *DummyReceiver) GetRedReceiver() sfu.TrackReceiver {
 	return d
 }
 
-func (d *DummyReceiver) GetRTCPSenderReportData(layer int32) (*buffer.RTCPSenderReportData, *buffer.RTCPSenderReportData) {
+func (d *DummyReceiver) GetCalculatedClockRate(layer int32) uint32 {
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
-		return r.GetRTCPSenderReportData(layer)
+		return r.GetCalculatedClockRate(layer)
 	}
-	return nil, nil
+	return 0
 }
 
 func (d *DummyReceiver) GetReferenceLayerRTPTimestamp(ts uint32, layer int32, referenceLayer int32) (uint32, error) {

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -861,17 +861,6 @@ func (r *RTPStats) GetExpectedRTPTimestamp(at time.Time) (expectedTSExt uint64, 
 	timeDiff := at.Sub(r.firstTime)
 	expectedRTPDiff := timeDiff.Nanoseconds() * int64(r.params.ClockRate) / 1e9
 	expectedTSExt = r.extStartTS + uint64(expectedRTPDiff)
-	r.logger.Debugw(
-		"expected RTP timestamp",
-		"firstTime", r.firstTime.String(),
-		"checkAt", at.String(),
-		"timeDiff", timeDiff,
-		"firstRTP", r.extStartTS,
-		"expectedRTPDiff", expectedRTPDiff,
-		"expectedTSExt", expectedTSExt,
-		"highestTS", r.highestTS,
-		"highestTime", r.highestTime.String(),
-	)
 	return
 }
 

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -750,12 +750,12 @@ func (r *RTPStats) GetRtt() uint32 {
 }
 
 func (r *RTPStats) SetRtcpSenderReportData(srData *RTCPSenderReportData) {
-	if srData == nil {
-		return
-	}
-
 	r.lock.Lock()
 	defer r.lock.Unlock()
+
+	if srData == nil || !r.initialized {
+		return
+	}
 
 	// prevent against extreme case of anachronous sender reports
 	if r.srNewest != nil && r.srNewest.NTPTimestamp > srData.NTPTimestamp {
@@ -765,29 +765,6 @@ func (r *RTPStats) SetRtcpSenderReportData(srData *RTCPSenderReportData) {
 			"last", r.srNewest.NTPTimestamp.Time(),
 		)
 		return
-	}
-
-	// monitor and log RTP timestamp anomalies
-	var ntpDiffSinceLast time.Duration
-	var rtpDiffSinceLast uint32
-	var arrivalDiffSinceLast time.Duration
-	var expectedTimeDiffSinceLast float64
-	var reason string
-	if r.srNewest != nil {
-		ntpDiffSinceLast = srData.NTPTimestamp.Time().Sub(r.srNewest.NTPTimestamp.Time())
-		rtpDiffSinceLast = srData.RTPTimestamp - r.srNewest.RTPTimestamp
-		arrivalDiffSinceLast = srData.At.Sub(r.srNewest.At)
-
-		expectedTimeDiffSinceLast = float64(rtpDiffSinceLast) / float64(r.params.ClockRate)
-
-		if (srData.RTPTimestamp - r.srNewest.RTPTimestamp) > (1 << 31) {
-			reason = "received sender report, out-of-order" // should not happen, just a sanity check
-		} else {
-			if math.Abs(expectedTimeDiffSinceLast-ntpDiffSinceLast.Seconds()) > 0.2 {
-				// more than 200 ms away from expected delta
-				reason = "received sender report, time warp"
-			}
-		}
 	}
 
 	cycles := uint64(0)
@@ -800,15 +777,47 @@ func (r *RTPStats) SetRtcpSenderReportData(srData *RTCPSenderReportData) {
 
 	srDataCopy := *srData
 	srDataCopy.RTPTimestampExt = uint64(srDataCopy.RTPTimestamp) + cycles
+
+	// monitor and log RTP timestamp anomalies
+	var ntpDiffSinceLast time.Duration
+	var rtpDiffSinceLast uint32
+	var arrivalDiffSinceLast time.Duration
+	var expectedTimeDiffSinceLast float64
+	var isWarped bool
+	if r.srNewest != nil {
+		if srDataCopy.RTPTimestampExt < r.srNewest.RTPTimestampExt {
+			// This can happen when a track is replaced with a null and then restored -
+			// i. e. muting replacing with null and unmute restoring the original track.
+			// Under such a condition reset the sender reports to start from this point.
+			// Resetting will ensure sample rate calculations do not go haywire due to negative time.
+			r.logger.Infow(
+				"received sender report, out-of-order, resetting",
+				"prevTSExt", r.srNewest.RTPTimestampExt,
+				"currTSExt", srDataCopy.RTPTimestampExt,
+			)
+			r.srFirst = &srDataCopy
+			r.srNewest = &srDataCopy
+		}
+
+		ntpDiffSinceLast = srDataCopy.NTPTimestamp.Time().Sub(r.srNewest.NTPTimestamp.Time())
+		rtpDiffSinceLast = srDataCopy.RTPTimestamp - r.srNewest.RTPTimestamp
+		arrivalDiffSinceLast = srDataCopy.At.Sub(r.srNewest.At)
+		expectedTimeDiffSinceLast = float64(rtpDiffSinceLast) / float64(r.params.ClockRate)
+		if math.Abs(expectedTimeDiffSinceLast-ntpDiffSinceLast.Seconds()) > 0.2 {
+			// more than 200 ms away from expected delta
+			isWarped = true
+		}
+	}
+
 	r.srNewest = &srDataCopy
 	if r.srFirst == nil {
 		r.srFirst = &srDataCopy
 	}
 
-	if reason != "" {
+	if isWarped {
 		packetDriftResult, reportDriftResult := r.getDrift()
 		r.logger.Infow(
-			reason,
+			"received sender report, time warp",
 			"ntp", srData.NTPTimestamp.Time().String(),
 			"rtp", srData.RTPTimestamp,
 			"arrival", srData.At.String(),
@@ -840,23 +849,42 @@ func (r *RTPStats) GetRtcpSenderReportData() (srFirst *RTCPSenderReportData, srN
 	return
 }
 
-func (r *RTPStats) GetExpectedRTPTimestamp(at time.Time) (uint32, uint64, error) {
+func (r *RTPStats) GetExpectedRTPTimestamp(at time.Time) (
+	expectedTSExt uint64,
+	latestSRTSExt uint64,
+	isLatestSRTSExtValid bool,
+	err error,
+) {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
 	if !r.initialized {
-		return 0, 0, errors.New("uninitilaized")
+		err = errors.New("uninitilaized")
+		return
 	}
 
 	timeDiff := at.Sub(r.firstTime)
 	expectedRTPDiff := timeDiff.Nanoseconds() * int64(r.params.ClockRate) / 1e9
-	expectedExtRTP := r.extStartTS + uint64(expectedRTPDiff)
+	expectedTSExt = r.extStartTS + uint64(expectedRTPDiff)
 
-	minTS := ^uint64(0)
 	if r.srNewest != nil {
-		minTS = r.srNewest.RTPTimestampExt
+		latestSRTSExt = r.srNewest.RTPTimestampExt
+		isLatestSRTSExtValid = true
 	}
-	return uint32(expectedExtRTP), minTS, nil
+	r.logger.Debugw(
+		"expected RTP timestamp",
+		"firstTime", r.firstTime.String(),
+		"checkAt", at.String(),
+		"timeDiff", timeDiff,
+		"firstRTP", r.extStartTS,
+		"expectedRTPDiff", expectedRTPDiff,
+		"expectedTSExt", expectedTSExt,
+		"latestSRTSExt", latestSRTSExt,
+		"isLatestSRTSExtValid", isLatestSRTSExtValid,
+		"highestTS", r.highestTS,
+		"highestTime", r.highestTime.String(),
+	)
+	return
 }
 
 func (r *RTPStats) GetRtcpSenderReport(ssrc uint32, srFirst *RTCPSenderReportData, srNewest *RTCPSenderReportData) *rtcp.SenderReport {

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -1102,8 +1102,7 @@ func (d *DownTrack) CreateSenderReport() *rtcp.SenderReport {
 		return nil
 	}
 
-	srFirst, srNewest := d.receiver.GetRTCPSenderReportData(d.forwarder.GetReferenceLayerSpatial())
-	return d.rtpStats.GetRtcpSenderReport(d.ssrc, srFirst, srNewest)
+	return d.rtpStats.GetRtcpSenderReport(d.ssrc, d.receiver.GetCalculatedClockRate(d.forwarder.CurrentLayer().Spatial))
 }
 
 func (d *DownTrack) writeBlankFrameRTP(duration float32, generation uint32) chan struct{} {
@@ -1542,7 +1541,7 @@ func (d *DownTrack) DebugInfo() map[string]interface{} {
 	}
 }
 
-func (d *DownTrack) getExpectedRTPTimestamp(at time.Time) (uint64, uint64, bool, error) {
+func (d *DownTrack) getExpectedRTPTimestamp(at time.Time) (uint64, error) {
 	return d.rtpStats.GetExpectedRTPTimestamp(at)
 }
 

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -1536,7 +1536,7 @@ func (d *DownTrack) DebugInfo() map[string]interface{} {
 	}
 }
 
-func (d *DownTrack) getExpectedRTPTimestamp(at time.Time) (uint32, uint64, error) {
+func (d *DownTrack) getExpectedRTPTimestamp(at time.Time) (uint64, uint64, bool, error) {
 	return d.rtpStats.GetExpectedRTPTimestamp(at)
 }
 

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -26,6 +26,10 @@ const (
 	FlagFilterRTX           = true
 	TransitionCostSpatial   = 10
 	ParkedLayerWaitDuration = 2 * time.Second
+
+	ResumeBehindThresholdSeconds      = float64(0.1)   // 100ms
+	LayerSwitchBehindThresholdSeconds = float64(0.05)  // 50ms
+	SwitchAheadThresholdSeconds       = float64(0.025) // 25ms
 )
 
 // -------------------------------------------------------------------
@@ -171,7 +175,7 @@ type Forwarder struct {
 	kind                          webrtc.RTPCodecType
 	logger                        logger.Logger
 	getReferenceLayerRTPTimestamp func(ts uint32, layer int32, referenceLayer int32) (uint32, error)
-	getExpectedRTPTimestamp       func(at time.Time) (uint64, uint64, bool, error)
+	getExpectedRTPTimestamp       func(at time.Time) (uint64, error)
 
 	muted    bool
 	pubMuted bool
@@ -202,7 +206,7 @@ func NewForwarder(
 	kind webrtc.RTPCodecType,
 	logger logger.Logger,
 	getReferenceLayerRTPTimestamp func(ts uint32, layer int32, referenceLayer int32) (uint32, error),
-	getExpectedRTPTimestamp func(at time.Time) (uint64, uint64, bool, error),
+	getExpectedRTPTimestamp func(at time.Time) (uint64, error),
 ) *Forwarder {
 	f := &Forwarder{
 		kind:                          kind,
@@ -506,13 +510,6 @@ func (f *Forwarder) TargetLayer() buffer.VideoLayer {
 	defer f.lock.RUnlock()
 
 	return f.vls.GetTarget()
-}
-
-func (f *Forwarder) GetReferenceLayerSpatial() int32 {
-	f.lock.RLock()
-	defer f.lock.RUnlock()
-
-	return f.referenceLayerSpatial
 }
 
 func (f *Forwarder) isDeficientLocked() bool {
@@ -1477,106 +1474,176 @@ func (f *Forwarder) GetTranslationParams(extPkt *buffer.ExtPacket, layer int32) 
 	return nil, ErrUnknownKind
 }
 
+func (f *Forwarder) processSourceSwitch(extPkt *buffer.ExtPacket, layer int32) error {
+	if !f.started {
+		f.started = true
+		f.referenceLayerSpatial = layer
+		f.rtpMunger.SetLastSnTs(extPkt)
+		f.codecMunger.SetLast(extPkt)
+		f.logger.Infow(
+			"starting forwarding",
+			"sequenceNumber", extPkt.Packet.SequenceNumber,
+			"timestamp", extPkt.Packet.Timestamp,
+			"layer", layer,
+			"referenceLayerSpatial", f.referenceLayerSpatial,
+		)
+		return nil
+	}
+
+	if f.referenceLayerSpatial == buffer.InvalidLayerSpatial {
+		// on a resume, reference layer may not be set, so only set when it is invalid
+		f.referenceLayerSpatial = layer
+	}
+
+	// Compute how much time passed between the previous forwarded packet
+	// and the current incoming (to be forwarded) packet and calculate
+	// timestamp offset on source change
+	//
+	// There are three time stamps to consider here
+	//   1. lastTS -> time stamp of last sent packet
+	//   2. refTS -> time stamp of this packet (after munging) calculated using feed's RTCP sender report
+	//   3. expectedTS -> expectdd time stamp of this packet calculated based on elapsed time since first packet
+	// Ideally, refTS and expectedTS should be very close and lastTS should be before both of those.
+	// But, cases like muting/unmuting, clock vagaries, pacing, etc. make them not satisfy those conditions always.
+	lastTS := f.rtpMunger.GetLast().LastTS
+	refTS := lastTS
+	expectedTS := lastTS
+	switchingAt := time.Now()
+	if f.getReferenceLayerRTPTimestamp != nil {
+		ts, err := f.getReferenceLayerRTPTimestamp(extPkt.Packet.Timestamp, layer, f.referenceLayerSpatial)
+		if err == nil {
+			refTS = ts
+		}
+		// AVSYNC-TODO: can error out here if refTS is not available. It can happen when there is no sender report
+		// for the layer being switched to. Can especially happen at the start of the track when layer switches are
+		// potentially happening very quickly. Erroring out and waiting for a layer for which a sender report has been
+		// received will calculate a better offset, but may result in initial adaptation to take a bit longer depending
+		// on how often publisher/remote side sends RTCP sender report.
+	}
+
+	if f.getExpectedRTPTimestamp != nil {
+		tsExt, err := f.getExpectedRTPTimestamp(switchingAt)
+		if err == nil {
+			expectedTS = uint32(tsExt)
+		} else {
+			rtpDiff := uint32(0)
+			if !f.preStartTime.IsZero() && f.refTSOffset == 0 {
+				timeSinceFirst := time.Since(f.preStartTime)
+				rtpDiff = uint32(timeSinceFirst.Nanoseconds() * int64(f.codec.ClockRate) / 1e9)
+				f.refTSOffset = f.firstTS + rtpDiff - refTS
+				f.logger.Infow(
+					"calculating refTSOffset",
+					"preStartTime", f.preStartTime.String(),
+					"firstTS", f.firstTS,
+					"timeSinceFirst", timeSinceFirst,
+					"rtpDiff", rtpDiff,
+					"refTS", refTS,
+					"refTSOffset", f.refTSOffset,
+				)
+			}
+			expectedTS += rtpDiff
+		}
+	}
+	refTS += f.refTSOffset
+
+	var nextTS uint32
+	if f.lastSSRC == 0 {
+		// If resuming (e. g. on unmute), keep next timestamp close to expected timestmap.
+		//
+		// Rationale:
+		// Case 1: If mute is implemented via something like stopping a track and resuming it on unmute,,
+		// the RTP time stamp may not have jumped across mute valley. In this case, old timestamp
+		// should not be used.
+		//
+		// Case 2: OTOH, something like pacing may be adding latency in the publisher path (even if
+		// the time stamps incremented correctly across the mute valley). In this case, reference
+		// time stamp should be used as things will catch up to real time when channel capacity
+		// increases and pacer starts sending at faster rate.
+		//
+		// But, the challenege is distinguishing between the two cases. As a compromise, the difference
+		// between expectedTS and refTS is thresholded. Difference below the threshold is treated as Case 2
+		// and above as Case 1.
+		//
+		// In the event of refTS > expectedTS, another threshold is used to pick the next timestamp.
+		// Ideally, refTS should not be ahead of expectedTS, but expectedTS uses the first packet's
+		// wall clock time. So, if the first packet experienced abmormal latency, it is possible
+		// for refTS > expectedTS
+		diffSeconds := float64(expectedTS-refTS) / float64(f.codec.ClockRate)
+		if diffSeconds >= 0.0 {
+			if diffSeconds > ResumeBehindThresholdSeconds {
+				f.logger.Infow("resume, reference too far behind", "expectedTS", expectedTS, "refTS", refTS, "diffSeconds", diffSeconds)
+				nextTS = expectedTS
+			} else {
+				nextTS = refTS
+			}
+		} else {
+			if math.Abs(diffSeconds) > SwitchAheadThresholdSeconds {
+				f.logger.Infow("resume, reference too far ahead", "expectedTS", expectedTS, "refTS", refTS, "diffSeconds", math.Abs(diffSeconds))
+				nextTS = expectedTS
+			} else {
+				nextTS = refTS
+			}
+		}
+	} else {
+		// switching between layers, check if refTS is too far behind the last sent
+		diffSeconds := float64(refTS-lastTS) / float64(f.codec.ClockRate)
+		if diffSeconds < 0.0 {
+			if diffSeconds > LayerSwitchBehindThresholdSeconds {
+				// AVSYNC-TODO: This could be due to pacer trickling out this layer. Should potentially return error here and wait for a more opportune time
+				// or some forcing function (like "have waited for too long for layer switch, nothing available, switch to whatever is available" kind of condition)
+				// to do the switch. Just logging it for now.
+				f.logger.Infow("layer switch, reference too far behind", "expectedTS", expectedTS, "refTS", refTS, "lastTS", lastTS, "diffSeconds", diffSeconds)
+			}
+			// use a nominal increase to ensure that time stamp is always moving forward
+			nextTS = lastTS + 1
+		} else {
+			diffSeconds = float64(expectedTS-refTS) / float64(f.codec.ClockRate)
+			if math.Abs(diffSeconds) > SwitchAheadThresholdSeconds {
+				f.logger.Infow("layer switch, reference too far ahead", "expectedTS", expectedTS, "refTS", refTS, "diffSeconds", math.Abs(diffSeconds))
+				nextTS = expectedTS
+			} else {
+				nextTS = refTS
+			}
+		}
+	}
+
+	if nextTS-lastTS == 0 || nextTS-lastTS > (1<<31) {
+		f.logger.Infow("next time stamp is before last, adjusting", "nextTS", nextTS, "lastTS", lastTS)
+		// nominal increase
+		nextTS = lastTS + 1
+	}
+	f.logger.Infow(
+		"next timestamp on switch",
+		"switchingAt", switchingAt.String(),
+		"layer", layer,
+		"lastTS", lastTS,
+		"refTS", refTS,
+		"refTSOffset", f.refTSOffset,
+		"referenceLayerSpatial", f.referenceLayerSpatial,
+		"expectedTS", expectedTS,
+		"nextTS", nextTS,
+		"jump", nextTS-lastTS,
+	)
+
+	f.rtpMunger.UpdateSnTsOffsets(extPkt, 1, nextTS-lastTS)
+	f.codecMunger.UpdateOffsets(extPkt)
+	return nil
+}
+
 // should be called with lock held
 func (f *Forwarder) getTranslationParamsCommon(extPkt *buffer.ExtPacket, layer int32, tp *TranslationParams) (*TranslationParams, error) {
+	if tp == nil {
+		tp = &TranslationParams{}
+	}
 	if f.lastSSRC != extPkt.Packet.SSRC {
-		if !f.started {
-			f.started = true
-			f.referenceLayerSpatial = layer
-			f.rtpMunger.SetLastSnTs(extPkt)
-			f.codecMunger.SetLast(extPkt)
-			f.logger.Infow(
-				"starting forwarding",
-				"sequenceNumber", extPkt.Packet.SequenceNumber,
-				"timestamp", extPkt.Packet.Timestamp,
-				"layer", layer,
-				"referenceLayerSpatial", f.referenceLayerSpatial,
-			)
-		} else {
-			if f.referenceLayerSpatial == buffer.InvalidLayerSpatial {
-				// on a resume, reference layer may not be set, so only set when it is invalid
-				f.referenceLayerSpatial = layer
-			}
-
-			// Compute how much time passed between the old RTP extPkt
-			// and the current packet, and fix timestamp on source change
-			//
-			// There are three time stamps to consider here
-			//   1. lastTS -> time stamp of last sent packet
-			//   2. refTS -> time stamp of this packet (after munging) calculated using feed's RTCP sender report
-			//   3. expectedTS -> time stamp of this packet (after munging) calculated using this stream's RTCP sender report
-			// Ideally, refTS and expectedTS should be very close and lastTS should be before both of those.
-			// But, cases like muting/unmuting, clock vagaries make them not satisfy those conditions always.
-			//
-			// There are 6 orderings to consider (considering only inequalities). Resolve them using following rules
-			//   1. Timestamp has to move forward
-			//   2. Keep next time stamp close to expected
-			lastTS := f.rtpMunger.GetLast().LastTS
-			refTS := lastTS
-			expectedTS := lastTS
-			latestSRTSExt := uint64(0)
-			isLatestSRTSExtValid := false
-			switchingAt := time.Now()
-			if f.getReferenceLayerRTPTimestamp != nil {
-				ts, err := f.getReferenceLayerRTPTimestamp(extPkt.Packet.Timestamp, layer, f.referenceLayerSpatial)
-				if err == nil {
-					refTS = ts
-				}
-			}
-			if f.getExpectedRTPTimestamp != nil {
-				tsExt, latest, isLatestValid, err := f.getExpectedRTPTimestamp(switchingAt)
-				if err == nil {
-					expectedTS = uint32(tsExt)
-					latestSRTSExt = latest
-					isLatestSRTSExtValid = isLatestValid
-				} else {
-					rtpDiff := uint32(0)
-					if !f.preStartTime.IsZero() && f.refTSOffset == 0 {
-						timeSinceFirst := time.Since(f.preStartTime)
-						rtpDiff = uint32(timeSinceFirst.Nanoseconds() * int64(f.codec.ClockRate) / 1e9)
-						f.refTSOffset = f.firstTS + rtpDiff - refTS
-						f.logger.Infow(
-							"calculating refTSOffset",
-							"preStartTime", f.preStartTime.String(),
-							"firstTS", f.firstTS,
-							"timeSinceFirst", timeSinceFirst,
-							"rtpDiff", rtpDiff,
-							"refTS", refTS,
-							"refTSOffset", f.refTSOffset,
-						)
-					}
-					expectedTS += rtpDiff
-				}
-			}
-			refTS += f.refTSOffset
-			nextTS, explain := getNextTimestamp(lastTS, refTS, expectedTS, latestSRTSExt, isLatestSRTSExtValid)
-			f.logger.Infow(
-				"next timestamp on switch",
-				"switchingAt", switchingAt.String(),
-				"layer", layer,
-				"lastTS", lastTS,
-				"refTS", refTS,
-				"refTSOffset", f.refTSOffset,
-				"referenceLayerSpatial", f.referenceLayerSpatial,
-				"expectedTS", expectedTS,
-				"latestSRTSExt", latestSRTSExt,
-				"isLatestSRTSExtValid", isLatestSRTSExtValid,
-				"nextTS", nextTS,
-				"jump", nextTS-lastTS,
-				"explanation", explain,
-			)
-
-			f.rtpMunger.UpdateSnTsOffsets(extPkt, 1, nextTS-lastTS)
-			f.codecMunger.UpdateOffsets(extPkt)
+		if err := f.processSourceSwitch(extPkt, layer); err != nil {
+			tp.shouldDrop = true
+			return tp, err
 		}
-
 		f.logger.Debugw("switching feed", "from", f.lastSSRC, "to", extPkt.Packet.SSRC)
 		f.lastSSRC = extPkt.Packet.SSRC
 	}
 
-	if tp == nil {
-		tp = &TranslationParams{}
-	}
 	tpRTP, err := f.rtpMunger.UpdateAndGetSnTs(extPkt)
 	if err != nil {
 		tp.shouldDrop = true
@@ -1654,7 +1721,7 @@ func (f *Forwarder) getTranslationParamsVideo(extPkt *buffer.ExtPacket, layer in
 	}
 
 	_, err := f.getTranslationParamsCommon(extPkt, layer, tp)
-	if tp.shouldDrop || len(extPkt.Packet.Payload) == 0 {
+	if tp.shouldDrop || len(extPkt.Packet.Payload) == 0 || err != nil {
 		maybeRollback(result.IsSwitching)
 		return tp, err
 	}
@@ -1744,18 +1811,16 @@ func (f *Forwarder) GetSnTsForBlankFrames(frameRate uint32, numPackets int) ([]S
 
 	lastTS := f.rtpMunger.GetLast().LastTS
 	expectedTS := lastTS
-	latestSRTSExt := uint64(0)
-	isLatestSRTSExtValid := false
 	if f.getExpectedRTPTimestamp != nil {
-		tsExt, latest, isLatestValid, err := f.getExpectedRTPTimestamp(time.Now())
+		tsExt, err := f.getExpectedRTPTimestamp(time.Now())
 		if err == nil {
 			expectedTS = uint32(tsExt)
-			latestSRTSExt = latest
-			isLatestSRTSExtValid = isLatestValid
 		}
 	}
-	nextTS, _ := getNextTimestamp(lastTS, expectedTS, expectedTS, latestSRTSExt, isLatestSRTSExtValid)
-	snts, err := f.rtpMunger.UpdateAndGetPaddingSnTs(numPackets, f.codec.ClockRate, frameRate, frameEndNeeded, nextTS)
+	if expectedTS-lastTS == 0 || expectedTS-lastTS > (1<<31) {
+		expectedTS = lastTS + 1
+	}
+	snts, err := f.rtpMunger.UpdateAndGetPaddingSnTs(numPackets, f.codec.ClockRate, frameRate, frameEndNeeded, expectedTS)
 	return snts, frameEndNeeded, err
 }
 
@@ -1892,45 +1957,4 @@ done:
 	}
 
 	return float64(distance) / float64(maxSeenLayer.Temporal+1)
-}
-
-func getNextTimestamp(lastTS uint32, refTS uint32, expectedTS uint32, latestSRTSExt uint64, isLatestSRTSExtValid bool) (uint32, string) {
-	isInOrder := func(val1, val2 uint32) bool {
-		diff := val1 - val2
-		return diff != 0 && diff < (1<<31)
-	}
-
-	rl := isInOrder(refTS, lastTS)
-	el := isInOrder(expectedTS, lastTS)
-	er := isInOrder(expectedTS, refTS)
-
-	nextTS := lastTS + 1
-	explain := "l = r = e"
-
-	switch {
-	case rl && el && er: // lastTS < refTS < expectedTS
-		nextTS = uint32(float64(refTS) + 0.05*float64(expectedTS-refTS))
-		explain = fmt.Sprintf("l < r < e, %d, %d", refTS-lastTS, expectedTS-refTS)
-	case rl && el && !er: // lastTS < expectedTS < refTS
-		nextTS = uint32(float64(expectedTS) + 0.5*float64(refTS-expectedTS))
-		explain = fmt.Sprintf("l < e < r, %d, %d", expectedTS-lastTS, refTS-expectedTS)
-	case !rl && el && er: // refTS < lastTS < expectedTS
-		nextTS = uint32(float64(lastTS) + 0.5*float64(expectedTS-lastTS))
-		explain = fmt.Sprintf("r < l < e, %d, %d", lastTS-refTS, expectedTS-lastTS)
-	case !rl && !el && er: // refTS < expectedTS < lastTS
-		nextTS = lastTS + 1
-		explain = fmt.Sprintf("r < e < l, %d, %d", expectedTS-refTS, lastTS-expectedTS)
-	case rl && !el && !er: // expectedTS < lastTS < refTS
-		nextTS = uint32(float64(lastTS) + 0.75*float64(refTS-lastTS))
-		explain = fmt.Sprintf("e < l < r, %d, %d", lastTS-expectedTS, refTS-lastTS)
-	case !rl && !el && !er: // expectedTS < refTS < lastTS
-		nextTS = lastTS + 1
-		explain = fmt.Sprintf("e < r < l, %d, %d", refTS-expectedTS, lastTS-refTS)
-	}
-
-	if isLatestSRTSExtValid && !isInOrder(nextTS, uint32(latestSRTSExt)) {
-		nextTS = uint32(latestSRTSExt) + 1
-	}
-
-	return nextTS, explain
 }

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -66,7 +66,7 @@ type TrackReceiver interface {
 
 	GetTemporalLayerFpsForSpatial(layer int32) []float32
 
-	GetRTCPSenderReportData(layer int32) (*buffer.RTCPSenderReportData, *buffer.RTCPSenderReportData)
+	GetCalculatedClockRate(layer int32) uint32
 	GetReferenceLayerRTPTimestamp(ts uint32, layer int32, referenceLayer int32) (uint32, error)
 }
 
@@ -752,8 +752,8 @@ func (w *WebRTCReceiver) GetTemporalLayerFpsForSpatial(layer int32) []float32 {
 	return b.GetTemporalLayerFpsForSpatial(layer)
 }
 
-func (w *WebRTCReceiver) GetRTCPSenderReportData(layer int32) (*buffer.RTCPSenderReportData, *buffer.RTCPSenderReportData) {
-	return w.streamTrackerManager.GetRTCPSenderReportData(layer)
+func (w *WebRTCReceiver) GetCalculatedClockRate(layer int32) uint32 {
+	return w.streamTrackerManager.GetCalculatedClockRate(layer)
 }
 
 func (w *WebRTCReceiver) GetReferenceLayerRTPTimestamp(ts uint32, layer int32, referenceLayer int32) (uint32, error) {


### PR DESCRIPTION
Trying to address a few challenges
1. With `replaceTrack(null)`, it is possible that the track time stamp does not jump across the mute valley. Also, RTCP sender reports jump ahead and then jump back. Address this by resetting the publisher SR cache if there is out-of-order reports.
2. Related to the above, the publisher side clock rate is used to adjust down stream RTCP sender report to adjust for cases of packet time stamp lagging publisher side RTCP sender report due to pacing. Introduce a stable clock rate calculation, i. e. declare clock rate calculation valid only time between first SR and newest SR is at least 15 seconds. With the above reset, it should not be possible to use bad clock rates even if things get out-of-order.
3. Another issue is that with congestion, during layer switch, it is possible that the new time stamp is behind expected due to pacing. There is some challenge here. With the first point above and pacing related delays, it is hard to distinguish. Using a reasonable threshold to make that decision (explanation in code)
4. Lock to reference or expected time stamp based on above rules. Not doing the array of conditions and doing half way between two or 75% of the distance etc. Keeping it simpler.
5. Added a couple of AVSYNC-TODO notes for further consideration based on data we can collect on this.

As usual, comments in code. Please let me know if something is unclear.