### PR TITLE
Ignore out-of-order receiver side sender reports.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_sender.go
+++ b/pkg/sfu/buffer/rtpstats_sender.go
@@ -665,16 +665,21 @@ func (r *RTPStatsSender) GetRtcpSenderReport(ssrc uint32, calculatedClockRate ui
 	nowRTPExtUsingTime := r.extStartTS + uint64(timeSinceFirst.Nanoseconds()*int64(r.params.ClockRate)/1e9)
 	nowRTPExt := nowRTPExtUsingTime
 
-	// It is possible that publisher is pacing at a slower rate.
-	// That would make `highestTS` to be lagging the RTP time stamp in the RTCP Sender Report from publisher.
-	// Check for that using calculated clock rate and use the later time stamp if applicable.
-	var nowRTPExtUsingRate uint64
-	if calculatedClockRate != 0 {
-		nowRTPExtUsingRate = r.extStartTS + uint64(float64(calculatedClockRate)*timeSinceFirst.Seconds())
-		if nowRTPExtUsingRate > nowRTPExt {
-			nowRTPExt = nowRTPExtUsingRate
+	/*
+		// TODO: Bad reports or unpaced publishing contorts the calculated clock rate a lot resulting in
+		// subsscriber sender reports jumping around. Needs more thinking.
+		//
+		// It is possible that publisher is pacing at a slower rate.
+		// That would make `highestTS` to be lagging the RTP time stamp in the RTCP Sender Report from publisher.
+		// Check for that using calculated clock rate and use the later time stamp if applicable.
+		var nowRTPExtUsingRate uint64
+		if calculatedClockRate != 0 {
+			nowRTPExtUsingRate = r.extStartTS + uint64(float64(calculatedClockRate)*timeSinceFirst.Seconds())
+			if nowRTPExtUsingRate > nowRTPExt {
+				nowRTPExt = nowRTPExtUsingRate
+			}
 		}
-	}
+	*/
 
 	srData := &RTCPSenderReportData{
 		NTPTimestamp:    nowNTP,
@@ -704,7 +709,7 @@ func (r *RTPStatsSender) GetRtcpSenderReport(ssrc uint32, calculatedClockRate ui
 					"timeSinceFirst", timeSinceFirst.String(),
 					"nowRTPExtUsingTime", nowRTPExtUsingTime,
 					"calculatedClockRate", calculatedClockRate,
-					"nowRTPExtUsingRate", nowRTPExtUsingRate,
+					// TODO "nowRTPExtUsingRate", nowRTPExtUsingRate,
 					"timeSinceLastReport", timeSinceLastReport.String(),
 					"rtpDiffSinceLastReport", rtpDiffSinceLastReport,
 					"windowClockRate", windowClockRate,
@@ -734,7 +739,7 @@ func (r *RTPStatsSender) GetRtcpSenderReport(ssrc uint32, calculatedClockRate ui
 			"timeSinceFirst", timeSinceFirst.String(),
 			"nowRTPExtUsingTime", nowRTPExtUsingTime,
 			"calculatedClockRate", calculatedClockRate,
-			"nowRTPExtUsingRate", nowRTPExtUsingRate,
+			// TODO "nowRTPExtUsingRate", nowRTPExtUsingRate,
 		)
 		return nil
 	}


### PR DESCRIPTION
Bad sender reports or unpaced publishing causes publisher side sender reports to have numbers that make the calculated clock rate to be too high. Resetting publisher side reports on an out-of-order and waiting for clock rate to be stable again means subscriber side sender reports get out-of-order.

Doing two things
- Ignore out-of-order receiver side sender report.
- Do not use sender side clock rate on susbcriber side.

This also makes me wonder if forwarding publisher side sender report as is is a good idea. Ideally, it should be, but bad sender reports could be problematic. Maybe, filtering out-of-order reports  and forwarding the rest as is (after mapping to SFU time base and simulcast layer mapping) is an option.