### PR TITLE
Clear flags in packet metadata cache before setting them.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_sender.go
+++ b/pkg/sfu/buffer/rtpstats_sender.go
@@ -844,6 +844,7 @@ func (r *RTPStatsSender) setSnInfo(esn uint64, ehsn uint64, pktSize uint16, hdrS
 	snInfo := &r.snInfos[slot]
 	snInfo.pktSize = pktSize
 	snInfo.hdrSize = hdrSize
+	snInfo.flags = 0
 	if marker {
 		snInfo.flags |= snInfoFlagMarker
 	}


### PR DESCRIPTION
Not sure if this could have resulted in bad FPS calculation, but could have contributed to it.