### PR TITLE
Use 32-bit time stamp to get reference time stamp on a switch.

### DIFF
--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -317,9 +317,9 @@ func (d *DummyReceiver) GetCalculatedClockRate(layer int32) uint32 {
 	return 0
 }
 
-func (d *DummyReceiver) GetReferenceLayerRTPTimestamp(ets uint64, layer int32, referenceLayer int32) (uint64, error) {
+func (d *DummyReceiver) GetReferenceLayerRTPTimestamp(ts uint32, layer int32, referenceLayer int32) (uint32, error) {
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
-		return r.GetReferenceLayerRTPTimestamp(ets, layer, referenceLayer)
+		return r.GetReferenceLayerRTPTimestamp(ts, layer, referenceLayer)
 	}
 	return 0, errors.New("receiver not available")
 }

--- a/pkg/sfu/buffer/rtpstats_base.go
+++ b/pkg/sfu/buffer/rtpstats_base.go
@@ -453,7 +453,7 @@ func (r *rtpStatsBase) GetRtt() uint32 {
 	return r.rtt
 }
 
-func (r *rtpStatsBase) maybeAdjustFirstPacketTime(ets uint64, extStartTS uint64) {
+func (r *rtpStatsBase) maybeAdjustFirstPacketTime(ts uint32, startTS uint32) {
 	if time.Since(r.startTime) > cFirstPacketTimeAdjustWindow {
 		return
 	}
@@ -464,7 +464,7 @@ func (r *rtpStatsBase) maybeAdjustFirstPacketTime(ets uint64, extStartTS uint64)
 	// abnormal delay (maybe due to pacing or maybe due to queuing
 	// in some network element along the way), push back first time
 	// to an earlier instance.
-	samplesDiff := int64(ets - extStartTS)
+	samplesDiff := int32(ts - startTS)
 	if samplesDiff < 0 {
 		// out-of-order, skip
 		return
@@ -482,8 +482,8 @@ func (r *rtpStatsBase) maybeAdjustFirstPacketTime(ets uint64, extStartTS uint64)
 			"before", r.firstTime.String(),
 			"after", firstTime.String(),
 			"adjustment", r.firstTime.Sub(firstTime).String(),
-			"extNowTS", ets,
-			"extStartTS", extStartTS,
+			"nowTS", ts,
+			"startTS", startTS,
 		)
 		if r.firstTime.Sub(firstTime) > cFirstPacketTimeAdjustThreshold {
 			r.logger.Infow("first packet time adjustment too big, ignoring",
@@ -492,8 +492,8 @@ func (r *rtpStatsBase) maybeAdjustFirstPacketTime(ets uint64, extStartTS uint64)
 				"before", r.firstTime.String(),
 				"after", firstTime.String(),
 				"adjustment", r.firstTime.Sub(firstTime).String(),
-				"extNowTS", ets,
-				"extStartTS", extStartTS,
+				"nowTS", ts,
+				"startTS", startTS,
 			)
 		} else {
 			r.firstTime = firstTime

--- a/pkg/sfu/buffer/rtpstats_receiver.go
+++ b/pkg/sfu/buffer/rtpstats_receiver.go
@@ -151,7 +151,19 @@ func (r *RTPStatsReceiver) Update(
 			}
 		}
 		if -gapSN >= cNumSequenceNumbers {
-			r.logger.Warnw("large sequence number gap negative", nil, "prev", resSN.PreExtendedHighest, "curr", resSN.ExtendedVal, "gap", gapSN)
+			r.logger.Warnw(
+				"large sequence number gap negative", nil,
+				"prev", resSN.PreExtendedHighest,
+				"curr", resSN.ExtendedVal,
+				"gap", gapSN,
+				"packetTime", packetTime.String(),
+				"sequenceNumber", sequenceNumber,
+				"timestamp", timestamp,
+				"marker", marker,
+				"hdrSize", hdrSize,
+				"payloadSize", payloadSize,
+				"paddingSize", paddingSize,
+			)
 		}
 
 		if gapSN != 0 {
@@ -205,7 +217,19 @@ func (r *RTPStatsReceiver) Update(
 		flowState.ExtTimestamp = resTS.ExtendedVal
 	} else { // in-order
 		if gapSN >= cNumSequenceNumbers {
-			r.logger.Warnw("large sequence number gap", nil, "prev", resSN.PreExtendedHighest, "curr", resSN.ExtendedVal, "gap", gapSN)
+			r.logger.Warnw(
+				"large sequence number gap", nil,
+				"prev", resSN.PreExtendedHighest,
+				"curr", resSN.ExtendedVal,
+				"gap", gapSN,
+				"packetTime", packetTime.String(),
+				"sequenceNumber", sequenceNumber,
+				"timestamp", timestamp,
+				"marker", marker,
+				"hdrSize", hdrSize,
+				"payloadSize", payloadSize,
+				"paddingSize", paddingSize,
+			)
 		}
 
 		// update gap histogram
@@ -284,7 +308,7 @@ func (r *RTPStatsReceiver) SetRtcpSenderReportData(srData *RTCPSenderReportData)
 	srDataCopy := *srData
 	srDataCopy.RTPTimestampExt = uint64(srDataCopy.RTPTimestamp) + tsCycles
 
-	r.maybeAdjustFirstPacketTime(srDataCopy.RTPTimestampExt, r.timestamp.GetExtendedStart())
+	r.maybeAdjustFirstPacketTime(srDataCopy.RTPTimestamp, r.timestamp.GetStart())
 
 	if r.srNewest != nil && srDataCopy.RTPTimestampExt < r.srNewest.RTPTimestampExt {
 		// This can happen when a track is replaced with a null and then restored -

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -1883,7 +1883,7 @@ func (d *DownTrack) sendSilentFrameOnMuteForOpus() {
 
 func (d *DownTrack) HandleRTCPSenderReportData(_payloadType webrtc.PayloadType, layer int32, srData *buffer.RTCPSenderReportData) error {
 	if layer == d.forwarder.GetReferenceLayerSpatial() && srData != nil {
-		d.rtpStats.MaybeAdjustFirstPacketTime(srData.RTPTimestampExt + d.forwarder.GetReferenceTimestampOffset())
+		d.rtpStats.MaybeAdjustFirstPacketTime(srData.RTPTimestamp + uint32(d.forwarder.GetReferenceTimestampOffset()))
 	}
 	return nil
 }

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1501,7 +1501,7 @@ func (f *Forwarder) processSourceSwitch(extPkt *buffer.ExtPacket, layer int32) e
 	rtpMungerState := f.rtpMunger.GetLast()
 	extLastTS := rtpMungerState.ExtLastTS
 	extExpectedTS := extLastTS
-	extRefTS := extExpectedTS & 0xFFFF_FFFF_0000_0000
+	extRefTS := extExpectedTS
 	switchingAt := time.Now()
 	if f.getReferenceLayerRTPTimestamp != nil {
 		ts, err := f.getReferenceLayerRTPTimestamp(extPkt.Packet.Timestamp, layer, f.referenceLayerSpatial)
@@ -1514,7 +1514,7 @@ func (f *Forwarder) processSourceSwitch(extPkt *buffer.ExtPacket, layer int32) e
 			return err
 		}
 
-		extRefTS += uint64(ts)
+		extRefTS = (extRefTS & 0xFFFF_FFFF_0000_0000) + uint64(ts)
 
 		expectedTS32 := uint32(extExpectedTS)
 		if (ts-expectedTS32) < 1<<31 && ts < expectedTS32 {

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -81,7 +81,7 @@ type TrackReceiver interface {
 	GetTemporalLayerFpsForSpatial(layer int32) []float32
 
 	GetCalculatedClockRate(layer int32) uint32
-	GetReferenceLayerRTPTimestamp(ets uint64, layer int32, referenceLayer int32) (uint64, error)
+	GetReferenceLayerRTPTimestamp(ts uint32, layer int32, referenceLayer int32) (uint32, error)
 }
 
 // WebRTCReceiver receives a media track
@@ -777,8 +777,8 @@ func (w *WebRTCReceiver) GetCalculatedClockRate(layer int32) uint32 {
 	return w.streamTrackerManager.GetCalculatedClockRate(layer)
 }
 
-func (w *WebRTCReceiver) GetReferenceLayerRTPTimestamp(ets uint64, layer int32, referenceLayer int32) (uint64, error) {
-	return w.streamTrackerManager.GetReferenceLayerRTPTimestamp(ets, layer, referenceLayer)
+func (w *WebRTCReceiver) GetReferenceLayerRTPTimestamp(ts uint32, layer int32, referenceLayer int32) (uint32, error) {
+	return w.streamTrackerManager.GetReferenceLayerRTPTimestamp(ts, layer, referenceLayer)
 }
 
 // closes all track senders in parallel, returns when all are closed

--- a/pkg/sfu/rtpmunger.go
+++ b/pkg/sfu/rtpmunger.go
@@ -220,7 +220,7 @@ func (r *RTPMunger) UpdateAndGetSnTs(extPkt *buffer.ExtPacket) (*TranslationPara
 
 		return &TranslationParamsRTP{
 			snOrdering:        SequenceNumberOrderingOutOfOrder,
-			extSequenceNumber: extPkt.ExtSequenceNumber - snOffset,
+			extSequenceNumber: extSequenceNumber,
 			extTimestamp:      extPkt.ExtTimestamp - r.tsOffset,
 		}, nil
 	}

--- a/pkg/sfu/rtpmunger.go
+++ b/pkg/sfu/rtpmunger.go
@@ -202,6 +202,22 @@ func (r *RTPMunger) UpdateAndGetSnTs(extPkt *buffer.ExtPacket) (*TranslationPara
 			}, ErrOutOfOrderSequenceNumberCacheMiss
 		}
 
+		extSequenceNumber := extPkt.ExtSequenceNumber - snOffset
+		if extSequenceNumber >= r.extLastSN {
+			// should not happen, just being paranoid
+			r.logger.Errorw(
+				"unexpected packet ordering", nil,
+				"extIncomingSN", extPkt.ExtSequenceNumber,
+				"extHighestIncominSN", r.extHighestIncomingSN,
+				"extLastSN", r.extLastSN,
+				"snOffsetIncoming", snOffset,
+				"snOffsetHighest", r.snOffset,
+			)
+			return &TranslationParamsRTP{
+				snOrdering: SequenceNumberOrderingOutOfOrder,
+			}, ErrOutOfOrderSequenceNumberCacheMiss
+		}
+
 		return &TranslationParamsRTP{
 			snOrdering:        SequenceNumberOrderingOutOfOrder,
 			extSequenceNumber: extPkt.ExtSequenceNumber - snOffset,


### PR DESCRIPTION
With relay and dyncast and migration, it is possible that different layers of a simulcast get out of sync in terms of extended type, i. e. layer 0 could keep running and its timestamp could have wrapped around and bumped the extended timestamp. But, another layer could start and stop.

One possible solution is sending the extended timestamp across relay.

But, that breaks down during migration if publisher has started afresh. Subscriber could still be using extended range.

So, use 32-bit timestamp to infer reference timestamp and patch it with expected extended time stamp to derive the extended reference.