### PR TITLE
Remove parked layer feature.

### DIFF
--- a/pkg/rtc/subscribedtrack.go
+++ b/pkg/rtc/subscribedtrack.go
@@ -215,14 +215,14 @@ func (t *SubscribedTrack) UpdateVideoLayer() {
 		return
 	}
 
-	t.logger.Debugw("updating video layer",
-		"settings", settings,
-	)
+	t.logger.Debugw("updating video layer", "settings", settings)
 
-	spatial := t.spatialLayerFromSettings(settings)
-	t.DownTrack().SetMaxSpatialLayer(spatial)
-	if settings.Fps > 0 {
-		t.DownTrack().SetMaxTemporalLayer(t.MediaTrack().GetTemporalLayerForSpatialFps(spatial, settings.Fps, t.DownTrack().Codec().MimeType))
+	if settings.Width > 0 || settings.Fps > 0 {
+		spatial := t.spatialLayerFromSettings(settings)
+		t.DownTrack().SetMaxSpatialLayer(spatial)
+		if settings.Fps > 0 {
+			t.DownTrack().SetMaxTemporalLayer(t.MediaTrack().GetTemporalLayerForSpatialFps(spatial, settings.Fps, t.DownTrack().Codec().MimeType))
+		}
 	}
 }
 

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -305,11 +305,6 @@ func NewDownTrack(
 		d.receiver.GetReferenceLayerRTPTimestamp,
 		d.getExpectedRTPTimestamp,
 	)
-	d.forwarder.OnParkedLayerExpired(func() {
-		if sal := d.getStreamAllocatorListener(); sal != nil {
-			sal.OnSubscriptionChanged(d)
-		}
-	})
 
 	d.rtpStats = buffer.NewRTPStats(buffer.RTPStatsParams{
 		ClockRate:              d.codec.ClockRate,

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -201,34 +201,13 @@ func TestForwarderAllocateOptimal(t *testing.T) {
 
 	f.PubMute(false)
 
-	// when parked layers valid, should stay there
-	f.vls.SetParked(buffer.VideoLayer{
-		Spatial:  0,
-		Temporal: 1,
-	})
-	expectedResult = VideoAllocation{
-		PauseReason:         VideoPauseReasonFeedDry,
-		BandwidthRequested:  0,
-		BandwidthDelta:      0,
-		Bitrates:            emptyBitrates,
-		TargetLayer:         f.vls.GetParked(),
-		RequestLayerSpatial: f.vls.GetParked().Spatial,
-		MaxLayer:            buffer.DefaultMaxLayer,
-		DistanceToDesired:   0,
-	}
-	result = f.AllocateOptimal(nil, emptyBitrates, true)
-	require.Equal(t, expectedResult, result)
-	require.Equal(t, expectedResult, f.lastAllocation)
-	require.Equal(t, f.vls.GetParked(), f.TargetLayer())
-	f.vls.SetParked(buffer.InvalidLayer)
-
 	// when max layers changes, target is opportunistic, but requested spatial layer should be at max
 	f.SetMaxTemporalLayerSeen(3)
 	f.vls.SetMax(buffer.VideoLayer{Spatial: 1, Temporal: 3})
 	expectedResult = VideoAllocation{
 		PauseReason:         VideoPauseReasonNone,
 		BandwidthRequested:  bitrates[1][3],
-		BandwidthDelta:      bitrates[1][3] - bitrates[0][1],
+		BandwidthDelta:      bitrates[1][3],
 		BandwidthNeeded:     bitrates[1][3],
 		Bitrates:            bitrates,
 		TargetLayer:         buffer.DefaultMaxLayer,

--- a/pkg/sfu/videolayerselector/base.go
+++ b/pkg/sfu/videolayerselector/base.go
@@ -33,9 +33,6 @@ type Base struct {
 
 	requestSpatial int32
 
-	parkedLayer         buffer.VideoLayer
-	previousParkedLayer buffer.VideoLayer
-
 	currentLayer  buffer.VideoLayer
 	previousLayer buffer.VideoLayer
 }
@@ -48,8 +45,6 @@ func NewBase(logger logger.Logger) *Base {
 		targetLayer:         buffer.InvalidLayer, // start off with nothing, let streamallocator/opportunistic forwarder set the target
 		previousTargetLayer: buffer.InvalidLayer,
 		requestSpatial:      buffer.InvalidLayerSpatial,
-		parkedLayer:         buffer.InvalidLayer,
-		previousParkedLayer: buffer.InvalidLayer,
 		currentLayer:        buffer.InvalidLayer,
 		previousLayer:       buffer.InvalidLayer,
 	}
@@ -98,7 +93,7 @@ func (b *Base) GetRequestSpatial() int32 {
 
 func (b *Base) CheckSync() (locked bool, layer int32) {
 	layer = b.GetRequestSpatial()
-	locked = layer == b.GetCurrent().Spatial || b.GetParked().IsValid()
+	locked = layer == b.GetCurrent().Spatial
 	return
 }
 
@@ -118,14 +113,6 @@ func (b *Base) GetMaxSeen() buffer.VideoLayer {
 	return b.maxSeenLayer
 }
 
-func (b *Base) SetParked(parkedLayer buffer.VideoLayer) {
-	b.parkedLayer = parkedLayer
-}
-
-func (b *Base) GetParked() buffer.VideoLayer {
-	return b.parkedLayer
-}
-
 func (b *Base) SetCurrent(currentLayer buffer.VideoLayer) {
 	b.currentLayer = currentLayer
 }
@@ -143,15 +130,12 @@ func (b *Base) Rollback() {
 		"rolling back",
 		"previous", b.previousLayer,
 		"current", b.currentLayer,
-		"previousParked", b.previousParkedLayer,
-		"parked", b.parkedLayer,
 		"previousTarget", b.previousTargetLayer,
 		"target", b.targetLayer,
 		"max", b.maxLayer,
 		"req", b.requestSpatial,
 		"maxSeen", b.maxSeenLayer,
 	)
-	b.parkedLayer = b.previousParkedLayer
 	b.currentLayer = b.previousLayer
 	b.targetLayer = b.previousTargetLayer
 }
@@ -170,8 +154,6 @@ func (b *Base) SelectTemporal(extPkt *buffer.ExtPacket) (int32, bool) {
 				"updating temporal layer",
 				"previous", b.previousLayer,
 				"current", b.currentLayer,
-				"previousParked", b.previousParkedLayer,
-				"parked", b.parkedLayer,
 				"previousTarget", b.previousTargetLayer,
 				"target", b.targetLayer,
 				"max", b.maxLayer,

--- a/pkg/sfu/videolayerselector/dependencydescriptor.go
+++ b/pkg/sfu/videolayerselector/dependencydescriptor.go
@@ -285,11 +285,6 @@ func (d *DependencyDescriptor) updateActiveDecodeTargets(activeDecodeTargetsBitm
 }
 
 func (d *DependencyDescriptor) CheckSync() (locked bool, layer int32) {
-	layer = d.GetRequestSpatial()
-	if d.GetParked().IsValid() {
-		return true, layer
-	}
-
 	d.decodeTargetsLock.RLock()
 	defer d.decodeTargetsLock.RUnlock()
 	for _, dt := range d.decodeTargets {

--- a/pkg/sfu/videolayerselector/dependencydescriptor.go
+++ b/pkg/sfu/videolayerselector/dependencydescriptor.go
@@ -285,6 +285,7 @@ func (d *DependencyDescriptor) updateActiveDecodeTargets(activeDecodeTargetsBitm
 }
 
 func (d *DependencyDescriptor) CheckSync() (locked bool, layer int32) {
+	layer = d.GetRequestSpatial()
 	d.decodeTargetsLock.RLock()
 	defer d.decodeTargetsLock.RUnlock()
 	for _, dt := range d.decodeTargets {

--- a/pkg/sfu/videolayerselector/simulcast.go
+++ b/pkg/sfu/videolayerselector/simulcast.go
@@ -40,10 +40,8 @@ func (s *Simulcast) IsOvershootOkay() bool {
 }
 
 func (s *Simulcast) Select(extPkt *buffer.ExtPacket, layer int32) (result VideoLayerSelectorResult) {
-	populateSwitches := func(isSwitching bool, isActive bool, reason string) {
-		if isSwitching {
-			result.IsSwitching = true
-		}
+	populateSwitches := func(isActive bool, reason string) {
+		result.IsSwitching = true
 
 		if !isActive {
 			result.IsResuming = true
@@ -54,8 +52,6 @@ func (s *Simulcast) Select(extPkt *buffer.ExtPacket, layer int32) (result VideoL
 				reason,
 				"previous", s.previousLayer,
 				"current", s.currentLayer,
-				"previousParked", s.previousParkedLayer,
-				"parked", s.parkedLayer,
 				"previousTarget", s.previousTargetLayer,
 				"target", s.targetLayer,
 				"max", s.maxLayer,
@@ -70,44 +66,30 @@ func (s *Simulcast) Select(extPkt *buffer.ExtPacket, layer int32) (result VideoL
 	if s.currentLayer.Spatial != s.targetLayer.Spatial {
 		currentLayer := s.currentLayer
 
-		// Three things to check when not locked to target
-		//   1. Resumable layer - don't need a key frame
-		//   2. Opportunistic layer upgrade - needs a key frame
-		//   3. Need to downgrade - needs a key frame
-		isSwitching := true
+		// Two things to check when not locked to target
+		//   1. Opportunistic layer upgrade - needs a key frame
+		//   2. Need to downgrade - needs a key frame
 		isActive := s.currentLayer.IsValid()
 		found := false
 		reason := ""
-		if s.parkedLayer.IsValid() {
-			if s.parkedLayer.Spatial == layer {
-				reason = "resuming at parked layer"
-				currentLayer = s.parkedLayer
-				isSwitching = false
+		if extPkt.KeyFrame {
+			if layer > s.currentLayer.Spatial && layer <= s.targetLayer.Spatial {
+				reason = "upgrading layer"
 				found = true
 			}
-		} else {
-			if extPkt.KeyFrame {
-				if layer > s.currentLayer.Spatial && layer <= s.targetLayer.Spatial {
-					reason = "upgrading layer"
-					found = true
-				}
 
-				if layer < s.currentLayer.Spatial && layer >= s.targetLayer.Spatial {
-					reason = "downgrading layer"
-					found = true
-				}
+			if layer < s.currentLayer.Spatial && layer >= s.targetLayer.Spatial {
+				reason = "downgrading layer"
+				found = true
+			}
 
-				if found {
-					currentLayer.Spatial = layer
-					currentLayer.Temporal = extPkt.VideoLayer.Temporal
-				}
+			if found {
+				currentLayer.Spatial = layer
+				currentLayer.Temporal = extPkt.VideoLayer.Temporal
 			}
 		}
 
 		if found {
-			s.previousParkedLayer = s.parkedLayer
-			s.parkedLayer = buffer.InvalidLayer
-
 			s.previousLayer = s.currentLayer
 			s.currentLayer = currentLayer
 
@@ -116,7 +98,7 @@ func (s *Simulcast) Select(extPkt *buffer.ExtPacket, layer int32) (result VideoL
 				s.targetLayer.Spatial = s.currentLayer.Spatial
 			}
 
-			populateSwitches(isSwitching, isActive, reason)
+			populateSwitches(isActive, reason)
 		}
 	}
 
@@ -130,7 +112,7 @@ func (s *Simulcast) Select(extPkt *buffer.ExtPacket, layer int32) (result VideoL
 			s.targetLayer.Spatial = layer
 		}
 
-		populateSwitches(true, true, "adjusting overshoot")
+		populateSwitches(true, "adjusting overshoot")
 	}
 
 	result.RTPMarker = extPkt.Packet.Marker

--- a/pkg/sfu/videolayerselector/videolayerselector.go
+++ b/pkg/sfu/videolayerselector/videolayerselector.go
@@ -51,9 +51,6 @@ type VideoLayerSelector interface {
 	SetMaxSeenTemporal(layer int32)
 	GetMaxSeen() buffer.VideoLayer
 
-	SetParked(parkedLayer buffer.VideoLayer)
-	GetParked() buffer.VideoLayer
-
 	SetCurrent(currentLayer buffer.VideoLayer)
 	GetCurrent() buffer.VideoLayer
 


### PR DESCRIPTION
Not worth the added complexity.

Several reasons
- Not seeing black frames on pub mute always.
- If they are there, it can consume more than 30kbps if the parked layer is high res. That is wasted bandwidth downstream when pub is muted.
- On resume, client some time sends PLI and that triggers a key frame request.

But, leaving the separate `PubMuted` flag in forwarder in case we can use it for better handling.