### PR TITLE
Participant.ConnectedAt to reflect when primary transport is connected

### DIFF
--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -263,8 +263,8 @@ func TestDisconnectTiming(t *testing.T) {
 func TestCorrectJoinedAt(t *testing.T) {
 	p := newParticipantForTest("test")
 	info := p.ToProto()
-	require.NotZero(t, info.JoinedAt)
-	require.True(t, time.Now().Unix()-info.JoinedAt <= 1)
+	// have not joined the room, only set when fully connected
+	require.Zero(t, info.JoinedAt)
 }
 
 func TestMuteSetting(t *testing.T) {

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -361,7 +361,7 @@ func (r *Room) Join(participant types.LocalParticipant, requestSource routing.Me
 			r.subscribeToExistingTracks(p)
 
 			meta := &livekit.AnalyticsClientMeta{
-				ClientConnectTime: uint32(time.Since(p.ConnectedAt()).Milliseconds()),
+				ClientConnectTime: uint32(p.ConnectionDuration().Milliseconds()),
 			}
 			cds := p.GetICEConnectionDetails()
 			for _, cd := range cds {

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -304,6 +304,7 @@ type LocalParticipant interface {
 	SupportsSyncStreamID() bool
 	SupportsTransceiverReuse() bool
 	ConnectedAt() time.Time
+	ConnectionDuration() time.Duration
 	IsClosed() bool
 	IsReady() bool
 	IsDisconnected() bool

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -158,6 +158,16 @@ type FakeLocalParticipant struct {
 	connectedAtReturnsOnCall map[int]struct {
 		result1 time.Time
 	}
+	ConnectionDurationStub        func() time.Duration
+	connectionDurationMutex       sync.RWMutex
+	connectionDurationArgsForCall []struct {
+	}
+	connectionDurationReturns struct {
+		result1 time.Duration
+	}
+	connectionDurationReturnsOnCall map[int]struct {
+		result1 time.Duration
+	}
 	DebugInfoStub        func() map[string]interface{}
 	debugInfoMutex       sync.RWMutex
 	debugInfoArgsForCall []struct {
@@ -1704,6 +1714,59 @@ func (fake *FakeLocalParticipant) ConnectedAtReturnsOnCall(i int, result1 time.T
 	}
 	fake.connectedAtReturnsOnCall[i] = struct {
 		result1 time.Time
+	}{result1}
+}
+
+func (fake *FakeLocalParticipant) ConnectionDuration() time.Duration {
+	fake.connectionDurationMutex.Lock()
+	ret, specificReturn := fake.connectionDurationReturnsOnCall[len(fake.connectionDurationArgsForCall)]
+	fake.connectionDurationArgsForCall = append(fake.connectionDurationArgsForCall, struct {
+	}{})
+	stub := fake.ConnectionDurationStub
+	fakeReturns := fake.connectionDurationReturns
+	fake.recordInvocation("ConnectionDuration", []interface{}{})
+	fake.connectionDurationMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLocalParticipant) ConnectionDurationCallCount() int {
+	fake.connectionDurationMutex.RLock()
+	defer fake.connectionDurationMutex.RUnlock()
+	return len(fake.connectionDurationArgsForCall)
+}
+
+func (fake *FakeLocalParticipant) ConnectionDurationCalls(stub func() time.Duration) {
+	fake.connectionDurationMutex.Lock()
+	defer fake.connectionDurationMutex.Unlock()
+	fake.ConnectionDurationStub = stub
+}
+
+func (fake *FakeLocalParticipant) ConnectionDurationReturns(result1 time.Duration) {
+	fake.connectionDurationMutex.Lock()
+	defer fake.connectionDurationMutex.Unlock()
+	fake.ConnectionDurationStub = nil
+	fake.connectionDurationReturns = struct {
+		result1 time.Duration
+	}{result1}
+}
+
+func (fake *FakeLocalParticipant) ConnectionDurationReturnsOnCall(i int, result1 time.Duration) {
+	fake.connectionDurationMutex.Lock()
+	defer fake.connectionDurationMutex.Unlock()
+	fake.ConnectionDurationStub = nil
+	if fake.connectionDurationReturnsOnCall == nil {
+		fake.connectionDurationReturnsOnCall = make(map[int]struct {
+			result1 time.Duration
+		})
+	}
+	fake.connectionDurationReturnsOnCall[i] = struct {
+		result1 time.Duration
 	}{result1}
 }
 
@@ -6343,6 +6406,8 @@ func (fake *FakeLocalParticipant) Invocations() map[string][][]interface{} {
 	defer fake.closeSignalConnectionMutex.RUnlock()
 	fake.connectedAtMutex.RLock()
 	defer fake.connectedAtMutex.RUnlock()
+	fake.connectionDurationMutex.RLock()
+	defer fake.connectionDurationMutex.RUnlock()
 	fake.debugInfoMutex.RLock()
 	defer fake.debugInfoMutex.RUnlock()
 	fake.getAdaptiveStreamMutex.RLock()

--- a/test/singlenode_test.go
+++ b/test/singlenode_test.go
@@ -65,6 +65,8 @@ func TestClientCouldConnect(t *testing.T) {
 		}
 		return ""
 	})
+
+	require.Less(t, time.Now().Unix()-c1.RemoteParticipants()[0].JoinedAt, int64(5))
 }
 
 func TestClientConnectDuplicate(t *testing.T) {


### PR DESCRIPTION
We do not want to report a participant has "joined" or "connected" when PeerConnection isn't successful