### PR TITLE
Skip video layer update if sub muted

### DIFF
--- a/pkg/rtc/subscribedtrack.go
+++ b/pkg/rtc/subscribedtrack.go
@@ -211,18 +211,15 @@ func (t *SubscribedTrack) UpdateVideoLayer() {
 	}
 
 	settings := t.settings.Load()
-	if settings == nil {
+	if settings == nil || settings.Disabled {
 		return
 	}
 
 	t.logger.Debugw("updating video layer", "settings", settings)
-
-	if settings.Width > 0 || settings.Fps > 0 {
-		spatial := t.spatialLayerFromSettings(settings)
-		t.DownTrack().SetMaxSpatialLayer(spatial)
-		if settings.Fps > 0 {
-			t.DownTrack().SetMaxTemporalLayer(t.MediaTrack().GetTemporalLayerForSpatialFps(spatial, settings.Fps, t.DownTrack().Codec().MimeType))
-		}
+	spatial := t.spatialLayerFromSettings(settings)
+	t.DownTrack().SetMaxSpatialLayer(spatial)
+	if settings.Fps > 0 {
+		t.DownTrack().SetMaxTemporalLayer(t.MediaTrack().GetTemporalLayerForSpatialFps(spatial, settings.Fps, t.DownTrack().Codec().MimeType))
 	}
 }
 


### PR DESCRIPTION
Previous change to check for non-zero width caused test failures as subscribed track settings can use the quality field and not necessarily width/height.