### PR TITLE
Log ClientInfo on participant close.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -717,7 +717,13 @@ func (p *ParticipantImpl) Close(sendLeave bool, reason types.ParticipantCloseRea
 		return nil
 	}
 
-	p.params.Logger.Infow("participant closing", "sendLeave", sendLeave, "reason", reason.String(), "isExpectedToResume", isExpectedToResume)
+	p.params.Logger.Infow(
+		"participant closing",
+		"sendLeave", sendLeave,
+		"reason", reason.String(),
+		"isExpectedToResume", isExpectedToResume,
+		"clientInfo", p.params.ClientInfo.String(),
+	)
 	p.clearDisconnectTimer()
 	p.clearMigrationTimer()
 


### PR DESCRIPTION
Want to check client distribution for negotiation failed induced closes.