### PR TITLE
Make extended sequence number 64-bit.

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -54,7 +54,7 @@ type pendingPacket struct {
 type ExtPacket struct {
 	VideoLayer
 	Arrival              time.Time
-	ExtSequenceNumber    uint32
+	ExtSequenceNumber    uint64
 	ExtTimestamp         uint64
 	Packet               *rtp.Packet
 	Payload              interface{}
@@ -83,7 +83,7 @@ type Buffer struct {
 	closed        atomic.Bool
 	mime          string
 
-	snRangeMap *utils.RangeMap[uint32, uint32]
+	snRangeMap *utils.RangeMap[uint64, uint64]
 
 	latestTSForAudioLevelInitialized bool
 	latestTSForAudioLevel            uint32
@@ -128,7 +128,7 @@ func NewBuffer(ssrc uint32, vp, ap *sync.Pool) *Buffer {
 		mediaSSRC:   ssrc,
 		videoPool:   vp,
 		audioPool:   ap,
-		snRangeMap:  utils.NewRangeMap[uint32, uint32](100),
+		snRangeMap:  utils.NewRangeMap[uint64, uint64](100),
 		pliThrottle: int64(500 * time.Millisecond),
 		logger:      l.WithComponent(sutils.ComponentPub).WithComponent(sutils.ComponentSFU),
 	}

--- a/pkg/sfu/buffer/buffer_test.go
+++ b/pkg/sfu/buffer/buffer_test.go
@@ -213,7 +213,7 @@ func TestNewBuffer(t *testing.T) {
 				_, _ = buff.Write(buf)
 			}
 			require.Equal(t, uint16(2), buff.rtpStats.sequenceNumber.GetHighest())
-			require.Equal(t, uint32(65536+2), buff.rtpStats.sequenceNumber.GetExtendedHighest())
+			require.Equal(t, uint64(65536+2), buff.rtpStats.sequenceNumber.GetExtendedHighest())
 		})
 	}
 }

--- a/pkg/sfu/buffer/helpers.go
+++ b/pkg/sfu/buffer/helpers.go
@@ -52,7 +52,7 @@ type VP8 struct {
 
 	I         bool
 	M         bool
-	PictureID uint16 /* 8 or 16 bits, picture ID */
+	PictureID uint16 /* 7 or 15 bits, picture ID */
 
 	L         bool
 	TL0PICIDX uint8 /* 8 bits temporal level zero index */

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -1491,7 +1491,7 @@ func (r *RTPStats) getPacketsLost() uint64 {
 }
 
 func (r *RTPStats) getSnInfoOutOfOrderPtr(esn uint64, ehsn uint64) int {
-	if int64(esn-ehsn) >= 0 {
+	if int64(esn-ehsn) > 0 {
 		return -1 // in-order, not expected, maybe too new
 	}
 

--- a/pkg/sfu/buffer/rtpstats_test.go
+++ b/pkg/sfu/buffer/rtpstats_test.go
@@ -114,8 +114,8 @@ func TestRTPStats_Update(t *testing.T) {
 	require.Equal(t, sequenceNumber, uint16(r.sequenceNumber.GetExtendedHighest()))
 	require.Equal(t, timestamp, r.timestamp.GetHighest())
 	require.Equal(t, timestamp, uint32(r.timestamp.GetExtendedHighest()))
-	require.Equal(t, uint32(1), r.packetsOutOfOrder)
-	require.Equal(t, uint32(0), r.packetsDuplicate)
+	require.Equal(t, uint64(1), r.packetsOutOfOrder)
+	require.Equal(t, uint64(0), r.packetsDuplicate)
 
 	// duplicate
 	packet = getPacket(sequenceNumber-10, timestamp-30000, 1000)
@@ -125,8 +125,8 @@ func TestRTPStats_Update(t *testing.T) {
 	require.Equal(t, sequenceNumber, uint16(r.sequenceNumber.GetExtendedHighest()))
 	require.Equal(t, timestamp, r.timestamp.GetHighest())
 	require.Equal(t, timestamp, uint32(r.timestamp.GetExtendedHighest()))
-	require.Equal(t, uint32(2), r.packetsOutOfOrder)
-	require.Equal(t, uint32(1), r.packetsDuplicate)
+	require.Equal(t, uint64(2), r.packetsOutOfOrder)
+	require.Equal(t, uint64(1), r.packetsDuplicate)
 
 	// loss
 	sequenceNumber += 10
@@ -134,9 +134,9 @@ func TestRTPStats_Update(t *testing.T) {
 	packet = getPacket(sequenceNumber, timestamp, 1000)
 	flowState = r.Update(&packet.Header, len(packet.Payload), 0, time.Now())
 	require.True(t, flowState.HasLoss)
-	require.Equal(t, uint32(sequenceNumber-9), flowState.LossStartInclusive)
-	require.Equal(t, uint32(sequenceNumber), flowState.LossEndExclusive)
-	require.Equal(t, uint32(17), r.packetsLost)
+	require.Equal(t, uint64(sequenceNumber-9), flowState.LossStartInclusive)
+	require.Equal(t, uint64(sequenceNumber), flowState.LossEndExclusive)
+	require.Equal(t, uint64(17), r.packetsLost)
 
 	// out-of-order should decrement number of lost packets
 	packet = getPacket(sequenceNumber-15, timestamp-45000, 1000)
@@ -146,11 +146,11 @@ func TestRTPStats_Update(t *testing.T) {
 	require.Equal(t, sequenceNumber, uint16(r.sequenceNumber.GetExtendedHighest()))
 	require.Equal(t, timestamp, r.timestamp.GetHighest())
 	require.Equal(t, timestamp, uint32(r.timestamp.GetExtendedHighest()))
-	require.Equal(t, uint32(3), r.packetsOutOfOrder)
-	require.Equal(t, uint32(1), r.packetsDuplicate)
-	require.Equal(t, uint32(16), r.packetsLost)
+	require.Equal(t, uint64(3), r.packetsOutOfOrder)
+	require.Equal(t, uint64(1), r.packetsDuplicate)
+	require.Equal(t, uint64(16), r.packetsLost)
 	intervalStats := r.getIntervalStats(r.sequenceNumber.GetExtendedStart(), r.sequenceNumber.GetExtendedHighest()+1)
-	require.Equal(t, uint32(16), intervalStats.packetsLost)
+	require.Equal(t, uint64(16), intervalStats.packetsLost)
 
 	r.Stop()
 }

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -1698,7 +1698,7 @@ func (d *DownTrack) getDeltaStatsOverridden() map[uint32]*buffer.StreamStatsWith
 }
 
 func (d *DownTrack) GetNackStats() (totalPackets uint32, totalRepeatedNACKs uint32) {
-	totalPackets = d.rtpStats.GetTotalPacketsPrimary()
+	totalPackets = uint32(d.rtpStats.GetTotalPacketsPrimary())
 	totalRepeatedNACKs = d.totalRepeatedNACKs.Load()
 	return
 }

--- a/pkg/sfu/rtpmunger.go
+++ b/pkg/sfu/rtpmunger.go
@@ -53,7 +53,7 @@ type SnTs struct {
 // ----------------------------------------------------------------------
 
 type RTPMungerState struct {
-	ExtLastSN uint32
+	ExtLastSN uint64
 	ExtLastTS uint64
 }
 
@@ -66,22 +66,22 @@ func (r RTPMungerState) String() string {
 type RTPMunger struct {
 	logger logger.Logger
 
-	extHighestIncomingSN uint32
-	snRangeMap           *utils.RangeMap[uint32, uint32]
+	extHighestIncomingSN uint64
+	snRangeMap           *utils.RangeMap[uint64, uint64]
 
-	extLastSN  uint32
+	extLastSN  uint64
 	extLastTS  uint64
 	tsOffset   uint64
 	lastMarker bool
 
-	extRtxGateSn      uint32
+	extRtxGateSn      uint64
 	isInRtxGateRegion bool
 }
 
 func NewRTPMunger(logger logger.Logger) *RTPMunger {
 	return &RTPMunger{
 		logger:     logger,
-		snRangeMap: utils.NewRangeMap[uint32, uint32](100),
+		snRangeMap: utils.NewRangeMap[uint64, uint64](100),
 	}
 }
 
@@ -115,7 +115,7 @@ func (r *RTPMunger) SetLastSnTs(extPkt *buffer.ExtPacket) {
 	r.extLastTS = extPkt.ExtTimestamp
 }
 
-func (r *RTPMunger) UpdateSnTsOffsets(extPkt *buffer.ExtPacket, snAdjust uint32, tsAdjust uint64) {
+func (r *RTPMunger) UpdateSnTsOffsets(extPkt *buffer.ExtPacket, snAdjust uint64, tsAdjust uint64) {
 	r.extHighestIncomingSN = extPkt.ExtSequenceNumber - 1
 	r.snRangeMap.ClearAndResetValue(extPkt.ExtSequenceNumber - r.extLastSN - snAdjust)
 	r.tsOffset = extPkt.ExtTimestamp - r.extLastTS - tsAdjust
@@ -260,7 +260,7 @@ func (r *RTPMunger) UpdateAndGetPaddingSnTs(num int, clockRate uint32, frameRate
 	}
 
 	r.extLastSN = extLastSN
-	r.snRangeMap.DecValue(uint32(num))
+	r.snRangeMap.DecValue(uint64(num))
 
 	r.tsOffset -= extLastTS - r.extLastTS
 	r.extLastTS = extLastTS

--- a/pkg/sfu/rtpmunger_test.go
+++ b/pkg/sfu/rtpmunger_test.go
@@ -41,12 +41,12 @@ func TestSetLastSnTs(t *testing.T) {
 	require.NotNil(t, extPkt)
 
 	r.SetLastSnTs(extPkt)
-	require.Equal(t, uint32(23332), r.extHighestIncomingSN)
-	require.Equal(t, uint32(23333), r.extLastSN)
+	require.Equal(t, uint64(23332), r.extHighestIncomingSN)
+	require.Equal(t, uint64(23333), r.extLastSN)
 	require.Equal(t, uint64(0xabcdef), r.extLastTS)
 	snOffset, err := r.snRangeMap.GetValue(r.extHighestIncomingSN)
 	require.NoError(t, err)
-	require.Equal(t, uint32(0), snOffset)
+	require.Equal(t, uint64(0), snOffset)
 	require.Equal(t, uint64(0), r.tsOffset)
 }
 
@@ -68,12 +68,12 @@ func TestUpdateSnTsOffsets(t *testing.T) {
 	}
 	extPkt, _ = testutils.GetTestExtPacket(params)
 	r.UpdateSnTsOffsets(extPkt, 1, 1)
-	require.Equal(t, uint32(33332), r.extHighestIncomingSN)
-	require.Equal(t, uint32(23333), r.extLastSN)
+	require.Equal(t, uint64(33332), r.extHighestIncomingSN)
+	require.Equal(t, uint64(23333), r.extLastSN)
 	require.Equal(t, uint64(0xabcdef), r.extLastTS)
 	snOffset, err := r.snRangeMap.GetValue(r.extHighestIncomingSN)
 	require.NoError(t, err)
-	require.Equal(t, uint32(9999), snOffset)
+	require.Equal(t, uint64(9999), snOffset)
 	require.Equal(t, uint64(0xffff_ffff_ffff_ffff), r.tsOffset)
 }
 
@@ -88,12 +88,12 @@ func TestPacketDropped(t *testing.T) {
 	}
 	extPkt, _ := testutils.GetTestExtPacket(params)
 	r.SetLastSnTs(extPkt)
-	require.Equal(t, uint32(23332), r.extHighestIncomingSN)
-	require.Equal(t, uint32(23333), r.extLastSN)
+	require.Equal(t, uint64(23332), r.extHighestIncomingSN)
+	require.Equal(t, uint64(23333), r.extLastSN)
 	require.Equal(t, uint64(0xabcdef), r.extLastTS)
 	snOffset, err := r.snRangeMap.GetValue(r.extHighestIncomingSN)
 	require.NoError(t, err)
-	require.Equal(t, uint32(0), snOffset)
+	require.Equal(t, uint64(0), snOffset)
 	require.Equal(t, uint64(0), r.tsOffset)
 
 	r.UpdateAndGetSnTs(extPkt) // update sequence number offset
@@ -106,11 +106,11 @@ func TestPacketDropped(t *testing.T) {
 	}
 	extPkt, _ = testutils.GetTestExtPacket(params)
 	r.PacketDropped(extPkt)
-	require.Equal(t, uint32(23333), r.extHighestIncomingSN)
-	require.Equal(t, uint32(23333), r.extLastSN)
+	require.Equal(t, uint64(23333), r.extHighestIncomingSN)
+	require.Equal(t, uint64(23333), r.extLastSN)
 	snOffset, err = r.snRangeMap.GetValue(r.extHighestIncomingSN)
 	require.NoError(t, err)
-	require.Equal(t, uint32(0), snOffset)
+	require.Equal(t, uint64(0), snOffset)
 
 	// drop a head packet and check offset increases
 	params = &testutils.TestExtPacketParams{
@@ -124,10 +124,10 @@ func TestPacketDropped(t *testing.T) {
 	r.UpdateAndGetSnTs(extPkt) // update sequence number offset
 
 	r.PacketDropped(extPkt)
-	require.Equal(t, uint32(44443), r.extLastSN)
+	require.Equal(t, uint64(44443), r.extLastSN)
 	snOffset, err = r.snRangeMap.GetValue(r.extHighestIncomingSN)
 	require.NoError(t, err)
-	require.Equal(t, uint32(1), snOffset)
+	require.Equal(t, uint64(1), snOffset)
 
 	params = &testutils.TestExtPacketParams{
 		SequenceNumber: 44445,
@@ -138,10 +138,10 @@ func TestPacketDropped(t *testing.T) {
 	extPkt, _ = testutils.GetTestExtPacket(params)
 
 	r.UpdateAndGetSnTs(extPkt) // update sequence number offset
-	require.Equal(t, r.extLastSN, uint32(44444))
+	require.Equal(t, r.extLastSN, uint64(44444))
 	snOffset, err = r.snRangeMap.GetValue(r.extHighestIncomingSN)
 	require.NoError(t, err)
-	require.Equal(t, uint32(1), snOffset)
+	require.Equal(t, uint64(1), snOffset)
 }
 
 func TestOutOfOrderSequenceNumber(t *testing.T) {
@@ -243,11 +243,11 @@ func TestPaddingOnlyPacket(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrPaddingOnlyPacket)
 	require.Equal(t, tpExpected, *tp)
-	require.Equal(t, uint32(23333), r.extHighestIncomingSN)
-	require.Equal(t, uint32(23333), r.extLastSN)
+	require.Equal(t, uint64(23333), r.extHighestIncomingSN)
+	require.Equal(t, uint64(23333), r.extLastSN)
 	snOffset, err := r.snRangeMap.GetValue(r.extHighestIncomingSN)
 	require.NoError(t, err)
-	require.Equal(t, uint32(1), snOffset)
+	require.Equal(t, uint64(1), snOffset)
 
 	// padding only packet with a gap should not report an error
 	params = &testutils.TestExtPacketParams{
@@ -266,11 +266,11 @@ func TestPaddingOnlyPacket(t *testing.T) {
 	tp, err = r.UpdateAndGetSnTs(extPkt)
 	require.NoError(t, err)
 	require.Equal(t, tpExpected, *tp)
-	require.Equal(t, uint32(23335), r.extHighestIncomingSN)
-	require.Equal(t, uint32(23334), r.extLastSN)
+	require.Equal(t, uint64(23335), r.extHighestIncomingSN)
+	require.Equal(t, uint64(23334), r.extLastSN)
 	snOffset, err = r.snRangeMap.GetValue(r.extHighestIncomingSN)
 	require.NoError(t, err)
-	require.Equal(t, uint32(1), snOffset)
+	require.Equal(t, uint64(1), snOffset)
 }
 
 func TestGapInSequenceNumber(t *testing.T) {
@@ -307,19 +307,19 @@ func TestGapInSequenceNumber(t *testing.T) {
 	tp, err := r.UpdateAndGetSnTs(extPkt)
 	require.NoError(t, err)
 	require.Equal(t, tpExpected, *tp)
-	require.Equal(t, uint32(65536+1), r.extHighestIncomingSN)
-	require.Equal(t, uint32(65536+1), r.extLastSN)
+	require.Equal(t, uint64(65536+1), r.extHighestIncomingSN)
+	require.Equal(t, uint64(65536+1), r.extLastSN)
 	snOffset, err := r.snRangeMap.GetValue(r.extHighestIncomingSN)
 	require.NoError(t, err)
-	require.Equal(t, uint32(0), snOffset)
+	require.Equal(t, uint64(0), snOffset)
 
 	// ensure missing sequence numbers got recorded in cache
 
 	// last received, three missing in between and current received should all be in cache
-	for i := uint32(65534); i != 65536+1; i++ {
+	for i := uint64(65534); i != 65536+1; i++ {
 		offset, err := r.snRangeMap.GetValue(i)
 		require.NoError(t, err)
-		require.Equal(t, uint32(0), offset)
+		require.Equal(t, uint64(0), offset)
 	}
 
 	// a padding only packet should be dropped
@@ -338,11 +338,11 @@ func TestGapInSequenceNumber(t *testing.T) {
 	tp, err = r.UpdateAndGetSnTs(extPkt)
 	require.ErrorIs(t, err, ErrPaddingOnlyPacket)
 	require.Equal(t, tpExpected, *tp)
-	require.Equal(t, uint32(65536+2), r.extHighestIncomingSN)
-	require.Equal(t, uint32(65536+1), r.extLastSN)
+	require.Equal(t, uint64(65536+2), r.extHighestIncomingSN)
+	require.Equal(t, uint64(65536+1), r.extLastSN)
 	snOffset, err = r.snRangeMap.GetValue(r.extHighestIncomingSN)
 	require.NoError(t, err)
-	require.Equal(t, uint32(1), snOffset)
+	require.Equal(t, uint64(1), snOffset)
 
 	// a packet with a gap should be adding to missing cache
 	params = &testutils.TestExtPacketParams{
@@ -363,11 +363,11 @@ func TestGapInSequenceNumber(t *testing.T) {
 	tp, err = r.UpdateAndGetSnTs(extPkt)
 	require.NoError(t, err)
 	require.Equal(t, tpExpected, *tp)
-	require.Equal(t, uint32(65536+4), r.extHighestIncomingSN)
-	require.Equal(t, uint32(65536+3), r.extLastSN)
+	require.Equal(t, uint64(65536+4), r.extHighestIncomingSN)
+	require.Equal(t, uint64(65536+3), r.extLastSN)
 	snOffset, err = r.snRangeMap.GetValue(r.extHighestIncomingSN)
 	require.NoError(t, err)
-	require.Equal(t, uint32(1), snOffset)
+	require.Equal(t, uint64(1), snOffset)
 
 	// another contiguous padding only packet should be dropped
 	params = &testutils.TestExtPacketParams{
@@ -385,11 +385,11 @@ func TestGapInSequenceNumber(t *testing.T) {
 	tp, err = r.UpdateAndGetSnTs(extPkt)
 	require.ErrorIs(t, err, ErrPaddingOnlyPacket)
 	require.Equal(t, tpExpected, *tp)
-	require.Equal(t, uint32(65536+5), r.extHighestIncomingSN)
-	require.Equal(t, uint32(65536+3), r.extLastSN)
+	require.Equal(t, uint64(65536+5), r.extHighestIncomingSN)
+	require.Equal(t, uint64(65536+3), r.extLastSN)
 	snOffset, err = r.snRangeMap.GetValue(r.extHighestIncomingSN)
 	require.NoError(t, err)
-	require.Equal(t, uint32(2), snOffset)
+	require.Equal(t, uint64(2), snOffset)
 
 	// a packet with a gap should be adding to missing cache
 	params = &testutils.TestExtPacketParams{
@@ -410,11 +410,11 @@ func TestGapInSequenceNumber(t *testing.T) {
 	tp, err = r.UpdateAndGetSnTs(extPkt)
 	require.NoError(t, err)
 	require.Equal(t, tpExpected, *tp)
-	require.Equal(t, uint32(65536+7), r.extHighestIncomingSN)
-	require.Equal(t, uint32(65536+5), r.extLastSN)
+	require.Equal(t, uint64(65536+7), r.extHighestIncomingSN)
+	require.Equal(t, uint64(65536+5), r.extLastSN)
 	snOffset, err = r.snRangeMap.GetValue(r.extHighestIncomingSN)
 	require.NoError(t, err)
-	require.Equal(t, uint32(2), snOffset)
+	require.Equal(t, uint64(2), snOffset)
 
 	// check the missing packets
 	params = &testutils.TestExtPacketParams{
@@ -434,11 +434,11 @@ func TestGapInSequenceNumber(t *testing.T) {
 	tp, err = r.UpdateAndGetSnTs(extPkt)
 	require.NoError(t, err)
 	require.Equal(t, tpExpected, *tp)
-	require.Equal(t, uint32(65536+7), r.extHighestIncomingSN)
-	require.Equal(t, uint32(65536+5), r.extLastSN)
+	require.Equal(t, uint64(65536+7), r.extHighestIncomingSN)
+	require.Equal(t, uint64(65536+5), r.extLastSN)
 	snOffset, err = r.snRangeMap.GetValue(r.extHighestIncomingSN)
 	require.NoError(t, err)
-	require.Equal(t, uint32(2), snOffset)
+	require.Equal(t, uint64(2), snOffset)
 
 	params = &testutils.TestExtPacketParams{
 		SequenceNumber: 3,
@@ -457,11 +457,11 @@ func TestGapInSequenceNumber(t *testing.T) {
 	tp, err = r.UpdateAndGetSnTs(extPkt)
 	require.NoError(t, err)
 	require.Equal(t, tpExpected, *tp)
-	require.Equal(t, uint32(65536+7), r.extHighestIncomingSN)
-	require.Equal(t, uint32(65536+5), r.extLastSN)
+	require.Equal(t, uint64(65536+7), r.extHighestIncomingSN)
+	require.Equal(t, uint64(65536+5), r.extLastSN)
 	snOffset, err = r.snRangeMap.GetValue(r.extHighestIncomingSN)
 	require.NoError(t, err)
-	require.Equal(t, uint32(2), snOffset)
+	require.Equal(t, uint64(2), snOffset)
 }
 
 func TestUpdateAndGetPaddingSnTs(t *testing.T) {

--- a/pkg/sfu/testutils/data.go
+++ b/pkg/sfu/testutils/data.go
@@ -64,7 +64,7 @@ func GetTestExtPacket(params *TestExtPacketParams) (*buffer.ExtPacket, error) {
 
 	ep := &buffer.ExtPacket{
 		VideoLayer:        params.VideoLayer,
-		ExtSequenceNumber: uint32(params.SNCycles<<16) + uint32(params.SequenceNumber),
+		ExtSequenceNumber: uint64(params.SNCycles<<16) + uint64(params.SequenceNumber),
 		ExtTimestamp:      uint64(params.TSCycles<<32) + uint64(params.Timestamp),
 		Arrival:           params.ArrivalTime,
 		Packet:            &packet,

--- a/pkg/sfu/utils/rangemap.go
+++ b/pkg/sfu/utils/rangemap.go
@@ -30,11 +30,11 @@ var (
 )
 
 type rangeType interface {
-	uint32
+	uint32 | uint64
 }
 
 type valueType interface {
-	uint32
+	uint32 | uint64
 }
 
 type rangeVal[RT rangeType, VT valueType] struct {


### PR DESCRIPTION
Should make out-of-order checks easier.
(assuming all roll overs are handled properly,
looks good in some test, but needs a bunch more testing)

There are probably which might still be using smaller range. Will change things as and when I encounter them.