### PR TITLE
Reduce RED weight in half.

### DIFF
--- a/pkg/sfu/connectionquality/connectionstats.go
+++ b/pkg/sfu/connectionquality/connectionstats.go
@@ -379,7 +379,7 @@ func (cs *ConnectionStats) updateStatsWorker() {
 // For audio:
 //
 //	o Opus without FEC or RED suffers the most through packet loss, hence has the highest weight
-//	o RED with two packet redundancy can absorb two out of every three packets lost, so packet loss is not as detrimental and therefore lower weight
+//	o RED with two packet redundancy can absorb one out of every two packets lost, so packet loss is not as detrimental and therefore lower weight
 //
 // For video:
 //
@@ -396,10 +396,10 @@ func getPacketLossWeight(mimeType string, isFecEnabled bool) float64 {
 		}
 
 	case strings.EqualFold(mimeType, "audio/red"):
-		// 10%: fall to GOOD, 30.0%: fall to POOR
-		plw = 2.0
+		// 5%: fall to GOOD, 15.0%: fall to POOR
+		plw = 4.0
 		if isFecEnabled {
-			// 15%: fall to GOOD, 45.0%: fall to POOR
+			// 7.5%: fall to GOOD, 22.5%: fall to POOR
 			plw /= 1.5
 		}
 

--- a/pkg/sfu/connectionquality/connectionstats_test.go
+++ b/pkg/sfu/connectionquality/connectionstats_test.go
@@ -563,7 +563,7 @@ func TestConnectionQuality(t *testing.T) {
 					},
 				},
 			},
-			// "audio/red" - no fec - 0 <= loss < 10%: EXCELLENT, 10% <= loss < 30%: GOOD, >= 30%: POOR
+			// "audio/red" - no fec - 0 <= loss < 5%: EXCELLENT, 5% <= loss < 15%: GOOD, >= 15%: POOR
 			{
 				name:            "audio/red - no fec",
 				mimeType:        "audio/red",
@@ -571,23 +571,23 @@ func TestConnectionQuality(t *testing.T) {
 				packetsExpected: 200,
 				expectedQualities: []expectedQuality{
 					{
-						packetLossPercentage: 8.0,
+						packetLossPercentage: 4.0,
 						expectedMOS:          4.6,
 						expectedQuality:      livekit.ConnectionQuality_EXCELLENT,
 					},
 					{
-						packetLossPercentage: 12.0,
+						packetLossPercentage: 6.0,
 						expectedMOS:          4.1,
 						expectedQuality:      livekit.ConnectionQuality_GOOD,
 					},
 					{
-						packetLossPercentage: 39.0,
+						packetLossPercentage: 19.5,
 						expectedMOS:          2.1,
 						expectedQuality:      livekit.ConnectionQuality_POOR,
 					},
 				},
 			},
-			// "audio/red" - fec - 0 <= loss < 15%: EXCELLENT, 15% <= loss < 45%: GOOD, >= 45%: POOR
+			// "audio/red" - fec - 0 <= loss < 7.5%: EXCELLENT, 7.5% <= loss < 22.5%: GOOD, >= 22.5%: POOR
 			{
 				name:            "audio/red - fec",
 				mimeType:        "audio/red",
@@ -595,17 +595,17 @@ func TestConnectionQuality(t *testing.T) {
 				packetsExpected: 200,
 				expectedQualities: []expectedQuality{
 					{
-						packetLossPercentage: 12.0,
+						packetLossPercentage: 6.0,
 						expectedMOS:          4.6,
 						expectedQuality:      livekit.ConnectionQuality_EXCELLENT,
 					},
 					{
-						packetLossPercentage: 20.0,
+						packetLossPercentage: 10.0,
 						expectedMOS:          4.1,
 						expectedQuality:      livekit.ConnectionQuality_GOOD,
 					},
 					{
-						packetLossPercentage: 60.0,
+						packetLossPercentage: 30.0,
 						expectedMOS:          2.1,
 						expectedQuality:      livekit.ConnectionQuality_POOR,
 					},


### PR DESCRIPTION
As RED uses only one packet depth. Used to be 2 packets at some point.