### PR TITLE
Remove un-preferred codecs for android firefox

### DIFF
--- a/pkg/rtc/clientinfo.go
+++ b/pkg/rtc/clientinfo.go
@@ -37,6 +37,10 @@ func (c ClientInfo) isGo() bool {
 	return c.ClientInfo != nil && c.ClientInfo.Sdk == livekit.ClientInfo_GO
 }
 
+func (c ClientInfo) isLinux() bool {
+	return c.ClientInfo != nil && strings.EqualFold(c.ClientInfo.Os, "linux")
+}
+
 func (c ClientInfo) SupportsAudioRED() bool {
 	return !c.isFirefox() && !c.isSafari()
 }
@@ -78,6 +82,10 @@ func (c ClientInfo) SupportsICETCP() bool {
 
 func (c ClientInfo) SupportsChangeRTPSenderEncodingActive() bool {
 	return !c.isFirefox()
+}
+
+func (c ClientInfo) ComplyWithCodecOrderInSDPAnswer() bool {
+	return !(c.isLinux() && c.isFirefox())
 }
 
 // compareVersion compares a semver against the current client SDK version

--- a/pkg/rtc/participant_sdp.go
+++ b/pkg/rtc/participant_sdp.go
@@ -181,7 +181,7 @@ func (p *ParticipantImpl) setCodecPreferencesVideoForPublisher(offer webrtc.Sess
 
 			unmatchVideo.MediaName.Formats = append(unmatchVideo.MediaName.Formats[:0], preferredCodecs...)
 			// if the client don't comply with codec order in SDP answer, only keep preferred codecs to force client to use it
-			if !p.params.ClientInfo.ComplyWithCodecOrderInSDPAnswer() {
+			if p.params.ClientInfo.ComplyWithCodecOrderInSDPAnswer() {
 				unmatchVideo.MediaName.Formats = append(unmatchVideo.MediaName.Formats, leftCodecs...)
 			}
 		}

--- a/pkg/rtc/participant_sdp.go
+++ b/pkg/rtc/participant_sdp.go
@@ -180,7 +180,10 @@ func (p *ParticipantImpl) setCodecPreferencesVideoForPublisher(offer webrtc.Sess
 			}
 
 			unmatchVideo.MediaName.Formats = append(unmatchVideo.MediaName.Formats[:0], preferredCodecs...)
-			unmatchVideo.MediaName.Formats = append(unmatchVideo.MediaName.Formats, leftCodecs...)
+			// if the client don't comply with codec order in SDP answer, only keep preferred codecs to force client to use it
+			if !p.params.ClientInfo.ComplyWithCodecOrderInSDPAnswer() {
+				unmatchVideo.MediaName.Formats = append(unmatchVideo.MediaName.Formats, leftCodecs...)
+			}
 		}
 	}
 


### PR DESCRIPTION
Android firefox don't comply with the codec order in answer sdp and
has problem to publish h.264, remove other codecs to fix this.