### PR TITLE
Reference time stamp for SVC.

### DIFF
--- a/pkg/sfu/streamtrackermanager.go
+++ b/pkg/sfu/streamtrackermanager.go
@@ -651,6 +651,12 @@ func (s *StreamTrackerManager) GetReferenceLayerRTPTimestamp(ts uint32, layer in
 		return 0, fmt.Errorf("invalid layer, target: %d, reference: %d", layer, referenceLayer)
 	}
 
+	// SVC-TODO: better SVC detection
+	if s.isSVC {
+		// there is only one stream in SVC
+		return ts, nil
+	}
+
 	if layer != referenceLayer && s.layerOffsets[referenceLayer][layer] == 0 {
 		return 0, fmt.Errorf("offset unavailable, target: %d, reference: %d", layer, referenceLayer)
 	}

--- a/pkg/sfu/videolayerselector/dependencydescriptor.go
+++ b/pkg/sfu/videolayerselector/dependencydescriptor.go
@@ -144,7 +144,7 @@ func (d *DependencyDescriptor) Select(extPkt *buffer.ExtPacket, _layer int32) (r
 		return
 	}
 
-	// // DD-TODO : if bandwidth in congest, could drop the 'Discardable' frame
+	// DD-TODO : if bandwidth in congest, could drop the 'Discardable' frame
 	if dti == dede.DecodeTargetNotPresent {
 		// d.logger.Debugw(fmt.Sprintf("drop packet for decode target not present, highestDecodeTarget %d, incoming %v, fn: %d/%d",
 		// 	highestDecodeTarget,
@@ -188,6 +188,7 @@ func (d *DependencyDescriptor) Select(extPkt *buffer.ExtPacket, _layer int32) (r
 				"req", d.requestSpatial,
 				"maxSeen", d.maxSeenLayer,
 				"feed", extPkt.Packet.SSRC,
+				"frame", extFrameNum,
 			)
 		}
 
@@ -196,7 +197,7 @@ func (d *DependencyDescriptor) Select(extPkt *buffer.ExtPacket, _layer int32) (r
 
 		d.previousActiveDecodeTargetsBitmask = d.activeDecodeTargetsBitmask
 		d.activeDecodeTargetsBitmask = buffer.GetActiveDecodeTargetBitmask(d.currentLayer, ddwdt.DecodeTargets)
-		d.logger.Debugw("switch to target", "highest", highestDecodeTarget.Layer, "current", d.currentLayer, "bitmask", *d.activeDecodeTargetsBitmask)
+		d.logger.Debugw("switch to target", "highest", highestDecodeTarget.Layer, "current", d.currentLayer, "bitmask", *d.activeDecodeTargetsBitmask, "frame", extFrameNum)
 	}
 
 	ddExtension := &dede.DependencyDescriptorExtension{

--- a/pkg/sfu/videolayerselector/framechain.go
+++ b/pkg/sfu/videolayerselector/framechain.go
@@ -49,7 +49,7 @@ func (fc *FrameChain) OnFrame(extFrameNum uint64, fd *dd.FrameDependencyTemplate
 	if fd.ChainDiffs[fc.chainIdx] == 0 {
 		if fc.broken {
 			fc.broken = false
-			fc.logger.Debugw("frame chain intact", "chanIdx", fc.chainIdx)
+			fc.logger.Debugw("frame chain intact", "chanIdx", fc.chainIdx, "frame", extFrameNum)
 		}
 		fc.expectFrames = fc.expectFrames[:0]
 		return true
@@ -62,7 +62,7 @@ func (fc *FrameChain) OnFrame(extFrameNum uint64, fd *dd.FrameDependencyTemplate
 	prevFrameInChain := extFrameNum - uint64(fd.ChainDiffs[fc.chainIdx])
 	sd, err := fc.decisions.GetDecision(prevFrameInChain)
 	if err != nil {
-		fc.logger.Debugw("could not get decision", "err", err, "frame", extFrameNum, "prevFrame", prevFrameInChain)
+		fc.logger.Debugw("could not get decision", "err", err, "chanIdx", fc.chainIdx, "frame", extFrameNum, "prevFrame", prevFrameInChain)
 	}
 
 	var intact bool


### PR DESCRIPTION
SVC has only one stream and when calculating reference time stamp, irrespective of reference layer, reference time stamp will be the same as the given time stamp as there is only one stream and no offset.

TODO: Need better all around SVC handling.