### PR TITLE
Removing one snapshot in down track.

### DIFF
--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -705,7 +705,7 @@ func (r *RTPStats) UpdateFromReceiverReport(rr rtcp.ReceptionReport) (rtt uint32
 	return
 }
 
-func (r *RTPStats) LastReceiverReport() time.Time {
+func (r *RTPStats) LastReceiverReportTime() time.Time {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 


### PR DESCRIPTION
Profiling showed updating jitter going through the snapshot maps. With the reduction of one, there should only be one snapshot and hopefully that should gain some cycles back.