### PR TITLE
Accept more range for first packet time adjustment.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1
-	github.com/livekit/mediatransportutil v0.0.0-20231005043905-c137afffe71c
+	github.com/livekit/mediatransportutil v0.0.0-20231017082622-43f077b4e60e
 	github.com/livekit/protocol v1.8.0
 	github.com/livekit/psrpc v0.3.3
 	github.com/mackerelio/go-osstat v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/lithammer/shortuuid/v4 v4.0.0 h1:QRbbVkfgNippHOS8PXDkti4NaWeyYfcBTHtw
 github.com/lithammer/shortuuid/v4 v4.0.0/go.mod h1:Zs8puNcrvf2rV9rTH51ZLLcj7ZXqQI3lv67aw4KiB1Y=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkDaKb5iXdynYrzB84ErPPO4LbRASk58=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
-github.com/livekit/mediatransportutil v0.0.0-20231005043905-c137afffe71c h1:eTghhsCfx2ltyzArXZ7wiNoFFzbfLXJ4uI/IsLXFZQc=
-github.com/livekit/mediatransportutil v0.0.0-20231005043905-c137afffe71c/go.mod h1:+WIOYwiBMive5T81V8B2wdAc2zQNRjNQiJIcPxMTILY=
+github.com/livekit/mediatransportutil v0.0.0-20231017082622-43f077b4e60e h1:yNeIo7MSMUWgoLu7LkNKnBYnJBFPFH9Wq4S6h1kS44M=
+github.com/livekit/mediatransportutil v0.0.0-20231017082622-43f077b4e60e/go.mod h1:+WIOYwiBMive5T81V8B2wdAc2zQNRjNQiJIcPxMTILY=
 github.com/livekit/protocol v1.8.0 h1:0z2eRmEXFFXiJ7WPAxRLMNCyUu55w41iikbbeT8dvlQ=
 github.com/livekit/protocol v1.8.0/go.mod h1:zbh0QPUcLGOeZeIO/VeigwWWbudz4Lv+Px94FnVfQH0=
 github.com/livekit/psrpc v0.3.3 h1:+lltbuN39IdaynXhLLxRShgYqYsRMWeeXKzv60oqyWo=

--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -228,7 +228,7 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.Tra
 			case *rtcp.SourceDescription:
 			// do nothing for now
 			case *rtcp.SenderReport:
-				buff.SetSenderReportData(pkt.RTPTime, pkt.NTPTime, pkt.PacketCount)
+				buff.SetSenderReportData(pkt.RTPTime, pkt.NTPTime)
 			}
 		}
 	})

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -715,12 +715,11 @@ func (b *Buffer) buildReceptionReport() *rtcp.ReceptionReport {
 	return b.rtpStats.GetRtcpReceptionReport(b.mediaSSRC, b.lastFractionLostToReport, b.rrSnapshotId)
 }
 
-func (b *Buffer) SetSenderReportData(rtpTime uint32, ntpTime uint64, packetCount uint32) {
+func (b *Buffer) SetSenderReportData(rtpTime uint32, ntpTime uint64) {
 	b.RLock()
 	srData := &RTCPSenderReportData{
 		RTPTimestamp: rtpTime,
 		NTPTimestamp: mediatransportutil.NtpTime(ntpTime),
-		PacketCount:  packetCount,
 		At:           time.Now(),
 	}
 

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -84,8 +84,7 @@ type Buffer struct {
 	closed        atomic.Bool
 	mime          string
 
-	snRangeMap       *utils.RangeMap[uint64, uint64]
-	paddingOnlyDrops uint64
+	snRangeMap *utils.RangeMap[uint64, uint64]
 
 	latestTSForAudioLevelInitialized bool
 	latestTSForAudioLevel            uint32
@@ -455,7 +454,6 @@ func (b *Buffer) calc(pkt []byte, arrivalTime time.Time) {
 			if err := b.snRangeMap.ExcludeRange(flowState.ExtSequenceNumber, flowState.ExtSequenceNumber+1); err != nil {
 				b.logger.Errorw("could not exclude range", err, "sn", rtpPacket.SequenceNumber, "esn", flowState.ExtSequenceNumber)
 			}
-			b.paddingOnlyDrops++
 		}
 		return
 	}
@@ -720,11 +718,10 @@ func (b *Buffer) buildReceptionReport() *rtcp.ReceptionReport {
 func (b *Buffer) SetSenderReportData(rtpTime uint32, ntpTime uint64, packetCount uint32) {
 	b.RLock()
 	srData := &RTCPSenderReportData{
-		RTPTimestamp:     rtpTime,
-		NTPTimestamp:     mediatransportutil.NtpTime(ntpTime),
-		PacketCount:      packetCount,
-		PaddingOnlyDrops: b.paddingOnlyDrops,
-		At:               time.Now(),
+		RTPTimestamp: rtpTime,
+		NTPTimestamp: mediatransportutil.NtpTime(ntpTime),
+		PacketCount:  packetCount,
+		At:           time.Now(),
 	}
 
 	if b.rtpStats != nil {

--- a/pkg/sfu/buffer/rtpstats_base.go
+++ b/pkg/sfu/buffer/rtpstats_base.go
@@ -32,7 +32,7 @@ const (
 	cFirstSnapshotID     = 1
 
 	cFirstPacketTimeAdjustWindow    = 2 * time.Minute
-	cFirstPacketTimeAdjustThreshold = 5 * time.Second
+	cFirstPacketTimeAdjustThreshold = 5 * time.Minute
 )
 
 // -------------------------------------------------------
@@ -110,9 +110,7 @@ type RTCPSenderReportData struct {
 	RTPTimestampExt uint64
 	NTPTimestamp    mediatransportutil.NtpTime
 	PacketCount     uint32
-	// RAJA-REMOVE PacketCountExt   uint64
-	PaddingOnlyDrops uint64
-	At               time.Time
+	At              time.Time
 }
 
 type RTPStatsParams struct {
@@ -484,7 +482,7 @@ func (r *rtpStatsBase) maybeAdjustFirstPacketTime(ets uint64, extStartTS uint64)
 			"nowTime", now.String(),
 			"before", r.firstTime.String(),
 			"after", firstTime.String(),
-			"adjustment", r.firstTime.Sub(firstTime),
+			"adjustment", r.firstTime.Sub(firstTime).String(),
 			"extNowTS", ets,
 			"extStartTS", extStartTS,
 		)
@@ -494,7 +492,7 @@ func (r *rtpStatsBase) maybeAdjustFirstPacketTime(ets uint64, extStartTS uint64)
 				"nowTime", now.String(),
 				"before", r.firstTime.String(),
 				"after", firstTime.String(),
-				"adjustment", r.firstTime.Sub(firstTime),
+				"adjustment", r.firstTime.Sub(firstTime).String(),
 				"extNowTS", ets,
 				"extStartTS", extStartTS,
 			)
@@ -537,7 +535,7 @@ func (r *rtpStatsBase) deltaInfo(snapshotID uint32, extStartSN uint64, extHighes
 			"packetsExpected", packetsExpected,
 			"startTime", startTime,
 			"endTime", endTime,
-			"duration", endTime.Sub(startTime),
+			"duration", endTime.Sub(startTime).String(),
 		)
 		return nil
 	}

--- a/pkg/sfu/buffer/rtpstats_base.go
+++ b/pkg/sfu/buffer/rtpstats_base.go
@@ -109,7 +109,6 @@ type RTCPSenderReportData struct {
 	RTPTimestamp    uint32
 	RTPTimestampExt uint64
 	NTPTimestamp    mediatransportutil.NtpTime
-	PacketCount     uint32
 	At              time.Time
 }
 

--- a/pkg/sfu/buffer/rtpstats_receiver.go
+++ b/pkg/sfu/buffer/rtpstats_receiver.go
@@ -359,6 +359,11 @@ func (r *RTPStatsReceiver) GetRtcpReceptionReport(ssrc uint32, proxyFracLost uin
 		fracLost = proxyFracLost
 	}
 
+	totalLost := r.packetsLost
+	if totalLost > 0xffffff { // 24-bits max
+		totalLost = 0xffffff
+	}
+
 	lastSR := uint32(0)
 	dlsr := uint32(0)
 	if r.srNewest != nil {
@@ -372,7 +377,7 @@ func (r *RTPStatsReceiver) GetRtcpReceptionReport(ssrc uint32, proxyFracLost uin
 	return &rtcp.ReceptionReport{
 		SSRC:               ssrc,
 		FractionLost:       fracLost,
-		TotalLost:          uint32(r.packetsLost),
+		TotalLost:          uint32(totalLost),
 		LastSequenceNumber: uint32(now.extStartSN),
 		Jitter:             uint32(r.jitter),
 		LastSenderReport:   lastSR,

--- a/pkg/sfu/buffer/rtpstats_sender.go
+++ b/pkg/sfu/buffer/rtpstats_sender.go
@@ -416,9 +416,9 @@ func (r *RTPStatsSender) UpdateFromReceiverReport(rr rtcp.ReceptionReport) (rtt 
 	if !r.lastRRTime.IsZero() && r.extHighestSNFromRR > extHighestSNFromRR {
 		r.logger.Debugw(
 			fmt.Sprintf("receiver report potentially out of order, highestSN: existing: %d, received: %d", r.extHighestSNFromRR, extHighestSNFromRR),
-			"lastRRTime", r.lastRRTime,
+			"lastRRTime", r.lastRRTime.String(),
 			"lastRR", r.lastRR,
-			"sinceLastRR", time.Since(r.lastRRTime),
+			"sinceLastRR", time.Since(r.lastRRTime).String(),
 			"receivedRR", rr,
 		)
 		return
@@ -482,9 +482,9 @@ func (r *RTPStatsSender) UpdateFromReceiverReport(rr rtcp.ReceptionReport) (rtt 
 		if is.packetsNotFound != 0 {
 			r.logger.Warnw(
 				"potential sequence number de-sync", nil,
-				"lastRRTime", r.lastRRTime,
+				"lastRRTime", r.lastRRTime.String(),
 				"lastRR", r.lastRR,
-				"sinceLastRR", time.Since(r.lastRRTime),
+				"sinceLastRR", time.Since(r.lastRRTime).String(),
 				"receivedRR", rr,
 				"extStartSN", r.extStartSN,
 				"extHighestSN", r.extHighestSN,
@@ -581,14 +581,15 @@ func (r *RTPStatsSender) GetRtcpSenderReport(ssrc uint32, calculatedClockRate ui
 			"prevTSExt", r.srNewest.RTPTimestampExt,
 			"prevRTP", r.srNewest.RTPTimestamp,
 			"prevNTP", r.srNewest.NTPTimestamp.Time().String(),
+			"extHighestTS", r.extHighestTS,
 			"currTSExt", nowRTPExt,
 			"currRTP", nowRTP,
 			"currNTP", nowNTP.Time().String(),
 			"timeNow", time.Now().String(),
 			"firstTime", r.firstTime.String(),
-			"timeSinceFirst", timeSinceFirst,
+			"timeSinceFirst", timeSinceFirst.String(),
 			"highestTime", r.highestTime.String(),
-			"timeSinceHighest", timeSinceHighest,
+			"timeSinceHighest", timeSinceHighest.String(),
 			"nowRTPExtUsingTime", nowRTPExtUsingTime,
 			"calculatedClockRate", calculatedClockRate,
 			"nowRTPExtUsingRate", nowRTPExtUsingRate,
@@ -646,9 +647,9 @@ func (r *RTPStatsSender) DeltaInfoSender(senderSnapshotID uint32) *RTPDeltaInfo 
 			"startSN", then.extStartSN,
 			"endSN", now.extStartSN,
 			"packetsExpected", packetsExpected,
-			"startTime", startTime,
-			"endTime", endTime,
-			"duration", endTime.Sub(startTime),
+			"startTime", startTime.String(),
+			"endTime", endTime.String(),
+			"duration", endTime.Sub(startTime).String(),
 		)
 		return nil
 	}


### PR DESCRIPTION
Across relay, it is possible that some old packet comes through and resets the start point. That made the first packet time adjustment large and not be applied.

With the change in mediatransportutil, hopefully very old packets will not be NACKed. Also, accept a larger range for first packet time adjustment. Had limited to 5 seconds before this to prevent any errors from creeping in. From logs, looks like larger values can indeed happen and they do not look wrong (as far as I could check logs). So, accepting a larger range should be fine.

Also, log time quantities as strings for easier reading.