### PR TITLE
Use timer in scorer lock scope.

### DIFF
--- a/pkg/sfu/connectionquality/connectionstats.go
+++ b/pkg/sfu/connectionquality/connectionstats.go
@@ -299,7 +299,11 @@ func (cs *ConnectionStats) updateStreamingStart(at time.Time) time.Time {
 	if packetsSent > cs.packetsSent {
 		if cs.streamingStartedAt.IsZero() {
 			// the start could be anywhere after last update, but using `at` as this is not required to be accurate
-			cs.streamingStartedAt = at
+			if at.IsZero() {
+				cs.streamingStartedAt = time.Now()
+			} else {
+				cs.streamingStartedAt = at
+			}
 		}
 	} else {
 		cs.streamingStartedAt = time.Time{}
@@ -310,7 +314,7 @@ func (cs *ConnectionStats) updateStreamingStart(at time.Time) time.Time {
 }
 
 func (cs *ConnectionStats) getStat() {
-	score, streams := cs.updateScoreAt(time.Now())
+	score, streams := cs.updateScoreAt(time.Time{})
 
 	if cs.onStatsUpdate != nil && len(streams) != 0 {
 		analyticsStreams := make([]*livekit.AnalyticsStream, 0, len(streams))


### PR DESCRIPTION
Using time from outside make anachronous samples in expected distance/bit rate measurement. So, have to let the time be snap shotted in scorer lock scope.

Previous PR, passed in time from outside to fix the down stream stats issue. Reverting that and dealing with streaming start able to handle zero time.