### PR TITLE
Use bit map.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,3 +105,5 @@ require (
 	google.golang.org/grpc v1.58.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/livekit/protocol => ../protocol

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1
 	github.com/livekit/mediatransportutil v0.0.0-20230906055425-e81fd5f6fb3f
-	github.com/livekit/protocol v1.7.3-0.20230911160509-47d330eafb32
+	github.com/livekit/protocol v1.7.3-0.20230915202328-cf9f95141e0e
 	github.com/livekit/psrpc v0.3.3
 	github.com/mackerelio/go-osstat v0.2.4
 	github.com/magefile/mage v1.15.0
@@ -105,5 +105,3 @@ require (
 	google.golang.org/grpc v1.58.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace github.com/livekit/protocol => ../protocol

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,6 @@ github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkD
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20230906055425-e81fd5f6fb3f h1:b4ri7hQESRSzJWzXXcmANG2hJ4HTj5LM01Ekm8lnQmg=
 github.com/livekit/mediatransportutil v0.0.0-20230906055425-e81fd5f6fb3f/go.mod h1:+WIOYwiBMive5T81V8B2wdAc2zQNRjNQiJIcPxMTILY=
-github.com/livekit/protocol v1.7.3-0.20230911160509-47d330eafb32 h1:5PdmCpGGXA2hz1pKGgKSJYTjmk3Kkm+kNiW5NOFARCI=
-github.com/livekit/protocol v1.7.3-0.20230911160509-47d330eafb32/go.mod h1:zbh0QPUcLGOeZeIO/VeigwWWbudz4Lv+Px94FnVfQH0=
 github.com/livekit/psrpc v0.3.3 h1:+lltbuN39IdaynXhLLxRShgYqYsRMWeeXKzv60oqyWo=
 github.com/livekit/psrpc v0.3.3/go.mod h1:n6JntEg+zT6Ji8InoyTpV7wusPNwGqqtxmHlkNhDN0U=
 github.com/mackerelio/go-osstat v0.2.4 h1:qxGbdPkFo65PXOb/F/nhDKpF2nGmGaCFDLXoZjJTtUs=

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkD
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20230906055425-e81fd5f6fb3f h1:b4ri7hQESRSzJWzXXcmANG2hJ4HTj5LM01Ekm8lnQmg=
 github.com/livekit/mediatransportutil v0.0.0-20230906055425-e81fd5f6fb3f/go.mod h1:+WIOYwiBMive5T81V8B2wdAc2zQNRjNQiJIcPxMTILY=
+github.com/livekit/protocol v1.7.3-0.20230915202328-cf9f95141e0e h1:WEet0iH/JazBFNhhH+YuZHtXpKefb7mnbCC2al3peyA=
+github.com/livekit/protocol v1.7.3-0.20230915202328-cf9f95141e0e/go.mod h1:zbh0QPUcLGOeZeIO/VeigwWWbudz4Lv+Px94FnVfQH0=
 github.com/livekit/psrpc v0.3.3 h1:+lltbuN39IdaynXhLLxRShgYqYsRMWeeXKzv60oqyWo=
 github.com/livekit/psrpc v0.3.3/go.mod h1:n6JntEg+zT6Ji8InoyTpV7wusPNwGqqtxmHlkNhDN0U=
 github.com/mackerelio/go-osstat v0.2.4 h1:qxGbdPkFo65PXOb/F/nhDKpF2nGmGaCFDLXoZjJTtUs=

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -758,7 +758,6 @@ func (b *Buffer) getRTCP() []rtcp.Packet {
 	var pkts []rtcp.Packet
 
 	rr := b.buildReceptionReport()
-	b.logger.Debugw("RAJA RR", "rr", rr) // REMOVE
 	if rr != nil {
 		pkts = append(pkts, &rtcp.ReceiverReport{
 			SSRC:    b.mediaSSRC,

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -758,6 +758,7 @@ func (b *Buffer) getRTCP() []rtcp.Packet {
 	var pkts []rtcp.Packet
 
 	rr := b.buildReceptionReport()
+	b.logger.Debugw("RAJA RR", "rr", rr) // REMOVE
 	if rr != nil {
 		pkts = append(pkts, &rtcp.ReceiverReport{
 			SSRC:    b.mediaSSRC,

--- a/pkg/sfu/buffer/rtpstats_receiver_test.go
+++ b/pkg/sfu/buffer/rtpstats_receiver_test.go
@@ -224,7 +224,7 @@ func Test_RTPStatsReceiver_Update(t *testing.T) {
 	require.Equal(t, uint64(sequenceNumber-1), flowState.LossStartInclusive)
 	require.Equal(t, uint64(sequenceNumber), flowState.LossEndExclusive)
 	require.Equal(t, uint64(17), r.packetsLost)
-	require.True(t, r.isLost(uint64(sequenceNumber)-1, r.sequenceNumber.GetExtendedHighest()))
+	require.False(t, r.history.IsSet(uint64(sequenceNumber)-1))
 
 	// out-of-order
 	sequenceNumber--
@@ -242,7 +242,7 @@ func Test_RTPStatsReceiver_Update(t *testing.T) {
 	require.False(t, flowState.HasLoss)
 	require.Equal(t, uint64(16), r.packetsLost)
 	require.Equal(t, uint64(4), r.packetsOutOfOrder)
-	require.False(t, r.isLost(uint64(sequenceNumber), r.sequenceNumber.GetExtendedHighest()))
+	require.True(t, r.history.IsSet(uint64(sequenceNumber)))
 
 	// padding only
 	sequenceNumber += 2
@@ -259,9 +259,9 @@ func Test_RTPStatsReceiver_Update(t *testing.T) {
 	require.False(t, flowState.HasLoss)
 	require.Equal(t, uint64(16), r.packetsLost)
 	require.Equal(t, uint64(4), r.packetsOutOfOrder)
-	require.False(t, r.isLost(uint64(sequenceNumber), r.sequenceNumber.GetExtendedHighest()))
-	require.False(t, r.isLost(uint64(sequenceNumber)-1, r.sequenceNumber.GetExtendedHighest()))
-	require.False(t, r.isLost(uint64(sequenceNumber)-2, r.sequenceNumber.GetExtendedHighest()))
+	require.True(t, r.history.IsSet(uint64(sequenceNumber)))
+	require.True(t, r.history.IsSet(uint64(sequenceNumber)-1))
+	require.True(t, r.history.IsSet(uint64(sequenceNumber)-2))
 
 	r.Stop()
 }


### PR DESCRIPTION
Also, duplicate packet detection is impoetant for dropping padding only packets at the publisher side itself. In the last PR, mentioned that it is only for stats.