### PR TITLE
Changing some log levels

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -561,10 +561,9 @@ func (p *ParticipantImpl) HandleSignalSourceClose() {
 	p.TransportManager.SetSignalSourceValid(false)
 
 	if !p.TransportManager.HasPublisherEverConnected() && !p.TransportManager.HasSubscriberEverConnected() {
-		p.params.Logger.Infow("closing disconnected participant",
-			"reason", types.ParticipantCloseReasonJoinFailed,
-		)
-		_ = p.Close(false, types.ParticipantCloseReasonJoinFailed, false)
+		reason := types.ParticipantCloseReasonJoinFailed
+		p.params.Logger.Infow("closing disconnected participant", "reason", reason)
+		_ = p.Close(false, reason, false)
 	}
 }
 
@@ -1404,10 +1403,9 @@ func (p *ParticipantImpl) setupDisconnectTimer() {
 		if p.IsClosed() || p.IsDisconnected() {
 			return
 		}
-		p.params.Logger.Infow("closing disconnected participant",
-			"reason", types.ParticipantCloseReasonPeerConnectionDisconnected,
-		)
-		_ = p.Close(true, types.ParticipantCloseReasonPeerConnectionDisconnected, false)
+		reason := types.ParticipantCloseReasonPeerConnectionDisconnected
+		p.params.Logger.Infow("closing disconnected participant", "reason", reason)
+		_ = p.Close(true, reason, false)
 	})
 	p.lock.Unlock()
 }

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -426,7 +426,6 @@ func (r *Room) ReplaceParticipantRequestSource(identity livekit.ParticipantIdent
 		rs.Close()
 	}
 	r.participantRequestSources[identity] = reqSource
-
 	r.lock.Unlock()
 }
 

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -832,7 +832,7 @@ func (t *PCTransport) CreateDataChannel(label string, dci *webrtc.DataChannelIni
 	}
 
 	dcErrorHandler := func(err error) {
-		if !errors.Is(err, sctp.ErrResetPacketInStateNotExist) {
+		if !errors.Is(err, sctp.ErrResetPacketInStateNotExist) && !errors.Is(err, sctp.ErrChunk) {
 			t.params.Logger.Errorw(dc.Label()+" data channel error", err)
 		}
 	}


### PR DESCRIPTION
Logging expected WS close at Infow to understand reasons for closure. Moving "read from ws" to Debugw as it happens when signalling closes.

Also filter out a data channel abort chunk log as it shows a bunch of errors, but those are expected though.