### PR TITLE
Mark packet relevant only when current layer is valid.

### DIFF
--- a/pkg/sfu/videolayerselector/dependencydescriptor.go
+++ b/pkg/sfu/videolayerselector/dependencydescriptor.go
@@ -58,7 +58,9 @@ func (d *DependencyDescriptor) IsOvershootOkay() bool {
 
 func (d *DependencyDescriptor) Select(extPkt *buffer.ExtPacket, _layer int32) (result VideoLayerSelectorResult) {
 	// a packet is always relevant for the svc codec
-	result.IsRelevant = true
+	if d.currentLayer.IsValid() {
+		result.IsRelevant = true
+	}
 
 	ddwdt := extPkt.DependencyDescriptor
 	if ddwdt == nil {
@@ -92,7 +94,7 @@ func (d *DependencyDescriptor) Select(extPkt *buffer.ExtPacket, _layer int32) (r
 	switch sd {
 	case selectorDecisionDropped:
 		// a packet of an alreadty dropped frame, maintain decision
-		d.logger.Debugw(fmt.Sprintf("drop packet already dropped, incoming %v, fn: %d/%d, sm: %d",
+		d.logger.Debugw(fmt.Sprintf("drop packet already dropped, incoming %v, fn: %d/%d, sn: %d",
 			incomingLayer,
 			dd.FrameNumber,
 			extFrameNum,
@@ -243,6 +245,8 @@ func (d *DependencyDescriptor) Select(extPkt *buffer.ExtPacket, _layer int32) (r
 			"sn", extPkt.Packet.SequenceNumber,
 			"isKeyFrame", extPkt.KeyFrame,
 		)
+
+		result.IsRelevant = true
 	}
 
 	ddExtension := &dede.DependencyDescriptorExtension{

--- a/pkg/sfu/videolayerselector/dependencydescriptor_test.go
+++ b/pkg/sfu/videolayerselector/dependencydescriptor_test.go
@@ -139,7 +139,7 @@ func TestDependencyDescriptor(t *testing.T) {
 	// no dd ext, dropped
 	ret := ddSelector.Select(&buffer.ExtPacket{Packet: &rtp.Packet{}}, 0)
 	require.False(t, ret.IsSelected)
-	require.True(t, ret.IsRelevant)
+	require.False(t, ret.IsRelevant)
 
 	// non key frame, dropped
 	ret = ddSelector.Select(&buffer.ExtPacket{
@@ -156,7 +156,7 @@ func TestDependencyDescriptor(t *testing.T) {
 		Packet: &rtp.Packet{},
 	}, 0)
 	require.False(t, ret.IsSelected)
-	require.True(t, ret.IsRelevant)
+	require.False(t, ret.IsRelevant)
 
 	frames := createDDFrames(buffer.VideoLayer{Spatial: 2, Temporal: 2}, 3)
 	// key frame, update structure and decode targets


### PR DESCRIPTION
Else, it introduces a large sequence number gap.