### PR TITLE
Use smaller default deque size.

### DIFF
--- a/pkg/rtc/dynacastmanager.go
+++ b/pkg/rtc/dynacastmanager.go
@@ -59,7 +59,7 @@ func NewDynacastManager(params DynacastManagerParams) *DynacastManager {
 		maxSubscribedQuality:          make(map[string]livekit.VideoQuality),
 		committedMaxSubscribedQuality: make(map[string]livekit.VideoQuality),
 		maxSubscribedQualityDebounce:  debounce.New(params.DynacastPauseDelay),
-		qualityNotifyOpQueue:          utils.NewOpsQueue("quality-notify", 0, true),
+		qualityNotifyOpQueue:          utils.NewOpsQueue("quality-notify", 64, true),
 	}
 	d.qualityNotifyOpQueue.Start()
 	return d

--- a/pkg/utils/opsqueue.go
+++ b/pkg/utils/opsqueue.go
@@ -41,7 +41,7 @@ func NewOpsQueue(name string, minSize uint, flushOnStop bool) *OpsQueue {
 		wake:        make(chan struct{}, 1),
 		doneChan:    make(chan struct{}),
 	}
-	oq.ops.SetMinCapacity(uint(utils.Min(bits.Len64(uint64(minSize-1)), 16)))
+	oq.ops.SetMinCapacity(uint(utils.Min(bits.Len64(uint64(minSize-1)), 7)))
 	return oq
 }
 


### PR DESCRIPTION
SetMinCapacity of deque is the exponent. So, default size was getting allocated as 512 KB for dynacast manager as dynacast manager was passing in min size of 0.

- Reduce default size to 128
- Use min size of 64 for dynacast manager.