### PR TITLE
Restore min score to 30.

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -476,7 +476,7 @@ func (b *Buffer) calc(pkt []byte, arrivalTime time.Time) {
 	if err != nil {
 		if errors.Is(err, bucket.ErrPacketTooOld) {
 			packetTooOldCount := b.packetTooOldCount.Inc()
-			if packetTooOldCount%20 == 0 {
+			if (packetTooOldCount-1)%100 == 0 {
 				b.logger.Warnw("could not add packet to bucket", err, "count", packetTooOldCount)
 			}
 		} else if err != bucket.ErrRTXPacket {


### PR DESCRIPTION
Was at 20 when LOST was introduced, but was going to 20 even when under not LOST conditions. When there are packets, want the min to be at 30. Going down to 20 resulted in reporting LOST quality even when packets were flowing (although they were experiencing heavy loss and quality would have been very bad, yet they are not lost).

Also, sample warning about adding packet to bucket even more.