### PR TITLE
Remove subscriber if track closed while adding subscriber.

### DIFF
--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -493,9 +493,9 @@ func (t *MediaTrackReceiver) AddSubscriber(sub types.LocalParticipant) (types.Su
 	t.lock.RLock()
 	if t.state != mediaTrackReceiverStateOpen {
 		willBeResumed = t.willBeResumed
-		t.lock.RUnlock()
 		remove = true
 	}
+	t.lock.RUnlock()
 
 	if remove {
 		_ = t.MediaTrackSubscriptions.RemoveSubscriber(sub.ID(), willBeResumed)


### PR DESCRIPTION
It is possible that the track is closed when subscriber add is processed. That subscriber would have been dangling off a closed track.

Check again after adding subscriber if track is closed. If it is, remove the subscriber and return error so that subscription manager re-resolves.