### PR TITLE
Do not post to closed channels.

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -637,16 +637,14 @@ func (d *DownTrack) keyFrameRequester(generation uint32, layer int32) {
 }
 
 func (d *DownTrack) postMaxLayerNotifierEvent() {
-	if d.kind != webrtc.RTPCodecTypeVideo {
+	if d.IsClosed() || d.kind != webrtc.RTPCodecTypeVideo {
 		return
 	}
 
 	d.bindLock.Lock()
-	if !d.IsClosed() {
-		select {
-		case d.maxLayerNotifierCh <- struct{}{}:
-		default:
-		}
+	select {
+	case d.maxLayerNotifierCh <- struct{}{}:
+	default:
 	}
 	d.bindLock.Unlock()
 }


### PR DESCRIPTION
Perils of atomics. Hard to imagine, but I guess it could happen. The postMaxLayerNotifier checked for closed and down track was not closed. But, between that check and posting to channel (which is a very small window), the down track could have been closed and the channel (maxLayerNotiferCh) is closed.

Protect that channel post + close with the bind lock.