### PR TITLE
Simplify migrate complete a bit more.

### DIFF
--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -100,7 +100,13 @@ func (p *ParticipantImpl) SendParticipantUpdate(participantsToUpdate []*livekit.
 			// this is a message delivered out of order, a more recent version of the message had already been
 			// sent.
 			if pi.Version < lastVersion.version {
-				p.params.Logger.Debugw("skipping outdated participant update", "otherParticipant", pi.Identity, "otherPID", pi.Sid, "version", pi.Version, "lastVersion", lastVersion)
+				p.params.Logger.Debugw(
+					"skipping outdated participant update",
+					"otherParticipant", pi.Identity,
+					"otherPID", pi.Sid,
+					"version", pi.Version,
+					"lastVersion", lastVersion,
+				)
 				isValid = false
 			}
 		}


### PR DESCRIPTION
Moving handling of migrated tracks to when the migration state moves to completed. Pending data channel were already happening only on complete. Move tracks also to that point.

Handling it earlier meant that track published callback happened and ownership of track moved to new node before the new node could finish peer connection. So, in cases where migration did not go through, this caused confusion of track ownership.