### PR TITLE
Use marshal + unmarshal to ensure unmarshallable fields are not copied.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,3 +105,5 @@ require (
 	google.golang.org/grpc v1.58.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/livekit/mediatransportutil => ../mediatransportutil

--- a/go.mod
+++ b/go.mod
@@ -107,3 +107,5 @@ require (
 )
 
 replace github.com/livekit/mediatransportutil => ../mediatransportutil
+
+replace github.com/livekit/protocol => ../protocol

--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.6
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1
-	github.com/livekit/mediatransportutil v0.0.0-20230906055425-e81fd5f6fb3f
-	github.com/livekit/protocol v1.7.3-0.20230918130519-dd24d071834c
+	github.com/livekit/mediatransportutil v0.0.0-20230919184714-b8f0fa0133c5
+	github.com/livekit/protocol v1.7.3-0.20230919182418-0708b5a5bb84
 	github.com/livekit/psrpc v0.3.3
 	github.com/mackerelio/go-osstat v0.2.4
 	github.com/magefile/mage v1.15.0
@@ -105,7 +105,3 @@ require (
 	google.golang.org/grpc v1.58.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace github.com/livekit/mediatransportutil => ../mediatransportutil
-
-replace github.com/livekit/protocol => ../protocol

--- a/go.sum
+++ b/go.sum
@@ -125,10 +125,6 @@ github.com/lithammer/shortuuid/v4 v4.0.0 h1:QRbbVkfgNippHOS8PXDkti4NaWeyYfcBTHtw
 github.com/lithammer/shortuuid/v4 v4.0.0/go.mod h1:Zs8puNcrvf2rV9rTH51ZLLcj7ZXqQI3lv67aw4KiB1Y=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkDaKb5iXdynYrzB84ErPPO4LbRASk58=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
-github.com/livekit/mediatransportutil v0.0.0-20230906055425-e81fd5f6fb3f h1:b4ri7hQESRSzJWzXXcmANG2hJ4HTj5LM01Ekm8lnQmg=
-github.com/livekit/mediatransportutil v0.0.0-20230906055425-e81fd5f6fb3f/go.mod h1:+WIOYwiBMive5T81V8B2wdAc2zQNRjNQiJIcPxMTILY=
-github.com/livekit/protocol v1.7.3-0.20230915202328-cf9f95141e0e h1:WEet0iH/JazBFNhhH+YuZHtXpKefb7mnbCC2al3peyA=
-github.com/livekit/protocol v1.7.3-0.20230915202328-cf9f95141e0e/go.mod h1:zbh0QPUcLGOeZeIO/VeigwWWbudz4Lv+Px94FnVfQH0=
 github.com/livekit/protocol v1.7.3-0.20230918130519-dd24d071834c h1:Z44UEdskI35V3nDJfVvYuJ4DOW1wQLku32wbNyz23MM=
 github.com/livekit/protocol v1.7.3-0.20230918130519-dd24d071834c/go.mod h1:zbh0QPUcLGOeZeIO/VeigwWWbudz4Lv+Px94FnVfQH0=
 github.com/livekit/psrpc v0.3.3 h1:+lltbuN39IdaynXhLLxRShgYqYsRMWeeXKzv60oqyWo=

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,10 @@ github.com/lithammer/shortuuid/v4 v4.0.0 h1:QRbbVkfgNippHOS8PXDkti4NaWeyYfcBTHtw
 github.com/lithammer/shortuuid/v4 v4.0.0/go.mod h1:Zs8puNcrvf2rV9rTH51ZLLcj7ZXqQI3lv67aw4KiB1Y=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkDaKb5iXdynYrzB84ErPPO4LbRASk58=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
+github.com/livekit/mediatransportutil v0.0.0-20230919184714-b8f0fa0133c5 h1:CjXYkNKSrdIn7GMD1ySoXrURhL5U9d6vG32vxcUhzIU=
+github.com/livekit/mediatransportutil v0.0.0-20230919184714-b8f0fa0133c5/go.mod h1:+WIOYwiBMive5T81V8B2wdAc2zQNRjNQiJIcPxMTILY=
+github.com/livekit/protocol v1.7.3-0.20230919182418-0708b5a5bb84 h1:4WOaspDesbbrjGPsu6Vp1VjcWxTXVjyjdtQAzIUXn5s=
+github.com/livekit/protocol v1.7.3-0.20230919182418-0708b5a5bb84/go.mod h1:zbh0QPUcLGOeZeIO/VeigwWWbudz4Lv+Px94FnVfQH0=
 github.com/livekit/psrpc v0.3.3 h1:+lltbuN39IdaynXhLLxRShgYqYsRMWeeXKzv60oqyWo=
 github.com/livekit/psrpc v0.3.3/go.mod h1:n6JntEg+zT6Ji8InoyTpV7wusPNwGqqtxmHlkNhDN0U=
 github.com/mackerelio/go-osstat v0.2.4 h1:qxGbdPkFo65PXOb/F/nhDKpF2nGmGaCFDLXoZjJTtUs=

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,6 @@ github.com/lithammer/shortuuid/v4 v4.0.0 h1:QRbbVkfgNippHOS8PXDkti4NaWeyYfcBTHtw
 github.com/lithammer/shortuuid/v4 v4.0.0/go.mod h1:Zs8puNcrvf2rV9rTH51ZLLcj7ZXqQI3lv67aw4KiB1Y=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkDaKb5iXdynYrzB84ErPPO4LbRASk58=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
-github.com/livekit/protocol v1.7.3-0.20230918130519-dd24d071834c h1:Z44UEdskI35V3nDJfVvYuJ4DOW1wQLku32wbNyz23MM=
-github.com/livekit/protocol v1.7.3-0.20230918130519-dd24d071834c/go.mod h1:zbh0QPUcLGOeZeIO/VeigwWWbudz4Lv+Px94FnVfQH0=
 github.com/livekit/psrpc v0.3.3 h1:+lltbuN39IdaynXhLLxRShgYqYsRMWeeXKzv60oqyWo=
 github.com/livekit/psrpc v0.3.3/go.mod h1:n6JntEg+zT6Ji8InoyTpV7wusPNwGqqtxmHlkNhDN0U=
 github.com/mackerelio/go-osstat v0.2.4 h1:qxGbdPkFo65PXOb/F/nhDKpF2nGmGaCFDLXoZjJTtUs=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,7 +54,7 @@ var (
 )
 
 type Config struct {
-	Port           uint32                   `yaml:"port"`
+	Port           uint32                   `yaml:"port,omitempty"`
 	BindAddresses  []string                 `yaml:"bind_addresses,omitempty"`
 	PrometheusPort uint32                   `yaml:"prometheus_port,omitempty"`
 	Environment    string                   `yaml:"environment,omitempty"`
@@ -108,9 +108,9 @@ type RTCConfig struct {
 }
 
 type TURNServer struct {
-	Host       string `yaml:"host"`
-	Port       int    `yaml:"port"`
-	Protocol   string `yaml:"protocol"`
+	Host       string `yaml:"host,omitempty"`
+	Port       int    `yaml:"port,omitempty"`
+	Protocol   string `yaml:"protocol,omitempty"`
 	Username   string `yaml:"username,omitempty"`
 	Credential string `yaml:"credential,omitempty"`
 }
@@ -157,7 +157,7 @@ type CongestionControlConfig struct {
 	NackRatioAttenuator              float64                                `yaml:"nack_ratio_attenuator,omitempty"`
 	ExpectedUsageThreshold           float64                                `yaml:"expected_usage_threshold,omitempty"`
 	UseSendSideBWE                   bool                                   `yaml:"send_side_bandwidth_estimation,omitempty"`
-	ProbeMode                        CongestionControlProbeMode             `yaml:"padding_mode,omitempty"`
+	ProbeMode                        CongestionControlProbeMode             `yaml:"probe_mode,omitempty"`
 	MinChannelCapacity               int64                                  `yaml:"min_channel_capacity,omitempty"`
 	ProbeConfig                      CongestionControlProbeConfig           `yaml:"probe_config,omitempty"`
 	ChannelObserverProbeConfig       CongestionControlChannelObserverConfig `yaml:"channel_observer_probe_config,omitempty"`
@@ -187,7 +187,7 @@ type StreamTrackerPacketConfig struct {
 }
 
 type StreamTrackerFrameConfig struct {
-	MinFPS float64 `yaml:"min_fps"`
+	MinFPS float64 `yaml:"min_fps,omitempty"`
 }
 
 type StreamTrackerConfig struct {
@@ -225,8 +225,8 @@ type RoomConfig struct {
 }
 
 type CodecSpec struct {
-	Mime     string `yaml:"mime"`
-	FmtpLine string `yaml:"fmtp_line"`
+	Mime     string `yaml:"mime,omitempty"`
+	FmtpLine string `yaml:"fmtp_line,omitempty"`
 }
 
 type LoggingConfig struct {
@@ -235,7 +235,7 @@ type LoggingConfig struct {
 }
 
 type TURNConfig struct {
-	Enabled             bool   `yaml:"enabled"`
+	Enabled             bool   `yaml:"enabled,omitempty"`
 	Domain              string `yaml:"domain,omitempty"`
 	CertFile            string `yaml:"cert_file,omitempty"`
 	KeyFile             string `yaml:"key_file,omitempty"`
@@ -247,13 +247,13 @@ type TURNConfig struct {
 }
 
 type WebHookConfig struct {
-	URLs []string `yaml:"urls"`
+	URLs []string `yaml:"urls,omitempty"`
 	// key to use for webhook
-	APIKey string `yaml:"api_key"`
+	APIKey string `yaml:"api_key,omitempty"`
 }
 
 type NodeSelectorConfig struct {
-	Kind         string         `yaml:"kind"`
+	Kind         string         `yaml:"kind,omitempty"`
 	SortBy       string         `yaml:"sort_by,omitempty"`
 	CPULoadLimit float32        `yaml:"cpu_load_limit,omitempty"`
 	SysloadLimit float32        `yaml:"sysload_limit,omitempty"`
@@ -261,7 +261,7 @@ type NodeSelectorConfig struct {
 }
 
 type SignalRelayConfig struct {
-	Enabled          bool          `yaml:"enabled"`
+	Enabled          bool          `yaml:"enabled,omitempty"`
 	RetryTimeout     time.Duration `yaml:"retry_timeout,omitempty"`
 	MinRetryInterval time.Duration `yaml:"min_retry_interval,omitempty"`
 	MaxRetryInterval time.Duration `yaml:"max_retry_interval,omitempty"`
@@ -271,9 +271,9 @@ type SignalRelayConfig struct {
 // RegionConfig lists available regions and their latitude/longitude, so the selector would prefer
 // regions that are closer
 type RegionConfig struct {
-	Name string  `yaml:"name"`
-	Lat  float64 `yaml:"lat"`
-	Lon  float64 `yaml:"lon"`
+	Name string  `yaml:"name,omitempty"`
+	Lat  float64 `yaml:"lat,omitempty"`
+	Lon  float64 `yaml:"lon,omitempty"`
 }
 
 type LimitConfig struct {
@@ -284,8 +284,8 @@ type LimitConfig struct {
 }
 
 type IngressConfig struct {
-	RTMPBaseURL string `yaml:"rtmp_base_url"`
-	WHIPBaseURL string `yaml:"whip_base_url"`
+	RTMPBaseURL string `yaml:"rtmp_base_url,omitempty"`
+	WHIPBaseURL string `yaml:"whip_base_url,omitempty"`
 }
 
 // not exposed to YAML
@@ -488,7 +488,17 @@ var DefaultConfig = Config{
 
 func NewConfig(confString string, strictMode bool, c *cli.Context, baseFlags []cli.Flag) (*Config, error) {
 	// start with defaults
-	conf := DefaultConfig
+	marshalled, err := yaml.Marshal(&DefaultConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	var conf Config
+	err = yaml.Unmarshal(marshalled, &conf)
+	if err != nil {
+		return nil, err
+	}
+
 	if confString != "" {
 		decoder := yaml.NewDecoder(strings.NewReader(confString))
 		decoder.KnownFields(strictMode)


### PR DESCRIPTION
Need to ensure that config structs/fields are marshallable.

There was a use of a = b copy of struct and some of the embeded structs had locks and copying was not good.

This is to get around the global use here - https://github.com/livekit/protocol/pull/475