### PR TITLE
Cache data synchronously for processing in worker.

### DIFF
--- a/pkg/rtc/room_test.go
+++ b/pkg/rtc/room_test.go
@@ -127,7 +127,7 @@ func TestRoomJoin(t *testing.T) {
 	t.Run("participant state change is broadcasted to others", func(t *testing.T) {
 		rm := newRoomWithParticipants(t, testRoomOpts{num: numParticipants})
 		var changedParticipant types.Participant
-		rm.OnParticipantChanged(func(participant types.LocalParticipant) {
+		rm.OnParticipantChanged(func(participant types.LocalParticipant, _pi *livekit.ParticipantInfo) {
 			changedParticipant = participant
 		})
 		participants := rm.GetParticipants()

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -577,10 +577,10 @@ func (r *RoomManager) getOrCreateRoom(ctx context.Context, roomName livekit.Room
 		}
 	})
 
-	newRoom.OnParticipantChanged(func(p types.LocalParticipant) {
-		if !p.IsDisconnected() {
-			if err := r.roomStore.StoreParticipant(ctx, roomName, p.ToProto()); err != nil {
-				newRoom.Logger.Errorw("could not handle participant change", err)
+	newRoom.OnParticipantChanged(func(p types.LocalParticipant, pi *livekit.ParticipantInfo) {
+		if pi.State != livekit.ParticipantInfo_DISCONNECTED {
+			if err := r.roomStore.StoreParticipant(ctx, roomName, pi); err != nil {
+				p.GetLogger().Errorw("could not handle participant change", err)
 			}
 		}
 	})


### PR DESCRIPTION
It is possible that state of underlying object has changed between event posting and event processing. So, cache data synchronously and use it during event processing.

This is still not perfect as things like `hidden` and `IsClosed` is accessed in worker. Ideally, it can be a snapshot of current state of all required values that can be posted to the worker and the worker just operates with data.