### PR TITLE
Declare audio inactive if stale.

### DIFF
--- a/pkg/sfu/audio/audiolevel.go
+++ b/pkg/sfu/audio/audiolevel.go
@@ -66,7 +66,7 @@ func NewAudioLevel(params AudioLevelParams) *AudioLevel {
 	return l
 }
 
-// Observes a new frame, must be called from the same thread
+// Observes a new frame
 func (l *AudioLevel) Observe(level uint8, durationMs uint32, arrivalTime time.Time) {
 	l.lock.Lock()
 	defer l.lock.Unlock()

--- a/pkg/sfu/audio/audiolevel_test.go
+++ b/pkg/sfu/audio/audiolevel_test.go
@@ -87,7 +87,7 @@ func TestAudioLevel(t *testing.T) {
 		require.Less(t, level, ConvertAudioLevel(float64(25)))
 	})
 
-	t.Run("not noist when samples are stale", func(t *testing.T) {
+	t.Run("not noisy when samples are stale", func(t *testing.T) {
 		clock := time.Now()
 		a := createAudioLevel(defaultActiveLevel, defaultPercentile, defaultObserveDuration)
 

--- a/pkg/sfu/audio/audiolevel_test.go
+++ b/pkg/sfu/audio/audiolevel_test.go
@@ -16,6 +16,7 @@ package audio
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -30,45 +31,77 @@ const (
 
 func TestAudioLevel(t *testing.T) {
 	t.Run("initially to return not noisy, within a few samples", func(t *testing.T) {
+		clock := time.Now()
 		a := createAudioLevel(defaultActiveLevel, defaultPercentile, defaultObserveDuration)
-		_, noisy := a.GetLevel()
+
+		_, noisy := a.GetLevel(clock)
 		require.False(t, noisy)
 
-		observeSamples(a, 28, 5)
-		_, noisy = a.GetLevel()
+		observeSamples(a, 28, 5, clock)
+		clock = clock.Add(5 * 20 * time.Millisecond)
+
+		_, noisy = a.GetLevel(clock)
 		require.False(t, noisy)
 	})
 
 	t.Run("not noisy when all samples are below threshold", func(t *testing.T) {
+		clock := time.Now()
 		a := createAudioLevel(defaultActiveLevel, defaultPercentile, defaultObserveDuration)
 
-		observeSamples(a, 35, 100)
-		_, noisy := a.GetLevel()
+		observeSamples(a, 35, 100, clock)
+		clock = clock.Add(100 * 20 * time.Millisecond)
+
+		_, noisy := a.GetLevel(clock)
 		require.False(t, noisy)
 	})
 
 	t.Run("not noisy when less than percentile samples are above threshold", func(t *testing.T) {
+		clock := time.Now()
 		a := createAudioLevel(defaultActiveLevel, defaultPercentile, defaultObserveDuration)
 
-		observeSamples(a, 35, samplesPerBatch-2)
-		observeSamples(a, 25, 1)
-		observeSamples(a, 35, 1)
+		observeSamples(a, 35, samplesPerBatch-2, clock)
+		clock = clock.Add((samplesPerBatch - 2) * 20 * time.Millisecond)
+		observeSamples(a, 25, 1, clock)
+		clock = clock.Add(20 * time.Millisecond)
+		observeSamples(a, 35, 1, clock)
+		clock = clock.Add(20 * time.Millisecond)
 
-		_, noisy := a.GetLevel()
+		_, noisy := a.GetLevel(clock)
 		require.False(t, noisy)
 	})
 
 	t.Run("noisy when higher than percentile samples are above threshold", func(t *testing.T) {
+		clock := time.Now()
 		a := createAudioLevel(defaultActiveLevel, defaultPercentile, defaultObserveDuration)
 
-		observeSamples(a, 35, samplesPerBatch-16)
-		observeSamples(a, 25, 8)
-		observeSamples(a, 29, 8)
+		observeSamples(a, 35, samplesPerBatch-16, clock)
+		clock = clock.Add((samplesPerBatch - 16) * 20 * time.Millisecond)
+		observeSamples(a, 25, 8, clock)
+		clock = clock.Add(8 * 20 * time.Millisecond)
+		observeSamples(a, 29, 8, clock)
+		clock = clock.Add(8 * 20 * time.Millisecond)
 
-		level, noisy := a.GetLevel()
+		level, noisy := a.GetLevel(clock)
 		require.True(t, noisy)
 		require.Greater(t, level, ConvertAudioLevel(float64(defaultActiveLevel)))
 		require.Less(t, level, ConvertAudioLevel(float64(25)))
+	})
+
+	t.Run("not noist when samples are stale", func(t *testing.T) {
+		clock := time.Now()
+		a := createAudioLevel(defaultActiveLevel, defaultPercentile, defaultObserveDuration)
+
+		observeSamples(a, 25, 100, clock)
+		clock = clock.Add(100 * 20 * time.Millisecond)
+		level, noisy := a.GetLevel(clock)
+		require.True(t, noisy)
+		require.Greater(t, level, ConvertAudioLevel(float64(defaultActiveLevel)))
+		require.Less(t, level, ConvertAudioLevel(float64(20)))
+
+		// let enough time pass to make the samples stale
+		clock = clock.Add(1500 * time.Millisecond)
+		_, noisy = a.GetLevel(clock)
+		require.False(t, noisy)
 	})
 }
 
@@ -80,8 +113,8 @@ func createAudioLevel(activeLevel uint8, minPercentile uint8, observeDuration ui
 	})
 }
 
-func observeSamples(a *AudioLevel, level uint8, count int) {
+func observeSamples(a *AudioLevel, level uint8, count int, baseTime time.Time) {
 	for i := 0; i < count; i++ {
-		a.Observe(level, 20)
+		a.Observe(level, 20, baseTime.Add(+time.Duration(i*20)*time.Millisecond))
 	}
 }

--- a/pkg/sfu/audio/audiolevel_test.go
+++ b/pkg/sfu/audio/audiolevel_test.go
@@ -100,7 +100,8 @@ func TestAudioLevel(t *testing.T) {
 
 		// let enough time pass to make the samples stale
 		clock = clock.Add(1500 * time.Millisecond)
-		_, noisy = a.GetLevel(clock)
+		level, noisy = a.GetLevel(clock)
+		require.Equal(t, float64(0.0), level)
 		require.False(t, noisy)
 	})
 }

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -583,7 +583,7 @@ func (b *Buffer) processHeaderExtensions(p *rtp.Packet, arrivalTime time.Time) {
 				if (p.Timestamp - b.latestTSForAudioLevel) < (1 << 31) {
 					duration := (int64(p.Timestamp) - int64(b.latestTSForAudioLevel)) * 1e3 / int64(b.clockRate)
 					if duration > 0 {
-						b.audioLevel.Observe(ext.Level, uint32(duration))
+						b.audioLevel.Observe(ext.Level, uint32(duration), arrivalTime)
 					}
 
 					b.latestTSForAudioLevel = p.Timestamp
@@ -842,7 +842,7 @@ func (b *Buffer) GetAudioLevel() (float64, bool) {
 		return 0, false
 	}
 
-	return b.audioLevel.GetLevel()
+	return b.audioLevel.GetLevel(time.Now())
 }
 
 func (b *Buffer) OnFpsChanged(f func()) {


### PR DESCRIPTION
Stale samples were used to declare audio active.
Maintain last update time and declare inactive if samples are stale.

Addresses https://github.com/livekit/livekit/issues/2228 and using the stale check approach suggested by @shoyu666 in that bug.