### PR TITLE
Reduce ghost participant disconnect timeout

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -56,7 +56,7 @@ const (
 	sdBatchSize       = 30
 	rttUpdateInterval = 5 * time.Second
 
-	disconnectCleanupDuration = 15 * time.Second
+	disconnectCleanupDuration = 5 * time.Second
 	migrationWaitDuration     = 3 * time.Second
 )
 
@@ -561,7 +561,9 @@ func (p *ParticipantImpl) HandleSignalSourceClose() {
 	p.TransportManager.SetSignalSourceValid(false)
 
 	if !p.TransportManager.HasPublisherEverConnected() && !p.TransportManager.HasSubscriberEverConnected() {
-		p.params.Logger.Infow("closing disconnected participant")
+		p.params.Logger.Infow("closing disconnected participant",
+			"reason", types.ParticipantCloseReasonJoinFailed,
+		)
 		_ = p.Close(false, types.ParticipantCloseReasonJoinFailed, false)
 	}
 }
@@ -1402,7 +1404,9 @@ func (p *ParticipantImpl) setupDisconnectTimer() {
 		if p.IsClosed() || p.IsDisconnected() {
 			return
 		}
-		p.params.Logger.Infow("closing disconnected participant")
+		p.params.Logger.Infow("closing disconnected participant",
+			"reason", types.ParticipantCloseReasonPeerConnectionDisconnected,
+		)
 		_ = p.Close(true, types.ParticipantCloseReasonPeerConnectionDisconnected, false)
 	})
 	p.lock.Unlock()

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -60,7 +60,7 @@ const (
 	dtlsRetransmissionInterval = 100 * time.Millisecond
 
 	iceDisconnectedTimeout = 10 * time.Second // compatible for ice-lite with firefox client
-	iceFailedTimeout       = 25 * time.Second // pion's default
+	iceFailedTimeout       = 5 * time.Second  // time between disconnected and failed
 	iceKeepaliveInterval   = 2 * time.Second  // pion's default
 
 	minTcpICEConnectTimeout = 5 * time.Second


### PR DESCRIPTION
It's been reported that "ghost" participants, those that did not terminate cleanly, hang around the room for too long after they disappear.

Evaluating our timeouts a bit, it seems that we are really conservative in waiting for participants to disconnect. This PR cuts down the disconnect timeout from 50s to 20s, a 30s reduction.