### PR TITLE
No sync when starting from nothing

### DIFF
--- a/pkg/sfu/buffer/dependencydescriptorparser.go
+++ b/pkg/sfu/buffer/dependencydescriptorparser.go
@@ -142,6 +142,12 @@ type DependencyDescriptorDecodeTarget struct {
 	Layer  VideoLayer
 }
 
+func (dt *DependencyDescriptorDecodeTarget) String() string {
+	return fmt.Sprintf("DecodeTarget{t: %d, l: %+v}", dt.Target, dt.Layer)
+}
+
+// ------------------------------------------------------------------------------
+
 func ProcessFrameDependencyStructure(structure *dd.FrameDependencyStructure) []DependencyDescriptorDecodeTarget {
 	decodeTargets := make([]DependencyDescriptorDecodeTarget, 0, structure.NumDecodeTargets)
 	for target := 0; target < structure.NumDecodeTargets; target++ {

--- a/pkg/sfu/videolayerselector/dependencydescriptor.go
+++ b/pkg/sfu/videolayerselector/dependencydescriptor.go
@@ -297,12 +297,19 @@ func (d *DependencyDescriptor) updateActiveDecodeTargets(activeDecodeTargetsBitm
 
 func (d *DependencyDescriptor) CheckSync() (locked bool, layer int32) {
 	layer = d.GetRequestSpatial()
+	if !d.currentLayer.IsValid() {
+		// always declare not locked when trying to resume from nothing
+		return false, layer
+	}
+
 	d.decodeTargetsLock.RLock()
 	defer d.decodeTargetsLock.RUnlock()
 	for _, dt := range d.decodeTargets {
 		if dt.Active() && dt.Layer.Spatial == layer && dt.Valid() {
+			d.logger.Debugw(fmt.Sprintf("checking sync, matching decode target, layer: %d, dt: %s, dts: %+v", layer, dt, d.decodeTargets))
 			return true, layer
 		}
 	}
+
 	return false, layer
 }


### PR DESCRIPTION
When starting from scratch (like mute -> unmute), it is possible that the check sync does not detect a broken chain. That results in PLIs not being sent and the video frozen till a gratuitous key frame arrives.

Unclear why there are not PLIs from client side. That is something else to dig into.