### PR TITLE
Increase accuracy of delay since last sender report.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_receiver.go
+++ b/pkg/sfu/buffer/rtpstats_receiver.go
@@ -361,9 +361,9 @@ func (r *RTPStatsReceiver) GetRtcpReceptionReport(ssrc uint32, proxyFracLost uin
 	if r.srNewest != nil {
 		lastSR = uint32(r.srNewest.NTPTimestamp >> 16)
 		if !r.srNewest.At.IsZero() {
-			delayMS := uint32(time.Since(r.srNewest.At).Milliseconds())
-			dlsr = (delayMS / 1e3) << 16
-			dlsr |= (delayMS % 1e3) * 65536 / 1000
+			delayUS := uint32(time.Since(r.srNewest.At).Microseconds())
+			dlsr = (delayUS / 1e6) << 16
+			dlsr |= (delayUS % 1e6) * 65536 / 1e6
 		}
 	}
 


### PR DESCRIPTION
It is in 1 / 65536 seconds units. That is about 0.015 ms. So, use microseconds to increase accuracy.