### PR TITLE
Cache extended highest.

### DIFF
--- a/pkg/sfu/utils/wraparound.go
+++ b/pkg/sfu/utils/wraparound.go
@@ -74,7 +74,7 @@ func (w *WrapAround[T, ET]) Update(val T) (result WrapAroundUpdateResult[ET]) {
 
 	gap := val - w.highest
 	if gap > T(w.fullRange>>1) {
-		// duplicate OR out-of-order
+		// out-of-order
 		result.IsRestart, result.PreExtendedStart, result.ExtendedVal = w.maybeAdjustStart(val)
 		return
 	}

--- a/pkg/sfu/utils/wraparound.go
+++ b/pkg/sfu/utils/wraparound.go
@@ -29,10 +29,11 @@ type extendedNumber interface {
 type WrapAround[T number, ET extendedNumber] struct {
 	fullRange ET
 
-	initialized bool
-	start       T
-	highest     T
-	cycles      ET
+	initialized     bool
+	start           T
+	highest         T
+	cycles          ET
+	extendedHighest ET
 }
 
 func NewWrapAround[T number, ET extendedNumber]() *WrapAround[T, ET] {
@@ -47,6 +48,7 @@ func (w *WrapAround[T, ET]) Seed(from *WrapAround[T, ET]) {
 	w.start = from.start
 	w.highest = from.highest
 	w.cycles = from.cycles
+	w.updateExtendedHighest()
 }
 
 type WrapAroundUpdateResult[ET extendedNumber] struct {
@@ -63,14 +65,15 @@ func (w *WrapAround[T, ET]) Update(val T) (result WrapAroundUpdateResult[ET]) {
 
 		w.start = val
 		w.highest = val
+		w.updateExtendedHighest()
 		w.initialized = true
 		return
 	}
 
-	result.PreExtendedHighest = w.GetExtendedHighest()
+	result.PreExtendedHighest = w.extendedHighest
 
 	gap := val - w.highest
-	if gap == 0 || gap > T(w.fullRange>>1) {
+	if gap > T(w.fullRange>>1) {
 		// duplicate OR out-of-order
 		result.IsRestart, result.PreExtendedStart, result.ExtendedVal = w.maybeAdjustStart(val)
 		return
@@ -82,13 +85,15 @@ func (w *WrapAround[T, ET]) Update(val T) (result WrapAroundUpdateResult[ET]) {
 	}
 	w.highest = val
 
-	result.ExtendedVal = w.getExtendedHighest(w.cycles, val)
+	w.updateExtendedHighest()
+	result.ExtendedVal = w.extendedHighest
 	return
 }
 
 func (w *WrapAround[T, ET]) RollbackRestart(ev ET) {
 	if w.isWrapBack(w.start, T(ev)) {
 		w.cycles -= w.fullRange
+		w.updateExtendedHighest()
 	}
 	w.start = T(ev)
 }
@@ -96,6 +101,7 @@ func (w *WrapAround[T, ET]) RollbackRestart(ev ET) {
 func (w *WrapAround[T, ET]) ResetHighest(ev ET) {
 	w.highest = T(ev)
 	w.cycles = ev & ^(w.fullRange - 1)
+	w.updateExtendedHighest()
 }
 
 func (w *WrapAround[T, ET]) GetStart() T {
@@ -111,7 +117,11 @@ func (w *WrapAround[T, ET]) GetHighest() T {
 }
 
 func (w *WrapAround[T, ET]) GetExtendedHighest() ET {
-	return w.getExtendedHighest(w.cycles, w.highest)
+	return w.extendedHighest
+}
+
+func (w *WrapAround[T, ET]) updateExtendedHighest() {
+	w.extendedHighest = getExtendedHighest(w.cycles, w.highest)
 }
 
 func (w *WrapAround[T, ET]) maybeAdjustStart(val T) (isRestart bool, preExtendedStart ET, extendedVal ET) {
@@ -125,7 +135,7 @@ func (w *WrapAround[T, ET]) maybeAdjustStart(val T) (isRestart bool, preExtended
 		if w.isWrapBack(val, w.highest) {
 			cycles -= w.fullRange
 		}
-		extendedVal = w.getExtendedHighest(cycles, val)
+		extendedVal = getExtendedHighest(cycles, val)
 		return
 	}
 
@@ -136,6 +146,7 @@ func (w *WrapAround[T, ET]) maybeAdjustStart(val T) (isRestart bool, preExtended
 
 		if w.isWrapBack(val, w.highest) {
 			w.cycles = w.fullRange
+			w.updateExtendedHighest()
 			cycles = 0
 		}
 		w.start = val
@@ -144,7 +155,7 @@ func (w *WrapAround[T, ET]) maybeAdjustStart(val T) (isRestart bool, preExtended
 			cycles -= w.fullRange
 		}
 	}
-	extendedVal = w.getExtendedHighest(cycles, val)
+	extendedVal = getExtendedHighest(cycles, val)
 	return
 }
 
@@ -152,6 +163,8 @@ func (w *WrapAround[T, ET]) isWrapBack(earlier T, later T) bool {
 	return ET(later) < (w.fullRange>>1) && ET(earlier) >= (w.fullRange>>1)
 }
 
-func (w *WrapAround[T, ET]) getExtendedHighest(cycles ET, val T) ET {
+// ------------------------------------
+
+func getExtendedHighest[T number, ET extendedNumber](cycles ET, val T) ET {
 	return cycles + ET(val)
 }


### PR DESCRIPTION
Prevents calculating extended highest on every update to populate PreExtendedHighest in the result.