### PR TITLE
Restrict scope of negotiation time out error logs

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2308,7 +2308,7 @@ func (p *ParticipantImpl) onSubscriptionError(trackID livekit.TrackID, fatal boo
 }
 
 func (p *ParticipantImpl) onAnyTransportNegotiationFailed() {
-	if p.TransportManager.SinceLastSignal() < negotiationFailedTimeout {
+	if p.TransportManager.SinceLastSignal() < negotiationFailedTimeout/2 {
 		p.params.Logger.Infow("negotiation failed, starting full reconnect")
 	}
 	p.IssueFullReconnect(types.ParticipantCloseReasonNegotiateFailed)

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -390,7 +390,7 @@ func NewPCTransport(params TransportParams) (*PCTransport, error) {
 		params:                   params,
 		debouncedNegotiate:       debounce.New(negotiationFrequency),
 		negotiationState:         NegotiationStateNone,
-		eventCh:                  make(chan event, 50),
+		eventCh:                  make(chan event, 100),
 		previousTrackDescription: make(map[string]*trackDescription),
 		canReuseTransceiver:      true,
 		allowedLocalCandidates:   utils.NewDedupedSlice[string](maxICECandidates),
@@ -1682,7 +1682,7 @@ func (t *PCTransport) setupSignalStateCheckTimer() {
 
 		failed := t.negotiationState != NegotiationStateNone
 
-		if t.negotiateCounter.Load() == negotiateVersion && failed {
+		if t.negotiateCounter.Load() == negotiateVersion && failed && t.pc.ConnectionState() == webrtc.PeerConnectionStateConnected {
 			t.params.Logger.Infow(
 				"negotiation timed out",
 				"localCurrent", t.pc.CurrentLocalDescription(),
@@ -1944,6 +1944,8 @@ func (t *PCTransport) handleRemoteOfferReceived(sd *webrtc.SessionDescription) e
 }
 
 func (t *PCTransport) handleRemoteAnswerReceived(sd *webrtc.SessionDescription) error {
+	t.clearSignalStateCheckTimer()
+
 	if err := t.setRemoteDescription(*sd); err != nil {
 		// Pion will call RTPSender.Send method for each new added Downtrack, and return error if the DownTrack.Bind
 		// returns error. In case of Downtrack.Bind returns ErrUnsupportedCodec, the signal state will be stable as negotiation is aleady compelted
@@ -1953,8 +1955,6 @@ func (t *PCTransport) handleRemoteAnswerReceived(sd *webrtc.SessionDescription) 
 			return err
 		}
 	}
-
-	t.clearSignalStateCheckTimer()
 
 	if t.negotiationState == NegotiationStateRetry {
 		t.setNegotiationState(NegotiationStateNone)

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -555,7 +555,7 @@ func (s *StreamAllocator) postEvent(event Event) {
 	select {
 	case s.eventCh <- event:
 	default:
-		s.params.Logger.Warnw("stream allocator: event queue full", nil)
+		s.params.Logger.Warnw("stream allocator: event queue full", nil, "event", event.String())
 	}
 	s.eventChMu.RUnlock()
 }


### PR DESCRIPTION
1. Log "negotiation failed" only if signal channel was active within half window of negotiation timeout. Negotiation timeout currently is at 15 seconds. Signal pings are every 10 seconds.
2. In transport.go, do not report negotiation timed out and do not callback negotiation failure if the peer connection state is not connected. Goal of negotiation failure tracker is to take remedial action when an in-session negotiation fails. Seeing a bunch of cases of the case hitting even without ICE connection forming. Negotiation timer is not intended for those cases.