### PR TITLE
Store identity in participant update cache.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -76,13 +76,14 @@ type downTrackState struct {
 // ---------------------------------------------------------------
 
 type participantUpdateInfo struct {
+	identity  livekit.ParticipantIdentity
 	version   uint32
 	state     livekit.ParticipantInfo_State
 	updatedAt time.Time
 }
 
 func (p participantUpdateInfo) String() string {
-	return fmt.Sprintf("version: %d, state: %s, updatedAt: %s", p.version, p.state.String(), p.updatedAt.String())
+	return fmt.Sprintf("identity: %s, version: %d, state: %s, updatedAt: %s", p.identity, p.version, p.state.String(), p.updatedAt.String())
 }
 
 // ---------------------------------------------------------------

--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -44,7 +44,12 @@ func (p *ParticipantImpl) SendJoinResponse(joinResponse *livekit.JoinResponse) e
 	// keep track of participant updates and versions
 	p.updateLock.Lock()
 	for _, op := range joinResponse.OtherParticipants {
-		p.updateCache.Add(livekit.ParticipantID(op.Sid), participantUpdateInfo{version: op.Version, state: op.State, updatedAt: time.Now()})
+		p.updateCache.Add(livekit.ParticipantID(op.Sid), participantUpdateInfo{
+			identity:  livekit.ParticipantIdentity(op.Identity),
+			version:   op.Version,
+			state:     op.State,
+			updatedAt: time.Now(),
+		})
 	}
 	p.updateLock.Unlock()
 
@@ -104,7 +109,12 @@ func (p *ParticipantImpl) SendParticipantUpdate(participantsToUpdate []*livekit.
 			isValid = false
 		}
 		if isValid {
-			p.updateCache.Add(pID, participantUpdateInfo{version: pi.Version, state: pi.State, updatedAt: time.Now()})
+			p.updateCache.Add(pID, participantUpdateInfo{
+				identity:  livekit.ParticipantIdentity(pi.Identity),
+				version:   pi.Version,
+				state:     pi.State,
+				updatedAt: time.Now(),
+			})
 			validUpdates = append(validUpdates, pi)
 		}
 	}
@@ -213,7 +223,7 @@ func (p *ParticipantImpl) sendDisconnectUpdatesForReconnect() error {
 			} else if info.state == livekit.ParticipantInfo_DISCONNECTED {
 				disconnectedParticipants = append(disconnectedParticipants, &livekit.ParticipantInfo{
 					Sid:      string(keys[i]),
-					Identity: string(p.Identity()),
+					Identity: string(info.identity),
 					Version:  info.version,
 					State:    livekit.ParticipantInfo_DISCONNECTED,
 				})
@@ -221,6 +231,10 @@ func (p *ParticipantImpl) sendDisconnectUpdatesForReconnect() error {
 		}
 	}
 	p.updateLock.Unlock()
+
+	if len(disconnectedParticipants) == 0 {
+		return nil
+	}
 
 	return p.writeMessage(&livekit.SignalResponse{
 		Message: &livekit.SignalResponse_Update{


### PR DESCRIPTION
Need to store identity of other partiicpant in cache so that it can be sent with the disconnected participant update. Side note: Feels like the cache can be made to hold the full proto to make things simpler, but just adding a field for now.