### PR TITLE
Include top bits from start in highest sequence number from RR.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_sender.go
+++ b/pkg/sfu/buffer/rtpstats_sender.go
@@ -284,7 +284,7 @@ func (r *RTPStatsSender) UpdateFromReceiverReport(rr rtcp.ReceptionReport) (rtt 
 			extHighestSNFromRR += (1 << 32)
 		}
 	}
-	if extHighestSNFromRR < r.extStartSN {
+	if (extHighestSNFromRR + (r.extStartSN & 0xFFFF_FFFF_FFFF_0000)) < r.extStartSN {
 		// it is possible that the `LastSequenceNumber` in the receiver report is before the starting
 		// sequence number when dummy packets are used to trigger Pion's OnTrack path.
 		return
@@ -343,7 +343,7 @@ func (r *RTPStatsSender) UpdateFromReceiverReport(rr rtcp.ReceptionReport) (rtt 
 		r.lastRR = rr
 	} else {
 		r.logger.Debugw(
-			fmt.Sprintf("receiver report potentially out of order, highestSN: existing: %d, received: %d", r.extHighestSNFromRR, rr.LastSequenceNumber),
+			fmt.Sprintf("receiver report potentially out of order, highestSN: existing: %d, received: %d", r.extHighestSNFromRR, extHighestSNFromRR),
 			"lastRRTime", r.lastRRTime,
 			"lastRR", r.lastRR,
 			"sinceLastRR", time.Since(r.lastRRTime),
@@ -605,7 +605,7 @@ func (r *RTPStatsSender) getAndResetSenderSnapshot(senderSnapshotID uint32) (*se
 			maxJitter:            r.jitter,
 			maxRtt:               r.rtt,
 		},
-		extStartSNFromRR:  r.extHighestSNFromRR + 1,
+		extStartSNFromRR:  r.extHighestSNFromRR + (r.extStartSN & 0xFFFF_FFFF_FFFF_0000) + 1,
 		packetsLostFromRR: r.packetsLostFromRR,
 		maxJitterFromRR:   r.jitterFromRR,
 	}

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1456,7 +1456,9 @@ func (f *Forwarder) processSourceSwitch(extPkt *buffer.ExtPacket, layer int32) e
 		f.logger.Debugw(
 			"starting forwarding",
 			"sequenceNumber", extPkt.Packet.SequenceNumber,
+			"extSequenceNumber", extPkt.ExtSequenceNumber,
 			"timestamp", extPkt.Packet.Timestamp,
+			"extTimestamp", extPkt.ExtTimestamp,
 			"layer", layer,
 			"referenceLayerSpatial", f.referenceLayerSpatial,
 		)
@@ -1466,7 +1468,9 @@ func (f *Forwarder) processSourceSwitch(extPkt *buffer.ExtPacket, layer int32) e
 		f.logger.Debugw(
 			"catch up forwarding",
 			"sequenceNumber", extPkt.Packet.SequenceNumber,
+			"extSequenceNumber", extPkt.ExtSequenceNumber,
 			"timestamp", extPkt.Packet.Timestamp,
+			"extTimestamp", extPkt.ExtTimestamp,
 			"layer", layer,
 			"referenceLayerSpatial", f.referenceLayerSpatial,
 		)


### PR DESCRIPTION
Streaming could start after 16-bits has rolled over. So, have to add that base back to what is received in receiver report.

Otherwise, it looks like there are not packets received in window leading to poor quality.