### PR TITLE
Log track info when media published.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1341,6 +1341,7 @@ func (p *ParticipantImpl) onMediaTrack(track *webrtc.TrackRemote, rtpReceiver *w
 		"rid", track.RID(),
 		"SSRC", track.SSRC(),
 		"mime", track.Codec().MimeType,
+		"trackInfo", logger.Proto(publishedTrack.ToProto()),
 	)
 
 	if !isNewTrack && !publishedTrack.HasPendingCodec() && p.IsReady() {


### PR DESCRIPTION
With pending track added moved to Debugw, will be good to have this when track is published.