### PR TITLE
Use 32-bit ts for first packet adjustment.

### DIFF
--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -819,8 +819,10 @@ func (r *RTPStats) SetRtcpSenderReportData(srData *RTCPSenderReportData) {
 	if r.srNewest != nil && r.srNewest.NTPTimestamp > srData.NTPTimestamp {
 		r.logger.Infow(
 			"received anachronous sender report",
-			"current", srData.NTPTimestamp.Time(),
-			"last", r.srNewest.NTPTimestamp.Time(),
+			"currentNTP", srData.NTPTimestamp.Time(),
+			"currentRTP", srData.RTPTimestamp,
+			"lastNTP", r.srNewest.NTPTimestamp.Time(),
+			"lastRTP", r.srNewest.RTPTimestamp,
 		)
 		return
 	}


### PR DESCRIPTION
Otherwise, a new subscriber on a long running sees a huge difference if the publisher side has rolled over.

As this happens only in the first two minutes of a track's lifecycle it is fine to not consider rollover.