### PR TITLE
Log time when there are too many packets.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_base.go
+++ b/pkg/sfu/buffer/rtpstats_base.go
@@ -531,8 +531,13 @@ func (r *rtpStatsBase) deltaInfo(snapshotID uint32, extStartSN uint64, extHighes
 	packetsExpected := now.extStartSN - then.extStartSN
 	if packetsExpected > cNumSequenceNumbers {
 		r.logger.Errorw(
-			"too many packets expected in delta",
-			fmt.Errorf("start: %d, end: %d, expected: %d", then.extStartSN, now.extStartSN, packetsExpected),
+			"too many packets expected in delta", nil,
+			"startSN", then.extStartSN,
+			"endSN", now.extStartSN,
+			"packetsExpected", packetsExpected,
+			"startTime", startTime,
+			"endTime", endTime,
+			"duration", endTime.Sub(startTime),
 		)
 		return nil
 	}

--- a/pkg/sfu/buffer/rtpstats_sender.go
+++ b/pkg/sfu/buffer/rtpstats_sender.go
@@ -600,8 +600,13 @@ func (r *RTPStatsSender) DeltaInfoSender(senderSnapshotID uint32) *RTPDeltaInfo 
 	packetsExpected := uint32(now.extStartSN - then.extStartSN)
 	if packetsExpected > cNumSequenceNumbers {
 		r.logger.Warnw(
-			"too many packets expected in delta (sender)",
-			fmt.Errorf("start: %d, end: %d, expected: %d", then.extStartSN, now.extStartSN, packetsExpected),
+			"too many packets expected in delta (sender)", nil,
+			"startSN", then.extStartSN,
+			"endSN", now.extStartSN,
+			"packetsExpected", packetsExpected,
+			"startTime", startTime,
+			"endTime", endTime,
+			"duration", endTime.Sub(startTime),
 		)
 		return nil
 	}


### PR DESCRIPTION
Ideally, can remove the nil return when there are too many packets as we have more information with extended sequence numbers, but logging duration first to understand what is happening better.