### PR TITLE
E2EE trailer for server injected packets.

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -53,6 +53,7 @@ type MediaTrackParams struct {
 	AudioConfig       config.AudioConfig
 	VideoConfig       config.VideoConfig
 	Telemetry         telemetry.TelemetryService
+	Trailer           string
 	Logger            logger.Logger
 	SimTracks         map[uint32]SimulcastTrackInfo
 }
@@ -73,6 +74,7 @@ func NewMediaTrack(params MediaTrackParams) *MediaTrack {
 		SubscriberConfig:    params.SubscriberConfig,
 		AudioConfig:         params.AudioConfig,
 		Telemetry:           params.Telemetry,
+		Trailer:             params.Trailer,
 		Logger:              params.Logger,
 	})
 	t.MediaTrackReceiver.OnVideoLayerUpdate(func(layers []*livekit.VideoLayer) {

--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -53,7 +53,6 @@ type MediaTrackParams struct {
 	AudioConfig       config.AudioConfig
 	VideoConfig       config.VideoConfig
 	Telemetry         telemetry.TelemetryService
-	Trailer           string
 	Logger            logger.Logger
 	SimTracks         map[uint32]SimulcastTrackInfo
 }
@@ -74,7 +73,6 @@ func NewMediaTrack(params MediaTrackParams) *MediaTrack {
 		SubscriberConfig:    params.SubscriberConfig,
 		AudioConfig:         params.AudioConfig,
 		Telemetry:           params.Telemetry,
-		Trailer:             params.Trailer,
 		Logger:              params.Logger,
 	})
 	t.MediaTrackReceiver.OnVideoLayerUpdate(func(layers []*livekit.VideoLayer) {

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -78,6 +78,7 @@ type MediaTrackReceiverParams struct {
 	SubscriberConfig    DirectionConfig
 	AudioConfig         config.AudioConfig
 	Telemetry           telemetry.TelemetryService
+	Trailer             string
 	Logger              logger.Logger
 }
 
@@ -116,6 +117,7 @@ func NewMediaTrackReceiver(params MediaTrackReceiverParams) *MediaTrackReceiver 
 		ReceiverConfig:   params.ReceiverConfig,
 		SubscriberConfig: params.SubscriberConfig,
 		Telemetry:        params.Telemetry,
+		Trailer:          params.Trailer,
 		Logger:           params.Logger,
 	})
 	t.MediaTrackSubscriptions.OnDownTrackCreated(t.onDownTrackCreated)

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -78,7 +78,6 @@ type MediaTrackReceiverParams struct {
 	SubscriberConfig    DirectionConfig
 	AudioConfig         config.AudioConfig
 	Telemetry           telemetry.TelemetryService
-	Trailer             string
 	Logger              logger.Logger
 }
 
@@ -117,7 +116,6 @@ func NewMediaTrackReceiver(params MediaTrackReceiverParams) *MediaTrackReceiver 
 		ReceiverConfig:   params.ReceiverConfig,
 		SubscriberConfig: params.SubscriberConfig,
 		Telemetry:        params.Telemetry,
-		Trailer:          params.Trailer,
 		Logger:           params.Logger,
 	})
 	t.MediaTrackSubscriptions.OnDownTrackCreated(t.onDownTrackCreated)
@@ -800,6 +798,13 @@ func (t *MediaTrackReceiver) GetTemporalLayerForSpatialFps(spatial int32, fps ui
 		}
 	}
 	return buffer.DefaultMaxLayerTemporal
+}
+
+func (t *MediaTrackReceiver) IsEncrypted() bool {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	return t.trackInfo.Encryption != livekit.Encryption_NONE
 }
 
 // ---------------------------

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -98,6 +98,10 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 	for _, c := range codecs {
 		c.RTCPFeedback = rtcpFeedback
 	}
+	var trailer []byte
+	if t.params.MediaTrack.IsEncrypted() {
+		trailer = sub.GetTrailer()
+	}
 	downTrack, err := sfu.NewDownTrack(
 		codecs,
 		wr,
@@ -105,13 +109,11 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 		subscriberID,
 		t.params.ReceiverConfig.PacketBufferSize,
 		sub.GetPacer(),
+		trailer,
 		LoggerWithTrack(sub.GetLogger(), trackID, t.params.IsRelayed),
 	)
 	if err != nil {
 		return nil, err
-	}
-	if t.params.MediaTrack.IsEncrypted() {
-		downTrack.SetTrailer(sub.GetTrailer())
 	}
 
 	if t.onDownTrackCreated != nil {

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -41,6 +41,8 @@ type MediaTrackSubscriptionsParams struct {
 
 	Telemetry telemetry.TelemetryService
 
+	Trailer string
+
 	Logger logger.Logger
 }
 
@@ -110,6 +112,7 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 	if err != nil {
 		return nil, err
 	}
+	downTrack.SetTrailer(t.params.Trailer)
 
 	if t.onDownTrackCreated != nil {
 		t.onDownTrackCreated(downTrack)

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -41,8 +41,6 @@ type MediaTrackSubscriptionsParams struct {
 
 	Telemetry telemetry.TelemetryService
 
-	Trailer string
-
 	Logger logger.Logger
 }
 
@@ -112,7 +110,9 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 	if err != nil {
 		return nil, err
 	}
-	downTrack.SetTrailer(t.params.Trailer)
+	if t.params.MediaTrack.IsEncrypted() {
+		downTrack.SetTrailer(sub.GetTrailer())
+	}
 
 	if t.onDownTrackCreated != nil {
 		t.onDownTrackCreated(downTrack)

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -68,6 +68,7 @@ type ParticipantParams struct {
 	VideoConfig                  config.VideoConfig
 	ProtocolVersion              types.ProtocolVersion
 	Telemetry                    telemetry.TelemetryService
+	Trailer                      string
 	PLIThrottleConfig            config.PLIThrottleConfig
 	CongestionControlConfig      config.CongestionControlConfig
 	EnabledCodecs                []*livekit.Codec
@@ -1759,6 +1760,10 @@ func (p *ParticipantImpl) addMigrateMutedTrack(cid string, ti *livekit.TrackInfo
 }
 
 func (p *ParticipantImpl) addMediaTrack(signalCid string, sdpCid string, ti *livekit.TrackInfo) *MediaTrack {
+	trailer := ""
+	if ti.Encryption != livekit.Encryption_NONE {
+		trailer = p.params.Trailer
+	}
 	mt := NewMediaTrack(MediaTrackParams{
 		TrackInfo:           proto.Clone(ti).(*livekit.TrackInfo),
 		SignalCid:           signalCid,
@@ -1772,6 +1777,7 @@ func (p *ParticipantImpl) addMediaTrack(signalCid string, sdpCid string, ti *liv
 		AudioConfig:         p.params.AudioConfig,
 		VideoConfig:         p.params.VideoConfig,
 		Telemetry:           p.params.Telemetry,
+		Trailer:             trailer,
 		Logger:              LoggerWithTrack(p.params.Logger, livekit.TrackID(ti.Sid), false),
 		SubscriberConfig:    p.params.Config.Subscriber,
 		PLIThrottleConfig:   p.params.PLIThrottleConfig,

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -68,7 +68,7 @@ type ParticipantParams struct {
 	VideoConfig                  config.VideoConfig
 	ProtocolVersion              types.ProtocolVersion
 	Telemetry                    telemetry.TelemetryService
-	Trailer                      string
+	Trailer                      []byte
 	PLIThrottleConfig            config.PLIThrottleConfig
 	CongestionControlConfig      config.CongestionControlConfig
 	EnabledCodecs                []*livekit.Codec
@@ -223,6 +223,12 @@ func NewParticipant(params ParticipantParams) (*ParticipantImpl, error) {
 	p.setupSubscriptionManager()
 
 	return p, nil
+}
+
+func (p *ParticipantImpl) GetTrailer() []byte {
+	trailer := make([]byte, len(p.params.Trailer))
+	copy(trailer, p.params.Trailer)
+	return trailer
 }
 
 func (p *ParticipantImpl) GetLogger() logger.Logger {
@@ -1760,10 +1766,6 @@ func (p *ParticipantImpl) addMigrateMutedTrack(cid string, ti *livekit.TrackInfo
 }
 
 func (p *ParticipantImpl) addMediaTrack(signalCid string, sdpCid string, ti *livekit.TrackInfo) *MediaTrack {
-	trailer := ""
-	if ti.Encryption != livekit.Encryption_NONE {
-		trailer = p.params.Trailer
-	}
 	mt := NewMediaTrack(MediaTrackParams{
 		TrackInfo:           proto.Clone(ti).(*livekit.TrackInfo),
 		SignalCid:           signalCid,
@@ -1777,7 +1779,6 @@ func (p *ParticipantImpl) addMediaTrack(signalCid string, sdpCid string, ti *liv
 		AudioConfig:         p.params.AudioConfig,
 		VideoConfig:         p.params.VideoConfig,
 		Telemetry:           p.params.Telemetry,
-		Trailer:             trailer,
 		Logger:              LoggerWithTrack(p.params.Logger, livekit.TrackID(ti.Sid), false),
 		SubscriberConfig:    p.params.Config.Subscriber,
 		PLIThrottleConfig:   p.params.PLIThrottleConfig,

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -77,7 +77,7 @@ type Room struct {
 	leftAt atomic.Int64
 	closed chan struct{}
 
-	trailer string
+	trailer []byte
 
 	onParticipantChanged func(p types.LocalParticipant)
 	onRoomUpdated        func()
@@ -113,7 +113,7 @@ func NewRoom(
 		bufferFactory:             buffer.NewFactoryOfBufferFactory(config.Receiver.PacketBufferSize),
 		batchedUpdates:            make(map[livekit.ParticipantIdentity]*livekit.ParticipantInfo),
 		closed:                    make(chan struct{}),
-		trailer:                   utils.RandomSecret(),
+		trailer:                   []byte(utils.RandomSecret()),
 	}
 	r.protoProxy = utils.NewProtoProxy[*livekit.Room](roomUpdateInterval, r.updateProto)
 	if r.protoRoom.EmptyTimeout == 0 {
@@ -142,8 +142,13 @@ func (r *Room) ID() livekit.RoomID {
 	return livekit.RoomID(r.protoRoom.Sid)
 }
 
-func (r *Room) Trailer() string {
-	return r.trailer
+func (r *Room) Trailer() []byte {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	trailer := make([]byte, len(r.trailer))
+	copy(trailer, r.trailer)
+	return trailer
 }
 
 func (r *Room) GetParticipant(identity livekit.ParticipantIdentity) types.LocalParticipant {
@@ -828,7 +833,7 @@ func (r *Room) createJoinResponseLocked(participant types.LocalParticipant, iceS
 		ServerInfo:    r.serverInfo,
 		ServerVersion: r.serverInfo.Version,
 		ServerRegion:  r.serverInfo.Region,
-		SifTrailer:    []byte(r.trailer),
+		SifTrailer:    r.trailer,
 	}
 }
 

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -277,6 +277,7 @@ type LocalParticipant interface {
 	ToProtoWithVersion() (*livekit.ParticipantInfo, utils.TimedVersion)
 
 	// getters
+	GetTrailer() []byte
 	GetLogger() logger.Logger
 	GetAdaptiveStream() bool
 	ProtocolVersion() ProtocolVersion
@@ -449,6 +450,8 @@ type MediaTrack interface {
 
 	Receivers() []sfu.TrackReceiver
 	ClearAllReceivers(willBeResumed bool)
+
+	IsEncrypted() bool
 }
 
 //counterfeiter:generate . LocalMediaTrack

--- a/pkg/rtc/types/typesfakes/fake_local_media_track.go
+++ b/pkg/rtc/types/typesfakes/fake_local_media_track.go
@@ -128,6 +128,16 @@ type FakeLocalMediaTrack struct {
 	iDReturnsOnCall map[int]struct {
 		result1 livekit.TrackID
 	}
+	IsEncryptedStub        func() bool
+	isEncryptedMutex       sync.RWMutex
+	isEncryptedArgsForCall []struct {
+	}
+	isEncryptedReturns struct {
+		result1 bool
+	}
+	isEncryptedReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	IsMutedStub        func() bool
 	isMutedMutex       sync.RWMutex
 	isMutedArgsForCall []struct {
@@ -925,6 +935,59 @@ func (fake *FakeLocalMediaTrack) IDReturnsOnCall(i int, result1 livekit.TrackID)
 	}
 	fake.iDReturnsOnCall[i] = struct {
 		result1 livekit.TrackID
+	}{result1}
+}
+
+func (fake *FakeLocalMediaTrack) IsEncrypted() bool {
+	fake.isEncryptedMutex.Lock()
+	ret, specificReturn := fake.isEncryptedReturnsOnCall[len(fake.isEncryptedArgsForCall)]
+	fake.isEncryptedArgsForCall = append(fake.isEncryptedArgsForCall, struct {
+	}{})
+	stub := fake.IsEncryptedStub
+	fakeReturns := fake.isEncryptedReturns
+	fake.recordInvocation("IsEncrypted", []interface{}{})
+	fake.isEncryptedMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLocalMediaTrack) IsEncryptedCallCount() int {
+	fake.isEncryptedMutex.RLock()
+	defer fake.isEncryptedMutex.RUnlock()
+	return len(fake.isEncryptedArgsForCall)
+}
+
+func (fake *FakeLocalMediaTrack) IsEncryptedCalls(stub func() bool) {
+	fake.isEncryptedMutex.Lock()
+	defer fake.isEncryptedMutex.Unlock()
+	fake.IsEncryptedStub = stub
+}
+
+func (fake *FakeLocalMediaTrack) IsEncryptedReturns(result1 bool) {
+	fake.isEncryptedMutex.Lock()
+	defer fake.isEncryptedMutex.Unlock()
+	fake.IsEncryptedStub = nil
+	fake.isEncryptedReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeLocalMediaTrack) IsEncryptedReturnsOnCall(i int, result1 bool) {
+	fake.isEncryptedMutex.Lock()
+	defer fake.isEncryptedMutex.Unlock()
+	fake.IsEncryptedStub = nil
+	if fake.isEncryptedReturnsOnCall == nil {
+		fake.isEncryptedReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.isEncryptedReturnsOnCall[i] = struct {
+		result1 bool
 	}{result1}
 }
 
@@ -1947,6 +2010,8 @@ func (fake *FakeLocalMediaTrack) Invocations() map[string][][]interface{} {
 	defer fake.hasSdpCidMutex.RUnlock()
 	fake.iDMutex.RLock()
 	defer fake.iDMutex.RUnlock()
+	fake.isEncryptedMutex.RLock()
+	defer fake.isEncryptedMutex.RUnlock()
 	fake.isMutedMutex.RLock()
 	defer fake.isMutedMutex.RUnlock()
 	fake.isOpenMutex.RLock()

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -304,6 +304,16 @@ type FakeLocalParticipant struct {
 	getSubscribedTracksReturnsOnCall map[int]struct {
 		result1 []types.SubscribedTrack
 	}
+	GetTrailerStub        func() []byte
+	getTrailerMutex       sync.RWMutex
+	getTrailerArgsForCall []struct {
+	}
+	getTrailerReturns struct {
+		result1 []byte
+	}
+	getTrailerReturnsOnCall map[int]struct {
+		result1 []byte
+	}
 	HandleAnswerStub        func(webrtc.SessionDescription)
 	handleAnswerMutex       sync.RWMutex
 	handleAnswerArgsForCall []struct {
@@ -2356,6 +2366,59 @@ func (fake *FakeLocalParticipant) GetSubscribedTracksReturnsOnCall(i int, result
 	}
 	fake.getSubscribedTracksReturnsOnCall[i] = struct {
 		result1 []types.SubscribedTrack
+	}{result1}
+}
+
+func (fake *FakeLocalParticipant) GetTrailer() []byte {
+	fake.getTrailerMutex.Lock()
+	ret, specificReturn := fake.getTrailerReturnsOnCall[len(fake.getTrailerArgsForCall)]
+	fake.getTrailerArgsForCall = append(fake.getTrailerArgsForCall, struct {
+	}{})
+	stub := fake.GetTrailerStub
+	fakeReturns := fake.getTrailerReturns
+	fake.recordInvocation("GetTrailer", []interface{}{})
+	fake.getTrailerMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLocalParticipant) GetTrailerCallCount() int {
+	fake.getTrailerMutex.RLock()
+	defer fake.getTrailerMutex.RUnlock()
+	return len(fake.getTrailerArgsForCall)
+}
+
+func (fake *FakeLocalParticipant) GetTrailerCalls(stub func() []byte) {
+	fake.getTrailerMutex.Lock()
+	defer fake.getTrailerMutex.Unlock()
+	fake.GetTrailerStub = stub
+}
+
+func (fake *FakeLocalParticipant) GetTrailerReturns(result1 []byte) {
+	fake.getTrailerMutex.Lock()
+	defer fake.getTrailerMutex.Unlock()
+	fake.GetTrailerStub = nil
+	fake.getTrailerReturns = struct {
+		result1 []byte
+	}{result1}
+}
+
+func (fake *FakeLocalParticipant) GetTrailerReturnsOnCall(i int, result1 []byte) {
+	fake.getTrailerMutex.Lock()
+	defer fake.getTrailerMutex.Unlock()
+	fake.GetTrailerStub = nil
+	if fake.getTrailerReturnsOnCall == nil {
+		fake.getTrailerReturnsOnCall = make(map[int]struct {
+			result1 []byte
+		})
+	}
+	fake.getTrailerReturnsOnCall[i] = struct {
+		result1 []byte
 	}{result1}
 }
 
@@ -5648,6 +5711,8 @@ func (fake *FakeLocalParticipant) Invocations() map[string][][]interface{} {
 	defer fake.getSubscribedParticipantsMutex.RUnlock()
 	fake.getSubscribedTracksMutex.RLock()
 	defer fake.getSubscribedTracksMutex.RUnlock()
+	fake.getTrailerMutex.RLock()
+	defer fake.getTrailerMutex.RUnlock()
 	fake.handleAnswerMutex.RLock()
 	defer fake.handleAnswerMutex.RUnlock()
 	fake.handleOfferMutex.RLock()

--- a/pkg/rtc/types/typesfakes/fake_media_track.go
+++ b/pkg/rtc/types/typesfakes/fake_media_track.go
@@ -93,6 +93,16 @@ type FakeMediaTrack struct {
 	iDReturnsOnCall map[int]struct {
 		result1 livekit.TrackID
 	}
+	IsEncryptedStub        func() bool
+	isEncryptedMutex       sync.RWMutex
+	isEncryptedArgsForCall []struct {
+	}
+	isEncryptedReturns struct {
+		result1 bool
+	}
+	isEncryptedReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	IsMutedStub        func() bool
 	isMutedMutex       sync.RWMutex
 	isMutedArgsForCall []struct {
@@ -686,6 +696,59 @@ func (fake *FakeMediaTrack) IDReturnsOnCall(i int, result1 livekit.TrackID) {
 	}
 	fake.iDReturnsOnCall[i] = struct {
 		result1 livekit.TrackID
+	}{result1}
+}
+
+func (fake *FakeMediaTrack) IsEncrypted() bool {
+	fake.isEncryptedMutex.Lock()
+	ret, specificReturn := fake.isEncryptedReturnsOnCall[len(fake.isEncryptedArgsForCall)]
+	fake.isEncryptedArgsForCall = append(fake.isEncryptedArgsForCall, struct {
+	}{})
+	stub := fake.IsEncryptedStub
+	fakeReturns := fake.isEncryptedReturns
+	fake.recordInvocation("IsEncrypted", []interface{}{})
+	fake.isEncryptedMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeMediaTrack) IsEncryptedCallCount() int {
+	fake.isEncryptedMutex.RLock()
+	defer fake.isEncryptedMutex.RUnlock()
+	return len(fake.isEncryptedArgsForCall)
+}
+
+func (fake *FakeMediaTrack) IsEncryptedCalls(stub func() bool) {
+	fake.isEncryptedMutex.Lock()
+	defer fake.isEncryptedMutex.Unlock()
+	fake.IsEncryptedStub = stub
+}
+
+func (fake *FakeMediaTrack) IsEncryptedReturns(result1 bool) {
+	fake.isEncryptedMutex.Lock()
+	defer fake.isEncryptedMutex.Unlock()
+	fake.IsEncryptedStub = nil
+	fake.isEncryptedReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeMediaTrack) IsEncryptedReturnsOnCall(i int, result1 bool) {
+	fake.isEncryptedMutex.Lock()
+	defer fake.isEncryptedMutex.Unlock()
+	fake.IsEncryptedStub = nil
+	if fake.isEncryptedReturnsOnCall == nil {
+		fake.isEncryptedReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.isEncryptedReturnsOnCall[i] = struct {
+		result1 bool
 	}{result1}
 }
 
@@ -1522,6 +1585,8 @@ func (fake *FakeMediaTrack) Invocations() map[string][][]interface{} {
 	defer fake.getTemporalLayerForSpatialFpsMutex.RUnlock()
 	fake.iDMutex.RLock()
 	defer fake.iDMutex.RUnlock()
+	fake.isEncryptedMutex.RLock()
+	defer fake.isEncryptedMutex.RUnlock()
 	fake.isMutedMutex.RLock()
 	defer fake.isMutedMutex.RUnlock()
 	fake.isOpenMutex.RLock()

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -351,6 +351,7 @@ func (r *RoomManager) StartSession(
 		VideoConfig:             r.config.Video,
 		ProtocolVersion:         pv,
 		Telemetry:               r.telemetry,
+		Trailer:                 room.Trailer(),
 		PLIThrottleConfig:       r.config.RTC.PLIThrottle,
 		CongestionControlConfig: r.config.RTC.CongestionControl,
 		EnabledCodecs:           protoRoom.EnabledCodecs,

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -1333,6 +1333,11 @@ func (d *DownTrack) maybeAddTrailer(buf []byte) int {
 	d.trailerMu.RLock()
 	defer d.trailerMu.RUnlock()
 
+	if len(buf) < len(d.trailer) {
+		d.logger.Warnw("trailer too big", nil, "bufLen", len(buf), "trailerLen", len(d.trailer))
+		return 0
+	}
+
 	copy(buf, d.trailer)
 	return len(d.trailer)
 }
@@ -1384,7 +1389,7 @@ func (d *DownTrack) getH264BlankFrame(_frameEndNeeded bool) ([]byte, error) {
 	// TODO - Jie Zeng
 	// now use STAP-A to compose sps, pps, idr together, most decoder support packetization-mode 1.
 	// if client only support packetization-mode 0, use single nalu unit packet
-	buf := make([]byte, 1462)
+	buf := make([]byte, 1000)
 	offset := 0
 	buf[0] = 0x18 // STAP-A
 	offset++


### PR DESCRIPTION
- Generate a 32-byte per room trailer. Too reasons for longer length
  o Laziness: utils generates a 32 byte string.
  o Longer length random string reduces chances of colliding with real data.
- Trailer sent in JoinResponse
- Trailer added to server injected frames (not to padding only packets)