### PR TITLE
Defer close of source and sink to prevent error logs.

### DIFF
--- a/pkg/service/roomservice.go
+++ b/pkg/service/roomservice.go
@@ -84,8 +84,8 @@ func (s *RoomService) CreateRoom(ctx context.Context, req *livekit.CreateRoomReq
 	if err != nil {
 		return nil, err
 	}
-	sink.Close()
-	source.Close()
+	defer sink.Close()
+	defer source.Close()
 
 	// ensure it's created correctly
 	err = s.confirmExecution(func() error {


### PR DESCRIPTION
When a room is created via room service, when `StartSession` runs, it sees a closed request source and returns an error and that gets logged. It is not a real error.

Defer the sink and source close so that room creation can finish without errors.