### PR TITLE
Fix panic occurs when starting livekit-server with key-file option

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -652,6 +652,7 @@ func (conf *Config) ValidateKeys() error {
 			_ = f.Close()
 		}()
 		decoder := yaml.NewDecoder(f)
+		conf.Keys = map[string]string{}
 		if err = decoder.Decode(conf.Keys); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fix: #2312 

Fixed an issue where a panic would occur when starting livekit-server with API Key and API secret specified in the key-file option.