### PR TITLE
Disconnect participant when signal proxy is closed

### DIFF
--- a/pkg/service/rtcservice.go
+++ b/pkg/service/rtcservice.go
@@ -34,6 +34,7 @@ import (
 	"github.com/livekit/livekit-server/pkg/utils"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
+	"github.com/livekit/psrpc"
 
 	"github.com/livekit/livekit-server/pkg/config"
 	"github.com/livekit/livekit-server/pkg/routing"
@@ -418,6 +419,10 @@ func (s *RTCService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		if err := cr.RequestSink.WriteMessage(req); err != nil {
 			pLogger.Warnw("error writing to request sink", err, "connID", cr.ConnectionID)
+			if errors.Is(err, psrpc.ErrStreamClosed) {
+				// disconnect the participant WS since the signal proxy has been broken
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
When signal proxy is closed, we'd want to stop writing to it and sever WS connection with the client. Client would go into a reconnect sequence