### PR TITLE
Fix time stamp adjustment when starting with dummy packets.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -16,6 +16,7 @@ package rtc
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"strconv"
@@ -69,11 +70,19 @@ type downTrackState struct {
 	downTrack   sfu.DownTrackState
 }
 
+// ---------------------------------------------------------------
+
 type participantUpdateInfo struct {
 	version   uint32
 	state     livekit.ParticipantInfo_State
 	updatedAt time.Time
 }
+
+func (p participantUpdateInfo) String() string {
+	return fmt.Sprintf("version: %d, state: %s, updatedAt: %s", p.version, p.state.String(), p.updatedAt.String())
+}
+
+// ---------------------------------------------------------------
 
 type ParticipantParams struct {
 	Identity                     livekit.ParticipantIdentity

--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -95,7 +95,7 @@ func (p *ParticipantImpl) SendParticipantUpdate(participantsToUpdate []*livekit.
 			// this is a message delivered out of order, a more recent version of the message had already been
 			// sent.
 			if pi.Version < lastVersion.version {
-				p.params.Logger.Debugw("skipping outdated participant update", "version", pi.Version, "lastVersion", lastVersion)
+				p.params.Logger.Debugw("skipping outdated participant update", "otherParticipant", pi.Identity, "otherPID", pi.Sid, "version", pi.Version, "lastVersion", lastVersion)
 				isValid = false
 			}
 		}

--- a/pkg/sfu/buffer/rtpstats.go
+++ b/pkg/sfu/buffer/rtpstats.go
@@ -863,13 +863,11 @@ func (r *RTPStats) GetRtt() uint32 {
 	return r.rtt
 }
 
-func (r *RTPStats) MaybeAdjustFirstPacketTime(srData *RTCPSenderReportData) {
+func (r *RTPStats) MaybeAdjustFirstPacketTime(ets uint64) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	if srData != nil {
-		r.maybeAdjustFirstPacketTime(srData.RTPTimestampExt)
-	}
+	r.maybeAdjustFirstPacketTime(ets)
 }
 
 func (r *RTPStats) maybeAdjustFirstPacketTime(ets uint64) {


### PR DESCRIPTION
- Populated extended values in ExtPacket on dummy packet.
- Have to pass reference time stamp offset to first packet time adjustment.