### PR TITLE
Log highest time update on padding packet.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_sender.go
+++ b/pkg/sfu/buffer/rtpstats_sender.go
@@ -380,6 +380,15 @@ func (r *RTPStatsSender) Update(
 		if extTimestamp != r.extHighestTS {
 			// update only on first packet as same timestamp could be in multiple packets.
 			// NOTE: this may not be the first packet with this time stamp if there is packet loss.
+			if payloadSize == 0 {
+				r.logger.Infow(
+					"updating highest time on padding packet",
+					"extTimestamp", extTimestamp,
+					"extHighestTS", r.extHighestTS,
+					"highestTime", r.highestTime.String(),
+					"packetTime", packetTime.String(),
+				)
+			}
 			r.highestTime = packetTime
 		}
 		r.extHighestSN = extSequenceNumber

--- a/pkg/sfu/buffer/rtpstats_sender.go
+++ b/pkg/sfu/buffer/rtpstats_sender.go
@@ -383,6 +383,8 @@ func (r *RTPStatsSender) Update(
 			if payloadSize == 0 {
 				r.logger.Infow(
 					"updating highest time on padding packet",
+					"extSequenceNumber", extSequenceNumber,
+					"extHighestSN", r.extHighestSN,
 					"extTimestamp", extTimestamp,
 					"extHighestTS", r.extHighestTS,
 					"highestTime", r.highestTime.String(),


### PR DESCRIPTION
Seeing a strange case of what looks like highest time getting updated on a padding packet. Can't see how it happens in code. So, logging to check. Will be removing log after checking.