### PR TITLE
Disable h264 for android firefox

### DIFF
--- a/pkg/clientconfiguration/conf.go
+++ b/pkg/clientconfiguration/conf.go
@@ -33,7 +33,8 @@ var StaticConfigurations = []ConfigurationItem{
 	// 	Merge: false,
 	// },
 	{
-		Match: &ScriptMatch{Expr: `c.device_model == "Xiaomi 2201117TI" && c.os == "android"`},
+		Match: &ScriptMatch{Expr: `(c.device_model == "xiaomi 2201117ti" && c.os == "android) ||
+		  ((c.browser == "firefox" || c.browser == "firefox mobile") && (c.os == "linux" || c.os == "android"))`},
 		Configuration: &livekit.ClientConfiguration{
 			DisabledCodecs: &livekit.DisabledCodecs{
 				Publish: []*livekit.Codec{{Mime: "video/h264"}},

--- a/pkg/clientconfiguration/conf.go
+++ b/pkg/clientconfiguration/conf.go
@@ -33,7 +33,7 @@ var StaticConfigurations = []ConfigurationItem{
 	// 	Merge: false,
 	// },
 	{
-		Match: &ScriptMatch{Expr: `(c.device_model == "xiaomi 2201117ti" && c.os == "android) ||
+		Match: &ScriptMatch{Expr: `(c.device_model == "xiaomi 2201117ti" && c.os == "android") ||
 		  ((c.browser == "firefox" || c.browser == "firefox mobile") && (c.os == "linux" || c.os == "android"))`},
 		Configuration: &livekit.ClientConfiguration{
 			DisabledCodecs: &livekit.DisabledCodecs{

--- a/pkg/clientconfiguration/conf_test.go
+++ b/pkg/clientconfiguration/conf_test.go
@@ -55,7 +55,7 @@ func TestScriptMatchConfiguration(t *testing.T) {
 				Merge: true,
 			},
 			{
-				Match: &ScriptMatch{Expr: `c.sdk == "ANDROID"`},
+				Match: &ScriptMatch{Expr: `c.sdk == "android"`},
 				Configuration: &livekit.ClientConfiguration{
 					Video: &livekit.VideoConfiguration{
 						HardwareEncoder: livekit.ClientConfigSetting_DISABLED,

--- a/pkg/clientconfiguration/conf_test.go
+++ b/pkg/clientconfiguration/conf_test.go
@@ -98,7 +98,9 @@ func TestScriptMatch(t *testing.T) {
 		{name: "simple match", expr: `c.protocol > 5`, result: true},
 		{name: "invalid expr", expr: `cc.protocol > 5`, err: true},
 		{name: "unexist field", expr: `c.protocols > 5`, err: true},
-		{name: "combined condition", expr: `c.protocol > 5 && (c.sdk=="ANDROID" || c.sdk=="IOS")`, result: true},
+		{name: "combined condition", expr: `c.protocol > 5 && (c.sdk=="android" || c.sdk=="ios")`, result: true},
+		{name: "combined condition2", expr: `(c.device_model == "xiaomi 2201117ti" && c.os == "android) ||
+		  ((c.browser == "firefox" || c.browser == "firefox mobile") && (c.os == "linux" || c.os == "android"))`, result: false},
 	}
 
 	for _, c := range cases {

--- a/pkg/clientconfiguration/conf_test.go
+++ b/pkg/clientconfiguration/conf_test.go
@@ -99,8 +99,7 @@ func TestScriptMatch(t *testing.T) {
 		{name: "invalid expr", expr: `cc.protocol > 5`, err: true},
 		{name: "unexist field", expr: `c.protocols > 5`, err: true},
 		{name: "combined condition", expr: `c.protocol > 5 && (c.sdk=="android" || c.sdk=="ios")`, result: true},
-		{name: "combined condition2", expr: `(c.device_model == "xiaomi 2201117ti" && c.os == "android) ||
-		  ((c.browser == "firefox" || c.browser == "firefox mobile") && (c.os == "linux" || c.os == "android"))`, result: false},
+		{name: "combined condition2", expr: `(c.device_model == "xiaomi 2201117ti" && c.os == "android) || ((c.browser == "firefox" || c.browser == "firefox mobile") && (c.os == "linux" || c.os == "android"))`, result: false},
 	}
 
 	for _, c := range cases {

--- a/pkg/clientconfiguration/match.go
+++ b/pkg/clientconfiguration/match.go
@@ -17,6 +17,7 @@ package clientconfiguration
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/d5/tengo/v2"
 
@@ -69,19 +70,19 @@ func (c *clientObject) IndexGet(index tengo.Object) (res tengo.Object, err error
 
 	switch field.Value {
 	case "sdk":
-		return &tengo.String{Value: c.info.Sdk.String()}, nil
+		return &tengo.String{Value: strings.ToLower(c.info.Sdk.String())}, nil
 	case "version":
 		return &tengo.String{Value: c.info.Version}, nil
 	case "protocol":
 		return &tengo.Int{Value: int64(c.info.Protocol)}, nil
 	case "os":
-		return &tengo.String{Value: c.info.Os}, nil
+		return &tengo.String{Value: strings.ToLower(c.info.Os)}, nil
 	case "os_version":
 		return &tengo.String{Value: c.info.OsVersion}, nil
 	case "device_model":
-		return &tengo.String{Value: c.info.DeviceModel}, nil
+		return &tengo.String{Value: strings.ToLower(c.info.DeviceModel)}, nil
 	case "browser":
-		return &tengo.String{Value: c.info.Browser}, nil
+		return &tengo.String{Value: strings.ToLower(c.info.Browser)}, nil
 	case "browser_version":
 		return &tengo.String{Value: c.info.BrowserVersion}, nil
 	case "address":

--- a/pkg/clientconfiguration/staticconfiguration.go
+++ b/pkg/clientconfiguration/staticconfiguration.go
@@ -15,8 +15,6 @@
 package clientconfiguration
 
 import (
-	"fmt"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/livekit/protocol/livekit"
@@ -42,7 +40,7 @@ func (s *StaticClientConfigurationManager) GetConfiguration(clientInfo *livekit.
 	for _, c := range s.confs {
 		matched, err := c.Match.Match(clientInfo)
 		if err != nil {
-			logger.Errorw(fmt.Sprintf("matchrule failed, clientInfo: %s", clientInfo.String()), err)
+			logger.Errorw("matchrule failed", err, "clientInfo", clientInfo.String())
 			continue
 		}
 		if !matched {

--- a/pkg/rtc/clientinfo.go
+++ b/pkg/rtc/clientinfo.go
@@ -26,7 +26,7 @@ type ClientInfo struct {
 }
 
 func (c ClientInfo) isFirefox() bool {
-	return c.ClientInfo != nil && strings.EqualFold(c.ClientInfo.Browser, "firefox")
+	return c.ClientInfo != nil && (strings.EqualFold(c.ClientInfo.Browser, "firefox") || strings.EqualFold(c.ClientInfo.Browser, "firefox mobile"))
 }
 
 func (c ClientInfo) isSafari() bool {
@@ -39,6 +39,10 @@ func (c ClientInfo) isGo() bool {
 
 func (c ClientInfo) isLinux() bool {
 	return c.ClientInfo != nil && strings.EqualFold(c.ClientInfo.Os, "linux")
+}
+
+func (c ClientInfo) isAndroid() bool {
+	return c.ClientInfo != nil && strings.EqualFold(c.ClientInfo.Os, "android")
 }
 
 func (c ClientInfo) SupportsAudioRED() bool {
@@ -85,7 +89,7 @@ func (c ClientInfo) SupportsChangeRTPSenderEncodingActive() bool {
 }
 
 func (c ClientInfo) ComplyWithCodecOrderInSDPAnswer() bool {
-	return !(c.isLinux() && c.isFirefox())
+	return !((c.isLinux() || c.isAndroid()) && c.isFirefox())
 }
 
 // compareVersion compares a semver against the current client SDK version

--- a/pkg/rtc/mediaengine.go
+++ b/pkg/rtc/mediaengine.go
@@ -132,3 +132,11 @@ func IsCodecEnabled(codecs []*livekit.Codec, cap webrtc.RTPCodecCapability) bool
 	}
 	return false
 }
+
+func selectAlternativeCodec(mime string) string {
+	if strings.EqualFold(mime, webrtc.MimeTypeVP8) {
+		return webrtc.MimeTypeH264
+	} else {
+		return webrtc.MimeTypeVP8
+	}
+}


### PR DESCRIPTION
Mainly cleaning up where we are doing codec filtering.

There's also behavior change of how we handle codec compatibility. If a client doesn't support the client's desired codec, we'll pick a backup automatically instead of rejecting the client's request.

Requires an update on multi-codec simulcast handling on the client side