### PR TITLE
Do not mute when stream is paused.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -121,7 +121,7 @@ type VideoAllocationProvisional struct {
 	pubMuted        bool
 	maxSeenLayer    buffer.VideoLayer
 	availableLayers []int32
-	Bitrates        Bitrates
+	bitrates        Bitrates
 	maxLayer        buffer.VideoLayer
 	currentLayer    buffer.VideoLayer
 	allocatedLayer  buffer.VideoLayer
@@ -372,7 +372,7 @@ func (f *Forwarder) SeedState(state ForwarderState) {
 	f.refTSOffset = state.RefTSOffset
 }
 
-func (f *Forwarder) Mute(muted bool) bool {
+func (f *Forwarder) Mute(muted bool, isSubscribeMutable bool) bool {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -394,7 +394,7 @@ func (f *Forwarder) Mute(muted bool) bool {
 	// The work around here to ignore mute does ignore an intentional mute.
 	// It could result in some bandwidth consumed for stream without visibility in
 	// the case of intentional mute.
-	if muted && f.isDeficientLocked() && f.lastAllocation.PauseReason == VideoPauseReasonBandwidth {
+	if muted && !isSubscribeMutable {
 		f.logger.Debugw("ignoring forwarder mute, paused due to congestion")
 		return false
 	}
@@ -722,7 +722,7 @@ func (f *Forwarder) AllocateOptimal(availableLayers []int32, brs Bitrates, allow
 	return f.updateAllocation(alloc, "optimal")
 }
 
-func (f *Forwarder) ProvisionalAllocatePrepare(availableLayers []int32, Bitrates Bitrates) {
+func (f *Forwarder) ProvisionalAllocatePrepare(availableLayers []int32, bitrates Bitrates) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -731,7 +731,7 @@ func (f *Forwarder) ProvisionalAllocatePrepare(availableLayers []int32, Bitrates
 		muted:          f.muted,
 		pubMuted:       f.pubMuted,
 		maxSeenLayer:   f.vls.GetMaxSeen(),
-		Bitrates:       Bitrates,
+		bitrates:       bitrates,
 		maxLayer:       f.vls.GetMax(),
 		currentLayer:   f.vls.GetCurrent(),
 	}
@@ -759,14 +759,14 @@ func (f *Forwarder) ProvisionalAllocate(availableChannelCapacity int64, layer bu
 		return false, 0
 	}
 
-	requiredBitrate := f.provisional.Bitrates[layer.Spatial][layer.Temporal]
+	requiredBitrate := f.provisional.bitrates[layer.Spatial][layer.Temporal]
 	if requiredBitrate == 0 {
 		return false, 0
 	}
 
 	alreadyAllocatedBitrate := int64(0)
 	if f.provisional.allocatedLayer.IsValid() {
-		alreadyAllocatedBitrate = f.provisional.Bitrates[f.provisional.allocatedLayer.Spatial][f.provisional.allocatedLayer.Temporal]
+		alreadyAllocatedBitrate = f.provisional.bitrates[f.provisional.allocatedLayer.Spatial][f.provisional.allocatedLayer.Temporal]
 	}
 
 	// a layer under maximum fits, take it
@@ -791,7 +791,7 @@ func (f *Forwarder) ProvisionalAllocate(availableChannelCapacity int64, layer bu
 	return false, 0
 }
 
-func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition(allowOvershoot bool) VideoTransition {
+func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition(allowOvershoot bool) (VideoTransition, []int32, Bitrates) {
 	//
 	// This is called when a track needs a change (could be mute/unmute, subscribed layers changed, published layers changed)
 	// when channel is congested.
@@ -820,8 +820,8 @@ func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition(allowOvershoot b
 		return VideoTransition{
 			From:           existingTargetLayer,
 			To:             f.provisional.allocatedLayer,
-			BandwidthDelta: -getBandwidthNeeded(f.provisional.Bitrates, existingTargetLayer, f.lastAllocation.BandwidthRequested),
-		}
+			BandwidthDelta: -getBandwidthNeeded(f.provisional.bitrates, existingTargetLayer, f.lastAllocation.BandwidthRequested),
+		}, f.provisional.availableLayers, f.provisional.bitrates
 	}
 
 	// check if we should preserve current target
@@ -831,9 +831,9 @@ func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition(allowOvershoot b
 		maximalBandwidthRequired := int64(0)
 		for s := f.provisional.maxLayer.Spatial; s >= 0; s-- {
 			for t := f.provisional.maxLayer.Temporal; t >= 0; t-- {
-				if f.provisional.Bitrates[s][t] != 0 {
+				if f.provisional.bitrates[s][t] != 0 {
 					maximalLayer = buffer.VideoLayer{Spatial: s, Temporal: t}
-					maximalBandwidthRequired = f.provisional.Bitrates[s][t]
+					maximalBandwidthRequired = f.provisional.bitrates[s][t]
 					break
 				}
 			}
@@ -844,7 +844,7 @@ func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition(allowOvershoot b
 		}
 
 		if maximalLayer.IsValid() {
-			if !existingTargetLayer.GreaterThan(maximalLayer) && f.provisional.Bitrates[existingTargetLayer.Spatial][existingTargetLayer.Temporal] != 0 {
+			if !existingTargetLayer.GreaterThan(maximalLayer) && f.provisional.bitrates[existingTargetLayer.Spatial][existingTargetLayer.Temporal] != 0 {
 				// currently streaming and maybe wanting an upgrade (existingTargetLayer <= maximalLayer),
 				// just preserve current target in the cooperative scheme of things
 				f.provisional.allocatedLayer = existingTargetLayer
@@ -852,7 +852,7 @@ func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition(allowOvershoot b
 					From:           existingTargetLayer,
 					To:             existingTargetLayer,
 					BandwidthDelta: 0,
-				}
+				}, f.provisional.availableLayers, f.provisional.bitrates
 			}
 
 			if existingTargetLayer.GreaterThan(maximalLayer) {
@@ -861,8 +861,8 @@ func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition(allowOvershoot b
 				return VideoTransition{
 					From:           existingTargetLayer,
 					To:             maximalLayer,
-					BandwidthDelta: maximalBandwidthRequired - getBandwidthNeeded(f.provisional.Bitrates, existingTargetLayer, f.lastAllocation.BandwidthRequested),
-				}
+					BandwidthDelta: maximalBandwidthRequired - getBandwidthNeeded(f.provisional.bitrates, existingTargetLayer, f.lastAllocation.BandwidthRequested),
+				}, f.provisional.availableLayers, f.provisional.bitrates
 			}
 		}
 	}
@@ -875,9 +875,9 @@ func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition(allowOvershoot b
 		bw := int64(0)
 		for s := minSpatial; s <= maxSpatial; s++ {
 			for t := minTemporal; t <= maxTemporal; t++ {
-				if f.provisional.Bitrates[s][t] != 0 {
+				if f.provisional.bitrates[s][t] != 0 {
 					layers = buffer.VideoLayer{Spatial: s, Temporal: t}
-					bw = f.provisional.Bitrates[s][t]
+					bw = f.provisional.bitrates[s][t]
 					break
 				}
 			}
@@ -914,7 +914,7 @@ func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition(allowOvershoot b
 	if !targetLayer.IsValid() {
 		targetLayer = f.provisional.currentLayer
 		if targetLayer.IsValid() {
-			bandwidthRequired = f.provisional.Bitrates[targetLayer.Spatial][targetLayer.Temporal]
+			bandwidthRequired = f.provisional.bitrates[targetLayer.Spatial][targetLayer.Temporal]
 		}
 	}
 
@@ -922,11 +922,11 @@ func (f *Forwarder) ProvisionalAllocateGetCooperativeTransition(allowOvershoot b
 	return VideoTransition{
 		From:           f.vls.GetTarget(),
 		To:             targetLayer,
-		BandwidthDelta: bandwidthRequired - getBandwidthNeeded(f.provisional.Bitrates, existingTargetLayer, f.lastAllocation.BandwidthRequested),
-	}
+		BandwidthDelta: bandwidthRequired - getBandwidthNeeded(f.provisional.bitrates, existingTargetLayer, f.lastAllocation.BandwidthRequested),
+	}, f.provisional.availableLayers, f.provisional.bitrates
 }
 
-func (f *Forwarder) ProvisionalAllocateGetBestWeightedTransition() VideoTransition {
+func (f *Forwarder) ProvisionalAllocateGetBestWeightedTransition() (VideoTransition, []int32, Bitrates) {
 	//
 	// This is called when a track needs a change (could be mute/unmute, subscribed layers changed, published layers changed)
 	// when channel is congested. This is called on tracks other than the one needing the change. When the track
@@ -951,14 +951,14 @@ func (f *Forwarder) ProvisionalAllocateGetBestWeightedTransition() VideoTransiti
 		return VideoTransition{
 			From:           targetLayer,
 			To:             f.provisional.allocatedLayer,
-			BandwidthDelta: 0 - getBandwidthNeeded(f.provisional.Bitrates, targetLayer, f.lastAllocation.BandwidthRequested),
-		}
+			BandwidthDelta: 0 - getBandwidthNeeded(f.provisional.bitrates, targetLayer, f.lastAllocation.BandwidthRequested),
+		}, f.provisional.availableLayers, f.provisional.bitrates
 	}
 
 	maxReachableLayerTemporal := buffer.InvalidLayerTemporal
 	for t := f.provisional.maxLayer.Temporal; t >= 0; t-- {
 		for s := f.provisional.maxLayer.Spatial; s >= 0; s-- {
-			if f.provisional.Bitrates[s][t] != 0 {
+			if f.provisional.bitrates[s][t] != 0 {
 				maxReachableLayerTemporal = t
 				break
 			}
@@ -976,13 +976,13 @@ func (f *Forwarder) ProvisionalAllocateGetBestWeightedTransition() VideoTransiti
 		return VideoTransition{
 			From:           targetLayer,
 			To:             f.provisional.allocatedLayer,
-			BandwidthDelta: 0 - getBandwidthNeeded(f.provisional.Bitrates, targetLayer, f.lastAllocation.BandwidthRequested),
-		}
+			BandwidthDelta: 0 - getBandwidthNeeded(f.provisional.bitrates, targetLayer, f.lastAllocation.BandwidthRequested),
+		}, f.provisional.availableLayers, f.provisional.bitrates
 	}
 
 	// starting from minimum to target, find transition which gives the best
 	// transition taking into account bits saved vs cost of such a transition
-	existingBandwidthNeeded := getBandwidthNeeded(f.provisional.Bitrates, targetLayer, f.lastAllocation.BandwidthRequested)
+	existingBandwidthNeeded := getBandwidthNeeded(f.provisional.bitrates, targetLayer, f.lastAllocation.BandwidthRequested)
 	bestLayer := buffer.InvalidLayer
 	bestBandwidthDelta := int64(0)
 	bestValue := float32(0)
@@ -992,7 +992,7 @@ func (f *Forwarder) ProvisionalAllocateGetBestWeightedTransition() VideoTransiti
 				break
 			}
 
-			bandwidthDelta := int64(math.Max(float64(0), float64(existingBandwidthNeeded-f.provisional.Bitrates[s][t])))
+			bandwidthDelta := int64(math.Max(float64(0), float64(existingBandwidthNeeded-f.provisional.bitrates[s][t])))
 
 			transitionCost := int32(0)
 			// SVC-TODO: SVC will need a different cost transition
@@ -1019,7 +1019,7 @@ func (f *Forwarder) ProvisionalAllocateGetBestWeightedTransition() VideoTransiti
 		From:           targetLayer,
 		To:             bestLayer,
 		BandwidthDelta: -bestBandwidthDelta,
-	}
+	}, f.provisional.availableLayers, f.provisional.bitrates
 }
 
 func (f *Forwarder) ProvisionalAllocateCommit() VideoAllocation {
@@ -1030,13 +1030,13 @@ func (f *Forwarder) ProvisionalAllocateCommit() VideoAllocation {
 		f.provisional.muted,
 		f.provisional.pubMuted,
 		f.provisional.maxSeenLayer.Spatial,
-		f.provisional.Bitrates,
+		f.provisional.bitrates,
 		f.provisional.maxLayer,
 	)
 	alloc := VideoAllocation{
 		BandwidthRequested:  0,
-		BandwidthDelta:      0 - getBandwidthNeeded(f.provisional.Bitrates, f.vls.GetTarget(), f.lastAllocation.BandwidthRequested),
-		Bitrates:            f.provisional.Bitrates,
+		BandwidthDelta:      0 - getBandwidthNeeded(f.provisional.bitrates, f.vls.GetTarget(), f.lastAllocation.BandwidthRequested),
+		Bitrates:            f.provisional.bitrates,
 		BandwidthNeeded:     optimalBandwidthNeeded,
 		TargetLayer:         f.provisional.allocatedLayer,
 		RequestLayerSpatial: f.provisional.allocatedLayer.Spatial,
@@ -1046,7 +1046,7 @@ func (f *Forwarder) ProvisionalAllocateCommit() VideoAllocation {
 			f.provisional.pubMuted,
 			f.provisional.maxSeenLayer,
 			f.provisional.availableLayers,
-			f.provisional.Bitrates,
+			f.provisional.bitrates,
 			f.provisional.allocatedLayer,
 			f.provisional.maxLayer,
 		),
@@ -1062,8 +1062,8 @@ func (f *Forwarder) ProvisionalAllocateCommit() VideoAllocation {
 	case optimalBandwidthNeeded == 0:
 		if f.provisional.allocatedLayer.IsValid() {
 			// overshoot
-			alloc.BandwidthRequested = f.provisional.Bitrates[f.provisional.allocatedLayer.Spatial][f.provisional.allocatedLayer.Temporal]
-			alloc.BandwidthDelta = alloc.BandwidthRequested - getBandwidthNeeded(f.provisional.Bitrates, f.vls.GetTarget(), f.lastAllocation.BandwidthRequested)
+			alloc.BandwidthRequested = f.provisional.bitrates[f.provisional.allocatedLayer.Spatial][f.provisional.allocatedLayer.Temporal]
+			alloc.BandwidthDelta = alloc.BandwidthRequested - getBandwidthNeeded(f.provisional.bitrates, f.vls.GetTarget(), f.lastAllocation.BandwidthRequested)
 		} else {
 			alloc.PauseReason = VideoPauseReasonFeedDry
 
@@ -1077,16 +1077,16 @@ func (f *Forwarder) ProvisionalAllocateCommit() VideoAllocation {
 
 	default:
 		if f.provisional.allocatedLayer.IsValid() {
-			alloc.BandwidthRequested = f.provisional.Bitrates[f.provisional.allocatedLayer.Spatial][f.provisional.allocatedLayer.Temporal]
+			alloc.BandwidthRequested = f.provisional.bitrates[f.provisional.allocatedLayer.Spatial][f.provisional.allocatedLayer.Temporal]
 		}
-		alloc.BandwidthDelta = alloc.BandwidthRequested - getBandwidthNeeded(f.provisional.Bitrates, f.vls.GetTarget(), f.lastAllocation.BandwidthRequested)
+		alloc.BandwidthDelta = alloc.BandwidthRequested - getBandwidthNeeded(f.provisional.bitrates, f.vls.GetTarget(), f.lastAllocation.BandwidthRequested)
 
 		if f.provisional.allocatedLayer.GreaterThan(f.provisional.maxLayer) ||
 			alloc.BandwidthRequested >= getOptimalBandwidthNeeded(
 				f.provisional.muted,
 				f.provisional.pubMuted,
 				f.provisional.maxSeenLayer.Spatial,
-				f.provisional.Bitrates,
+				f.provisional.bitrates,
 				f.provisional.maxLayer,
 			) {
 			// could be greater than optimal if overshooting

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -515,6 +515,18 @@ func (s *StreamAllocator) IsBWEEnabled(downTrack *sfu.DownTrack) bool {
 	return true
 }
 
+// called to check if track subscription mute can be applied
+func (s *StreamAllocator) IsSubscribeMutable(downTrack *sfu.DownTrack) bool {
+	s.videoTracksMu.Lock()
+	defer s.videoTracksMu.Unlock()
+
+	if track := s.videoTracks[livekit.TrackID(downTrack.ID())]; track != nil {
+		return track.IsSubscribeMutable()
+	}
+
+	return true
+}
+
 func (s *StreamAllocator) maybePostEventAllocateTrack(downTrack *sfu.DownTrack) {
 	shouldPost := false
 	s.videoTracksMu.Lock()

--- a/pkg/sfu/streamallocator/track.go
+++ b/pkg/sfu/streamallocator/track.go
@@ -101,6 +101,10 @@ func (t *Track) SetStreamState(streamState StreamState) bool {
 	return true
 }
 
+func (t *Track) IsSubscribeMutable() bool {
+	return t.streamState != StreamStatePaused
+}
+
 func (t *Track) SetPriority(priority uint8) bool {
 	if priority == 0 {
 		switch t.source {


### PR DESCRIPTION
The following sequence caused a stream to be stuck
- Stream was paused due to bandwidth limitation.
- In this state, publisher also experienced congestion and started stopping layers (or atleast stream tracker started reporting layers stopping). That triggered a re-allocation.
- That re-allocation set the reason for no video to FEED_DRY.
- Following that, there was a video layer update from the client. Possibly caused by the video tile visibility changing to off view port. As the video pause reason now is not due to congestion, the mute was applied.
- As apps could display an overlay when congested (thus triggering visibility changes and triggering a video layer update to mute), a subcriber mute should be ignored. The way to remove that overlay is by resuming the track and notifying the client.
- Resume would have been attempted when the publisher re-started the layers. But, those attempts were ignored because of applying mute.
- Now things are stuck as server thinks that client has subscribe muted, but client still has the overlay and is not triggering visibility changes.

There was code to ignore mute when congested, but it did not handle the case of a subsequent allocation having a different reason.

Address it by consulting stream allocator if a track's subscribe mute is okay to apply.