### PR TITLE
Don't create new slice when return broadcast downtrack

### DIFF
--- a/pkg/sfu/downtrackspreader.go
+++ b/pkg/sfu/downtrackspreader.go
@@ -47,12 +47,7 @@ func NewDownTrackSpreader(params DownTrackSpreaderParams) *DownTrackSpreader {
 func (d *DownTrackSpreader) GetDownTracks() []TrackSender {
 	d.downTrackMu.RLock()
 	defer d.downTrackMu.RUnlock()
-
-	downTracks := make([]TrackSender, 0, len(d.downTracksShadow))
-	for _, dt := range d.downTracksShadow {
-		downTracks = append(downTracks, dt)
-	}
-	return downTracks
+	return d.downTracksShadow
 }
 
 func (d *DownTrackSpreader) ResetAndGetDownTracks() []TrackSender {


### PR DESCRIPTION
@boks1971 I saw you have changed the `GetDownTracks()` to return a copy in #1902, but don't find the code that can change the shadow downtracks, so I'm confused about the PR. As this function will be called in every packet broadcast path that is expensive so revert it to return the shadow downtracks itself.