### PR TITLE
Do not enqueue after stop.

### DIFF
--- a/pkg/utils/opsqueue.go
+++ b/pkg/utils/opsqueue.go
@@ -75,8 +75,12 @@ func (oq *OpsQueue) Enqueue(op func()) {
 	oq.lock.Lock()
 	defer oq.lock.Unlock()
 
+	if oq.isStopped {
+		return
+	}
+
 	oq.ops.PushBack(op)
-	if oq.ops.Len() == 1 && !oq.isStopped {
+	if oq.ops.Len() == 1 {
 		select {
 		case oq.wake <- struct{}{}:
 		default:


### PR DESCRIPTION
Else, that could leak as the process routine may have exited and the entries are not processed anywhere.