### PR TITLE
Blocking is causing a long wait.

### DIFF
--- a/pkg/rtc/dynacastmanager.go
+++ b/pkg/rtc/dynacastmanager.go
@@ -96,7 +96,7 @@ func (d *DynacastManager) Restart() {
 }
 
 func (d *DynacastManager) Close() {
-	<-d.qualityNotifyOpQueue.Stop()
+	d.qualityNotifyOpQueue.Stop()
 
 	d.lock.Lock()
 	dqs := d.getDynacastQualitiesLocked()


### PR DESCRIPTION
If a network notification times out, it could be stuck for long.