### PR TITLE
fix of error message about "note: module requires Go 1.19"

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Read our [deployment docs](https://docs.livekit.io/deploy/) for more information
 
 Pre-requisites:
 
-- Go 1.18+ is installed
+- Go 1.20+ is installed
 - GOPATH/bin is in your PATH
 
 Then run


### PR DESCRIPTION
Get error message "note: module requires Go 1.19"

When i run main.go .I got a message like below:
```
# go.uber.org/multierr
../../go/pkg/mod/go.uber.org/multierr@v1.10.0/error.go:224:20: undefined: atomic.Bool
note: module requires Go 1.19
# github.com/livekit/mediatransportutil/pkg/transport
../../go/pkg/mod/github.com/livekit/mediatransportutil@v0.0.0-20231005043905-c137afffe71c/pkg/transport/udpmultimux.go:40:23: undefined: atomic.Int32
# google.golang.org/grpc
../../go/pkg/mod/google.golang.org/grpc@v1.58.3/server.go:2096:14: undefined: atomic.Int64
note: module requires Go 1.19
```

But Pre-requisites in readme is 1.18+. and version of 1.20 on go.mod. So the version of golang must be 1.20 will be ok.