### PR TITLE
Plug a couple of holes in stream transitions.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1013,7 +1013,7 @@ func (f *Forwarder) ProvisionalAllocateGetBestWeightedTransition() VideoTransiti
 			bandwidthDelta := int64(math.Max(float64(0), float64(existingBandwidthNeeded-f.provisional.Bitrates[s][t])))
 
 			transitionCost := int32(0)
-			// LK-TODO: SVC will need a different cost transition
+			// SVC-TODO: SVC will need a different cost transition
 			if targetLayer.Spatial != s {
 				transitionCost = TransitionCostSpatial
 			}
@@ -1036,7 +1036,7 @@ func (f *Forwarder) ProvisionalAllocateGetBestWeightedTransition() VideoTransiti
 	return VideoTransition{
 		From:           targetLayer,
 		To:             bestLayer,
-		BandwidthDelta: bestBandwidthDelta,
+		BandwidthDelta: -bestBandwidthDelta,
 	}
 }
 

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -847,7 +847,7 @@ func TestForwarderProvisionalAllocateGetBestWeightedTransition(t *testing.T) {
 	expectedTransition := VideoTransition{
 		From:           f.TargetLayer(),
 		To:             buffer.VideoLayer{Spatial: 2, Temporal: 0},
-		BandwidthDelta: 2,
+		BandwidthDelta: -2,
 	}
 	transition := f.ProvisionalAllocateGetBestWeightedTransition()
 	require.Equal(t, expectedTransition, transition)

--- a/pkg/sfu/streamallocator/streamstateupdate.go
+++ b/pkg/sfu/streamallocator/streamstateupdate.go
@@ -48,7 +48,7 @@ func NewStreamStateUpdate() *StreamStateUpdate {
 func (s *StreamStateUpdate) HandleStreamingChange(track *Track, streamState StreamState) {
 	switch streamState {
 	case StreamStateInactive:
-		// inactive is not a not a notification, could get into this state because of mute
+		// inactive is not a notification, could get into this state because of mute
 	case StreamStateActive:
 		s.StreamStates = append(s.StreamStates, &StreamStateInfo{
 			ParticipantID: track.PublisherID(),

--- a/pkg/sfu/streamallocator/streamstateupdate.go
+++ b/pkg/sfu/streamallocator/streamstateupdate.go
@@ -1,6 +1,8 @@
 package streamallocator
 
 import (
+	"fmt"
+
 	"github.com/livekit/protocol/livekit"
 )
 
@@ -9,18 +11,21 @@ import (
 type StreamState int
 
 const (
-	StreamStateActive StreamState = iota
+	StreamStateInactive StreamState = iota
+	StreamStateActive
 	StreamStatePaused
 )
 
 func (s StreamState) String() string {
 	switch s {
+	case StreamStateInactive:
+		return "INACTIVE"
 	case StreamStateActive:
-		return "active"
+		return "ACTIVE"
 	case StreamStatePaused:
-		return "paused"
+		return "PAUSED"
 	default:
-		return "unknown"
+		return fmt.Sprintf("UNKNOWN: %d", int(s))
 	}
 }
 
@@ -40,18 +45,21 @@ func NewStreamStateUpdate() *StreamStateUpdate {
 	return &StreamStateUpdate{}
 }
 
-func (s *StreamStateUpdate) HandleStreamingChange(isPaused bool, track *Track) {
-	if isPaused {
-		s.StreamStates = append(s.StreamStates, &StreamStateInfo{
-			ParticipantID: track.PublisherID(),
-			TrackID:       track.ID(),
-			State:         StreamStatePaused,
-		})
-	} else {
+func (s *StreamStateUpdate) HandleStreamingChange(track *Track, streamState StreamState) {
+	switch streamState {
+	case StreamStateInactive:
+		// inactive is not a not a notification, could get into this state because of mute
+	case StreamStateActive:
 		s.StreamStates = append(s.StreamStates, &StreamStateInfo{
 			ParticipantID: track.PublisherID(),
 			TrackID:       track.ID(),
 			State:         StreamStateActive,
+		})
+	case StreamStatePaused:
+		s.StreamStates = append(s.StreamStates, &StreamStateInfo{
+			ParticipantID: track.PublisherID(),
+			TrackID:       track.ID(),
+			State:         StreamStatePaused,
 		})
 	}
 }

--- a/pkg/sfu/streamallocator/track.go
+++ b/pkg/sfu/streamallocator/track.go
@@ -42,7 +42,7 @@ type Track struct {
 
 	isDirty bool
 
-	isPaused bool
+	streamState StreamState
 }
 
 func NewTrack(
@@ -61,7 +61,7 @@ func NewTrack(
 		nackInfos:             make(map[uint16]sfu.NackInfo),
 		nackHistory:           make([]string, 0, 10),
 		receiverReportHistory: make([]string, 0, 10),
-		isPaused:              true,
+		streamState:           StreamStateInactive,
 	}
 	t.SetPriority(0)
 	t.SetMaxLayer(downTrack.MaxLayer())
@@ -78,12 +78,12 @@ func (t *Track) SetDirty(isDirty bool) bool {
 	return true
 }
 
-func (t *Track) SetPaused(isPaused bool) bool {
-	if t.isPaused == isPaused {
+func (t *Track) SetStreamState(streamState StreamState) bool {
+	if t.streamState == streamState {
 		return false
 	}
 
-	t.isPaused = isPaused
+	t.streamState = streamState
 	return true
 }
 


### PR DESCRIPTION
1. Missed negative sign meant stealing bits from other tracks was not working.
2. When a track change (mute, unmute, subscription change) cannot be allocated, explicitly pause so that stream state update happens.

Refactor stream state update a bit to make it a bit cleaner.