### PR TITLE
Delay retransmission after first send.

### DIFF
--- a/pkg/sfu/sequencer_test.go
+++ b/pkg/sfu/sequencer_test.go
@@ -37,7 +37,7 @@ func Test_sequencer(t *testing.T) {
 
 	req := []uint16{57, 58, 62, 63, 513, 514, 515, 516, 517}
 	res := seq.getPacketsMeta(req)
-	// nothing should be return as not enough time has elapsed since sending packet
+	// nothing should be returned as not enough time has elapsed since sending packet
 	require.Equal(t, 0, len(res))
 
 	time.Sleep((ignoreRetransmission + 10) * time.Millisecond)

--- a/pkg/sfu/sequencer_test.go
+++ b/pkg/sfu/sequencer_test.go
@@ -35,13 +35,12 @@ func Test_sequencer(t *testing.T) {
 	seq.push(519, 519+off, 123, false, 2, nil, nil)
 	seq.push(518, 518+off, 123, true, 2, nil, nil)
 
-	time.Sleep(60 * time.Millisecond)
 	req := []uint16{57, 58, 62, 63, 513, 514, 515, 516, 517}
 	res := seq.getPacketsMeta(req)
 	// nothing should be return as not enough time has elapsed since sending packet
 	require.Equal(t, 0, len(res))
 
-	time.Sleep(60 * time.Millisecond)
+	time.Sleep((ignoreRetransmission + 10) * time.Millisecond)
 	res = seq.getPacketsMeta(req)
 	require.Equal(t, len(req), len(res))
 	for i, val := range res {

--- a/pkg/sfu/sequencer_test.go
+++ b/pkg/sfu/sequencer_test.go
@@ -38,6 +38,11 @@ func Test_sequencer(t *testing.T) {
 	time.Sleep(60 * time.Millisecond)
 	req := []uint16{57, 58, 62, 63, 513, 514, 515, 516, 517}
 	res := seq.getPacketsMeta(req)
+	// nothing should be return as not enough time has elapsed since sending packet
+	require.Equal(t, 0, len(res))
+
+	time.Sleep(60 * time.Millisecond)
+	res = seq.getPacketsMeta(req)
 	require.Equal(t, len(req), len(res))
 	for i, val := range res {
 		require.Equal(t, val.targetSeqNo, req[i])
@@ -46,7 +51,7 @@ func Test_sequencer(t *testing.T) {
 	}
 	res = seq.getPacketsMeta(req)
 	require.Equal(t, 0, len(res))
-	time.Sleep(150 * time.Millisecond)
+	time.Sleep((ignoreRetransmission + 10) * time.Millisecond)
 	res = seq.getPacketsMeta(req)
 	require.Equal(t, len(req), len(res))
 	for i, val := range res {
@@ -57,9 +62,15 @@ func Test_sequencer(t *testing.T) {
 
 	seq.push(521, 521+off, 123, true, 1, nil, nil)
 	m := seq.getPacketsMeta([]uint16{521 + off})
+	require.Equal(t, 0, len(m))
+	time.Sleep((ignoreRetransmission + 10) * time.Millisecond)
+	m = seq.getPacketsMeta([]uint16{521 + off})
 	require.Equal(t, 1, len(m))
 
 	seq.push(505, 505+off, 123, false, 1, nil, nil)
+	m = seq.getPacketsMeta([]uint16{505 + off})
+	require.Equal(t, 0, len(m))
+	time.Sleep((ignoreRetransmission + 10) * time.Millisecond)
 	m = seq.getPacketsMeta([]uint16{505 + off})
 	require.Equal(t, 1, len(m))
 }
@@ -121,6 +132,7 @@ func Test_sequencer_getNACKSeqNo(t *testing.T) {
 				n.pushPadding(i + tt.fields.offset)
 			}
 
+			time.Sleep((ignoreRetransmission + 10) * time.Millisecond)
 			g := n.getPacketsMeta(tt.args.seqNo)
 			var got []uint16
 			for _, sn := range g {


### PR DESCRIPTION
Give a bit of wiggle room for out-of-order packets.

Example
```
t: Sun Jul 30 05:40:41 UTC 2023|Sun Jul 30 05:49:28 UTC 2023|526.32s, sn: 20100|52849, ep: 32750|62.22/s, p: 32732|62.19/s, l: 18|0.0/s|0.05%, b: 31586135|480104.4bps|654640, f: 12619|24.0/s / 12|Sun Jul 30 05:48:26 UTC 2023, d: 30|0.06/s, bd: 28899|439.3bps|600, pp: 0|0.00/s, bp: 0|0.0bps|0, o: 58, c: 90000, j: 373(4144.4us)|626(6955.6us), gh:[2:16, 3:1, 4:1, 7:1], n:89|30|0|2, pli:4|Sun Jul 30 05:42:10 UTC 2023 / 15|Sun Jul 30 05:42:11 UTC 2023, fir:0|Mon Jan  1 00:00:00 UTC 0001, rtt(ms):145|151, drift(ms):-13.38, sr(Hz):89997.71
```
This stats is for a down track. Looking at the gap histogram, there are 46 gaps `gh:[2:16, 3:1, 4:1, 7:1]`. These were from publisher side.

Out of those 28 arrived at publisher out-of-order and were forwarded resulting in a loss of 18 packets (these were never received from publisher side).

Those 28 packets show up as out-of-order in the forwarding path `o: 58`. But, the issue is, in addition, all those packets were NACKed too. That can be seen as
`n:89|30|0|2` -> 30 NACK cache hits and 2 repeated NACKs
`d: 30|0.06/s, bd: 28899|439.3bps|600` -> 30 duplicate packets, this is 28 out-of-order packets getting retransmitted + 2 repeated retransmission.

Ideally, only the two repeated NACKs should have retransmitted. But, not waiting for a retransmission on the first NACK, any out-of-order packet could result in a retransmit due to aggressive NACKing from browsers.