### PR TITLE
Issue full reconnect if subscriber PC is closed on ICERestart

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -863,7 +863,9 @@ func (p *ParticipantImpl) ICERestart(iceConfig *livekit.ICEConfig) {
 		t.(types.LocalMediaTrack).Restart()
 	}
 
-	p.TransportManager.ICERestart(iceConfig)
+	if err := p.TransportManager.ICERestart(iceConfig); err != nil {
+		p.IssueFullReconnect(types.ParticipantCloseReasonNegotiateFailed)
+	}
 }
 
 func (p *ParticipantImpl) OnICEConfigChanged(f func(participant types.LocalParticipant, iceConfig *livekit.ICEConfig)) {

--- a/pkg/rtc/transportmanager.go
+++ b/pkg/rtc/transportmanager.go
@@ -521,12 +521,12 @@ func (t *TransportManager) HandleClientReconnect(reason livekit.ReconnectReason)
 	}
 }
 
-func (t *TransportManager) ICERestart(iceConfig *livekit.ICEConfig) {
+func (t *TransportManager) ICERestart(iceConfig *livekit.ICEConfig) error {
 	if iceConfig != nil {
 		t.SetICEConfig(iceConfig)
 	}
 
-	t.subscriber.ICERestart()
+	return t.subscriber.ICERestart()
 }
 
 func (t *TransportManager) OnICEConfigChanged(f func(iceConfig *livekit.ICEConfig)) {


### PR DESCRIPTION
Server could have closed subscriber PC to aid migration. But, if a resumes lands back on that node, a resume of the participant session is not possible as subscriber PC is already closed. While theoretically possible to form a new subscriber peer conenction, reducing complexity and issuing a full reconnect as this should be a rare case.