### PR TITLE
fix pli throttle locking

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -457,13 +457,13 @@ func (b *Buffer) SetPLIThrottle(duration int64) {
 
 func (b *Buffer) SendPLI(force bool) {
 	b.RLock()
-	if (b.rtpStats == nil || b.rtpStats.TimeSinceLastPli() < b.pliThrottle) && !force {
-		b.RUnlock()
+	rtpStats := b.rtpStats
+	pliThrottle := b.pliThrottle
+	b.RUnlock()
+
+	if (rtpStats == nil && !force) || !rtpStats.CheckAndUpdatePli(pliThrottle, force) {
 		return
 	}
-
-	b.rtpStats.UpdatePliAndTime(1)
-	b.RUnlock()
 
 	b.logger.Debugw("send pli", "ssrc", b.mediaSSRC, "force", force)
 	pli := []rtcp.Packet{

--- a/pkg/sfu/buffer/rtpstats_base.go
+++ b/pkg/sfu/buffer/rtpstats_base.go
@@ -348,6 +348,18 @@ func (r *rtpStatsBase) CheckAndUpdatePli(throttle int64, force bool) bool {
 	return true
 }
 
+func (r *rtpStatsBase) UpdatePliAndTime(pliCount uint32) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if !r.endTime.IsZero() {
+		return
+	}
+
+	r.updatePliLocked(pliCount)
+	r.updatePliTimeLocked()
+}
+
 func (r *rtpStatsBase) UpdatePli(pliCount uint32) {
 	r.lock.Lock()
 	defer r.lock.Unlock()


### PR DESCRIPTION
There is no lock held between `TimeSinceLastPli` and `UpdatePliAndTime`, so multiple plis can be sent at the same time if requested by multiple downtracks