### PR TITLE
Do not need to flush stream allocator events.

### DIFF
--- a/pkg/rtc/dynacastmanager.go
+++ b/pkg/rtc/dynacastmanager.go
@@ -91,7 +91,7 @@ func (d *DynacastManager) Restart() {
 }
 
 func (d *DynacastManager) Close() {
-	d.qualityNotifyOpQueue.Stop()
+	<-d.qualityNotifyOpQueue.Stop()
 
 	d.lock.Lock()
 	dqs := d.getDynacastQualitiesLocked()
@@ -305,9 +305,11 @@ func (d *DynacastManager) enqueueSubscribedQualityChange() {
 		}
 	}
 
-	d.params.Logger.Debugw("subscribedMaxQualityChange",
+	d.params.Logger.Debugw(
+		"subscribedMaxQualityChange",
 		"subscribedCodecs", subscribedCodecs,
-		"maxSubscribedQualities", maxSubscribedQualities)
+		"maxSubscribedQualities", maxSubscribedQualities,
+	)
 	d.qualityNotifyOpQueue.Enqueue(func() {
 		d.onSubscribedMaxQualityChange(subscribedCodecs, maxSubscribedQualities)
 	})

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -180,7 +180,7 @@ func NewStreamAllocator(params StreamAllocatorParams) *StreamAllocator {
 		}),
 		rateMonitor: NewRateMonitor(),
 		videoTracks: make(map[livekit.TrackID]*Track),
-		eventsQueue: utils.NewOpsQueue("stream-allocator", 64, true),
+		eventsQueue: utils.NewOpsQueue("stream-allocator", 64, false),
 	}
 
 	s.probeController = NewProbeController(ProbeControllerParams{


### PR DESCRIPTION
Wondering if this is getting into some kind of loop/stuck condition preventing transport from getting closed and causing a leak. There is a periodic ping, but that is 100ms interval. So, that should be enough for ops queue stop to finish even if it is flushing on stop.

Anyhow, flushing is not needed.