### PR TITLE
Use Deque in ops queue.

### DIFF
--- a/pkg/rtc/dynacastmanager.go
+++ b/pkg/rtc/dynacastmanager.go
@@ -59,7 +59,7 @@ func NewDynacastManager(params DynacastManagerParams) *DynacastManager {
 		maxSubscribedQuality:          make(map[string]livekit.VideoQuality),
 		committedMaxSubscribedQuality: make(map[string]livekit.VideoQuality),
 		maxSubscribedQualityDebounce:  debounce.New(params.DynacastPauseDelay),
-		qualityNotifyOpQueue:          utils.NewOpsQueue(params.Logger, "quality-notify", 100),
+		qualityNotifyOpQueue:          utils.NewOpsQueue("quality-notify", 0),
 	}
 	d.qualityNotifyOpQueue.Start()
 	return d

--- a/pkg/rtc/dynacastmanager.go
+++ b/pkg/rtc/dynacastmanager.go
@@ -59,7 +59,7 @@ func NewDynacastManager(params DynacastManagerParams) *DynacastManager {
 		maxSubscribedQuality:          make(map[string]livekit.VideoQuality),
 		committedMaxSubscribedQuality: make(map[string]livekit.VideoQuality),
 		maxSubscribedQualityDebounce:  debounce.New(params.DynacastPauseDelay),
-		qualityNotifyOpQueue:          utils.NewOpsQueue("quality-notify", 0),
+		qualityNotifyOpQueue:          utils.NewOpsQueue("quality-notify", 0, true),
 	}
 	d.qualityNotifyOpQueue.Start()
 	return d

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -31,6 +31,7 @@ import (
 	"github.com/livekit/livekit-server/pkg/config"
 	"github.com/livekit/livekit-server/pkg/sfu"
 	"github.com/livekit/livekit-server/pkg/sfu/buffer"
+	"github.com/livekit/livekit-server/pkg/utils"
 )
 
 const (
@@ -165,8 +166,7 @@ type StreamAllocator struct {
 
 	state streamAllocatorState
 
-	eventChMu sync.RWMutex
-	eventCh   chan Event
+	eventsQueue *utils.OpsQueue
 
 	isStopped atomic.Bool
 }
@@ -180,13 +180,16 @@ func NewStreamAllocator(params StreamAllocatorParams) *StreamAllocator {
 		}),
 		rateMonitor: NewRateMonitor(),
 		videoTracks: make(map[livekit.TrackID]*Track),
-		eventCh:     make(chan Event, 1000),
+		eventsQueue: utils.NewOpsQueue("stream-allocator", 64),
 	}
 
 	s.probeController = NewProbeController(ProbeControllerParams{
 		Config: s.params.Config.ProbeConfig,
 		Prober: s.prober,
 		Logger: params.Logger,
+	})
+	s.eventsQueue.SetFinalize(func() {
+		s.probeController.StopProbe()
 	})
 
 	s.resetState()
@@ -197,19 +200,16 @@ func NewStreamAllocator(params StreamAllocatorParams) *StreamAllocator {
 }
 
 func (s *StreamAllocator) Start() {
-	go s.processEvents()
+	s.eventsQueue.Start()
 	go s.ping()
 }
 
 func (s *StreamAllocator) Stop() {
-	s.eventChMu.Lock()
 	if s.isStopped.Swap(true) {
-		s.eventChMu.Unlock()
 		return
 	}
 
-	close(s.eventCh)
-	s.eventChMu.Unlock()
+	s.eventsQueue.Stop()
 }
 
 func (s *StreamAllocator) OnStreamStateChange(f func(update *StreamStateUpdate) error) {
@@ -546,30 +546,9 @@ func (s *StreamAllocator) maybePostEventAllocateTrack(downTrack *sfu.DownTrack) 
 }
 
 func (s *StreamAllocator) postEvent(event Event) {
-	s.eventChMu.RLock()
-	if s.isStopped.Load() {
-		s.eventChMu.RUnlock()
-		return
-	}
-
-	select {
-	case s.eventCh <- event:
-	default:
-		s.params.Logger.Warnw("stream allocator: event queue full", nil, "event", event.String())
-	}
-	s.eventChMu.RUnlock()
-}
-
-func (s *StreamAllocator) processEvents() {
-	for event := range s.eventCh {
-		if s.isStopped.Load() {
-			break
-		}
-
+	s.eventsQueue.Enqueue(func() {
 		s.handleEvent(&event)
-	}
-
-	s.probeController.StopProbe()
+	})
 }
 
 func (s *StreamAllocator) ping() {

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -102,7 +102,7 @@ func NewTelemetryService(notifier webhook.QueuedNotifier, analytics AnalyticsSer
 		AnalyticsService: analytics,
 
 		notifier:  notifier,
-		jobsQueue: utils.NewOpsQueue("telemetry", jobsQueueMinSize),
+		jobsQueue: utils.NewOpsQueue("telemetry", jobsQueueMinSize, true),
 		workers:   make(map[livekit.ParticipantID]*StatsWorker),
 	}
 

--- a/pkg/utils/opsqueue.go
+++ b/pkg/utils/opsqueue.go
@@ -106,7 +106,6 @@ done:
 		}
 	}
 
-	// flush events if queue is configured thus
 	if oq.flushOnStop {
 		for {
 			oq.lock.Lock()


### PR DESCRIPTION
Standardizing some uses
- Change OpsQueue to use Deque so that it can grow/shrink as necessary and need not worry about channel getting full and dropping events.
- Change StreamAllocator and TelemetryService to use OpsQueue so that they also need not worry about channel size and overflows.