### PR TITLE
Slight sequencer tweaks.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_receiver.go
+++ b/pkg/sfu/buffer/rtpstats_receiver.go
@@ -154,7 +154,7 @@ func (r *RTPStatsReceiver) Update(
 				return
 			}
 		}
-		if -gapSN >= cNumSequenceNumbers {
+		if -gapSN >= cNumSequenceNumbers/2 {
 			r.logger.Warnw(
 				"large sequence number gap negative", nil,
 				"extStartSN", r.sequenceNumber.GetExtendedStart(),
@@ -226,7 +226,7 @@ func (r *RTPStatsReceiver) Update(
 		flowState.ExtSequenceNumber = resSN.ExtendedVal
 		flowState.ExtTimestamp = resTS.ExtendedVal
 	} else { // in-order
-		if gapSN >= cNumSequenceNumbers {
+		if gapSN >= cNumSequenceNumbers/2 {
 			r.logger.Warnw(
 				"large sequence number gap", nil,
 				"extStartSN", r.sequenceNumber.GetExtendedStart(),

--- a/pkg/sfu/buffer/rtpstats_sender.go
+++ b/pkg/sfu/buffer/rtpstats_sender.go
@@ -286,7 +286,7 @@ func (r *RTPStatsSender) Update(
 			// do not start on a padding only packet
 			return
 		}
-		if -gapSN >= cNumSequenceNumbers {
+		if -gapSN >= cNumSequenceNumbers/2 {
 			r.logger.Warnw(
 				"large sequence number gap negative", nil,
 				"extStartSN", r.extStartSN,
@@ -352,7 +352,7 @@ func (r *RTPStatsSender) Update(
 			r.setSnInfo(extSequenceNumber, r.extHighestSN, uint16(pktSize), uint8(hdrSize), uint16(payloadSize), marker, true)
 		}
 	} else { // in-order
-		if gapSN >= cNumSequenceNumbers {
+		if gapSN >= cNumSequenceNumbers/2 {
 			r.logger.Warnw(
 				"large sequence number gap", nil,
 				"extStartSN", r.extStartSN,
@@ -399,8 +399,12 @@ func (r *RTPStatsSender) Update(
 				"invalid start timestamp", nil,
 				"snBefore", r.extStartSN,
 				"snAfter", extSequenceNumber,
+				"snHighest", r.extHighestSN,
 				"tsBefore", r.extStartTS,
 				"tsAfter", extTimestamp,
+				"tsHighest", r.extHighestTS,
+				"firstTime", r.firstTime.String(),
+				"startTime", r.startTime.String(),
 			)
 		}
 		if extTimestamp != 0 {


### PR DESCRIPTION
The buffer is not for padding packets. So, calculate adjusted sequence numbers before comparing against size.

Also, it is possible that invalidated slot is accessed due to not being able to exclude padding range. This was causing time stamp reset to 0. Will remove the error log after this goes out and the condition does not show up for a few days.