### PR TITLE
Unify muted and unmuted migration paths.

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -125,6 +125,7 @@ func NewMediaTrack(params MediaTrackParams, ti *livekit.TrackInfo) *MediaTrack {
 func (t *MediaTrack) OnSubscribedMaxQualityChange(
 	f func(
 		trackID livekit.TrackID,
+		trackInfo *livekit.TrackInfo,
 		subscribedQualities []*livekit.SubscribedCodec,
 		maxSubscribedQualities []types.SubscribedCodecQuality,
 	) error,
@@ -135,7 +136,7 @@ func (t *MediaTrack) OnSubscribedMaxQualityChange(
 
 	handler := func(subscribedQualities []*livekit.SubscribedCodec, maxSubscribedQualities []types.SubscribedCodecQuality) {
 		if f != nil && !t.IsMuted() {
-			_ = f(t.ID(), subscribedQualities, maxSubscribedQualities)
+			_ = f(t.ID(), t.ToProto(), subscribedQualities, maxSubscribedQualities)
 		}
 
 		for _, q := range maxSubscribedQualities {

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1867,7 +1867,7 @@ func (p *ParticipantImpl) mediaTrackReceived(track *webrtc.TrackRemote, rtpRecei
 }
 
 func (p *ParticipantImpl) addMigratedTrack(cid string, ti *livekit.TrackInfo) *MediaTrack {
-	p.pubLogger.Infow("add migrate muted track", "cid", cid, "trackID", ti.Sid, "track", logger.Proto(ti))
+	p.pubLogger.Infow("add migrated track", "cid", cid, "trackID", ti.Sid, "track", logger.Proto(ti))
 	rtpReceiver := p.TransportManager.GetPublisherRTPReceiver(ti.Mid)
 	if rtpReceiver == nil {
 		p.pubLogger.Errorw("could not find receiver for migrated track", nil, "trackID", ti.Sid)
@@ -1914,7 +1914,7 @@ func (p *ParticipantImpl) addMigratedTrack(cid string, ti *livekit.TrackInfo) *M
 		}
 	}
 	mt.SetSimulcast(ti.Simulcast)
-	mt.SetMuted(true)
+	mt.SetMuted(ti.Muted)
 
 	return mt
 }


### PR DESCRIPTION
If dynacast had disabled all layers, after a migration, the client did not restart publish (it is akin to muted track). That failed migration because migration state machine waits for unmuted tracks to be published (i. e. server has to receive packets).

If a migrating track is in muted state, server does not wait for packets. It synthesises the published event and catches up later when packets actually come in.

Just treating all migrations as the erstwhile muted case. Sythesise publish whether track is muted or not. In the unmuted case, packets might arrive soon after whereas in muted case, it will depend on when unmute happens.

This is tricky stuff. So, will need good testing.