### PR TITLE
Decrement value when end is in open range.

### DIFF
--- a/pkg/sfu/rtpmunger.go
+++ b/pkg/sfu/rtpmunger.go
@@ -297,14 +297,7 @@ func (r *RTPMunger) UpdateAndGetPaddingSnTs(num int, clockRate uint32, frameRate
 
 	r.extSecondLastSN = extLastSN - 1
 	r.extLastSN = extLastSN
-	if err := r.snRangeMap.CloseRangeAndDecValue(r.extHighestIncomingSN, uint64(num)); err != nil {
-		r.logger.Errorw(
-			"could not close range", err,
-			"extHighestIncomingSN", r.extHighestIncomingSN,
-			"startSN", vals[0].extSequenceNumber,
-			"endSN", vals[len(vals)-1].extSequenceNumber,
-		)
-	}
+	r.snRangeMap.DecValue(r.extHighestIncomingSN, uint64(num))
 	r.updateSnOffset("pad")
 
 	r.tsOffset -= extLastTS - r.extLastTS

--- a/pkg/sfu/rtpmunger.go
+++ b/pkg/sfu/rtpmunger.go
@@ -298,7 +298,12 @@ func (r *RTPMunger) UpdateAndGetPaddingSnTs(num int, clockRate uint32, frameRate
 	r.extSecondLastSN = extLastSN - 1
 	r.extLastSN = extLastSN
 	if err := r.snRangeMap.CloseRangeAndDecValue(r.extHighestIncomingSN, uint64(num)); err != nil {
-		r.logger.Errorw("could not close range", err, "sn", r.extHighestIncomingSN)
+		r.logger.Errorw(
+			"could not close range", err,
+			"extHighestIncomingSN", r.extHighestIncomingSN,
+			"startSN", vals[0].extSequenceNumber,
+			"endSN", vals[len(vals)-1].extSequenceNumber,
+		)
 	}
 	r.updateSnOffset("pad")
 


### PR DESCRIPTION
Not an error when end is in open range.

Including @lukasIO just in case server folks are not available. It is that time of day :-) 
@lukasIO It is a simple enough change. Getting some video freezes with the latest under congestion + probing scenario. This is a fix for that 🤞 