### PR TITLE
Fix race condition causing new participants to have stale room metadata

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -740,9 +740,7 @@ func (r *Room) sendRoomUpdate() {
 	roomInfo := r.ToProto()
 	// Send update to participants
 	for _, p := range r.GetParticipants() {
-		// new participants receive the update as part of JoinResponse
-		// skip inactive participants
-		if p.State() != livekit.ParticipantInfo_ACTIVE {
+		if !p.IsReady() {
 			continue
 		}
 


### PR DESCRIPTION
If room metadata is changed in between when a participant is joining and when they've became active, that participant will not have the latest room metadata.