### PR TITLE
Use SubscriberID() in calls to `DeleteDownTrack`.

### DIFF
--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -263,13 +263,13 @@ func (d *DummyReceiver) AddDownTrack(track sfu.TrackSender) error {
 	return nil
 }
 
-func (d *DummyReceiver) DeleteDownTrack(participantID livekit.ParticipantID) {
+func (d *DummyReceiver) DeleteDownTrack(subscriberID livekit.ParticipantID) {
 	d.downtrackLock.Lock()
 	defer d.downtrackLock.Unlock()
 	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
-		r.DeleteDownTrack(participantID)
+		r.DeleteDownTrack(subscriberID)
 	} else {
-		delete(d.downtracks, participantID)
+		delete(d.downtracks, subscriberID)
 	}
 }
 

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -981,7 +981,7 @@ func (d *DownTrack) CloseWithFlush(flush bool) {
 		d.onBindAndConnectedChange()
 		d.params.Logger.Debugw("closing sender", "kind", d.kind)
 	}
-	d.params.Receiver.DeleteDownTrack(d.params.SubID)
+	d.params.Receiver.DeleteDownTrack(d.SubscriberID())
 
 	if d.rtcpReader != nil && flush {
 		d.params.Logger.Debugw("downtrack close rtcp reader")


### PR DESCRIPTION
Thank you @cnderrauber for catching this.