### PR TITLE
Fix log marshal error

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -352,7 +352,7 @@ func (b *Buffer) Close() error {
 			b.rtpStats.Stop()
 			b.logger.Debugw("rtp stats",
 				"direction", "upstream",
-				"stats", func() interface{} { return b.rtpStats.ToString() },
+				"stats", b.rtpStats,
 			)
 			if b.onFinalRtpStats != nil {
 				b.onFinalRtpStats(b.rtpStats.ToProto())

--- a/pkg/sfu/buffer/rtpstats_receiver.go
+++ b/pkg/sfu/buffer/rtpstats_receiver.go
@@ -402,7 +402,7 @@ func (r *RTPStatsReceiver) DeltaInfo(snapshotID uint32) *RTPDeltaInfo {
 	return r.deltaInfo(snapshotID, r.sequenceNumber.GetExtendedStart(), r.sequenceNumber.GetExtendedHighest())
 }
 
-func (r *RTPStatsReceiver) ToString() string {
+func (r *RTPStatsReceiver) String() string {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 

--- a/pkg/sfu/buffer/rtpstats_receiver_test.go
+++ b/pkg/sfu/buffer/rtpstats_receiver_test.go
@@ -20,9 +20,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/livekit/protocol/logger"
 	"github.com/pion/rtp"
 	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/protocol/logger"
 )
 
 func getPacket(sn uint16, ts uint32, payloadSize int) *rtp.Packet {
@@ -82,7 +83,7 @@ func Test_RTPStatsReceiver(t *testing.T) {
 	}
 
 	r.Stop()
-	fmt.Printf("%s\n", r.ToString())
+	fmt.Printf("%s\n", r.String())
 }
 
 func Test_RTPStatsReceiver_Update(t *testing.T) {

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -989,9 +989,8 @@ func (d *DownTrack) CloseWithFlush(flush bool) {
 		"mime", d.mime,
 		"ssrc", d.ssrc,
 		// evaluate only if log level matches
-		"stats", func() interface{} {
-			return d.rtpStats.ToString()
-		})
+		"stats", d.rtpStats,
+	)
 
 	d.maxLayerNotifierChMu.Lock()
 	d.maxLayerNotifierChClosed = true


### PR DESCRIPTION
There are `json: unsupported type: func() interface {}` error in the function evaluation for log value,  use a fmt.Stringer instead for lazy evaluation