### PR TITLE
Fix out-of-range access.

### DIFF
--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -539,7 +539,7 @@ func (w *WebRTCReceiver) getBufferLocked(layer int32) *buffer.Buffer {
 		layer = 0
 	}
 
-	if int(layer) >= len(w.buffers) {
+	if layer < 0 || int(layer) >= len(w.buffers) {
 		return nil
 	}
 


### PR DESCRIPTION
Happens when converting quality in subscibed settings to layer. Looks like it can happen only if the provided quality is OFF. Don't know of any client that does that. Anyhow, prevent out-of-range access which causea a panic.