### PR TITLE
Do not re-pause a paused track.

### DIFF
--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -883,8 +883,8 @@ func (s *StreamAllocator) allocateTrack(track *Track) {
 		return
 	}
 
-	// already streaming at some layer and transition is not requesting any change, i. e. BandwidthDelta == 0
-	if transition.From.IsValid() && transition.BandwidthDelta == 0 {
+	// a no-op transition
+	if transition.From == transition.To {
 		return
 	}
 


### PR DESCRIPTION
The following situation caused trouble
- Track paused due to bandwidth
- Publisher stopping layers causes a re-allocation, but ends up changing the pause reason to FEED_DRY
- Then a subscriber mute is not ignored because pause reason is not BANDWIDTH
- Eventually subscriber never restarts because of no visibility change.

Address by not re-pausing if already paused.