### PR TITLE
Use random NodeID instead of MAC based

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -152,7 +152,7 @@ keys:
 #   enable_remote_unmute: true
 #   # limit size of room and participant's metadata, 0 for no limit
 #   max_metadata_size: 0
-#   # control playout delay in ms of video track (and associated audio track) 
+#   # control playout delay in ms of video track (and associated audio track)
 #   playout_delay:
 #     enabled: true
 #     min: 100
@@ -171,7 +171,7 @@ keys:
 # since v1.4.0, a more reliable, psrpc based signal relay is available
 # this gives us the ability to reliably proxy messages between a signal server and RTC node
 # signal_relay:
-#   # disabled by default. will be enabled by default in future versions
+#   # enabled by default as of v1.5.0, legacy signal proxy will be removed in v1.6
 #   enabled: true
 #   # amount of time a message delivery is tried before giving up
 #   retry_timeout: 30s

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -476,7 +476,7 @@ var DefaultConfig = Config{
 		CPULoadLimit: 0.9,
 	},
 	SignalRelay: SignalRelayConfig{
-		Enabled:          false,
+		Enabled:          true,
 		RetryTimeout:     7500 * time.Millisecond,
 		MinRetryInterval: 500 * time.Millisecond,
 		MaxRetryInterval: 4 * time.Second,

--- a/pkg/routing/node.go
+++ b/pkg/routing/node.go
@@ -27,10 +27,7 @@ import (
 type LocalNode *livekit.Node
 
 func NewLocalNode(conf *config.Config) (LocalNode, error) {
-	nodeID, err := utils.LocalNodeID()
-	if err != nil {
-		return nil, err
-	}
+	nodeID := utils.NewGuid(utils.NodePrefix)
 	if conf.RTC.NodeIP == "" {
 		return nil, ErrIPNotSet
 	}

--- a/pkg/routing/redisrouter.go
+++ b/pkg/routing/redisrouter.go
@@ -212,7 +212,7 @@ func (r *RedisRouter) WriteParticipantRTC(_ context.Context, roomName livekit.Ro
 		return err
 	}
 
-	rtcSink := NewRTCNodeSink(r.rc, livekit.NodeID(rtcNode), livekit.ConnectionID("ephemeral"), pkey, pkeyB62)
+	rtcSink := NewRTCNodeSink(r.rc, livekit.NodeID(rtcNode), "ephemeral", pkey, pkeyB62)
 	msg.ParticipantKey = string(ParticipantKeyLegacy(roomName, identity))
 	msg.ParticipantKeyB62 = string(ParticipantKey(roomName, identity))
 	return r.writeRTCMessage(rtcSink, msg)
@@ -229,7 +229,7 @@ func (r *RedisRouter) WriteRoomRTC(ctx context.Context, roomName livekit.RoomNam
 }
 
 func (r *RedisRouter) WriteNodeRTC(_ context.Context, rtcNodeID string, msg *livekit.RTCNodeMessage) error {
-	rtcSink := NewRTCNodeSink(r.rc, livekit.NodeID(rtcNodeID), livekit.ConnectionID("ephemeral"), livekit.ParticipantKey(msg.ParticipantKey), livekit.ParticipantKey(msg.ParticipantKeyB62))
+	rtcSink := NewRTCNodeSink(r.rc, livekit.NodeID(rtcNodeID), "ephemeral", livekit.ParticipantKey(msg.ParticipantKey), livekit.ParticipantKey(msg.ParticipantKeyB62))
 	return r.writeRTCMessage(rtcSink, msg)
 }
 


### PR DESCRIPTION
Makes it possible to run multiple instances of livekit-server locally.

Also enables Signal Relay by default as default signal proxy.