### PR TITLE
Populate disconnect updates with participant identity

### DIFF
--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -212,9 +212,10 @@ func (p *ParticipantImpl) sendDisconnectUpdatesForReconnect() error {
 				break
 			} else if info.state == livekit.ParticipantInfo_DISCONNECTED {
 				disconnectedParticipants = append(disconnectedParticipants, &livekit.ParticipantInfo{
-					Sid:     string(keys[i]),
-					Version: info.version,
-					State:   livekit.ParticipantInfo_DISCONNECTED,
+					Sid:      string(keys[i]),
+					Identity: string(p.Identity()),
+					Version:  info.version,
+					State:    livekit.ParticipantInfo_DISCONNECTED,
 				})
 			}
 		}


### PR DESCRIPTION
With client libs switching to processing primarily participant identities, we'll want the participant info to always be populated with the participant's identity.