### PR TITLE
Notify initial permissions

### DIFF
--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -497,8 +497,6 @@ func (m *SubscriptionManager) subscribe(s *trackSubscription) error {
 
 	s.setPublisher(res.PublisherIdentity, res.PublisherID)
 
-	// since hasPermission defaults to true, we will want to send a message to the client the first time
-	// that we discover permissions were denied
 	permChanged := s.setHasPermission(res.HasPermission)
 	if permChanged {
 		m.params.Participant.SubscriptionPermissionUpdate(s.getPublisherID(), trackID, res.HasPermission)

--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -745,8 +745,6 @@ func newTrackSubscription(subscriberID livekit.ParticipantID, trackID livekit.Tr
 		subscriberID: subscriberID,
 		trackID:      trackID,
 		logger:       l,
-		// default allow
-		hasPermission: true,
 	}
 }
 


### PR DESCRIPTION
NOTE: This does add an initial subscription permission notification which should be fine, but something to watch for.

A stress test combining
- mute/unmute on publisher side.
- allowing/revoking permission for subscriber from publisher side.
- subscribing/unsubscribing from subscriber side

results in a scenario where a subscription permission update of `not_allowed` being sent and on a re-subscribe, an `allowed` update does not happen.

It happens like so
- Subscription revoke closes the down track of subscriber.
- The subscription is still desired.
- So, a subscription reconcile runs and sees `permission: false`. This sends subscription permission of `not_allowed`.
- Unsubscribe request comes in and sets `desired: false`.
- Reconciler runs again and sees `desired: false` and `subscribedTrack: nil`. This cleans up the subscription.
- Publisher grants permission for the subscriber.
- Subscriber subscribes to the track again. A new subscription is created.
- Reconciler runs and sees `permission: true`, but there is no permission change as it is a new subscription object. So, `allowed` subscription permission update is not sent and the client is stuck at `not_allowed`.

Fix, maintain if permission has been initialized. Has the effect of sending an initial update which should be fine.