### PR TITLE
Make a config option to skip unmanaged tracks in bandwidth estimation

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -152,16 +152,17 @@ type CongestionControlChannelObserverConfig struct {
 }
 
 type CongestionControlConfig struct {
-	Enabled                       bool                                   `yaml:"enabled,omitempty"`
-	AllowPause                    bool                                   `yaml:"allow_pause,omitempty"`
-	NackRatioAttenuator           float64                                `yaml:"nack_ratio_attenuator,omitempty"`
-	ExpectedUsageThreshold        float64                                `yaml:"expected_usage_threshold,omitempty"`
-	UseSendSideBWE                bool                                   `yaml:"send_side_bandwidth_estimation,omitempty"`
-	ProbeMode                     CongestionControlProbeMode             `yaml:"padding_mode,omitempty"`
-	MinChannelCapacity            int64                                  `yaml:"min_channel_capacity,omitempty"`
-	ProbeConfig                   CongestionControlProbeConfig           `yaml:"probe_config,omitempty"`
-	ChannelObserverProbeConfig    CongestionControlChannelObserverConfig `yaml:"channel_observer_probe_config,omitempty"`
-	ChannelObserverNonProbeConfig CongestionControlChannelObserverConfig `yaml:"channel_observer_non_probe_config,omitempty"`
+	Enabled                          bool                                   `yaml:"enabled,omitempty"`
+	AllowPause                       bool                                   `yaml:"allow_pause,omitempty"`
+	NackRatioAttenuator              float64                                `yaml:"nack_ratio_attenuator,omitempty"`
+	ExpectedUsageThreshold           float64                                `yaml:"expected_usage_threshold,omitempty"`
+	UseSendSideBWE                   bool                                   `yaml:"send_side_bandwidth_estimation,omitempty"`
+	ProbeMode                        CongestionControlProbeMode             `yaml:"padding_mode,omitempty"`
+	MinChannelCapacity               int64                                  `yaml:"min_channel_capacity,omitempty"`
+	ProbeConfig                      CongestionControlProbeConfig           `yaml:"probe_config,omitempty"`
+	ChannelObserverProbeConfig       CongestionControlChannelObserverConfig `yaml:"channel_observer_probe_config,omitempty"`
+	ChannelObserverNonProbeConfig    CongestionControlChannelObserverConfig `yaml:"channel_observer_non_probe_config,omitempty"`
+	DisableEstimationUnmanagedTracks bool                                   `yaml:"disable_etimation_unmanaged_tracks,omitempty"`
 }
 
 type AudioConfig struct {

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -47,7 +47,6 @@ const (
 	FlagAllowOvershootInProbe                   = true
 	FlagAllowOvershootInCatchup                 = false
 	FlagAllowOvershootInBoost                   = true
-	FlagBWEManagedTracksOnly                    = true
 )
 
 // ---------------------------------------------------------------------------
@@ -502,7 +501,7 @@ func (s *StreamAllocator) OnActiveChanged(isActive bool) {
 
 // called to check if track should participate in BWE
 func (s *StreamAllocator) IsBWEEnabled(downTrack *sfu.DownTrack) bool {
-	if !FlagBWEManagedTracksOnly {
+	if !s.params.Config.DisableEstimationUnmanagedTracks {
 		return true
 	}
 
@@ -1114,7 +1113,7 @@ func (s *StreamAllocator) allocateAllTracks() {
 		updateStreamStateChange(track, allocation, update)
 
 		// STREAM-ALLOCATOR-TODO: optimistic allocation before bitrate is available will return 0. How to account for that?
-		if !FlagBWEManagedTracksOnly {
+		if !s.params.Config.DisableEstimationUnmanagedTracks {
 			availableChannelCapacity -= allocation.BandwidthRequested
 		}
 	}


### PR DESCRIPTION
Disabled by default.

Currently, only non-simulcast screen share video track is unmanaged. Unmanaged means, it is always given the optimal allocation. Including them in bandwidth estimation (especially screen share which varies in bit rate a lot) makes it challenging to allocate under when its bit rate varies a lot.

This option when enabled will not add BWE specific extension (abs-send-time OR TWCC) to the down stream packet for that track. So, that track is pretty much like a cross traffic (can be thought of similar to audio).

If this provides more stable readings (i. e. if the bandwidth estimation stays stable during temporary spikes in screen share bit rate), it could be interesting.

It is a hard one to get right. Let's say the channel is 1 Mbps. Let's say 3 video tracks are streaming at 200 kbps. If there is a screen share doing 100 - 150 kbps because of low movement, all that + audio can fit well. But, if screen share spikes to 1 Mbps briefly, if that track is included in the estimation, the estimation could fall quite a bit and congestion control will kick in.

Excluding screen share from bandwidth estimation is not a solution. That 1 Mbps spike will still congest the channel and cause some disturbance. But, the goal here is to have the option of excluding it and check if bandwidth estimation can be more stable resulting in more streaming, i. e. if the estimate remains stable around 800 kbps during a transient spike in screen share bit rate, yes channel will be overloaded temporarily and cause some disturbance, but because of stable estimate videos can continue without pausing after the spike is over.

Needs more experimentation/testing.