### PR TITLE
Fix race condition on Participant.updateState

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1242,12 +1242,11 @@ func (p *ParticipantImpl) setupParticipantTrafficLoad() {
 
 func (p *ParticipantImpl) updateState(state livekit.ParticipantInfo_State) {
 	oldState := p.State()
-	if state == oldState {
+	if !(p.state.Swap(state) != state) {
 		return
 	}
 
 	p.params.Logger.Debugw("updating participant state", "state", state.String())
-	p.state.Store(state)
 	p.dirty.Store(true)
 
 	p.lock.RLock()


### PR DESCRIPTION
The comparisson between the last and current `ParticipantInfo_State` wasn't atomic. This sometimes resulted in two calls to `onStateChange` method for the same participant state. In the end this was reflected in two ACTIVE events being generated for the same participant at exactly the same moment. The fix actually uses the atomic method Swap to properly protect the "compare and set" operation and avoid any race condition.

The previous behavior is reflected in the debug line https://github.com/livekit/livekit/blob/867325d1204df2a42e0300bc871000a6e135361b/pkg/rtc/participant.go#L1249 which sometimes can log the following lines (happens more for rooms with different users connecting at the same time):

```
2024-01-22T20:32:56.556+0100    DEBUG    livekit rtc/participant.go:1249 updating participant state      {"room": "TestRoom", "roomID": "RM_3jbM9omtMHeK", "participant": "MyTestParticipant", "pID": "PA_3mn978AGXRXr", "remote": false, "state": "ACTIVE"}
2024-01-22T20:32:56.556+0100    DEBUG    livekit rtc/participant.go:1249 updating participant state      {"room": "TestRoom", "roomID": "RM_3jbM9omtMHeK", "participant": "MyTestParticipant", "pID": "PA_4nk5DzkY9SpX", "remote": false, "state": "ACTIVE"}
```

Which leads to the execution of https://github.com/livekit/livekit/blob/867325d1204df2a42e0300bc871000a6e135361b/pkg/rtc/room.go#L343 twice in a row with the exact same participant and state.