### PR TITLE
Skip SendDataPacket logging on transport failure

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -1331,7 +1331,8 @@ func BroadcastDataPacketForRoom(r types.Room, source types.LocalParticipant, dp 
 
 	utils.ParallelExec(destParticipants, dataForwardLoadBalanceThreshold, 1, func(op types.LocalParticipant) {
 		err := op.SendDataPacket(dp, dpData)
-		if err != nil && !errors.Is(err, io.ErrClosedPipe) && !errors.Is(err, sctp.ErrStreamClosed) {
+		if err != nil && !errors.Is(err, io.ErrClosedPipe) && !errors.Is(err, sctp.ErrStreamClosed) &&
+			!errors.Is(err, ErrTransportFailure) {
 			op.GetLogger().Infow("send data packet error", "error", err)
 		}
 	})


### PR DESCRIPTION
That's a sign of peer connection failure, we do not need to log these