### PR TITLE
Don't filter out ipv6 address for client don't support prflx over relay

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -322,6 +322,9 @@ func newPeerConnection(params TransportParams, onBandwidthEstimator func(estimat
 			params.Logger.Infow("client doesn't support prflx over relay, use external ip only as host candidate", "ips", nat1to1Ips)
 			se.SetNAT1To1IPs(nat1to1Ips, webrtc.ICECandidateTypeHost)
 			se.SetIPFilter(func(ip net.IP) bool {
+				if ip.To4() == nil {
+					return true
+				}
 				ipstr := ip.String()
 				for _, inc := range includeIps {
 					if inc == ipstr {


### PR DESCRIPTION
candidate