### PR TITLE
Fix media track close check.

### DIFF
--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -161,6 +161,7 @@ func (t *MediaTrackReceiver) SetupReceiver(receiver sfu.TrackReceiver, priority 
 	receivers := slices.Clone(t.receivers)
 
 	// codec position maybe taken by DummyReceiver, check and upgrade to WebRTCReceiver
+	receiverToAdd := receiver
 	idx := -1
 	for i, r := range receivers {
 		if strings.EqualFold(r.Codec().MimeType, receiver.Codec().MimeType) {
@@ -171,11 +172,12 @@ func (t *MediaTrackReceiver) SetupReceiver(receiver sfu.TrackReceiver, priority 
 	if idx != -1 {
 		if d, ok := receivers[idx].TrackReceiver.(*DummyReceiver); ok {
 			d.Upgrade(receiver)
+			receiverToAdd = d
 		}
 		// replace receiver
 		receivers = slices.Delete(receivers, idx, idx+1)
 	}
-	receivers = append(receivers, &simulcastReceiver{TrackReceiver: receiver, priority: priority})
+	receivers = append(receivers, &simulcastReceiver{TrackReceiver: receiverToAdd, priority: priority})
 
 	sort.Slice(receivers, func(i, j int) bool {
 		return receivers[i].Priority() < receivers[j].Priority()
@@ -321,15 +323,21 @@ func (t *MediaTrackReceiver) TryClose() bool {
 		return true
 	}
 
+	numActiveReceivers := 0
 	for _, receiver := range t.receivers {
-		if dr, _ := receiver.TrackReceiver.(*DummyReceiver); dr != nil && dr.Receiver() != nil {
-			t.lock.RUnlock()
-			return false
+		dr, ok := receiver.TrackReceiver.(*DummyReceiver)
+		if !ok || dr.Receiver() != nil {
+			// !ok means real receiver OR
+			// dummy receiver with a regular receiver attached
+			numActiveReceivers++
 		}
 	}
 	t.lock.RUnlock()
-	t.Close()
+	if numActiveReceivers != 0 {
+		return false
+	}
 
+	t.Close()
 	return true
 }
 


### PR DESCRIPTION
With the change in https://github.com/livekit/livekit/pull/2611, the dummy receiver was replaced with real receiver. But, the close check was using the dummy receiver.

Doing two things
- Use the dummy receiver post upgrade also (NOTE: this is not needed, but just keeping old behaviour)
- Fix the close check to count number of open receivers.