### PR TITLE
Synthesise codec when adding pending track for no simulcast case also.

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -221,8 +221,17 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.Tra
 				break
 			}
 		}
-		if len(ti.Codecs) == 0 {
-			priority = 0
+		if priority < 0 {
+			switch len(ti.Codecs) {
+			case 0:
+				// audio track
+				priority = 0
+			case 1:
+				// older clients or non simulcast-codec, mime type only set later
+				if ti.Codecs[0].MimeType == "" {
+					priority = 0
+				}
+			}
 		}
 		if priority < 0 {
 			t.params.Logger.Warnw("could not find codec for webrtc receiver", nil, "webrtcCodec", mime, "track", logger.Proto(ti))

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1647,11 +1647,13 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 	p.setStableTrackID(req.Cid, ti)
 
 	if len(req.SimulcastCodecs) == 0 {
-		// clients not supporting simulcast codecs, synthesise a codec
-		ti.Codecs = append(ti.Codecs, &livekit.SimulcastCodecInfo{
-			Cid:    req.Cid,
-			Layers: req.Layers,
-		})
+		if req.Type == livekit.TrackType_VIDEO {
+			// clients not supporting simulcast codecs, synthesise a codec
+			ti.Codecs = append(ti.Codecs, &livekit.SimulcastCodecInfo{
+				Cid:    req.Cid,
+				Layers: req.Layers,
+			})
+		}
 	} else {
 		seenCodecs := make(map[string]struct{})
 		for _, codec := range req.SimulcastCodecs {

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1646,16 +1646,11 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 	}
 	p.setStableTrackID(req.Cid, ti)
 
-	clonedLayers := make([]*livekit.VideoLayer, 0, len(req.Layers))
-	for _, l := range req.Layers {
-		clonedLayers = append(clonedLayers, proto.Clone(l).(*livekit.VideoLayer))
-	}
-
 	if len(req.SimulcastCodecs) == 0 {
 		// clients not supporting simulcast codecs, synthesise a codec
 		ti.Codecs = append(ti.Codecs, &livekit.SimulcastCodecInfo{
 			Cid:    req.Cid,
-			Layers: clonedLayers,
+			Layers: req.Layers,
 		})
 	} else {
 		seenCodecs := make(map[string]struct{})
@@ -1684,6 +1679,10 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 			}
 			seenCodecs[mime] = struct{}{}
 
+			clonedLayers := make([]*livekit.VideoLayer, 0, len(req.Layers))
+			for _, l := range req.Layers {
+				clonedLayers = append(clonedLayers, proto.Clone(l).(*livekit.VideoLayer))
+			}
 			ti.Codecs = append(ti.Codecs, &livekit.SimulcastCodecInfo{
 				MimeType: mime,
 				Cid:      codec.Cid,


### PR DESCRIPTION
Older clients not using simulcast codecs were failing e2e migration tests. Problem is that they did not have layer information and hence SSRC could not be set on migration.

A codec was getting added later (when OnTrack was received). I missed adding layers in that code. Could have cloned layers there and added it. But, simplifying and adding at the start itself.

Also, cleaning up code in `MediaTrackReceiver` for no codecs case as it should not happen any more.