### PR TITLE
Consolidate TrackInfo. 

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -252,12 +252,13 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.Tra
 				}
 			}
 		})
-		// TELEMETRY-MIME-TODO: these need to be receiver/mime aware, setting it up only for primary now
+		// SIMULCAST-CODEC-TODO: these need to be receiver/mime aware, setting it up only for primary now
 		if priority == 0 {
 			newWR.OnStatsUpdate(func(_ *sfu.WebRTCReceiver, stat *livekit.AnalyticsStat) {
 				key := telemetry.StatsKeyForTrack(livekit.StreamType_UPSTREAM, t.PublisherID(), t.ID(), ti.Source, ti.Type)
 				t.params.Telemetry.TrackStats(key, stat)
 			})
+
 			newWR.OnMaxLayerChange(t.onMaxLayerChange)
 		}
 		if t.PrimaryReceiver() == nil {

--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pion/rtcp"
 	"github.com/pion/webrtc/v3"
 	"go.uber.org/atomic"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/livekit/mediatransportutil/pkg/twcc"
 	"github.com/livekit/protocol/livekit"
@@ -165,7 +164,7 @@ func (t *MediaTrack) HasSdpCid(cid string) bool {
 		return true
 	}
 
-	ti := t.MediaTrackReceiver.TrackInfo()
+	ti := t.MediaTrackReceiver.TrackInfoClone()
 	for _, c := range ti.Codecs {
 		if c.Cid == cid {
 			return true
@@ -175,7 +174,7 @@ func (t *MediaTrack) HasSdpCid(cid string) bool {
 }
 
 func (t *MediaTrack) ToProto() *livekit.TrackInfo {
-	return proto.Clone(t.MediaTrackReceiver.TrackInfo()).(*livekit.TrackInfo)
+	return t.MediaTrackReceiver.TrackInfoClone()
 }
 
 func (t *MediaTrack) UpdateCodecCid(codecs []*livekit.SimulcastCodec) {
@@ -208,7 +207,7 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.Tra
 		}
 	})
 
-	ti := t.MediaTrackReceiver.TrackInfo()
+	ti := t.MediaTrackReceiver.TrackInfoClone()
 	t.lock.Lock()
 	mime := strings.ToLower(track.Codec().MimeType)
 	layer := buffer.RidToSpatialLayer(track.RID(), ti)

--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pion/rtcp"
 	"github.com/pion/webrtc/v3"
 	"go.uber.org/atomic"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/livekit/mediatransportutil/pkg/twcc"
 	"github.com/livekit/protocol/livekit"
@@ -174,7 +175,7 @@ func (t *MediaTrack) HasSdpCid(cid string) bool {
 }
 
 func (t *MediaTrack) ToProto() *livekit.TrackInfo {
-	return t.MediaTrackReceiver.TrackInfo()
+	return proto.Clone(t.MediaTrackReceiver.TrackInfo()).(*livekit.TrackInfo)
 }
 
 func (t *MediaTrack) UpdateCodecCid(codecs []*livekit.SimulcastCodec) {

--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -177,8 +177,8 @@ func (t *MediaTrack) ToProto() *livekit.TrackInfo {
 	return t.MediaTrackReceiver.TrackInfo()
 }
 
-func (t *MediaTrack) SetPendingCodecSid(codecs []*livekit.SimulcastCodec) {
-	t.MediaTrackReceiver.SetPendingCodecSid(codecs)
+func (t *MediaTrack) UpdateCodecCid(codecs []*livekit.SimulcastCodec) {
+	t.MediaTrackReceiver.UpdateCodecCid(codecs)
 }
 
 // AddReceiver adds a new RTP receiver to the track, returns true when receiver represents a new codec

--- a/pkg/rtc/mediatrack_test.go
+++ b/pkg/rtc/mediatrack_test.go
@@ -35,9 +35,7 @@ func TestTrackInfo(t *testing.T) {
 		Muted:     true,
 	}
 
-	mt := NewMediaTrack(MediaTrackParams{
-		TrackInfo: &ti,
-	})
+	mt := NewMediaTrack(MediaTrackParams{}, &ti)
 	outInfo := mt.ToProto()
 	require.Equal(t, ti.Muted, outInfo.Muted)
 	require.Equal(t, ti.Name, outInfo.Name)
@@ -51,17 +49,17 @@ func TestTrackInfo(t *testing.T) {
 	require.Equal(t, ti.Simulcast, outInfo.Simulcast)
 
 	// make it simulcasted
-	mt.simulcasted.Store(true)
+	mt.SetSimulcast(true)
 	require.True(t, mt.ToProto().Simulcast)
 }
 
 func TestGetQualityForDimension(t *testing.T) {
 	t.Run("landscape source", func(t *testing.T) {
-		mt := NewMediaTrack(MediaTrackParams{TrackInfo: &livekit.TrackInfo{
+		mt := NewMediaTrack(MediaTrackParams{}, &livekit.TrackInfo{
 			Type:   livekit.TrackType_VIDEO,
 			Width:  1080,
 			Height: 720,
-		}})
+		})
 
 		require.Equal(t, livekit.VideoQuality_LOW, mt.GetQualityForDimension(120, 120))
 		require.Equal(t, livekit.VideoQuality_LOW, mt.GetQualityForDimension(300, 200))
@@ -71,11 +69,11 @@ func TestGetQualityForDimension(t *testing.T) {
 	})
 
 	t.Run("portrait source", func(t *testing.T) {
-		mt := NewMediaTrack(MediaTrackParams{TrackInfo: &livekit.TrackInfo{
+		mt := NewMediaTrack(MediaTrackParams{}, &livekit.TrackInfo{
 			Type:   livekit.TrackType_VIDEO,
 			Width:  540,
 			Height: 960,
-		}})
+		})
 
 		require.Equal(t, livekit.VideoQuality_LOW, mt.GetQualityForDimension(200, 400))
 		require.Equal(t, livekit.VideoQuality_MEDIUM, mt.GetQualityForDimension(400, 400))
@@ -84,7 +82,7 @@ func TestGetQualityForDimension(t *testing.T) {
 	})
 
 	t.Run("layers provided", func(t *testing.T) {
-		mt := NewMediaTrack(MediaTrackParams{TrackInfo: &livekit.TrackInfo{
+		mt := NewMediaTrack(MediaTrackParams{}, &livekit.TrackInfo{
 			Type:   livekit.TrackType_VIDEO,
 			Width:  1080,
 			Height: 720,
@@ -105,7 +103,7 @@ func TestGetQualityForDimension(t *testing.T) {
 					Height:  720,
 				},
 			},
-		}})
+		})
 
 		require.Equal(t, livekit.VideoQuality_LOW, mt.GetQualityForDimension(120, 120))
 		require.Equal(t, livekit.VideoQuality_LOW, mt.GetQualityForDimension(300, 300))
@@ -114,7 +112,7 @@ func TestGetQualityForDimension(t *testing.T) {
 	})
 
 	t.Run("highest layer with smallest dimensions", func(t *testing.T) {
-		mt := NewMediaTrack(MediaTrackParams{TrackInfo: &livekit.TrackInfo{
+		mt := NewMediaTrack(MediaTrackParams{}, &livekit.TrackInfo{
 			Type:   livekit.TrackType_VIDEO,
 			Width:  1080,
 			Height: 720,
@@ -135,7 +133,7 @@ func TestGetQualityForDimension(t *testing.T) {
 					Height:  720,
 				},
 			},
-		}})
+		})
 
 		require.Equal(t, livekit.VideoQuality_LOW, mt.GetQualityForDimension(120, 120))
 		require.Equal(t, livekit.VideoQuality_LOW, mt.GetQualityForDimension(300, 300))
@@ -143,7 +141,7 @@ func TestGetQualityForDimension(t *testing.T) {
 		require.Equal(t, livekit.VideoQuality_HIGH, mt.GetQualityForDimension(1000, 700))
 		require.Equal(t, livekit.VideoQuality_HIGH, mt.GetQualityForDimension(1200, 800))
 
-		mt = NewMediaTrack(MediaTrackParams{TrackInfo: &livekit.TrackInfo{
+		mt = NewMediaTrack(MediaTrackParams{}, &livekit.TrackInfo{
 			Type:   livekit.TrackType_VIDEO,
 			Width:  1080,
 			Height: 720,
@@ -164,7 +162,7 @@ func TestGetQualityForDimension(t *testing.T) {
 					Height:  720,
 				},
 			},
-		}})
+		})
 
 		require.Equal(t, livekit.VideoQuality_MEDIUM, mt.GetQualityForDimension(120, 120))
 		require.Equal(t, livekit.VideoQuality_MEDIUM, mt.GetQualityForDimension(300, 300))

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -713,6 +713,13 @@ func (t *MediaTrackReceiver) TrackInfo() *livekit.TrackInfo {
 	return t.trackInfo
 }
 
+func (t *MediaTrackReceiver) TrackInfoClone() *livekit.TrackInfo {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	return proto.Clone(t.trackInfo).(*livekit.TrackInfo)
+}
+
 func (t *MediaTrackReceiver) NotifyMaxLayerChange(maxLayer int32) {
 	t.lock.RLock()
 	quality := buffer.SpatialLayerToVideoQuality(maxLayer, t.trackInfo)

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -633,6 +633,7 @@ func (t *MediaTrackReceiver) UpdateTrackInfo(ti *livekit.TrackInfo) {
 					}
 				}
 			}
+			break
 		}
 
 		if i == 0 {

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -197,14 +197,18 @@ func (t *MediaTrackReceiver) SetupReceiver(receiver sfu.TrackReceiver, priority 
 		}
 	}
 
-	onSetupReceiver := t.onSetupReceiver
+	var receiverCodecs []string
+	for _, r := range t.receivers {
+		receiverCodecs = append(receiverCodecs, r.Codec().MimeType)
+	}
 	t.params.Logger.Debugw(
 		"setup receiver",
 		"mime", receiver.Codec().MimeType,
 		"priority", priority,
-		"receivers", t.receivers,
+		"receivers", receiverCodecs,
 		"mid", mid,
 	)
+	onSetupReceiver := t.onSetupReceiver
 	t.lock.Unlock()
 
 	if onSetupReceiver != nil {

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1907,7 +1907,6 @@ func (p *ParticipantImpl) addMigrateMutedTrack(cid string, ti *livekit.TrackInfo
 
 func (p *ParticipantImpl) addMediaTrack(signalCid string, sdpCid string, ti *livekit.TrackInfo) *MediaTrack {
 	mt := NewMediaTrack(MediaTrackParams{
-		TrackInfo:           proto.Clone(ti).(*livekit.TrackInfo),
 		SignalCid:           signalCid,
 		SdpCid:              sdpCid,
 		ParticipantID:       p.params.SID,
@@ -1923,7 +1922,7 @@ func (p *ParticipantImpl) addMediaTrack(signalCid string, sdpCid string, ti *liv
 		SubscriberConfig:    p.params.Config.Subscriber,
 		PLIThrottleConfig:   p.params.PLIThrottleConfig,
 		SimTracks:           p.params.SimTracks,
-	})
+	}, ti)
 
 	mt.OnSubscribedMaxQualityChange(p.onSubscribedMaxQualityChange)
 

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1622,7 +1622,7 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 			return nil
 		}
 
-		track.(*MediaTrack).SetPendingCodecSid(req.SimulcastCodecs)
+		track.(*MediaTrack).UpdateCodecCid(req.SimulcastCodecs)
 		ti := track.ToProto()
 		return ti
 	}

--- a/pkg/rtc/participant_sdp.go
+++ b/pkg/rtc/participant_sdp.go
@@ -242,7 +242,7 @@ func (p *ParticipantImpl) configurePublisherAnswer(answer webrtc.SessionDescript
 						_, ti, _ = p.getPendingTrack(streamID, livekit.TrackType_AUDIO)
 						p.pendingTracksLock.RUnlock()
 					} else {
-						ti = track.TrackInfo(false)
+						ti = track.ToProto()
 					}
 					break
 				}

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -446,7 +446,6 @@ type MediaTrack interface {
 
 	UpdateTrackInfo(ti *livekit.TrackInfo)
 	ToProto() *livekit.TrackInfo
-	Version() utils.TimedVersion
 
 	PublisherID() livekit.ParticipantID
 	PublisherIdentity() livekit.ParticipantIdentity

--- a/pkg/rtc/types/typesfakes/fake_local_media_track.go
+++ b/pkg/rtc/types/typesfakes/fake_local_media_track.go
@@ -7,7 +7,6 @@ import (
 	"github.com/livekit/livekit-server/pkg/rtc/types"
 	"github.com/livekit/livekit-server/pkg/sfu"
 	"github.com/livekit/protocol/livekit"
-	"github.com/livekit/protocol/utils"
 )
 
 type FakeLocalMediaTrack struct {
@@ -342,16 +341,6 @@ type FakeLocalMediaTrack struct {
 	updateVideoLayersMutex       sync.RWMutex
 	updateVideoLayersArgsForCall []struct {
 		arg1 []*livekit.VideoLayer
-	}
-	VersionStub        func() utils.TimedVersion
-	versionMutex       sync.RWMutex
-	versionArgsForCall []struct {
-	}
-	versionReturns struct {
-		result1 utils.TimedVersion
-	}
-	versionReturnsOnCall map[int]struct {
-		result1 utils.TimedVersion
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -2157,59 +2146,6 @@ func (fake *FakeLocalMediaTrack) UpdateVideoLayersArgsForCall(i int) []*livekit.
 	return argsForCall.arg1
 }
 
-func (fake *FakeLocalMediaTrack) Version() utils.TimedVersion {
-	fake.versionMutex.Lock()
-	ret, specificReturn := fake.versionReturnsOnCall[len(fake.versionArgsForCall)]
-	fake.versionArgsForCall = append(fake.versionArgsForCall, struct {
-	}{})
-	stub := fake.VersionStub
-	fakeReturns := fake.versionReturns
-	fake.recordInvocation("Version", []interface{}{})
-	fake.versionMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeLocalMediaTrack) VersionCallCount() int {
-	fake.versionMutex.RLock()
-	defer fake.versionMutex.RUnlock()
-	return len(fake.versionArgsForCall)
-}
-
-func (fake *FakeLocalMediaTrack) VersionCalls(stub func() utils.TimedVersion) {
-	fake.versionMutex.Lock()
-	defer fake.versionMutex.Unlock()
-	fake.VersionStub = stub
-}
-
-func (fake *FakeLocalMediaTrack) VersionReturns(result1 utils.TimedVersion) {
-	fake.versionMutex.Lock()
-	defer fake.versionMutex.Unlock()
-	fake.VersionStub = nil
-	fake.versionReturns = struct {
-		result1 utils.TimedVersion
-	}{result1}
-}
-
-func (fake *FakeLocalMediaTrack) VersionReturnsOnCall(i int, result1 utils.TimedVersion) {
-	fake.versionMutex.Lock()
-	defer fake.versionMutex.Unlock()
-	fake.VersionStub = nil
-	if fake.versionReturnsOnCall == nil {
-		fake.versionReturnsOnCall = make(map[int]struct {
-			result1 utils.TimedVersion
-		})
-	}
-	fake.versionReturnsOnCall[i] = struct {
-		result1 utils.TimedVersion
-	}{result1}
-}
-
 func (fake *FakeLocalMediaTrack) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -2287,8 +2223,6 @@ func (fake *FakeLocalMediaTrack) Invocations() map[string][][]interface{} {
 	defer fake.updateTrackInfoMutex.RUnlock()
 	fake.updateVideoLayersMutex.RLock()
 	defer fake.updateVideoLayersMutex.RUnlock()
-	fake.versionMutex.RLock()
-	defer fake.versionMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/rtc/types/typesfakes/fake_media_track.go
+++ b/pkg/rtc/types/typesfakes/fake_media_track.go
@@ -7,7 +7,6 @@ import (
 	"github.com/livekit/livekit-server/pkg/rtc/types"
 	"github.com/livekit/livekit-server/pkg/sfu"
 	"github.com/livekit/protocol/livekit"
-	"github.com/livekit/protocol/utils"
 )
 
 type FakeMediaTrack struct {
@@ -278,16 +277,6 @@ type FakeMediaTrack struct {
 	updateVideoLayersMutex       sync.RWMutex
 	updateVideoLayersArgsForCall []struct {
 		arg1 []*livekit.VideoLayer
-	}
-	VersionStub        func() utils.TimedVersion
-	versionMutex       sync.RWMutex
-	versionArgsForCall []struct {
-	}
-	versionReturns struct {
-		result1 utils.TimedVersion
-	}
-	versionReturnsOnCall map[int]struct {
-		result1 utils.TimedVersion
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -1743,59 +1732,6 @@ func (fake *FakeMediaTrack) UpdateVideoLayersArgsForCall(i int) []*livekit.Video
 	return argsForCall.arg1
 }
 
-func (fake *FakeMediaTrack) Version() utils.TimedVersion {
-	fake.versionMutex.Lock()
-	ret, specificReturn := fake.versionReturnsOnCall[len(fake.versionArgsForCall)]
-	fake.versionArgsForCall = append(fake.versionArgsForCall, struct {
-	}{})
-	stub := fake.VersionStub
-	fakeReturns := fake.versionReturns
-	fake.recordInvocation("Version", []interface{}{})
-	fake.versionMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeMediaTrack) VersionCallCount() int {
-	fake.versionMutex.RLock()
-	defer fake.versionMutex.RUnlock()
-	return len(fake.versionArgsForCall)
-}
-
-func (fake *FakeMediaTrack) VersionCalls(stub func() utils.TimedVersion) {
-	fake.versionMutex.Lock()
-	defer fake.versionMutex.Unlock()
-	fake.VersionStub = stub
-}
-
-func (fake *FakeMediaTrack) VersionReturns(result1 utils.TimedVersion) {
-	fake.versionMutex.Lock()
-	defer fake.versionMutex.Unlock()
-	fake.VersionStub = nil
-	fake.versionReturns = struct {
-		result1 utils.TimedVersion
-	}{result1}
-}
-
-func (fake *FakeMediaTrack) VersionReturnsOnCall(i int, result1 utils.TimedVersion) {
-	fake.versionMutex.Lock()
-	defer fake.versionMutex.Unlock()
-	fake.VersionStub = nil
-	if fake.versionReturnsOnCall == nil {
-		fake.versionReturnsOnCall = make(map[int]struct {
-			result1 utils.TimedVersion
-		})
-	}
-	fake.versionReturnsOnCall[i] = struct {
-		result1 utils.TimedVersion
-	}{result1}
-}
-
 func (fake *FakeMediaTrack) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -1857,8 +1793,6 @@ func (fake *FakeMediaTrack) Invocations() map[string][][]interface{} {
 	defer fake.updateTrackInfoMutex.RUnlock()
 	fake.updateVideoLayersMutex.RLock()
 	defer fake.updateVideoLayersMutex.RUnlock()
-	fake.versionMutex.RLock()
-	defer fake.versionMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -294,6 +294,12 @@ func (d *DummyReceiver) TrackInfo() *livekit.TrackInfo {
 	return nil
 }
 
+func (d *DummyReceiver) UpdateTrackInfo(ti *livekit.TrackInfo) {
+	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
+		r.UpdateTrackInfo(ti)
+	}
+}
+
 func (d *DummyReceiver) IsClosed() bool {
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return r.IsClosed()

--- a/pkg/sfu/buffer/videolayerutils.go
+++ b/pkg/sfu/buffer/videolayerutils.go
@@ -25,6 +25,7 @@ const (
 	FullResolution    = "f"
 )
 
+// RAJA-TODO: these need to be codec mime aware, not just top level trackInfo
 func LayerPresenceFromTrackInfo(trackInfo *livekit.TrackInfo) *[livekit.VideoQuality_HIGH + 1]bool {
 	if trackInfo == nil || len(trackInfo.Layers) == 0 {
 		return nil

--- a/pkg/sfu/buffer/videolayerutils.go
+++ b/pkg/sfu/buffer/videolayerutils.go
@@ -25,7 +25,7 @@ const (
 	FullResolution    = "f"
 )
 
-// RAJA-TODO: these need to be codec mime aware, not just top level trackInfo
+// SIMULCAST-CODEC-TODO: these need to be codec mime aware if and when each codec suppports different layers
 func LayerPresenceFromTrackInfo(trackInfo *livekit.TrackInfo) *[livekit.VideoQuality_HIGH + 1]bool {
 	if trackInfo == nil || len(trackInfo.Layers) == 0 {
 		return nil

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pion/rtcp"
 	"github.com/pion/webrtc/v3"
 	"go.uber.org/atomic"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/livekit/mediatransportutil/pkg/bucket"
 	"github.com/livekit/mediatransportutil/pkg/twcc"
@@ -71,6 +72,7 @@ type TrackReceiver interface {
 	DebugInfo() map[string]interface{}
 
 	TrackInfo() *livekit.TrackInfo
+	UpdateTrackInfo(ti *livekit.TrackInfo)
 
 	// Get primary receiver if this receiver represents a RED codec; otherwise it will return itself
 	GetPrimaryReceiverForRed() TrackReceiver
@@ -104,7 +106,7 @@ type WebRTCReceiver struct {
 	closeOnce      sync.Once
 	closed         atomic.Bool
 	useTrackers    bool
-	trackInfo      *livekit.TrackInfo
+	trackInfo      atomic.Pointer[livekit.TrackInfo]
 
 	rtcpCh chan []rtcp.Packet
 
@@ -200,21 +202,21 @@ func NewWebRTCReceiver(
 	opts ...ReceiverOpts,
 ) *WebRTCReceiver {
 	w := &WebRTCReceiver{
-		logger:    logger,
-		receiver:  receiver,
-		trackID:   livekit.TrackID(track.ID()),
-		streamID:  track.StreamID(),
-		codec:     track.Codec(),
-		kind:      track.Kind(),
-		twcc:      twcc,
-		trackInfo: trackInfo,
-		isSVC:     IsSvcCodec(track.Codec().MimeType),
-		isRED:     IsRedCodec(track.Codec().MimeType),
+		logger:   logger,
+		receiver: receiver,
+		trackID:  livekit.TrackID(track.ID()),
+		streamID: track.StreamID(),
+		codec:    track.Codec(),
+		kind:     track.Kind(),
+		twcc:     twcc,
+		isSVC:    IsSvcCodec(track.Codec().MimeType),
+		isRED:    IsRedCodec(track.Codec().MimeType),
 	}
 
 	for _, opt := range opts {
 		w = opt(w)
 	}
+	w.trackInfo.Store(proto.Clone(trackInfo).(*livekit.TrackInfo))
 
 	w.downTrackSpreader = NewDownTrackSpreader(DownTrackSpreaderParams{
 		Threshold: w.lbThreshold,
@@ -232,7 +234,7 @@ func NewWebRTCReceiver(
 			w.onStatsUpdate(w, stat)
 		}
 	})
-	w.connectionStats.Start(w.trackInfo)
+	w.connectionStats.Start(trackInfo)
 
 	w.streamTrackerManager = NewStreamTrackerManager(logger, trackInfo, w.isSVC, w.codec.ClockRate, trackersConfig)
 	w.streamTrackerManager.SetListener(w)
@@ -250,7 +252,12 @@ func NewWebRTCReceiver(
 }
 
 func (w *WebRTCReceiver) TrackInfo() *livekit.TrackInfo {
-	return w.trackInfo
+	return w.trackInfo.Load()
+}
+
+func (w *WebRTCReceiver) UpdateTrackInfo(ti *livekit.TrackInfo) {
+	w.trackInfo.Store(proto.Clone(ti).(*livekit.TrackInfo))
+	w.streamTrackerManager.UpdateTrackInfo(ti)
 }
 
 func (w *WebRTCReceiver) OnStatsUpdate(fn func(w *WebRTCReceiver, stat *livekit.AnalyticsStat)) {
@@ -328,7 +335,7 @@ func (w *WebRTCReceiver) AddUpTrack(track *webrtc.TrackRemote, buff *buffer.Buff
 
 	layer := int32(0)
 	if w.Kind() == webrtc.RTPCodecTypeVideo && !w.isSVC {
-		layer = buffer.RidToSpatialLayer(track.RID(), w.trackInfo)
+		layer = buffer.RidToSpatialLayer(track.RID(), w.trackInfo.Load())
 	}
 	buff.SetLogger(w.logger.WithValues("layer", layer))
 	buff.SetTWCC(w.twcc)
@@ -700,9 +707,13 @@ func (w *WebRTCReceiver) closeTracks() {
 }
 
 func (w *WebRTCReceiver) DebugInfo() map[string]interface{} {
+	isSimulcast := !w.isSVC
+	if ti := w.trackInfo.Load(); ti != nil {
+		isSimulcast = isSimulcast && len(ti.Layers) > 1
+	}
 	info := map[string]interface{}{
 		"SVC":       w.isSVC,
-		"Simulcast": !w.isSVC && len(w.trackInfo.Layers) > 1,
+		"Simulcast": isSimulcast,
 	}
 
 	w.upTrackMu.RLock()


### PR DESCRIPTION
TrackInfo was spread across a bit.

Will leave more inline notes. But, at a high level
- Reduce fields. Keep updates inside `trackInfo`.
- Use `MediaTrackReceiver` as the holder of `trackInfo`.
- Distribute `trackInfo` update to receivers and further.

With the new `Version` added, looking to distribute and check versions. So, want to keep it more consolidated.