### PR TITLE
bootstrap.sh: replace /bin/bash with env call

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2023 LiveKit, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Fixes build on FreeBSD, which uses /usr/local/bin/bash, and also is just a more idiomatic way to handle shells.