### PR TITLE
Add option to issue full reconnect on data channel error.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -102,6 +102,9 @@ type RTCConfig struct {
 
 	// force a reconnect on a subscription error
 	ReconnectOnSubscriptionError *bool `yaml:"reconnect_on_subscription_error,omitempty"`
+
+	// force a reconnect on a data channel error
+	ReconnectOnDataChannelError *bool `yaml:"reconnect_on_data_channel_error,omitempty"`
 }
 
 type TURNServer struct {

--- a/pkg/rtc/errors.go
+++ b/pkg/rtc/errors.go
@@ -23,6 +23,7 @@ var (
 	ErrLimitExceeded           = errors.New("node has exceeded its configured limit")
 	ErrAlreadyJoined           = errors.New("a participant with the same identity is already in the room")
 	ErrDataChannelUnavailable  = errors.New("data channel is not available")
+	ErrTransportFailure        = errors.New("transport faolure")
 	ErrEmptyIdentity           = errors.New("participant identity cannot be empty")
 	ErrEmptyParticipantID      = errors.New("participant ID cannot be empty")
 	ErrMissingGrants           = errors.New("VideoGrant is missing")

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -102,6 +102,7 @@ const (
 	ParticipantCloseReasonOvercommitted
 	ParticipantCloseReasonPublicationError
 	ParticipantCloseReasonSubscriptionError
+	ParticipantCloseReasonDataChannelError
 )
 
 func (p ParticipantCloseReason) String() string {
@@ -148,6 +149,8 @@ func (p ParticipantCloseReason) String() string {
 		return "PUBLICATION_ERROR"
 	case ParticipantCloseReasonSubscriptionError:
 		return "SUBSCRIPTION_ERROR"
+	case ParticipantCloseReasonDataChannelError:
+		return "DATA_CHANNEL_ERROR"
 	default:
 		return fmt.Sprintf("%d", int(p))
 	}
@@ -178,7 +181,7 @@ func (p ParticipantCloseReason) ToDisconnectReason() livekit.DisconnectReason {
 		return livekit.DisconnectReason_SERVER_SHUTDOWN
 	case ParticipantCloseReasonOvercommitted:
 		return livekit.DisconnectReason_SERVER_SHUTDOWN
-	case ParticipantCloseReasonNegotiateFailed, ParticipantCloseReasonPublicationError, ParticipantCloseReasonSubscriptionError:
+	case ParticipantCloseReasonNegotiateFailed, ParticipantCloseReasonPublicationError, ParticipantCloseReasonSubscriptionError, ParticipantCloseReasonDataChannelError:
 		return livekit.DisconnectReason_STATE_MISMATCH
 	default:
 		// the other types will map to unknown reason
@@ -197,6 +200,7 @@ const (
 	SignallingCloseReasonTransportFailure
 	SignallingCloseReasonFullReconnectPublicationError
 	SignallingCloseReasonFullReconnectSubscriptionError
+	SignallingCloseReasonFullReconnectDataChannelError
 	SignallingCloseReasonFullReconnectNegotiateFailed
 	SignallingCloseReasonParticipantClose
 )
@@ -215,6 +219,8 @@ func (s SignallingCloseReason) String() string {
 		return "FULL_RECONNECT_PUBLICATION_ERROR"
 	case SignallingCloseReasonFullReconnectSubscriptionError:
 		return "FULL_RECONNECT_SUBSCRIPTION_ERROR"
+	case SignallingCloseReasonFullReconnectDataChannelError:
+		return "FULL_RECONNECT_DATA_CHANNEL_ERROR"
 	case SignallingCloseReasonFullReconnectNegotiateFailed:
 		return "FULL_RECONNECT_NEGOTIATE_FAILED"
 	case SignallingCloseReasonParticipantClose:

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -355,6 +355,11 @@ func (r *RoomManager) StartSession(
 	if r.config.RTC.ReconnectOnSubscriptionError != nil {
 		reconnectOnSubscriptionError = *r.config.RTC.ReconnectOnSubscriptionError
 	}
+	// default do not force full reconnect on a data channel error
+	reconnectOnDataChannelError := false
+	if r.config.RTC.ReconnectOnDataChannelError != nil {
+		reconnectOnDataChannelError = *r.config.RTC.ReconnectOnDataChannelError
+	}
 	subscriberAllowPause := r.config.RTC.CongestionControl.AllowPause
 	if pi.SubscriberAllowPause != nil {
 		subscriberAllowPause = *pi.SubscriberAllowPause
@@ -389,6 +394,7 @@ func (r *RoomManager) StartSession(
 		},
 		ReconnectOnPublicationError:  reconnectOnPublicationError,
 		ReconnectOnSubscriptionError: reconnectOnSubscriptionError,
+		ReconnectOnDataChannelError:  reconnectOnDataChannelError,
 		VersionGenerator:             r.versionGenerator,
 		TrackResolver:                room.ResolveMediaTrackForSubscriber,
 		SubscriberAllowPause:         subscriberAllowPause,


### PR DESCRIPTION
There are situations where send data packet fails because of "stream closed". It is unclear when that happens. Seems to be after an ICERestart after ICE failed and connection type switching to TURN from ICE.

Once the failure happens, it is not recoverable. Potentially, it is recoverable, but unclear where the problem lies. Attempts to reproduce looking at the pattern of failures has been unsuccesful.

In the mean time, adding an option to issue full reconnect when send data packet fails.