### PR TITLE
Do not block on down track close with flush.

### DIFF
--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -304,7 +304,12 @@ func (t *MediaTrackSubscriptions) closeSubscribedTrack(subTrack types.Subscribed
 		return
 	}
 
-	dt.CloseWithFlush(!willBeResumed)
+	if willBeResumed {
+		dt.CloseWithFlush(!willBeResumed)
+	} else {
+		// flushing blocks, avoid blocking when publisher removes all its subscribers
+		go dt.CloseWithFlush(!willBeResumed)
+	}
 
 	if willBeResumed {
 		tr := dt.GetTransceiver()

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -306,17 +306,16 @@ func (t *MediaTrackSubscriptions) closeSubscribedTrack(subTrack types.Subscribed
 
 	if willBeResumed {
 		dt.CloseWithFlush(!willBeResumed)
-	} else {
-		// flushing blocks, avoid blocking when publisher removes all its subscribers
-		go dt.CloseWithFlush(!willBeResumed)
-	}
 
-	if willBeResumed {
+		// cache transceiver for potential re-use on resume
 		tr := dt.GetTransceiver()
 		if tr != nil {
 			sub := subTrack.Subscriber()
 			sub.CacheDownTrack(subTrack.ID(), tr, dt.GetState())
 		}
+	} else {
+		// flushing blocks, avoid blocking when publisher removes all its subscribers
+		go dt.CloseWithFlush(!willBeResumed)
 	}
 }
 

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -305,7 +305,7 @@ func (t *MediaTrackSubscriptions) closeSubscribedTrack(subTrack types.Subscribed
 	}
 
 	if willBeResumed {
-		dt.CloseWithFlush(!willBeResumed)
+		dt.CloseWithFlush(false)
 
 		// cache transceiver for potential re-use on resume
 		tr := dt.GetTransceiver()
@@ -315,7 +315,7 @@ func (t *MediaTrackSubscriptions) closeSubscribedTrack(subTrack types.Subscribed
 		}
 	} else {
 		// flushing blocks, avoid blocking when publisher removes all its subscribers
-		go dt.CloseWithFlush(!willBeResumed)
+		go dt.CloseWithFlush(true)
 	}
 }
 


### PR DESCRIPTION
When publisher removes all subscribers, publisher side should not be blocked for long. With close with flush, it could happen if there a lot of bunch of subscribers.

So, when is expected, run it in a goroutine like it is done in subscription manager.

Not moving the entire `RemoveSubscriber` bit to subscription manager as there are two bits which are not tracked now
- mime type
- willBeResumed Those two would have to be tracked in track manager and notified to subscription manager so that it can act for that mine and if the track will be resumed or not. As that touch more parts and could get complicated, doing the simpler thing of cloning behaviour from subscription manager for now.