### PR TITLE
Ensure older session does not clobeer newer session.

### DIFF
--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -51,7 +51,7 @@ func (p *ParticipantImpl) SendJoinResponse(joinResponse *livekit.JoinResponse) e
 		return err
 	}
 
-	// update state after to sending message, so that no participant updates could slip through before JoinResponse is sent
+	// update state after sending message, so that no participant updates could slip through before JoinResponse is sent
 	p.updateLock.Lock()
 	for _, op := range joinResponse.OtherParticipants {
 		p.updateCache.Add(livekit.ParticipantID(op.Sid), participantUpdateInfo{version: op.Version, state: op.State, updatedAt: time.Now()})

--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -41,13 +41,6 @@ func (p *ParticipantImpl) SetResponseSink(sink routing.MessageSink) {
 }
 
 func (p *ParticipantImpl) SendJoinResponse(joinResponse *livekit.JoinResponse) error {
-	// keep track of participant updates and versions
-	p.updateLock.Lock()
-	for _, op := range joinResponse.OtherParticipants {
-		p.updateCache.Add(livekit.ParticipantID(op.Sid), participantUpdateInfo{version: op.Version, state: op.State, updatedAt: time.Now()})
-	}
-	p.updateLock.Unlock()
-
 	// send Join response
 	err := p.writeMessage(&livekit.SignalResponse{
 		Message: &livekit.SignalResponse_Join{
@@ -58,9 +51,12 @@ func (p *ParticipantImpl) SendJoinResponse(joinResponse *livekit.JoinResponse) e
 		return err
 	}
 
-	// update state after to sending message, so that no participant updates could slip through before JoinResponse is
-	// sent
+	// update state after to sending message, so that no participant updates could slip through before JoinResponse is sent
 	p.updateLock.Lock()
+	for _, op := range joinResponse.OtherParticipants {
+		p.updateCache.Add(livekit.ParticipantID(op.Sid), participantUpdateInfo{version: op.Version, state: op.State, updatedAt: time.Now()})
+	}
+
 	if p.State() == livekit.ParticipantInfo_JOINING {
 		p.updateState(livekit.ParticipantInfo_JOINED)
 	}
@@ -105,7 +101,6 @@ func (p *ParticipantImpl) SendParticipantUpdate(participantsToUpdate []*livekit.
 			isValid = false
 		}
 		if isValid {
-			p.updateCache.Add(pID, participantUpdateInfo{version: pi.Version, state: pi.State, updatedAt: time.Now()})
 			validUpdates = append(validUpdates, pi)
 		}
 	}
@@ -115,13 +110,23 @@ func (p *ParticipantImpl) SendParticipantUpdate(participantsToUpdate []*livekit.
 		return nil
 	}
 
-	return p.writeMessage(&livekit.SignalResponse{
+	err := p.writeMessage(&livekit.SignalResponse{
 		Message: &livekit.SignalResponse_Update{
 			Update: &livekit.ParticipantUpdate{
 				Participants: validUpdates,
 			},
 		},
 	})
+	if err != nil {
+		return err
+	}
+
+	p.updateLock.Lock()
+	for _, pi := range validUpdates {
+		p.updateCache.Add(livekit.ParticipantID(pi.Sid), participantUpdateInfo{version: pi.Version, state: pi.State, updatedAt: time.Now()})
+	}
+	p.updateLock.Unlock()
+	return nil
 }
 
 // SendSpeakerUpdate notifies participant changes to speakers. only send members that have changed since last update

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -1069,6 +1069,15 @@ func (r *Room) pushAndDequeueUpdates(pi *livekit.ParticipantInfo, isImmediate bo
 				return nil
 			}
 		}
+	} else {
+		ep := r.GetParticipant(identity)
+		if ep != nil {
+			epi := ep.ToProto()
+			if epi.JoinedAt > pi.JoinedAt {
+				// older session update, newer session has already become active, so nothing to do
+				return nil
+			}
+		}
 	}
 
 	if shouldSend {


### PR DESCRIPTION
The following sequence caused older session to kill newer session.
- User 1 joins - u1s1 (User 1, Session 1)
- User 2 joins
- User 1 leaves - u1s1 leaves
- User 1 joins immediately - u1s2 joins
- User 2 gets ParticipantInfo of u1s2
- u1s1 leave - participant close - change to DISCONNECTED state propagates - as this is in a goroutine, the participant update happens after u1s2 has propogated and sent to User 2.
- In the non-publisher path, batched updates checks for existing participant update for that identity and ignores if theere is a newer session.
- But, for publisher (which is always immediately sent), there was no check for a newer session of that participant identity. So, the participant DISCONNECTED of u1s1 ended up getting sent to User 2 and client saw that as a change in participant SID.

Fix by checking for newer session of participant.

Also changing the participant cache update to do them after sending the update message. Else, there was a window where cached version would have been updated before send and a version compare could have concluded that the update has been sent.