### PR TITLE
Ignore `disabled` when adpative stream is enabled.

### DIFF
--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -404,10 +404,7 @@ func (t *MediaTrackSubscriptions) DebugInfo() []map[string]interface{} {
 	subscribedTrackInfo := make([]map[string]interface{}, 0)
 	for _, val := range t.getAllSubscribedTracks() {
 		if st, ok := val.(*SubscribedTrack); ok {
-			dt := st.DownTrack().DebugInfo()
-			dt["PubMuted"] = st.pubMuted.Load()
-			dt["SubMuted"] = st.subMuted.Load()
-			subscribedTrackInfo = append(subscribedTrackInfo, dt)
+			subscribedTrackInfo = append(subscribedTrackInfo, st.DownTrack().DebugInfo())
 		}
 	}
 

--- a/pkg/rtc/subscribedtrack.go
+++ b/pkg/rtc/subscribedtrack.go
@@ -55,7 +55,6 @@ type SubscribedTrack struct {
 
 	versionGenerator utils.TimedVersionGenerator
 	settingsLock     sync.Mutex
-	pubMuted         bool
 	settings         *livekit.UpdateTrackSettings
 	settingsVersion  *utils.TimedVersion
 
@@ -211,8 +210,7 @@ func (t *SubscribedTrack) isMutedLocked() bool {
 
 func (t *SubscribedTrack) SetPublisherMuted(muted bool) {
 	t.settingsLock.Lock()
-	t.pubMuted = muted
-	t.DownTrack().PubMute(t.pubMuted)
+	t.DownTrack().PubMute(muted)
 	t.settingsLock.Unlock()
 }
 

--- a/pkg/rtc/subscribedtrack.go
+++ b/pkg/rtc/subscribedtrack.go
@@ -209,9 +209,7 @@ func (t *SubscribedTrack) isMutedLocked() bool {
 }
 
 func (t *SubscribedTrack) SetPublisherMuted(muted bool) {
-	t.settingsLock.Lock()
 	t.DownTrack().PubMute(muted)
-	t.settingsLock.Unlock()
 }
 
 func (t *SubscribedTrack) UpdateSubscriberSettings(settings *livekit.UpdateTrackSettings, isImmediate bool) {


### PR DESCRIPTION
Due to interplay of adaptive stream/visibility/dynacast, when adaptive stream is enabled, subscribed track forces visibility and starts streaming at low quality. This would trigger a render on client and trigger a visibility update.

So, even if a migration disables a track, upon migration complete and subscription bind, ignore disable and stream.