### PR TITLE
Adjust TS and cycles when adjusting start.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_test.go
+++ b/pkg/sfu/buffer/rtpstats_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/livekit/protocol/logger"
 	"github.com/pion/rtp"
 	"github.com/stretchr/testify/require"
 )
@@ -38,6 +39,7 @@ func TestRTPStats(t *testing.T) {
 	clockRate := uint32(90000)
 	r := NewRTPStats(RTPStatsParams{
 		ClockRate: clockRate,
+		Logger:    logger.GetLogger(),
 	})
 
 	totalDuration := 5 * time.Second
@@ -79,6 +81,7 @@ func TestRTPStats_Update(t *testing.T) {
 	clockRate := uint32(90000)
 	r := NewRTPStats(RTPStatsParams{
 		ClockRate: clockRate,
+		Logger:    logger.GetLogger(),
 	})
 
 	sequenceNumber := uint16(rand.Float64() * float64(1<<16))

--- a/pkg/sfu/utils/wraparound.go
+++ b/pkg/sfu/utils/wraparound.go
@@ -113,7 +113,7 @@ func (w *WrapAround[T, ET]) maybeAdjustStart(val T) (isRestart bool, preExtended
 
 	// re-adjust start if necessary. The conditions are
 	// 1. Not seen more than half the range yet
-	// 1. wrap around compared to start and not completed a half cycle, sequences like (10, 65530) in uint16 space
+	// 1. wrap back compared to start and not completed a half cycle, sequences like (10, 65530) in uint16 space
 	// 2. no wrap around, but out-of-order compared to start and not completed a half cycle , sequences like (10, 9), (65530, 65528) in uint16 space
 	cycles := w.cycles
 	totalNum := w.GetExtendedHighest() - w.GetExtendedStart() + 1


### PR DESCRIPTION
Chasing some AddPacket errors across relay.
Noticed that in one case the start/end sequence was flipped. There is a known issue of it happening with resync. Unclear if this instance was due to resync or not. The start was close to the edge (64513). So, thought maybe adjust at start and noticed that it needs to maybe increase cycle count if start is wrapping back. In this case, the start is 1000 before wrap point. So, may not be a wrap back issue, but addressing what I found anyway.