### PR TITLE
Cache transceiver before closing subscribed track.

### DIFF
--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -322,13 +322,6 @@ func (t *MediaTrackSubscriptions) closeSubscribedTrack(subTrack types.Subscribed
 
 	if willBeResumed {
 		dt.CloseWithFlush(false)
-
-		// cache transceiver for potential re-use on resume
-		tr := dt.GetTransceiver()
-		if tr != nil {
-			sub := subTrack.Subscriber()
-			sub.CacheDownTrack(subTrack.ID(), tr, dt.GetState())
-		}
 	} else {
 		// flushing blocks, avoid blocking when publisher removes all its subscribers
 		go dt.CloseWithFlush(true)
@@ -426,6 +419,16 @@ func (t *MediaTrackSubscriptions) downTrackClosed(
 	t.subscribedTracksMu.Unlock()
 
 	if subTrack != nil {
+		// cache transceiver for potential re-use on resume
+		if willBeResumed {
+			dt := subTrack.DownTrack()
+			tr := dt.GetTransceiver()
+			if tr != nil {
+				sub := subTrack.Subscriber()
+				sub.CacheDownTrack(subTrack.ID(), tr, dt.GetState())
+			}
+		}
+
 		subTrack.Close(willBeResumed)
 	}
 }

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2362,6 +2362,7 @@ func (p *ParticipantImpl) CacheDownTrack(trackID livekit.TrackID, rtpTransceiver
 		p.subLogger.Infow("cached transceiver changed", "trackID", trackID)
 	}
 	p.cachedDownTracks[trackID] = &downTrackState{transceiver: rtpTransceiver, downTrack: downTrack}
+	p.subLogger.Debugw("caching downtrack", "trackID", trackID)
 	p.lock.Unlock()
 }
 
@@ -2369,6 +2370,9 @@ func (p *ParticipantImpl) UncacheDownTrack(rtpTransceiver *webrtc.RTPTransceiver
 	p.lock.Lock()
 	for trackID, dts := range p.cachedDownTracks {
 		if dts.transceiver == rtpTransceiver {
+			if dts := p.cachedDownTracks[trackID]; dts != nil {
+				p.subLogger.Debugw("uncaching downtrack", "trackID", trackID)
+			}
 			delete(p.cachedDownTracks, trackID)
 			break
 		}
@@ -2380,8 +2384,7 @@ func (p *ParticipantImpl) GetCachedDownTrack(trackID livekit.TrackID) (*webrtc.R
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
-	dts := p.cachedDownTracks[trackID]
-	if dts != nil {
+	if dts := p.cachedDownTracks[trackID]; dts != nil {
 		return dts.transceiver, dts.downTrack
 	}
 

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -533,13 +533,9 @@ func (d *DownTrack) SubscriberID() livekit.ParticipantID {
 
 // Sets RTP header extensions for this track
 func (d *DownTrack) SetRTPHeaderExtensions(rtpHeaderExtensions []webrtc.RTPHeaderExtensionParameter) {
-	d.streamAllocatorLock.RLock()
-	listener := d.streamAllocatorListener
-	d.streamAllocatorLock.RUnlock()
-
 	isBWEEnabled := true
-	if listener != nil {
-		isBWEEnabled = listener.IsBWEEnabled(d)
+	if sal := d.getStreamAllocatorListener(); sal != nil {
+		isBWEEnabled = sal.IsBWEEnabled(d)
 	}
 	for _, ext := range rtpHeaderExtensions {
 		switch ext.URI {
@@ -669,13 +665,23 @@ func (d *DownTrack) maxLayerNotifierWorker() {
 		d.params.Logger.Debugw("max subscribed layer processed", "layer", maxLayerSpatial, "event", event)
 
 		if onMaxSubscribedLayerChanged := d.getOnMaxLayerChanged(); onMaxSubscribedLayerChanged != nil {
-			d.params.Logger.Debugw("notifying max subscribed layer", "layer", maxLayerSpatial, "event", event)
+			d.params.Logger.Debugw(
+				"notifying max subscribed layer",
+				"layer", maxLayerSpatial,
+				"event", event,
+				"subscriberID", d.SubscriberID(),
+			)
 			onMaxSubscribedLayerChanged(d, maxLayerSpatial)
 		}
 	}
 
 	if onMaxSubscribedLayerChanged := d.getOnMaxLayerChanged(); onMaxSubscribedLayerChanged != nil {
-		d.params.Logger.Debugw("notifying max subscribed layer", "layer", buffer.InvalidLayerSpatial, "event", "close")
+		d.params.Logger.Debugw(
+			"notifying max subscribed layer",
+			"layer", buffer.InvalidLayerSpatial,
+			"event", "close",
+			"subscriberID", d.SubscriberID(),
+		)
 		onMaxSubscribedLayerChanged(d, buffer.InvalidLayerSpatial)
 	}
 }
@@ -865,13 +871,9 @@ func (d *DownTrack) WritePaddingRTP(bytesToSend int, paddingOnMute bool, forceMa
 
 // Mute enables or disables media forwarding - subscriber triggered
 func (d *DownTrack) Mute(muted bool) {
-	d.streamAllocatorLock.RLock()
-	listener := d.streamAllocatorListener
-	d.streamAllocatorLock.RUnlock()
-
 	isSubscribeMutable := true
-	if listener != nil {
-		isSubscribeMutable = listener.IsSubscribeMutable(d)
+	if sal := d.getStreamAllocatorListener(); sal != nil {
+		isSubscribeMutable = sal.IsSubscribeMutable(d)
 	}
 	changed := d.forwarder.Mute(muted, isSubscribeMutable)
 	d.handleMute(muted, changed)
@@ -987,9 +989,10 @@ func (d *DownTrack) CloseWithFlush(flush bool) {
 		d.rtcpReader.Close()
 		d.rtcpReader.OnPacket(nil)
 	}
-
 	d.bindLock.Unlock()
+
 	d.connectionStats.Close()
+
 	d.rtpStats.Stop()
 	d.params.Logger.Debugw("rtp stats",
 		"direction", "downstream",

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -241,9 +241,15 @@ func (s *StreamAllocator) AddTrack(downTrack *sfu.DownTrack, params AddTrackPara
 	track := NewTrack(downTrack, params.Source, params.IsSimulcast, params.PublisherID, s.params.Logger)
 	track.SetPriority(params.Priority)
 
+	trackID := livekit.TrackID(downTrack.ID())
 	s.videoTracksMu.Lock()
-	s.videoTracks[livekit.TrackID(downTrack.ID())] = track
+	oldTrack := s.videoTracks[trackID]
+	s.videoTracks[trackID] = track
 	s.videoTracksMu.Unlock()
+
+	if oldTrack != nil {
+		oldTrack.DownTrack().SetStreamAllocatorListener(nil)
+	}
 
 	downTrack.SetStreamAllocatorListener(s)
 	if s.prober.IsRunning() {


### PR DESCRIPTION
On migration, when subscription moved from remote -> local, transceiver caching was racing. Although a very small possibility, it could happen like so

1. down track close
2. down track close callback fires go routine to close subscribed track
3. subscribed track close handler in subscription manager tries to reconcile
4. reconcile adds subscribed track again
5. cannot find cached transceiver as caching happens after down track close finishes in stap 1 above. Although there are a couple of gortouine jumps (step 2 fires a goroutine to close subscribed track and step 4 will reconcile in a goroutine too), it is theoretically possible that the step 1 has not finished and hence transceiver is not cached.

Fix is to move caching to before closing subscribed track.