### PR TITLE
LeaveRequest changes.

### DIFF
--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -178,7 +178,7 @@ func (p ParticipantCloseReason) ToDisconnectReason() livekit.DisconnectReason {
 		return livekit.DisconnectReason_STATE_MISMATCH
 	case ParticipantCloseReasonDuplicateIdentity, ParticipantCloseReasonStale:
 		return livekit.DisconnectReason_DUPLICATE_IDENTITY
-	case ParticipantCloseReasonMigrationComplete, ParticipantCloseReasonSimulateMigration:
+	case ParticipantCloseReasonMigrationRequested, ParticipantCloseReasonMigrationComplete, ParticipantCloseReasonSimulateMigration:
 		return livekit.DisconnectReason_MIGRATION
 	case ParticipantCloseReasonServiceRequestRemoveParticipant:
 		return livekit.DisconnectReason_PARTICIPANT_REMOVED
@@ -422,8 +422,6 @@ type LocalParticipant interface {
 	GetPacer() pacer.Pacer
 
 	GetTrafficLoad() *TrafficLoad
-
-	SetRegionSettings(regionSettings *livekit.RegionSettings)
 }
 
 // Room is a container of participants, and can provide room-level actions

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -753,11 +753,6 @@ type FakeLocalParticipant struct {
 	setPermissionReturnsOnCall map[int]struct {
 		result1 bool
 	}
-	SetRegionSettingsStub        func(*livekit.RegionSettings)
-	setRegionSettingsMutex       sync.RWMutex
-	setRegionSettingsArgsForCall []struct {
-		arg1 *livekit.RegionSettings
-	}
 	SetResponseSinkStub        func(routing.MessageSink)
 	setResponseSinkMutex       sync.RWMutex
 	setResponseSinkArgsForCall []struct {
@@ -4982,38 +4977,6 @@ func (fake *FakeLocalParticipant) SetPermissionReturnsOnCall(i int, result1 bool
 	}{result1}
 }
 
-func (fake *FakeLocalParticipant) SetRegionSettings(arg1 *livekit.RegionSettings) {
-	fake.setRegionSettingsMutex.Lock()
-	fake.setRegionSettingsArgsForCall = append(fake.setRegionSettingsArgsForCall, struct {
-		arg1 *livekit.RegionSettings
-	}{arg1})
-	stub := fake.SetRegionSettingsStub
-	fake.recordInvocation("SetRegionSettings", []interface{}{arg1})
-	fake.setRegionSettingsMutex.Unlock()
-	if stub != nil {
-		fake.SetRegionSettingsStub(arg1)
-	}
-}
-
-func (fake *FakeLocalParticipant) SetRegionSettingsCallCount() int {
-	fake.setRegionSettingsMutex.RLock()
-	defer fake.setRegionSettingsMutex.RUnlock()
-	return len(fake.setRegionSettingsArgsForCall)
-}
-
-func (fake *FakeLocalParticipant) SetRegionSettingsCalls(stub func(*livekit.RegionSettings)) {
-	fake.setRegionSettingsMutex.Lock()
-	defer fake.setRegionSettingsMutex.Unlock()
-	fake.SetRegionSettingsStub = stub
-}
-
-func (fake *FakeLocalParticipant) SetRegionSettingsArgsForCall(i int) *livekit.RegionSettings {
-	fake.setRegionSettingsMutex.RLock()
-	defer fake.setRegionSettingsMutex.RUnlock()
-	argsForCall := fake.setRegionSettingsArgsForCall[i]
-	return argsForCall.arg1
-}
-
 func (fake *FakeLocalParticipant) SetResponseSink(arg1 routing.MessageSink) {
 	fake.setResponseSinkMutex.Lock()
 	fake.setResponseSinkArgsForCall = append(fake.setResponseSinkArgsForCall, struct {
@@ -6352,8 +6315,6 @@ func (fake *FakeLocalParticipant) Invocations() map[string][][]interface{} {
 	defer fake.setNameMutex.RUnlock()
 	fake.setPermissionMutex.RLock()
 	defer fake.setPermissionMutex.RUnlock()
-	fake.setRegionSettingsMutex.RLock()
-	defer fake.setRegionSettingsMutex.RUnlock()
 	fake.setResponseSinkMutex.RLock()
 	defer fake.setResponseSinkMutex.RUnlock()
 	fake.setSignalSourceValidMutex.RLock()


### PR DESCRIPTION
Reworking this a bit
1. Send leave whenever the signal channel is closed to induce a resume.
2. Use a getter to get regions rather than setting.

@davidzhao Addressing your feedback. There was a point about getting regions in `controller`. Feels like it is better to get it on media node rather than intercepting `LeaveRequest` in `controller` and adding region settings. So, using a getter method.