### PR TITLE
#2539, do not kill the keepaliveWorker task when the ping timeout occurs

### DIFF
--- a/pkg/routing/redisrouter.go
+++ b/pkg/routing/redisrouter.go
@@ -246,7 +246,7 @@ func (r *RedisRouter) keepaliveWorker(startedChan chan error) {
 	for ping := range pings.Channel() {
 		if time.Since(time.Unix(ping.Timestamp, 0)) > statsUpdateInterval {
 			logger.Infow("keep alive too old, skipping", "timestamp", ping.Timestamp)
-			break
+			continue
 		}
 
 		r.nodeMu.Lock()


### PR DESCRIPTION
#2539  If Redis is unavailable for more than 30 seconds, the server remains frozen and does not accept connections, even after the connection to redis is restored, because Stats.UpdatedAt is no longer updated and the node becomes unavailable until restarted.