### PR TITLE
Handle duplicate padding packet in the up stream.

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -445,7 +445,7 @@ func (b *Buffer) calc(pkt []byte, arrivalTime time.Time) {
 	// add to RTX buffer using sequence number after accounting for dropped padding only packets
 	snAdjustment, err := b.snRangeMap.GetValue(flowState.ExtSequenceNumber)
 	if err != nil {
-		b.logger.Errorw("could not get sequence number adjustment", err)
+		b.logger.Errorw("could not get sequence number adjustment", err, "sn", flowState.ExtSequenceNumber, "payloadSize", len(rtpPacket.Payload))
 		return
 	}
 	rtpPacket.Header.SequenceNumber = uint16(flowState.ExtSequenceNumber - snAdjustment)

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -417,9 +417,12 @@ func (b *Buffer) calc(pkt []byte, arrivalTime time.Time) {
 
 	flowState := b.updateStreamState(&rtpPacket, arrivalTime)
 	b.processHeaderExtensions(&rtpPacket, arrivalTime)
-	if !flowState.IsOutOfOrder && len(rtpPacket.Payload) == 0 {
-		// drop padding only in-order packet
-		b.snRangeMap.IncValue(1)
+	if len(rtpPacket.Payload) == 0 && (!flowState.IsOutOfOrder || flowState.IsDuplicate) {
+		// drop padding only in-order or duplicate packet
+		if !flowState.IsOutOfOrder {
+			// in-order packet - increment sequence number for subsequent packets
+			b.snRangeMap.IncValue(1)
+		}
 		return
 	}
 

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -435,8 +435,8 @@ func (b *Buffer) calc(pkt []byte, arrivalTime time.Time) {
 			//   45 - regular packet - offset = 2 (running offset) - passed through with adjusted sequence number as 43
 			//   44 - padding only - out-of-order + duplicate - dropped as duplicate
 			//
-			if err := b.snRangeMap.CloseRangeAndIncValue(flowState.ExtSequenceNumber+1, 1); err != nil {
-				b.logger.Errorw("could not close range", err, "sn", flowState.ExtSequenceNumber)
+			if err := b.snRangeMap.ExcludeRange(flowState.ExtSequenceNumber, flowState.ExtSequenceNumber+1); err != nil {
+				b.logger.Errorw("could not exclude range", err, "sn", flowState.ExtSequenceNumber)
 			}
 		}
 		return

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -1214,7 +1214,7 @@ func TestForwarderGetTranslationParamsAudio(t *testing.T) {
 	require.Equal(t, expectedTP, *actualTP)
 
 	// add a missing sequence number to the cache
-	f.rtpMunger.snRangeMap.CloseRangeAndIncValue(23333, 10)
+	f.rtpMunger.snRangeMap.ExcludeRange(23332, 23333)
 
 	// out-of-order packet should get offset from cache
 	params = &testutils.TestExtPacketParams{
@@ -1263,7 +1263,7 @@ func TestForwarderGetTranslationParamsAudio(t *testing.T) {
 	expectedTP = TranslationParams{
 		rtp: &TranslationParamsRTP{
 			snOrdering:     SequenceNumberOrderingContiguous,
-			sequenceNumber: 23324,
+			sequenceNumber: 23333,
 			timestamp:      0xabcdef,
 		},
 	}
@@ -1282,7 +1282,7 @@ func TestForwarderGetTranslationParamsAudio(t *testing.T) {
 	expectedTP = TranslationParams{
 		rtp: &TranslationParamsRTP{
 			snOrdering:     SequenceNumberOrderingGap,
-			sequenceNumber: 23326,
+			sequenceNumber: 23335,
 			timestamp:      0xabcdef,
 		},
 	}
@@ -1302,7 +1302,7 @@ func TestForwarderGetTranslationParamsAudio(t *testing.T) {
 	expectedTP = TranslationParams{
 		rtp: &TranslationParamsRTP{
 			snOrdering:     SequenceNumberOrderingOutOfOrder,
-			sequenceNumber: 23325,
+			sequenceNumber: 23334,
 			timestamp:      0xabcdef,
 		},
 	}
@@ -1322,7 +1322,7 @@ func TestForwarderGetTranslationParamsAudio(t *testing.T) {
 	expectedTP = TranslationParams{
 		rtp: &TranslationParamsRTP{
 			snOrdering:     SequenceNumberOrderingContiguous,
-			sequenceNumber: 23327,
+			sequenceNumber: 23336,
 			timestamp:      0xabcdf0,
 		},
 	}

--- a/pkg/sfu/rtpmunger.go
+++ b/pkg/sfu/rtpmunger.go
@@ -195,6 +195,7 @@ func (r *RTPMunger) UpdateAndGetSnTs(extPkt *buffer.ExtPacket) (*TranslationPara
 
 	snOffset, err := r.snRangeMap.GetValue(extPkt.ExtSequenceNumber)
 	if err != nil {
+		r.logger.Errorw("could not get sequence number adjustment", err, "sn", extPkt.ExtSequenceNumber, "payloadSize", len(extPkt.Packet.Payload))
 		return &TranslationParamsRTP{
 			snOrdering: ordering,
 		}, ErrSequenceNumberOffsetNotFound

--- a/pkg/sfu/utils/rangemap.go
+++ b/pkg/sfu/utils/rangemap.go
@@ -81,9 +81,15 @@ func (r *RangeMap[RT, VT]) CloseRangeAndDecValue(endExclusive RT, dec VT) error 
 }
 
 func (r *RangeMap[RT, VT]) closeRange(endExclusive RT) error {
+	numRanges := len(r.ranges)
 	startInclusive := RT(0)
-	if len(r.ranges) != 0 {
-		startInclusive = r.ranges[len(r.ranges)-1].end + 1
+	if numRanges != 0 {
+		startInclusive = r.ranges[numRanges-1].end + 1
+
+		if endExclusive == r.ranges[numRanges-1].end+1 {
+			// key already in map and corresponding range recorded
+			return nil
+		}
 	}
 	if endExclusive == startInclusive || endExclusive-startInclusive > r.halfRange {
 		return errReversedOrder

--- a/pkg/sfu/utils/rangemap_test.go
+++ b/pkg/sfu/utils/rangemap_test.go
@@ -27,96 +27,267 @@ func TestRangeMapUint32(t *testing.T) {
 	value, err := r.GetValue(33333)
 	require.NoError(t, err)
 	require.Equal(t, uint32(0), value)
-	value, err = r.GetValue(0xffffffff)
+
+	expectedRangeVal := rangeVal[uint32, uint32]{
+		start: 0,
+		end:   0,
+		value: 0,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[0])
+
+	// add an exclusion, should create a new range
+	err = r.ExcludeRange(10, 11)
+	require.NoError(t, err)
+
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 0,
+		end:   9,
+		value: 0,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[0])
+
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 11,
+		end:   0,
+		value: 1,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[1])
+
+	// getting value in old range should return 0
+	value, err = r.GetValue(6)
 	require.NoError(t, err)
 	require.Equal(t, uint32(0), value)
 
-	// getting value for older key should be un-incremented value
-	// should get incremented value post the end
-	err = r.CloseRangeAndIncValue(66666667, 2)
+	// newer should return 1
+	value, err = r.GetValue(11)
 	require.NoError(t, err)
-	value, err = r.GetValue(66666666)
+	require.Equal(t, uint32(1), value)
+
+	// excluded range should return error
+	value, err = r.GetValue(10)
+	require.Error(t, err, errKeyNotFound)
+
+	// add adjacent exclusion range of length = 1
+	err = r.ExcludeRange(11, 12)
 	require.NoError(t, err)
-	require.Equal(t, uint32(0), value)
-	value, err = r.GetValue(0)
+
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 0,
+		end:   9,
+		value: 0,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[0])
+
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 12,
+		end:   0,
+		value: 2,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[1])
+
+	// excluded range should return error, now is excluded because exclusion range could be extended
+	value, err = r.GetValue(11)
+	require.Error(t, err, errKeyNotFound)
+
+	// getting value in old range should return 0
+	value, err = r.GetValue(6)
 	require.NoError(t, err)
-	require.Equal(t, uint32(0), value)
-	value, err = r.GetValue(66666667)
+
+	// newer should return 2
+	value, err = r.GetValue(12)
 	require.NoError(t, err)
 	require.Equal(t, uint32(2), value)
 
-	require.Equal(t, uint32(0), r.ranges[0].start)
-	require.Equal(t, uint32(66666666), r.ranges[0].end)
-	require.Equal(t, uint32(0), r.ranges[0].value)
-
-	// duplicate should not create a new range
-	err = r.CloseRangeAndIncValue(66666667, 2)
+	// add adjacent exclusion range of length = 10
+	err = r.ExcludeRange(12, 22)
 	require.NoError(t, err)
 
-	require.Equal(t, 1, len(r.ranges))
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 0,
+		end:   9,
+		value: 0,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[0])
 
-	require.Equal(t, uint32(0), r.ranges[0].start)
-	require.Equal(t, uint32(66666666), r.ranges[0].end)
-	require.Equal(t, uint32(0), r.ranges[0].value)
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 22,
+		end:   0,
+		value: 12,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[1])
 
-	require.Equal(t, uint32(4), r.runningValue)
-
-	// out-of-order should fail
-	err = r.CloseRangeAndIncValue(66666666, 2)
-	require.Error(t, err, errReversedOrder)
-
-	// add a couple of more increments and the first one should fall off
-	err = r.CloseRangeAndIncValue(88888889, 2)
-	require.NoError(t, err)
-
-	require.Equal(t, uint32(0), r.ranges[0].start)
-	require.Equal(t, uint32(66666666), r.ranges[0].end)
-	require.Equal(t, uint32(0), r.ranges[0].value)
-
-	require.Equal(t, uint32(66666667), r.ranges[1].start)
-	require.Equal(t, uint32(88888888), r.ranges[1].end)
-	require.Equal(t, uint32(4), r.ranges[1].value)
-
-	err = r.CloseRangeAndIncValue(99999999, 2)
-	require.NoError(t, err)
-
-	require.Equal(t, uint32(66666667), r.ranges[0].start)
-	require.Equal(t, uint32(88888888), r.ranges[0].end)
-	require.Equal(t, uint32(4), r.ranges[0].value)
-
-	require.Equal(t, uint32(88888889), r.ranges[1].start)
-	require.Equal(t, uint32(99999998), r.ranges[1].end)
-	require.Equal(t, uint32(6), r.ranges[1].value)
-
-	// getting an old value should not succeed, but start of first range should return no error
-	value, err = r.GetValue(66666666)
+	// excluded range should return error, now is excluded because exclusion range could be extended
+	value, err = r.GetValue(15)
 	require.Error(t, err, errKeyNotFound)
-	value, err = r.GetValue(66666667)
-	require.NoError(t, err)
-	require.Equal(t, uint32(4), value)
 
-	// something newer than what is in ranges should return running value
-	value, err = r.GetValue(99999999)
+	// newer should return 12
+	value, err = r.GetValue(25)
 	require.NoError(t, err)
-	require.Equal(t, uint32(8), value)
+	require.Equal(t, uint32(12), value)
 
-	// decrement running value
-	err = r.CloseRangeAndDecValue(99999999+1000, 3)
+	// add a disjoint exclusion of length = 4
+	err = r.ExcludeRange(26, 30)
 	require.NoError(t, err)
 
-	require.Equal(t, uint32(88888889), r.ranges[0].start)
-	require.Equal(t, uint32(99999998), r.ranges[0].end)
-	require.Equal(t, uint32(6), r.ranges[0].value)
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 0,
+		end:   9,
+		value: 0,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[0])
 
-	require.Equal(t, uint32(99999999), r.ranges[1].start)
-	require.Equal(t, uint32(99999999+999), r.ranges[1].end)
-	require.Equal(t, uint32(8), r.ranges[1].value)
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 22,
+		end:   25,
+		value: 12,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[1])
 
-	value, err = r.GetValue(99999999)
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 30,
+		end:   0,
+		value: 16,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[2])
+
+	// get a value from newly closed range [22, 25]
+	value, err = r.GetValue(23)
 	require.NoError(t, err)
-	require.Equal(t, uint32(8), value)
+	require.Equal(t, uint32(12), value)
 
-	value, err = r.GetValue(99999999 + 1000)
+	// add a disjoint exclusion of length = 1
+	err = r.ExcludeRange(50, 51)
 	require.NoError(t, err)
-	require.Equal(t, uint32(5), value)
+
+	// previously first range would have been pruned due to size limitations
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 22,
+		end:   25,
+		value: 12,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[0])
+
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 30,
+		end:   49,
+		value: 16,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[1])
+
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 51,
+		end:   0,
+		value: 17,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[2])
+
+	// excluded range should return error
+	value, err = r.GetValue(50)
+	require.Error(t, err, errKeyNotFound)
+	value, err = r.GetValue(28)
+	require.Error(t, err, errKeyNotFound)
+	value, err = r.GetValue(17)
+	require.Error(t, err, errKeyNotFound)
+
+	// previously valid, but aged out key should return error
+	value, err = r.GetValue(5)
+	require.Error(t, err, errKeyNotFound)
+
+	// valid range access should return values
+	value, err = r.GetValue(24)
+	require.NoError(t, err)
+	require.Equal(t, uint32(12), value)
+
+	value, err = r.GetValue(34)
+	require.NoError(t, err)
+	require.Equal(t, uint32(16), value)
+
+	value, err = r.GetValue(49)
+	require.NoError(t, err)
+	require.Equal(t, uint32(16), value)
+
+	value, err = r.GetValue(55555555)
+	require.NoError(t, err)
+	require.Equal(t, uint32(17), value)
+
+	// reset
+	r.ClearAndResetValue(23)
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 0,
+		end:   0,
+		value: 23,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[0])
+
+	value, err = r.GetValue(55555555)
+	require.NoError(t, err)
+	require.Equal(t, uint32(23), value)
+
+	// decrement value and ensure that any key returns that value
+	r.DecValue(12)
+
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 0,
+		end:   0,
+		value: 11,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[0])
+
+	value, err = r.GetValue(55555555)
+	require.NoError(t, err)
+	require.Equal(t, uint32(11), value)
+
+	// add an exclusion and then decrement value
+	err = r.ExcludeRange(10, 15)
+	require.NoError(t, err)
+
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 0,
+		end:   9,
+		value: 11,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[0])
+
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 15,
+		end:   0,
+		value: 16,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[1])
+
+	// first range access
+	value, err = r.GetValue(5)
+	require.NoError(t, err)
+	require.Equal(t, uint32(11), value)
+
+	// open range access
+	value, err = r.GetValue(55555555)
+	require.NoError(t, err)
+	require.Equal(t, uint32(16), value)
+
+	r.DecValue(6)
+
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 0,
+		end:   9,
+		value: 11,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[0])
+
+	expectedRangeVal = rangeVal[uint32, uint32]{
+		start: 15,
+		end:   0,
+		value: 10,
+	}
+	require.Equal(t, expectedRangeVal, r.ranges[1])
+
+	// first range access
+	value, err = r.GetValue(5)
+	require.NoError(t, err)
+	require.Equal(t, uint32(11), value)
+
+	// open range access
+	value, err = r.GetValue(55555555)
+	require.NoError(t, err)
+	require.Equal(t, uint32(10), value)
 }

--- a/pkg/sfu/utils/rangemap_test.go
+++ b/pkg/sfu/utils/rangemap_test.go
@@ -65,7 +65,17 @@ func TestRangeMapUint32(t *testing.T) {
 
 	// excluded range should return error
 	value, err = r.GetValue(10)
-	require.Error(t, err, errKeyNotFound)
+	require.ErrorIs(t, err, errKeyExcluded)
+
+	// out-of-order exclusion should return error
+	err = r.ExcludeRange(9, 10)
+	require.ErrorIs(t, err, errReversedOrder)
+
+	// flipped exclusion should return error
+	err = r.ExcludeRange(12, 11)
+	require.ErrorIs(t, err, errReversedOrder)
+	err = r.ExcludeRange(11, 11)
+	require.ErrorIs(t, err, errReversedOrder)
 
 	// add adjacent exclusion range of length = 1
 	err = r.ExcludeRange(11, 12)
@@ -87,7 +97,7 @@ func TestRangeMapUint32(t *testing.T) {
 
 	// excluded range should return error, now is excluded because exclusion range could be extended
 	value, err = r.GetValue(11)
-	require.Error(t, err, errKeyNotFound)
+	require.ErrorIs(t, err, errKeyExcluded)
 
 	// getting value in old range should return 0
 	value, err = r.GetValue(6)
@@ -118,7 +128,7 @@ func TestRangeMapUint32(t *testing.T) {
 
 	// excluded range should return error, now is excluded because exclusion range could be extended
 	value, err = r.GetValue(15)
-	require.Error(t, err, errKeyNotFound)
+	require.ErrorIs(t, err, errKeyExcluded)
 
 	// newer should return 12
 	value, err = r.GetValue(25)
@@ -183,15 +193,15 @@ func TestRangeMapUint32(t *testing.T) {
 
 	// excluded range should return error
 	value, err = r.GetValue(50)
-	require.Error(t, err, errKeyNotFound)
+	require.ErrorIs(t, err, errKeyExcluded)
 	value, err = r.GetValue(28)
-	require.Error(t, err, errKeyNotFound)
+	require.ErrorIs(t, err, errKeyExcluded)
 	value, err = r.GetValue(17)
-	require.Error(t, err, errKeyNotFound)
+	require.ErrorIs(t, err, errKeyTooOld)
 
 	// previously valid, but aged out key should return error
 	value, err = r.GetValue(5)
-	require.Error(t, err, errKeyNotFound)
+	require.ErrorIs(t, err, errKeyTooOld)
 
 	// valid range access should return values
 	value, err = r.GetValue(24)

--- a/pkg/sfu/utils/rangemap_test.go
+++ b/pkg/sfu/utils/rangemap_test.go
@@ -31,99 +31,83 @@ func TestRangeMapUint32(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint32(0), value)
 
-	// getting value for any key should be incremented value
-	r.IncValue(2)
+	// getting value for older key should be un-incremented value
+	// should get incremented value post the end
+	err = r.CloseRangeAndIncValue(66666667, 2)
+	require.NoError(t, err)
 	value, err = r.GetValue(66666666)
 	require.NoError(t, err)
-	require.Equal(t, uint32(2), value)
+	require.Equal(t, uint32(0), value)
 	value, err = r.GetValue(0)
 	require.NoError(t, err)
-	require.Equal(t, uint32(2), value)
-
-	// add a couple of ranges, as the value is same should just extend
-	err = r.AddRange(10, 20)
-	require.NoError(t, err)
-	err = r.AddRange(30, 40)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(r.ranges))
-	require.Equal(t, uint32(10), r.ranges[0].start)
-	require.Equal(t, uint32(39), r.ranges[0].end)
-	require.Equal(t, uint32(2), r.ranges[0].value)
-
-	// bump value
-	r.IncValue(1)
-	// getting value in previously added range should return 2
-	value, err = r.GetValue(22)
+	require.Equal(t, uint32(0), value)
+	value, err = r.GetValue(66666667)
 	require.NoError(t, err)
 	require.Equal(t, uint32(2), value)
 
-	// outside range should return 3
-	value, err = r.GetValue(662)
-	require.NoError(t, err)
-	require.Equal(t, uint32(3), value)
+	require.Equal(t, uint32(0), r.ranges[0].start)
+	require.Equal(t, uint32(66666666), r.ranges[0].end)
+	require.Equal(t, uint32(0), r.ranges[0].value)
 
-	// adding out-of-order range should return error
-	err = r.AddRange(60, 50)
+	// out-or-order should fail
+	err = r.CloseRangeAndIncValue(66666667, 2)
 	require.Error(t, err, errReversedOrder)
 
-	// adding overlapping should return error
-	err = r.AddRange(30, 50)
+	err = r.CloseRangeAndIncValue(66666666, 2)
 	require.Error(t, err, errReversedOrder)
 
-	// adding a non-overlapping range should extend previous range and add new one
-	err = r.AddRange(50, 60)
+	// add a couple of more increments and the first one should fall off
+	err = r.CloseRangeAndIncValue(88888889, 2)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(r.ranges))
 
-	require.Equal(t, uint32(10), r.ranges[0].start)
-	require.Equal(t, uint32(49), r.ranges[0].end)
+	require.Equal(t, uint32(0), r.ranges[0].start)
+	require.Equal(t, uint32(66666666), r.ranges[0].end)
+	require.Equal(t, uint32(0), r.ranges[0].value)
+
+	require.Equal(t, uint32(66666667), r.ranges[1].start)
+	require.Equal(t, uint32(88888888), r.ranges[1].end)
+	require.Equal(t, uint32(2), r.ranges[1].value)
+
+	err = r.CloseRangeAndIncValue(99999999, 2)
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(66666667), r.ranges[0].start)
+	require.Equal(t, uint32(88888888), r.ranges[0].end)
 	require.Equal(t, uint32(2), r.ranges[0].value)
 
-	require.Equal(t, uint32(50), r.ranges[1].start)
-	require.Equal(t, uint32(59), r.ranges[1].end)
-	require.Equal(t, uint32(3), r.ranges[1].value)
+	require.Equal(t, uint32(88888889), r.ranges[1].start)
+	require.Equal(t, uint32(99999998), r.ranges[1].end)
+	require.Equal(t, uint32(4), r.ranges[1].value)
 
 	// getting an old value should not succeed, but start of first range should return no error
-	value, err = r.GetValue(9)
+	value, err = r.GetValue(66666666)
 	require.Error(t, err, errKeyNotFound)
-	value, err = r.GetValue(10)
+	value, err = r.GetValue(66666667)
 	require.NoError(t, err)
 	require.Equal(t, uint32(2), value)
 
-	// adding another range should prune the first one as size if set to 2
-	r.IncValue(10)
-	err = r.AddRange(1000, 1233)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(r.ranges))
-
-	require.Equal(t, uint32(50), r.ranges[0].start)
-	require.Equal(t, uint32(999), r.ranges[0].end)
-	require.Equal(t, uint32(3), r.ranges[0].value)
-
-	require.Equal(t, uint32(1000), r.ranges[1].start)
-	require.Equal(t, uint32(1232), r.ranges[1].end)
-	require.Equal(t, uint32(13), r.ranges[1].value)
-
-	// previously valid range should return key not found after pruning
-	value, err = r.GetValue(10)
-	require.Error(t, err, errKeyNotFound)
-
-	value, err = r.GetValue(999)
-	require.NoError(t, err)
-	require.Equal(t, uint32(3), value)
-
-	value, err = r.GetValue(1200)
-	require.NoError(t, err)
-	require.Equal(t, uint32(13), value)
-
 	// something newer than what is in ranges should return running value
-	value, err = r.GetValue(3000)
+	value, err = r.GetValue(99999999)
 	require.NoError(t, err)
-	require.Equal(t, uint32(13), value)
+	require.Equal(t, uint32(6), value)
 
 	// decrement running value
-	r.DecValue(23)
-	value, err = r.GetValue(3000)
+	err = r.CloseRangeAndDecValue(99999999+1000, 3)
 	require.NoError(t, err)
-	require.Equal(t, uint32((1<<32)-10), value)
+
+	require.Equal(t, uint32(88888889), r.ranges[0].start)
+	require.Equal(t, uint32(99999998), r.ranges[0].end)
+	require.Equal(t, uint32(4), r.ranges[0].value)
+
+	require.Equal(t, uint32(99999999), r.ranges[1].start)
+	require.Equal(t, uint32(99999999+999), r.ranges[1].end)
+	require.Equal(t, uint32(6), r.ranges[1].value)
+
+	value, err = r.GetValue(99999999)
+	require.NoError(t, err)
+	require.Equal(t, uint32(6), value)
+
+	value, err = r.GetValue(99999999 + 1000)
+	require.NoError(t, err)
+	require.Equal(t, uint32(3), value)
 }


### PR DESCRIPTION
The following sequence would have produce incorrect results
- Sequence number 39 - regular packet - offset = 0
- Sequence number 40 - padding only - drop - offset = 1
- Sequence number 40 - padding only duplicate - was not dropped (this is the bug) - apply offet - sequence number becomes 39 and clashes with previous packet
- Sequence number 41 - regular packet - apply offset - goes through as 40.
- Sequence number 40 again - does not get dropped - will pass through as 39.

Reviewers: probably easier to read with "Hide whitespace"