### PR TITLE
make 64bit atomics also align on 32bit

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -135,6 +135,10 @@ type ParticipantParams struct {
 }
 
 type ParticipantImpl struct {
+	// utils.TimedVersion is a atomic. To be correctly aligned also on 32bit archs
+	// 64it atomics need to be at the front of a struct
+	timedVersion utils.TimedVersion
+
 	params ParticipantParams
 
 	isClosed    atomic.Bool
@@ -195,7 +199,6 @@ type ParticipantImpl struct {
 
 	dirty        atomic.Bool
 	version      atomic.Uint32
-	timedVersion utils.TimedVersion
 
 	// callbacks & handlers
 	onTrackPublished     func(types.LocalParticipant, types.MediaTrack)

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -67,6 +67,15 @@ type broadcastOptions struct {
 }
 
 type Room struct {
+	// atomics always need to be 64bit/8byte aligned
+	// on 32bit arch only the beginning of the struct
+	// starts at such a boundary.
+	// time the first participant joined the room
+	joinedAt atomic.Int64
+	// time that the last participant left the room
+	leftAt atomic.Int64
+	holds    atomic.Int32
+
 	lock sync.RWMutex
 
 	protoRoom  *livekit.Room
@@ -96,11 +105,6 @@ type Room struct {
 	batchedUpdates   map[livekit.ParticipantIdentity]*livekit.ParticipantInfo
 	batchedUpdatesMu sync.Mutex
 
-	// time the first participant joined the room
-	joinedAt atomic.Int64
-	holds    atomic.Int32
-	// time that the last participant left the room
-	leftAt atomic.Int64
 	closed chan struct{}
 
 	trailer []byte

--- a/pkg/rtc/uptrackmanager.go
+++ b/pkg/rtc/uptrackmanager.go
@@ -37,6 +37,10 @@ type UpTrackManagerParams struct {
 
 // UpTrackManager manages all uptracks from a participant
 type UpTrackManager struct {
+	// utils.TimedVersion is a atomic. To be correctly aligned also on 32bit archs
+	// 64it atomics need to be at the front of a struct
+	subscriptionPermissionVersion utils.TimedVersion
+
 	params UpTrackManagerParams
 
 	closed bool
@@ -44,7 +48,6 @@ type UpTrackManager struct {
 	// publishedTracks that participant is publishing
 	publishedTracks               map[livekit.TrackID]types.MediaTrack
 	subscriptionPermission        *livekit.SubscriptionPermission
-	subscriptionPermissionVersion utils.TimedVersion
 	// subscriber permission for published tracks
 	subscriberPermissions map[livekit.ParticipantIdentity]*livekit.TrackPermission // subscriberIdentity => *livekit.TrackPermission
 


### PR DESCRIPTION
do this by simply putting them at the front of each struct

see https://pkg.go.dev/sync/atomic#pkg-note-BUG

fixes #2383