### PR TITLE
Proper RTCP report past mute.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -561,10 +561,10 @@ func (f *Forwarder) GetCurrentSpatialAndTSOffset() (int32, uint64) {
 	defer f.lock.RUnlock()
 
 	if f.kind == webrtc.RTPCodecTypeAudio {
-		return 0, f.rtpMunger.GetTSOffset()
+		return 0, f.rtpMunger.GetPinnedTSOffset()
 	}
 
-	return f.vls.GetCurrent().Spatial, f.rtpMunger.GetTSOffset()
+	return f.vls.GetCurrent().Spatial, f.rtpMunger.GetPinnedTSOffset()
 }
 
 func (f *Forwarder) isDeficientLocked() bool {

--- a/pkg/sfu/rtpmunger.go
+++ b/pkg/sfu/rtpmunger.go
@@ -83,6 +83,7 @@ type RTPMunger struct {
 	extLastTS       uint64
 	extSecondLastTS uint64
 	tsOffset        uint64
+	pinnedTSOffset  uint64
 
 	lastMarker       bool
 	secondLastMarker bool
@@ -107,6 +108,7 @@ func (r *RTPMunger) DebugInfo() map[string]interface{} {
 		"ExtLastTS":            r.extLastTS,
 		"ExtSecondLastTS":      r.extSecondLastTS,
 		"TSOffset":             r.tsOffset,
+		"PinnedTSOffset":       r.pinnedTSOffset,
 		"LastMarker":           r.lastMarker,
 		"SecondLastMarker":     r.secondLastMarker,
 	}
@@ -123,8 +125,8 @@ func (r *RTPMunger) GetLast() RTPMungerState {
 	}
 }
 
-func (r *RTPMunger) GetTSOffset() uint64 {
-	return r.tsOffset
+func (r *RTPMunger) GetPinnedTSOffset() uint64 {
+	return r.pinnedTSOffset
 }
 
 func (r *RTPMunger) SeedLast(state RTPMungerState) {
@@ -146,6 +148,8 @@ func (r *RTPMunger) SetLastSnTs(extPkt *buffer.ExtPacket) {
 
 	r.extLastTS = extPkt.ExtTimestamp
 	r.extSecondLastTS = extPkt.ExtTimestamp
+	r.tsOffset = 0
+	r.pinnedTSOffset = r.tsOffset
 }
 
 func (r *RTPMunger) UpdateSnTsOffsets(extPkt *buffer.ExtPacket, snAdjust uint64, tsAdjust uint64) {
@@ -155,6 +159,7 @@ func (r *RTPMunger) UpdateSnTsOffsets(extPkt *buffer.ExtPacket, snAdjust uint64,
 	r.updateSnOffset()
 
 	r.tsOffset = extPkt.ExtTimestamp - r.extLastTS - tsAdjust
+	r.pinnedTSOffset = r.tsOffset
 }
 
 func (r *RTPMunger) PacketDropped(extPkt *buffer.ExtPacket) {


### PR DESCRIPTION
- When audio is muted, server injects silence frames which moves the time stamp forward and adjusts offset. That cannot be used against publisher side sender report. Use a pinned version.
- Ignore small changes to propagation delay even while checking for sharp increase. That is spamming a lot for small changes, i.e. existing delta is 100 micro seconds or so and the new one is 300 micro seconds. Also rename to `longTerm` from `smoothed` as it is a slow varying long term estimate of propagation delay delta. And slow down that adaptation more.