### PR TITLE
Populate simulcast codec layers.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1670,9 +1670,15 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 			continue
 		}
 		seenCodecs[mime] = struct{}{}
+
+		clonedLayers := make([]*livekit.VideoLayer, 0, len(req.Layers))
+		for _, l := range req.Layers {
+			clonedLayers = append(clonedLayers, proto.Clone(l).(*livekit.VideoLayer))
+		}
 		ti.Codecs = append(ti.Codecs, &livekit.SimulcastCodecInfo{
 			MimeType: mime,
 			Cid:      codec.Cid,
+			Layers:   clonedLayers,
 		})
 	}
 


### PR DESCRIPTION
Previously, it was done on read. Missed populating it on write in the TrackInfo consolidation effort.

Fix by populating layers when adding pending track itself. As all codecs will have same layers, clone the top level layers and add it all codecs.

This was causing migration e2e tests to fail. With this change, it is passing locally.