### PR TITLE
Reset sender reports before measuring clock skew.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_receiver.go
+++ b/pkg/sfu/buffer/rtpstats_receiver.go
@@ -271,6 +271,25 @@ func (r *RTPStatsReceiver) SetRtcpSenderReportData(srData *RTCPSenderReportData)
 
 	r.maybeAdjustFirstPacketTime(srDataCopy.RTPTimestamp, r.timestamp.GetStart())
 
+	if r.srNewest != nil && srDataCopy.RTPTimestampExt < r.srNewest.RTPTimestampExt {
+		// This can happen when a track is replaced with a null and then restored -
+		// i. e. muting replacing with null and unmute restoring the original track.
+		// Under such a condition reset the sender reports to start from this point.
+		// Resetting will ensure sample rate calculations do not go haywire due to negative time.
+		if r.outOfOrderSsenderReportCount%10 == 0 {
+			r.logger.Infow(
+				"received sender report, out-of-order, resetting",
+				"last", r.srNewest.ToString(),
+				"current", srDataCopy.ToString(),
+				"count", r.outOfOrderSsenderReportCount,
+			)
+		}
+		r.outOfOrderSsenderReportCount++
+
+		r.srFirst = nil
+		r.srNewest = nil
+	}
+
 	if r.srNewest != nil {
 		timeSinceLast := srData.NTPTimestamp.Time().Sub(r.srNewest.NTPTimestamp.Time()).Seconds()
 		rtpDiffSinceLast := srDataCopy.RTPTimestampExt - r.srNewest.RTPTimestampExt
@@ -295,24 +314,6 @@ func (r *RTPStatsReceiver) SetRtcpSenderReportData(srData *RTCPSenderReportData)
 			}
 			r.clockSkewCount++
 		}
-	}
-
-	if r.srNewest != nil && srDataCopy.RTPTimestampExt < r.srNewest.RTPTimestampExt {
-		// This can happen when a track is replaced with a null and then restored -
-		// i. e. muting replacing with null and unmute restoring the original track.
-		// Under such a condition reset the sender reports to start from this point.
-		// Resetting will ensure sample rate calculations do not go haywire due to negative time.
-		if r.outOfOrderSsenderReportCount%10 == 0 {
-			r.logger.Infow(
-				"received sender report, out-of-order, resetting",
-				"last", r.srNewest.ToString(),
-				"current", srDataCopy.ToString(),
-				"count", r.outOfOrderSsenderReportCount,
-			)
-		}
-		r.outOfOrderSsenderReportCount++
-
-		r.srFirst = nil
 	}
 
 	r.srNewest = &srDataCopy


### PR DESCRIPTION
There are cases where the RTP timestamp in RTCP reports move backwards. Seems to happen when pausing track on mute and resuming on unmute. That was logging a clock skew with a clock rate of some ridiculously high number ((uint64 subtraction). Reverse the order, i. e. reset the sender report and then calculate skew.