### PR TITLE
Reduce packet meta data cache - part 1

### DIFF
--- a/pkg/sfu/buffer/rtpstats_base.go
+++ b/pkg/sfu/buffer/rtpstats_base.go
@@ -89,17 +89,32 @@ type RTPDeltaInfo struct {
 }
 
 type snapshot struct {
-	startTime             time.Time
-	extStartSN            uint64
-	packetsDuplicate      uint64
-	bytesDuplicate        uint64
-	headerBytesDuplicate  uint64
-	packetsLostOverridden uint64
-	nacks                 uint32
-	plis                  uint32
-	firs                  uint32
-	maxRtt                uint32
-	maxJitter             float64
+	isValid bool
+
+	startTime time.Time
+
+	extStartSN  uint64
+	bytes       uint64
+	headerBytes uint64
+
+	packetsPadding     uint64
+	bytesPadding       uint64
+	headerBytesPadding uint64
+
+	packetsDuplicate     uint64
+	bytesDuplicate       uint64
+	headerBytesDuplicate uint64
+
+	packetsLost uint64
+
+	frames uint32
+
+	nacks uint32
+	plis  uint32
+	firs  uint32
+
+	maxRtt    uint32
+	maxJitter float64
 }
 
 type snInfo struct {
@@ -153,8 +168,7 @@ type rtpStatsBase struct {
 
 	packetsOutOfOrder uint64
 
-	packetsLost           uint64
-	packetsLostOverridden uint64
+	packetsLost uint64
 
 	frames uint32
 
@@ -189,7 +203,7 @@ type rtpStatsBase struct {
 	srNewest *RTCPSenderReportData
 
 	nextSnapshotID uint32
-	snapshots      map[uint32]*snapshot
+	snapshots      []snapshot
 }
 
 func newRTPStatsBase(params RTPStatsParams) *rtpStatsBase {
@@ -197,7 +211,7 @@ func newRTPStatsBase(params RTPStatsParams) *rtpStatsBase {
 		params:         params,
 		logger:         params.Logger,
 		nextSnapshotID: cFirstSnapshotID,
-		snapshots:      make(map[uint32]*snapshot),
+		snapshots:      make([]snapshot, 2),
 	}
 }
 
@@ -273,10 +287,8 @@ func (r *rtpStatsBase) seed(from *rtpStatsBase) bool {
 	}
 
 	r.nextSnapshotID = from.nextSnapshotID
-	for id, ss := range from.snapshots {
-		ssCopy := *ss
-		r.snapshots[id] = &ssCopy
-	}
+	r.snapshots = make([]snapshot, cap(from.snapshots))
+	copy(r.snapshots, from.snapshots)
 	return true
 }
 
@@ -295,8 +307,15 @@ func (r *rtpStatsBase) newSnapshotID(extStartSN uint64) uint32 {
 	id := r.nextSnapshotID
 	r.nextSnapshotID++
 
+	if cap(r.snapshots) < int(r.nextSnapshotID) {
+		snapshots := make([]snapshot, r.nextSnapshotID)
+		copy(snapshots, r.snapshots)
+		r.snapshots = snapshots
+	}
+
 	if r.initialized {
-		r.snapshots[id] = &snapshot{
+		r.snapshots[id] = snapshot{
+			isValid:    true,
 			startTime:  time.Now(),
 			extStartSN: extStartSN,
 		}
@@ -551,21 +570,24 @@ func (r *rtpStatsBase) deltaInfo(snapshotID uint32, extStartSN uint64, extHighes
 		}
 	}
 
-	intervalStats := r.getIntervalStats(then.extStartSN, now.extStartSN, extHighestSN)
+	packetsLost := uint32(now.packetsLost - then.packetsLost)
+	if int32(packetsLost) < 0 {
+		packetsLost = 0
+	}
 	return &RTPDeltaInfo{
 		StartTime:            startTime,
 		Duration:             endTime.Sub(startTime),
-		Packets:              uint32(packetsExpected - intervalStats.packetsPadding),
-		Bytes:                intervalStats.bytes,
-		HeaderBytes:          intervalStats.headerBytes,
+		Packets:              uint32(packetsExpected - (now.packetsPadding - then.packetsPadding)),
+		Bytes:                now.bytes - then.bytes,
+		HeaderBytes:          now.headerBytes - then.headerBytes,
 		PacketsDuplicate:     uint32(now.packetsDuplicate - then.packetsDuplicate),
 		BytesDuplicate:       now.bytesDuplicate - then.bytesDuplicate,
 		HeaderBytesDuplicate: now.headerBytesDuplicate - then.headerBytesDuplicate,
-		PacketsPadding:       uint32(intervalStats.packetsPadding),
-		BytesPadding:         intervalStats.bytesPadding,
-		HeaderBytesPadding:   intervalStats.headerBytesPadding,
-		PacketsLost:          uint32(intervalStats.packetsLost),
-		Frames:               intervalStats.frames,
+		PacketsPadding:       uint32(now.packetsPadding - then.packetsPadding),
+		BytesPadding:         now.bytesPadding - then.bytesPadding,
+		HeaderBytesPadding:   now.headerBytesPadding - then.headerBytesPadding,
+		PacketsLost:          packetsLost,
+		Frames:               now.frames - then.frames,
 		RttMax:               then.maxRtt,
 		JitterMax:            then.maxJitter / float64(r.params.ClockRate) * 1e6,
 		Nacks:                now.nacks - then.nacks,
@@ -894,31 +916,15 @@ func (r *rtpStatsBase) getAndResetSnapshot(snapshotID uint32, extStartSN uint64,
 	}
 
 	then := r.snapshots[snapshotID]
-	if then == nil {
-		then = &snapshot{
-			startTime:  r.startTime,
-			extStartSN: extStartSN,
-		}
+	if !then.isValid {
+		then = r.initSnapshot(r.startTime, extStartSN)
 		r.snapshots[snapshotID] = then
 	}
 
 	// snapshot now
-	r.snapshots[snapshotID] = &snapshot{
-		startTime:            time.Now(),
-		extStartSN:           extHighestSN + 1,
-		packetsDuplicate:     r.packetsDuplicate,
-		bytesDuplicate:       r.bytesDuplicate,
-		headerBytesDuplicate: r.headerBytesDuplicate,
-		nacks:                r.nacks,
-		plis:                 r.plis,
-		firs:                 r.firs,
-		maxJitter:            r.jitter,
-		maxRtt:               r.rtt,
-	}
-	// make a copy so that it can be used independently
-	now := *r.snapshots[snapshotID]
-
-	return then, &now
+	now := r.getSnapshot(time.Now(), extHighestSN+1)
+	r.snapshots[snapshotID] = now
+	return &then, &now
 }
 
 func (r *rtpStatsBase) getDrift(extStartTS, extHighestTS uint64) (packetDrift *livekit.RTPDrift, reportDrift *livekit.RTPDrift) {
@@ -972,6 +978,37 @@ func (r *rtpStatsBase) updateGapHistogram(gap int) {
 		r.gapHistogram[len(r.gapHistogram)-1]++
 	} else {
 		r.gapHistogram[missing-1]++
+	}
+}
+
+func (r *rtpStatsBase) initSnapshot(startTime time.Time, extStartSN uint64) snapshot {
+	return snapshot{
+		isValid:    true,
+		startTime:  time.Now(),
+		extStartSN: extStartSN,
+	}
+}
+
+func (r *rtpStatsBase) getSnapshot(startTime time.Time, extStartSN uint64) snapshot {
+	return snapshot{
+		isValid:              true,
+		startTime:            time.Now(),
+		extStartSN:           extStartSN,
+		bytes:                r.bytes,
+		headerBytes:          r.headerBytes,
+		packetsPadding:       r.packetsPadding,
+		bytesPadding:         r.bytesPadding,
+		headerBytesPadding:   r.headerBytesPadding,
+		packetsDuplicate:     r.packetsDuplicate,
+		bytesDuplicate:       r.bytesDuplicate,
+		headerBytesDuplicate: r.headerBytesDuplicate,
+		packetsLost:          r.packetsLost,
+		frames:               r.frames,
+		nacks:                r.nacks,
+		plis:                 r.plis,
+		firs:                 r.firs,
+		maxRtt:               r.rtt,
+		maxJitter:            r.jitter,
 	}
 }
 

--- a/pkg/sfu/buffer/rtpstats_base.go
+++ b/pkg/sfu/buffer/rtpstats_base.go
@@ -316,11 +316,7 @@ func (r *rtpStatsBase) newSnapshotID(extStartSN uint64) uint32 {
 	}
 
 	if r.initialized {
-		r.snapshots[id] = snapshot{
-			isValid:    true,
-			startTime:  time.Now(),
-			extStartSN: extStartSN,
-		}
+		r.snapshots[id] = r.initSnapshot(time.Now(), extStartSN)
 	}
 	return id
 }

--- a/pkg/sfu/buffer/rtpstats_base.go
+++ b/pkg/sfu/buffer/rtpstats_base.go
@@ -105,6 +105,8 @@ type snapshot struct {
 	bytesDuplicate       uint64
 	headerBytesDuplicate uint64
 
+	packetsOutOfOrder uint64
+
 	packetsLost uint64
 
 	frames uint32
@@ -587,6 +589,7 @@ func (r *rtpStatsBase) deltaInfo(snapshotID uint32, extStartSN uint64, extHighes
 		BytesPadding:         now.bytesPadding - then.bytesPadding,
 		HeaderBytesPadding:   now.headerBytesPadding - then.headerBytesPadding,
 		PacketsLost:          packetsLost,
+		PacketsOutOfOrder:    uint32(now.packetsOutOfOrder - then.packetsOutOfOrder),
 		Frames:               now.frames - then.frames,
 		RttMax:               then.maxRtt,
 		JitterMax:            then.maxJitter / float64(r.params.ClockRate) * 1e6,
@@ -1003,6 +1006,7 @@ func (r *rtpStatsBase) getSnapshot(startTime time.Time, extStartSN uint64) snaps
 		bytesDuplicate:       r.bytesDuplicate,
 		headerBytesDuplicate: r.headerBytesDuplicate,
 		packetsLost:          r.packetsLost,
+		packetsOutOfOrder:    r.packetsOutOfOrder,
 		frames:               r.frames,
 		nacks:                r.nacks,
 		plis:                 r.plis,

--- a/pkg/sfu/buffer/rtpstats_receiver.go
+++ b/pkg/sfu/buffer/rtpstats_receiver.go
@@ -174,7 +174,6 @@ func (r *RTPStatsReceiver) Update(
 			flowState.IsDuplicate = true
 		} else {
 			r.packetsLost--
-			r.setSnInfo(resSN.ExtendedVal, resSN.PreExtendedHighest, uint16(pktSize), uint16(hdrSize), uint16(payloadSize), marker, true)
 		}
 
 		flowState.IsOutOfOrder = true
@@ -184,11 +183,7 @@ func (r *RTPStatsReceiver) Update(
 		// update gap histogram
 		r.updateGapHistogram(int(gapSN))
 
-		// update missing sequence numbers
-		r.clearSnInfos(resSN.PreExtendedHighest+1, resSN.ExtendedVal)
 		r.packetsLost += uint64(gapSN - 1)
-
-		r.setSnInfo(resSN.ExtendedVal, resSN.PreExtendedHighest, uint16(pktSize), uint16(hdrSize), uint16(payloadSize), marker, false)
 
 		if timestamp != uint32(resTS.PreExtendedHighest) {
 			// update only on first packet as same timestamp could be in multiple packets.


### PR DESCRIPTION
Packet meta data cache takes a good amount of space.
That cache is 8K entries deep and each entry is 8 bytes.
So, that takes 64KB per RTP stream.

It is mostly needed for down stream to line up with receiver reports.

So, removing cache from up stream (RTPStatsReceiver) as part 1.
Will look at optimising the down stream in part 2.

Only tricky bit here is `packetsLost` which can move backwards, i. e. if in one snap shot, the value is 10, a retransmitted packet can decrement that and make it 9. So, when delta snap shot is taken, `packetsLost` could be negative. There is a check for that. Getting that exact value within a delta snap shot's sequence numbers is not worth the added complexity (in terms of both memory and CPU).

Another aspect is calculating duplicate packets. It is not really used, but a useful stat. So, using a bit mask to cover last 2048 packets which takes up 256 bytes which is a reasonable compromise.