### PR TITLE
Fix deadlock

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -650,7 +650,7 @@ func (d *DownTrack) postMaxLayerNotifierEvent() {
 		default:
 		}
 	}
-	d.maxLayerNotifierChMu.Unlock()
+	d.maxLayerNotifierChMu.RUnlock()
 }
 
 func (d *DownTrack) maxLayerNotifierWorker() {


### PR DESCRIPTION
My previous PR to wrap layer notifier post in bind lock was problematic as `onBinding` callback happens within that lock and that onBinding callback can call set max layer which will post to channel. Use a separate mutex.