### PR TITLE
fix: Firefox missing SVC layers with RTX enabled 

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -1689,13 +1689,6 @@ func (t *PCTransport) handleRemoteOfferReceived(sd *webrtc.SessionDescription) e
 	if err := t.setRemoteDescription(*sd); err != nil {
 		return err
 	}
-	rtxRepairs := rtxRepairsFromSDP(parsed, t.params.Logger)
-	if len(rtxRepairs) > 0 {
-		t.params.Logger.Debugw("rtx pairs found from sdp", "ssrcs", rtxRepairs)
-		for repair, base := range rtxRepairs {
-			t.params.Config.BufferFactory.SetRTXPair(repair, base)
-		}
-	}
 
 	if t.currentOfferIceCredential == "" || offerRestartICE {
 		t.currentOfferIceCredential = iceCredential


### PR DESCRIPTION
Description:
``` 
  In the SFU, we allocated SRTP buffers before we send back an answer
  for each RTX repairs and other SVC layers. However, Pion uses these
  allocated buffers to probe the RTP header for the interceptor chain and
  track creations. SVC layers are carried by a single RTP stream. When the
  Pion RTP probing occurs for other allocated SSRCs (other SVC layers), the reader
  ended prematurely with EOF.

  End result, 2 out of 3 SVC layers are unhandled by Pion. Only the
  first track in the SDP being used, "q" encoding quality.
```

Solution:
Let Livekit's interceptor to setup RTX pair, https://github.com/livekit/livekit/blob/5df630c9b0497328cd78e470d16424894d03c7a3//pkg/rtc/transport.go#L371-L374. This will make sure that Pion's allocation order is maintained.

References:
* EOF occurs on unhandled SVC layers on probing, https://github.com/pion/webrtc/blob/e2454d1c00da7219d10520f707a578c520b1de66//peerconnection.go#L1575-L1576
* Parsing SDP for getting RTX FID has been done in Pion, https://github.com/pion/webrtc/blob/e2454d1c00da7219d10520f707a578c520b1de66//peerconnection.go#L1538-L1554
* Pion SRTP uses the same buffer factory: https://github.com/pion/srtp/blob/31573970e0cab76976d8f7cc9b3c99953bef4475//stream_srtp.go#L55-L57
* Livekit Buffer Factory: https://github.com/livekit/livekit/blob/5df630c9b0497328cd78e470d16424894d03c7a3//pkg/sfu/buffer/factory.go#L55-L55
* Pion got confused with empty buffers instead of using the main RTP buffer, https://github.com/pion/srtp/blob/31573970e0cab76976d8f7cc9b3c99953bef4475//session_srtp.go#L174-L182