### PR TITLE
Move caching of publisher sender report to subscriber side.

### DIFF
--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -26,7 +26,6 @@ import (
 	"github.com/livekit/protocol/logger"
 
 	"github.com/livekit/livekit-server/pkg/sfu"
-	"github.com/livekit/livekit-server/pkg/sfu/buffer"
 )
 
 // wrapper around WebRTC receiver, overriding its ID
@@ -315,20 +314,6 @@ func (d *DummyReceiver) GetPrimaryReceiverForRed() sfu.TrackReceiver {
 
 func (d *DummyReceiver) GetRedReceiver() sfu.TrackReceiver {
 	return d
-}
-
-func (d *DummyReceiver) GetReferenceLayerRTPTimestamp(ts uint32, layer int32, referenceLayer int32) (uint32, error) {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
-		return r.GetReferenceLayerRTPTimestamp(ts, layer, referenceLayer)
-	}
-	return 0, errors.New("receiver not available")
-}
-
-func (d *DummyReceiver) GetRTCPSenderReportData(layer int32) *buffer.RTCPSenderReportData {
-	if r, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
-		return r.GetRTCPSenderReportData(layer)
-	}
-	return nil
 }
 
 func (d *DummyReceiver) GetTrackStats() *livekit.RTPStats {

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -317,6 +317,7 @@ func NewDownTrack(params DowntrackParams) (*DownTrack, error) {
 	d.forwarder = NewForwarder(
 		d.kind,
 		params.Logger,
+		false,
 		d.getExpectedRTPTimestamp,
 	)
 

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -317,7 +317,6 @@ func NewDownTrack(params DowntrackParams) (*DownTrack, error) {
 	d.forwarder = NewForwarder(
 		d.kind,
 		params.Logger,
-		d.params.Receiver.GetReferenceLayerRTPTimestamp,
 		d.getExpectedRTPTimestamp,
 	)
 
@@ -1306,8 +1305,8 @@ func (d *DownTrack) CreateSenderReport() *rtcp.SenderReport {
 		return nil
 	}
 
-	layer, tsOffset := d.forwarder.GetCurrentSpatialAndTSOffset()
-	return d.rtpStats.GetRtcpSenderReport(d.ssrc, d.params.Receiver.GetRTCPSenderReportData(layer), tsOffset)
+	_, tsOffset, refSenderReport := d.forwarder.GetSenderReportParams()
+	return d.rtpStats.GetRtcpSenderReport(d.ssrc, refSenderReport, tsOffset)
 }
 
 func (d *DownTrack) writeBlankFrameRTP(duration float32, generation uint32) chan struct{} {
@@ -1950,9 +1949,11 @@ func (d *DownTrack) HandleRTCPSenderReportData(
 	layer int32,
 	publisherSRData *buffer.RTCPSenderReportData,
 ) error {
-	currentLayer, tsOffset := d.forwarder.GetCurrentSpatialAndTSOffset()
+	d.forwarder.SetRefSenderReport(isSVC, layer, publisherSRData)
+
+	currentLayer, tsOffset, refSenderReport := d.forwarder.GetSenderReportParams()
 	if layer == currentLayer || (layer == 0 && isSVC) {
-		d.handleRTCPSenderReportData(publisherSRData, tsOffset)
+		d.handleRTCPSenderReportData(refSenderReport, tsOffset)
 	}
 	return nil
 }
@@ -2010,10 +2011,6 @@ func (d *DownTrack) sendingPacket(hdr *rtp.Header, payloadSize int, spmd *sendPa
 		}
 
 		if spmd.tp.isResuming {
-			// adjust first packet time on a resumption so that subsequent switches get a more accurate expected time stamp
-			currentLayer, tsOffset := d.forwarder.GetCurrentSpatialAndTSOffset()
-			d.handleRTCPSenderReportData(d.params.Receiver.GetRTCPSenderReportData(currentLayer), tsOffset)
-
 			if sal := d.getStreamAllocatorListener(); sal != nil {
 				sal.OnResume(d)
 			}

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1538,7 +1538,7 @@ func (f *Forwarder) getReferenceLayerRTPTimestamp(ts uint32, refLayer, targetLay
 	srRef := f.refSenderReports[refLayer]
 	srTarget := f.refSenderReports[targetLayer]
 	if srRef == nil || srRef.NTPTimestamp == 0 || srTarget == nil || srTarget.NTPTimestamp == 0 {
-		return 0, fmt.Errorf("invalid layer(s), refLayer: %d, targetLayer", refLayer, targetLayer)
+		return 0, fmt.Errorf("invalid layer(s), refLayer: %d, targetLayer: %d", refLayer, targetLayer)
 	}
 
 	ntpDiff := srRef.NTPTimestamp.Time().Sub(srTarget.NTPTimestamp.Time())

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -32,7 +32,7 @@ func disable(f *Forwarder) {
 }
 
 func newForwarder(codec webrtc.RTPCodecCapability, kind webrtc.RTPCodecType) *Forwarder {
-	f := NewForwarder(kind, logger.GetLogger(), nil, nil)
+	f := NewForwarder(kind, logger.GetLogger(), nil)
 	f.DetermineCodec(codec, nil)
 	return f
 }

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -32,7 +32,7 @@ func disable(f *Forwarder) {
 }
 
 func newForwarder(codec webrtc.RTPCodecCapability, kind webrtc.RTPCodecType) *Forwarder {
-	f := NewForwarder(kind, logger.GetLogger(), nil)
+	f := NewForwarder(kind, logger.GetLogger(), true, nil)
 	f.DetermineCodec(codec, nil)
 	return f
 }

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -83,9 +83,6 @@ type TrackReceiver interface {
 
 	GetTemporalLayerFpsForSpatial(layer int32) []float32
 
-	GetReferenceLayerRTPTimestamp(ts uint32, layer int32, referenceLayer int32) (uint32, error)
-	GetRTCPSenderReportData(layer int32) *buffer.RTCPSenderReportData
-
 	GetTrackStats() *livekit.RTPStats
 }
 
@@ -350,8 +347,6 @@ func (w *WebRTCReceiver) AddUpTrack(track *webrtc.TrackRemote, buff *buffer.Buff
 	buff.OnRtcpFeedback(w.sendRTCP)
 	buff.OnRtcpSenderReport(func() {
 		srData := buff.GetSenderReportData()
-		w.streamTrackerManager.SetRTCPSenderReportData(layer, srData)
-
 		w.downTrackSpreader.Broadcast(func(dt TrackSender) {
 			_ = dt.HandleRTCPSenderReportData(w.codec.PayloadType, w.isSVC, layer, srData)
 		})
@@ -804,14 +799,6 @@ func (w *WebRTCReceiver) GetTemporalLayerFpsForSpatial(layer int32) []float32 {
 	}
 
 	return b.GetTemporalLayerFpsForSpatial(layer)
-}
-
-func (w *WebRTCReceiver) GetReferenceLayerRTPTimestamp(ts uint32, layer int32, referenceLayer int32) (uint32, error) {
-	return w.streamTrackerManager.GetReferenceLayerRTPTimestamp(ts, layer, referenceLayer)
-}
-
-func (w *WebRTCReceiver) GetRTCPSenderReportData(layer int32) *buffer.RTCPSenderReportData {
-	return w.streamTrackerManager.GetRTCPSenderReportData(layer)
 }
 
 // closes all track senders in parallel, returns when all are closed


### PR DESCRIPTION
Please see inline for descriptive comments on why. Basically, pause/unpause using replaceTrack(null)/replaceTrack(actualTrack) can cause time stamp in sender report sent to subscribers jump ahead. This prevents that.

With the caching on subscriber side, cleaning up the caching on publisher side.