### PR TITLE
Null out on slice compaction.

### DIFF
--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -259,6 +259,7 @@ func (t *MediaTrackReceiver) ClearReceiver(mime string, willBeResumed bool) {
 	for idx, receiver := range receivers {
 		if strings.EqualFold(receiver.Codec().MimeType, mime) {
 			receivers[idx] = receivers[len(receivers)-1]
+			receivers[len(receivers)-1] = nil
 			receivers = receivers[:len(receivers)-1]
 			break
 		}

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -733,6 +733,7 @@ func (p *ParticipantImpl) removePendingMigratedTrack(mt *MediaTrack) {
 	for i, t := range p.pendingMigratedTracks {
 		if t == mt {
 			p.pendingMigratedTracks[i] = p.pendingMigratedTracks[len(p.pendingMigratedTracks)-1]
+			p.pendingMigratedTracks[len(p.pendingMigratedTracks)-1] = nil
 			p.pendingMigratedTracks = p.pendingMigratedTracks[:len(p.pendingMigratedTracks)-1]
 			break
 		}

--- a/pkg/rtc/participant_sdp.go
+++ b/pkg/rtc/participant_sdp.go
@@ -157,6 +157,7 @@ func (p *ParticipantImpl) setCodecPreferencesVideoForPublisher(offer webrtc.Sess
 			for i, attr := range unmatchVideo.Attributes {
 				if strings.Contains(attr.Value, dd.ExtensionURI) {
 					unmatchVideo.Attributes[i] = unmatchVideo.Attributes[len(unmatchVideo.Attributes)-1]
+					unmatchVideo.Attributes[len(unmatchVideo.Attributes)-1] = sdp.Attribute{}
 					unmatchVideo.Attributes = unmatchVideo.Attributes[:len(unmatchVideo.Attributes)-1]
 					break
 				}


### PR DESCRIPTION
Go 1.22 does this automatically with `slices` - https://go.dev/blog/generic-slice-functions