### PR TITLE
Drop not relevant packet only if contiguous.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1691,7 +1691,7 @@ func (f *Forwarder) getTranslationParamsVideo(extPkt *buffer.ExtPacket, layer in
 		tp.shouldDrop = true
 		if f.started && result.IsRelevant {
 			// call to update highest incoming sequence number and other internal structures
-			if _, err := f.rtpMunger.UpdateAndGetSnTs(extPkt); err == nil {
+			if tpRTP, err := f.rtpMunger.UpdateAndGetSnTs(extPkt); err == nil && tpRTP.snOrdering == SequenceNumberOrderingContiguous {
 				f.rtpMunger.PacketDropped(extPkt)
 			}
 		}


### PR DESCRIPTION
The probing + munging has not been set up to drop packets that follow a gap. Dropping such a packet leads to padding packet sequence numbers overlapping with regular packets.

This change does two things though.
- The not relevant packet will still not be sent over the wire. That could create holes in the sequence number leading to NACKs
- Would the hole cause decode issues? Unclear as making this condition is hard. Simulating it is not showing issues, but that may not be producing the bad sequence if any.

Will look at the ability to drop a packet after a gap later.