### PR TITLE
Post a PLI check request on connected.

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -1858,6 +1858,9 @@ func (d *DownTrack) onBindAndConnectedChange() {
 		if d.activePaddingOnMuteUpTrack.Load() {
 			go d.sendPaddingOnMute()
 		}
+
+		// kick off PLI request if allocation is pending
+		d.postKeyFrameRequestEvent()
 	}
 }
 


### PR DESCRIPTION
Otherwise, it gets delayed by timer and could wait upto to interval (which could be 200 ms when there is no RTT information yet).