### PR TITLE
Do not update highest time on padding packet.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_sender.go
+++ b/pkg/sfu/buffer/rtpstats_sender.go
@@ -381,14 +381,16 @@ func (r *RTPStatsSender) Update(
 			// update only on first packet as same timestamp could be in multiple packets.
 			// NOTE: this may not be the first packet with this time stamp if there is packet loss.
 			if payloadSize == 0 {
-				r.logger.Infow(
-					"updating highest time on padding packet",
+				r.logger.Errorw(
+					"updating highest time on padding packet", nil,
 					"extSequenceNumber", extSequenceNumber,
 					"extHighestSN", r.extHighestSN,
 					"extTimestamp", extTimestamp,
 					"extHighestTS", r.extHighestTS,
 					"highestTime", r.highestTime.String(),
 					"packetTime", packetTime.String(),
+					"hdrSize", hdrSize,
+					"paddingSize", paddingSize,
 				)
 			}
 			r.highestTime = packetTime

--- a/pkg/sfu/buffer/rtpstats_sender.go
+++ b/pkg/sfu/buffer/rtpstats_sender.go
@@ -327,17 +327,6 @@ func (r *RTPStatsSender) Update(
 			r.extStartSN = extSequenceNumber
 		}
 
-		if extTimestamp < r.extStartTS {
-			r.logger.Infow(
-				"adjusting start timestamp",
-				"snBefore", r.extStartSN,
-				"snAfter", extSequenceNumber,
-				"tsBefore", r.extStartTS,
-				"tsAfter", extTimestamp,
-			)
-			r.extStartTS = extTimestamp
-		}
-
 		if gapSN != 0 {
 			r.packetsOutOfOrder++
 		}
@@ -377,25 +366,27 @@ func (r *RTPStatsSender) Update(
 
 		r.setSnInfo(extSequenceNumber, r.extHighestSN, uint16(pktSize), uint8(hdrSize), uint16(payloadSize), marker, false)
 
-		if extTimestamp != r.extHighestTS {
-			// update only on first packet as same timestamp could be in multiple packets.
-			// NOTE: this may not be the first packet with this time stamp if there is packet loss.
-			if payloadSize == 0 {
-				r.logger.Errorw(
-					"updating highest time on padding packet", nil,
-					"extSequenceNumber", extSequenceNumber,
-					"extHighestSN", r.extHighestSN,
-					"extTimestamp", extTimestamp,
-					"extHighestTS", r.extHighestTS,
-					"highestTime", r.highestTime.String(),
-					"packetTime", packetTime.String(),
-					"hdrSize", hdrSize,
-					"paddingSize", paddingSize,
-				)
-			}
+		r.extHighestSN = extSequenceNumber
+	}
+
+	if extTimestamp < r.extStartTS {
+		r.logger.Infow(
+			"adjusting start timestamp",
+			"snBefore", r.extStartSN,
+			"snAfter", extSequenceNumber,
+			"tsBefore", r.extStartTS,
+			"tsAfter", extTimestamp,
+		)
+		r.extStartTS = extTimestamp
+	}
+
+	if extTimestamp > r.extHighestTS {
+		// update only on first packet as same timestamp could be in multiple packets.
+		// NOTE: this may not be the first packet with this time stamp if there is packet loss.
+		if payloadSize > 0 {
+			// skip updating on padding only packets as they could re-use an old timestamp
 			r.highestTime = packetTime
 		}
-		r.extHighestSN = extSequenceNumber
 		r.extHighestTS = extTimestamp
 	}
 


### PR DESCRIPTION
Padding packets use time stamp of last packet sent.
Padding packets could be sent when probing much after last packet
was sent. Updating highest time on that screws up sender report
calculations. We have ways of making sure sender reports do not
get too out-of-whack, but it logs during that repair.
That repair should be unnecessary unless the source is behaving weird
(things like publisher sending all packets at the same time, publisher
sample rate is incorrect, etc.)