### PR TITLE
Use a worker to report signal/data stats.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -786,7 +786,7 @@ func (p *ParticipantImpl) Close(sendLeave bool, reason types.ParticipantCloseRea
 		p.TransportManager.Close()
 	}()
 
-	p.dataChannelStats.Report()
+	p.dataChannelStats.Stop()
 	return nil
 }
 

--- a/pkg/service/rtcservice.go
+++ b/pkg/service/rtcservice.go
@@ -269,7 +269,7 @@ func (s *RTCService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		close(done)
 
 		if signalStats != nil {
-			signalStats.Report()
+			signalStats.Stop()
 		}
 	}()
 

--- a/pkg/telemetry/signalanddatastats.go
+++ b/pkg/telemetry/signalanddatastats.go
@@ -25,8 +25,6 @@ import (
 	"github.com/livekit/protocol/utils"
 )
 
-const statsReportInterval = 10 * time.Second
-
 type BytesTrackType string
 
 const (

--- a/pkg/telemetry/statsworker.go
+++ b/pkg/telemetry/statsworker.go
@@ -126,8 +126,6 @@ func (s *StatsWorker) ClosedAt() time.Time {
 	return s.closedAt
 }
 
-// -------------------------------------------------------------------------
-
 func (s *StatsWorker) collectStats(
 	ts *timestamppb.Timestamp,
 	streamType livekit.StreamType,
@@ -150,6 +148,8 @@ func (s *StatsWorker) collectStats(
 	}
 	return stats
 }
+
+// -------------------------------------------------------------------------
 
 // create a single stream and single video layer post aggregation
 func coalesce(stats []*livekit.AnalyticsStat) *livekit.AnalyticsStat {


### PR DESCRIPTION
Was checking if reporting is needed on every update. The check is wasted work if volume of signal/data messages is high as reporting happens only once in 10 seconds.

Changing to a worker based on a timer. And also aligning with telemetry reporting interval which defaults to 30 seconds.