### PR TITLE
Log ICE candidates when closing the peer connection.

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -1443,6 +1443,7 @@ func (t *PCTransport) processEvents() {
 
 	t.clearSignalStateCheckTimer()
 	t.params.Logger.Debugw("leaving events processor")
+	t.handleLogICECandidates(nil)
 }
 
 func (t *PCTransport) handleEvent(e *event) error {


### PR DESCRIPTION
There are cases that experience the signalling channel timeout and disconnect and there are no logs of what the state of ICE at all. Log ICE candidates when closing transport so that there is some visibility in those cases.
n