### PR TITLE
Send data

### DIFF
--- a/pkg/routing/localrouter.go
+++ b/pkg/routing/localrouter.go
@@ -142,7 +142,6 @@ func (r *LocalRouter) WriteNodeRTC(_ context.Context, _ string, msg *livekit.RTC
 }
 
 func (r *LocalRouter) writeRTCMessage(sink MessageSink, msg *livekit.RTCNodeMessage) error {
-	defer sink.Close()
 	msg.SenderTime = time.Now().Unix()
 	return sink.WriteMessage(msg)
 }
@@ -171,6 +170,8 @@ func (r *LocalRouter) Drain() {
 }
 
 func (r *LocalRouter) Stop() {
+	// make sure that rtcMessageWorker terminates
+	// r.isStarted.Swap(false)
 	r.rtcMessageChan.Close()
 }
 

--- a/pkg/routing/localrouter.go
+++ b/pkg/routing/localrouter.go
@@ -170,8 +170,6 @@ func (r *LocalRouter) Drain() {
 }
 
 func (r *LocalRouter) Stop() {
-	// make sure that rtcMessageWorker terminates
-	// r.isStarted.Swap(false)
 	r.rtcMessageChan.Close()
 }
 

--- a/pkg/routing/redisrouter.go
+++ b/pkg/routing/redisrouter.go
@@ -215,6 +215,7 @@ func (r *RedisRouter) WriteParticipantRTC(_ context.Context, roomName livekit.Ro
 	rtcSink := NewRTCNodeSink(r.rc, livekit.NodeID(rtcNode), "ephemeral", pkey, pkeyB62)
 	msg.ParticipantKey = string(ParticipantKeyLegacy(roomName, identity))
 	msg.ParticipantKeyB62 = string(ParticipantKey(roomName, identity))
+	defer rtcSink.Close()
 	return r.writeRTCMessage(rtcSink, msg)
 }
 
@@ -230,6 +231,7 @@ func (r *RedisRouter) WriteRoomRTC(ctx context.Context, roomName livekit.RoomNam
 
 func (r *RedisRouter) WriteNodeRTC(_ context.Context, rtcNodeID string, msg *livekit.RTCNodeMessage) error {
 	rtcSink := NewRTCNodeSink(r.rc, livekit.NodeID(rtcNodeID), "ephemeral", livekit.ParticipantKey(msg.ParticipantKey), livekit.ParticipantKey(msg.ParticipantKeyB62))
+	defer rtcSink.Close()
 	return r.writeRTCMessage(rtcSink, msg)
 }
 


### PR DESCRIPTION
The current implementation closes the sink after each message. rtcMessageWorker will then loop, detect the closed channel and sleep for 1 second. If multiple message are sent during this time they will be dropped as each message will create (and drop) the channel.

This PR moves closing the sink back into RedisRouter to keep the current functionality. LocalRouter only closes the channel on shutdown.