### PR TITLE
Return error if TURN is not enabled.

### DIFF
--- a/pkg/service/turn.go
+++ b/pkg/service/turn.go
@@ -47,7 +47,7 @@ const (
 func NewTurnServer(conf *config.Config, authHandler turn.AuthHandler, standalone bool) (*turn.Server, error) {
 	turnConf := conf.TURN
 	if !turnConf.Enabled {
-		return nil, nil
+		return nil, errors.New("TURN not enabled")
 	}
 
 	if turnConf.TLSPort <= 0 && turnConf.UDPPort <= 0 {


### PR DESCRIPTION
 By golang convention, caller was just checking for
error and assuming the other value is valid if no error. Follow convention.