### PR TITLE
Do codec munging when munging RTP header.

### DIFF
--- a/pkg/sfu/codecmunger/codecmunger.go
+++ b/pkg/sfu/codecmunger/codecmunger.go
@@ -33,7 +33,7 @@ type CodecMunger interface {
 	SetLast(extPkt *buffer.ExtPacket)
 	UpdateOffsets(extPkt *buffer.ExtPacket)
 
-	UpdateAndGet(extPkt *buffer.ExtPacket, snOutOfOrder bool, snHasGap bool, maxTemporal int32, outputHeader []byte) (int, int, error)
+	UpdateAndGet(extPkt *buffer.ExtPacket, snOutOfOrder bool, snHasGap bool, maxTemporal int32) (int, []byte, error)
 
-	UpdateAndGetPadding(newPicture bool, outputHeader []byte) (int, error)
+	UpdateAndGetPadding(newPicture bool) ([]byte, error)
 }

--- a/pkg/sfu/codecmunger/null.go
+++ b/pkg/sfu/codecmunger/null.go
@@ -45,10 +45,10 @@ func (n *Null) SetLast(_extPkt *buffer.ExtPacket) {
 func (n *Null) UpdateOffsets(_extPkt *buffer.ExtPacket) {
 }
 
-func (n *Null) UpdateAndGet(_extPkt *buffer.ExtPacket, snOutOfOrder bool, snHasGap bool, maxTemporal int32, outputHeader []byte) (int, int, error) {
-	return 0, 0, nil
+func (n *Null) UpdateAndGet(_extPkt *buffer.ExtPacket, snOutOfOrder bool, snHasGap bool, maxTemporal int32) (int, []byte, error) {
+	return 0, nil, nil
 }
 
-func (n *Null) UpdateAndGetPadding(newPicture bool, outputHeader []byte) (int, error) {
-	return 0, nil
+func (n *Null) UpdateAndGetPadding(newPicture bool) ([]byte, error) {
+	return nil, nil
 }

--- a/pkg/sfu/codecmunger/vp8.go
+++ b/pkg/sfu/codecmunger/vp8.go
@@ -158,10 +158,10 @@ func (v *VP8) UpdateOffsets(extPkt *buffer.ExtPacket) {
 	v.exemptedPictureIds = orderedmap.NewOrderedMap[int32, bool]()
 }
 
-func (v *VP8) UpdateAndGet(extPkt *buffer.ExtPacket, snOutOfOrder bool, snHasGap bool, maxTemporalLayer int32, outputHeader []byte) (int, int, error) {
+func (v *VP8) UpdateAndGet(extPkt *buffer.ExtPacket, snOutOfOrder bool, snHasGap bool, maxTemporalLayer int32) (int, []byte, error) {
 	vp8, ok := extPkt.Payload.(buffer.VP8)
 	if !ok {
-		return 0, 0, ErrNotVP8
+		return 0, nil, ErrNotVP8
 	}
 
 	extPictureId := v.pictureIdWrapHandler.Unwrap(vp8.PictureID, vp8.M)
@@ -170,7 +170,7 @@ func (v *VP8) UpdateAndGet(extPkt *buffer.ExtPacket, snOutOfOrder bool, snHasGap
 	if snOutOfOrder {
 		pictureIdOffset, ok := v.missingPictureIds.Get(extPictureId)
 		if !ok {
-			return 0, 0, ErrOutOfOrderVP8PictureIdCacheMiss
+			return 0, nil, ErrOutOfOrderVP8PictureIdCacheMiss
 		}
 
 		// the out-of-order picture id cannot be deleted from the cache
@@ -195,11 +195,11 @@ func (v *VP8) UpdateAndGet(extPkt *buffer.ExtPacket, snOutOfOrder bool, snHasGap
 			IsKeyFrame: vp8.IsKeyFrame,
 			HeaderSize: vp8.HeaderSize + buffer.VPxPictureIdSizeDiff(mungedPictureId > 127, vp8.M),
 		}
-		n, err := vp8Packet.MarshalTo(outputHeader)
+		vp8HeaderBytes, err := vp8Packet.Marshal()
 		if err != nil {
-			return 0, 0, err
+			return 0, nil, err
 		}
-		return vp8.HeaderSize, n, nil
+		return vp8.HeaderSize, vp8HeaderBytes, nil
 	}
 
 	prevMaxPictureId := v.pictureIdWrapHandler.MaxPictureId()
@@ -267,7 +267,7 @@ func (v *VP8) UpdateAndGet(extPkt *buffer.ExtPacket, snOutOfOrder bool, snHasGap
 
 					v.pictureIdOffset += 1
 				}
-				return 0, 0, ErrFilteredVP8TemporalLayer
+				return 0, nil, ErrFilteredVP8TemporalLayer
 			}
 		}
 	}
@@ -302,14 +302,14 @@ func (v *VP8) UpdateAndGet(extPkt *buffer.ExtPacket, snOutOfOrder bool, snHasGap
 		IsKeyFrame: vp8.IsKeyFrame,
 		HeaderSize: vp8.HeaderSize + buffer.VPxPictureIdSizeDiff(mungedPictureId > 127, vp8.M),
 	}
-	n, err := vp8Packet.MarshalTo(outputHeader)
+	vp8HeaderBytes, err := vp8Packet.Marshal()
 	if err != nil {
-		return 0, 0, err
+		return 0, nil, err
 	}
-	return vp8.HeaderSize, n, nil
+	return vp8.HeaderSize, vp8HeaderBytes, nil
 }
 
-func (v *VP8) UpdateAndGetPadding(newPicture bool, outputHeader []byte) (int, error) {
+func (v *VP8) UpdateAndGetPadding(newPicture bool) ([]byte, error) {
 	offset := 0
 	if newPicture {
 		offset = 1
@@ -367,7 +367,7 @@ func (v *VP8) UpdateAndGetPadding(newPicture bool, outputHeader []byte) (int, er
 		IsKeyFrame: true,
 		HeaderSize: headerSize,
 	}
-	return vp8Packet.MarshalTo(outputHeader)
+	return vp8Packet.Marshal()
 }
 
 // for testing only

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -1502,15 +1502,16 @@ func (d *DownTrack) getVP8BlankFrame(frameEndNeeded bool) ([]byte, error) {
 	// Used even when closing out a previous frame. Looks like receivers
 	// do not care about content (it will probably end up being an undecodable
 	// frame, but that should be okay as there are key frames following)
-	payload := make([]byte, 1000)
-	n, err := d.forwarder.GetPadding(frameEndNeeded, payload)
+	header, err := d.forwarder.GetPadding(frameEndNeeded)
 	if err != nil {
 		return nil, err
 	}
 
-	copy(payload[n:], VP8KeyFrame8x8)
-	trailerLen := d.maybeAddTrailer(payload[n+len(VP8KeyFrame8x8):])
-	return payload[:n+len(VP8KeyFrame8x8)+trailerLen], nil
+	payload := make([]byte, 1000)
+	copy(payload, header)
+	copy(payload[len(header):], VP8KeyFrame8x8)
+	trailerLen := d.maybeAddTrailer(payload[len(header)+len(VP8KeyFrame8x8):])
+	return payload[:len(header)+len(VP8KeyFrame8x8)+trailerLen], nil
 }
 
 func (d *DownTrack) getH264BlankFrame(_frameEndNeeded bool) ([]byte, error) {

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -179,8 +179,8 @@ type TranslationParams struct {
 	isSwitching        bool
 	rtp                TranslationParamsRTP
 	ddBytes            []byte
-	codecBytes         []byte
 	incomingHeaderSize int
+	codecBytes         []byte
 	marker             bool
 }
 

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -1625,7 +1625,6 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 			extSequenceNumber: 23336,
 			extTimestamp:      0xabcdef,
 		},
-		codecBytes: []byte{},
 	}
 	actualTP, err = f.GetTranslationParams(extPkt, 0)
 	require.NoError(t, err)
@@ -1930,7 +1929,6 @@ func TestForwarderGetSnTsForBlankFrames(t *testing.T) {
 }
 
 func TestForwarderGetPaddingVP8(t *testing.T) {
-	buf := make([]byte, 100)
 	f := newForwarder(testutils.TestVP8Codec, webrtc.RTPCodecTypeVideo)
 
 	params := &testutils.TestExtPacketParams{
@@ -1981,11 +1979,11 @@ func TestForwarderGetPaddingVP8(t *testing.T) {
 		HeaderSize: 6,
 		IsKeyFrame: true,
 	}
-	n, err := f.GetPadding(true, buf)
+	buf, err := f.GetPadding(true)
 	require.NoError(t, err)
 	marshalledVP8, err := expectedVP8.Marshal()
 	require.NoError(t, err)
-	require.Equal(t, marshalledVP8, buf[:n])
+	require.Equal(t, marshalledVP8, buf)
 
 	// getting padding with no frame end needed, should get next picture id
 	expectedVP8 = buffer.VP8{
@@ -2003,9 +2001,9 @@ func TestForwarderGetPaddingVP8(t *testing.T) {
 		HeaderSize: 6,
 		IsKeyFrame: true,
 	}
-	n, err = f.GetPadding(false, buf)
+	buf, err = f.GetPadding(false)
 	require.NoError(t, err)
 	marshalledVP8, err = expectedVP8.Marshal()
 	require.NoError(t, err)
-	require.Equal(t, marshalledVP8, buf[:n])
+	require.Equal(t, marshalledVP8, buf)
 }

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -1368,7 +1368,6 @@ func TestForwarderGetTranslationParamsAudio(t *testing.T) {
 }
 
 func TestForwarderGetTranslationParamsVideo(t *testing.T) {
-	buf := make([]byte, 100)
 	f := newForwarder(testutils.TestVP8Codec, webrtc.RTPCodecTypeVideo)
 
 	params := &testutils.TestExtPacketParams{
@@ -1432,22 +1431,6 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 		IsKeyFrame: true,
 	}
 	extPkt, _ = testutils.GetTestExtPacketVP8(params, vp8)
-	expectedTP = TranslationParams{
-		isSwitching: true,
-		isResuming:  true,
-		rtp: TranslationParamsRTP{
-			snOrdering:        SequenceNumberOrderingContiguous,
-			extSequenceNumber: 23333,
-			extTimestamp:      0xabcdef,
-		},
-		marker: true,
-	}
-	actualTP, err = f.GetTranslationParams(extPkt, 0)
-	require.NoError(t, err)
-	require.Equal(t, expectedTP, actualTP)
-	require.True(t, f.started)
-	require.Equal(t, f.lastSSRC, params.SSRC)
-
 	expectedVP8 := &buffer.VP8{
 		FirstByte:  25,
 		I:          true,
@@ -1464,13 +1447,23 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 		IsKeyFrame: true,
 	}
 	marshalledVP8, err := expectedVP8.Marshal()
+	expectedTP = TranslationParams{
+		isSwitching: true,
+		isResuming:  true,
+		rtp: TranslationParamsRTP{
+			snOrdering:        SequenceNumberOrderingContiguous,
+			extSequenceNumber: 23333,
+			extTimestamp:      0xabcdef,
+		},
+		codecBytes:         marshalledVP8,
+		incomingHeaderSize: 6,
+		marker:             true,
+	}
+	actualTP, err = f.GetTranslationParams(extPkt, 0)
 	require.NoError(t, err)
-	shouldForward, incomingHeaderSize, outgoingHeaderSize, err := f.TranslateCodecHeader(extPkt, &actualTP.rtp, buf)
-	require.NoError(t, err)
-	require.True(t, shouldForward)
-	require.Equal(t, 6, incomingHeaderSize)
-	require.Equal(t, 6, outgoingHeaderSize)
-	require.Equal(t, marshalledVP8, buf[:outgoingHeaderSize])
+	require.Equal(t, expectedTP, actualTP)
+	require.True(t, f.started)
+	require.Equal(t, f.lastSSRC, params.SSRC)
 
 	// send a duplicate, should be dropped
 	expectedTP = TranslationParams{
@@ -1518,17 +1511,6 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 		PayloadSize:    20,
 	}
 	extPkt, _ = testutils.GetTestExtPacketVP8(params, vp8)
-	expectedTP = TranslationParams{
-		rtp: TranslationParamsRTP{
-			snOrdering:        SequenceNumberOrderingContiguous,
-			extSequenceNumber: 23334,
-			extTimestamp:      0xabcdef,
-		},
-	}
-	actualTP, err = f.GetTranslationParams(extPkt, 0)
-	require.NoError(t, err)
-	require.Equal(t, expectedTP, actualTP)
-
 	expectedVP8 = &buffer.VP8{
 		FirstByte:  25,
 		I:          true,
@@ -1546,12 +1528,18 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 	}
 	marshalledVP8, err = expectedVP8.Marshal()
 	require.NoError(t, err)
-	shouldForward, incomingHeaderSize, outgoingHeaderSize, err = f.TranslateCodecHeader(extPkt, &actualTP.rtp, buf)
+	expectedTP = TranslationParams{
+		rtp: TranslationParamsRTP{
+			snOrdering:        SequenceNumberOrderingContiguous,
+			extSequenceNumber: 23334,
+			extTimestamp:      0xabcdef,
+		},
+		codecBytes:         marshalledVP8,
+		incomingHeaderSize: 6,
+	}
+	actualTP, err = f.GetTranslationParams(extPkt, 0)
 	require.NoError(t, err)
-	require.True(t, shouldForward)
-	require.Equal(t, 6, incomingHeaderSize)
-	require.Equal(t, 6, outgoingHeaderSize)
-	require.Equal(t, marshalledVP8, buf[:outgoingHeaderSize])
+	require.Equal(t, expectedTP, actualTP)
 
 	// temporal layer matching target, should be forwarded
 	params = &testutils.TestExtPacketParams{
@@ -1577,17 +1565,6 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 		IsKeyFrame: true,
 	}
 	extPkt, _ = testutils.GetTestExtPacketVP8(params, vp8)
-	expectedTP = TranslationParams{
-		rtp: TranslationParamsRTP{
-			snOrdering:        SequenceNumberOrderingContiguous,
-			extSequenceNumber: 23335,
-			extTimestamp:      0xabcdef,
-		},
-	}
-	actualTP, err = f.GetTranslationParams(extPkt, 0)
-	require.NoError(t, err)
-	require.Equal(t, expectedTP, actualTP)
-
 	expectedVP8 = &buffer.VP8{
 		FirstByte:  25,
 		I:          true,
@@ -1605,12 +1582,18 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 	}
 	marshalledVP8, err = expectedVP8.Marshal()
 	require.NoError(t, err)
-	shouldForward, incomingHeaderSize, outgoingHeaderSize, err = f.TranslateCodecHeader(extPkt, &actualTP.rtp, buf)
+	expectedTP = TranslationParams{
+		rtp: TranslationParamsRTP{
+			snOrdering:        SequenceNumberOrderingContiguous,
+			extSequenceNumber: 23335,
+			extTimestamp:      0xabcdef,
+		},
+		codecBytes:         marshalledVP8,
+		incomingHeaderSize: 6,
+	}
+	actualTP, err = f.GetTranslationParams(extPkt, 0)
 	require.NoError(t, err)
-	require.True(t, shouldForward)
-	require.Equal(t, 6, incomingHeaderSize)
-	require.Equal(t, 6, outgoingHeaderSize)
-	require.Equal(t, marshalledVP8, buf[:outgoingHeaderSize])
+	require.Equal(t, expectedTP, actualTP)
 
 	// temporal layer higher than target, should be dropped
 	params = &testutils.TestExtPacketParams{
@@ -1636,19 +1619,17 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 	}
 	extPkt, _ = testutils.GetTestExtPacketVP8(params, vp8)
 	expectedTP = TranslationParams{
+		shouldDrop: true,
 		rtp: TranslationParamsRTP{
 			snOrdering:        SequenceNumberOrderingContiguous,
 			extSequenceNumber: 23336,
 			extTimestamp:      0xabcdef,
 		},
+		codecBytes: []byte{},
 	}
 	actualTP, err = f.GetTranslationParams(extPkt, 0)
 	require.NoError(t, err)
 	require.Equal(t, expectedTP, actualTP)
-
-	shouldForward, incomingHeaderSize, outgoingHeaderSize, err = f.TranslateCodecHeader(extPkt, &actualTP.rtp, buf)
-	require.NoError(t, err)
-	require.False(t, shouldForward)
 
 	// RTP sequence number and VP8 picture id should be contiguous after dropping higher temporal layer picture
 	params = &testutils.TestExtPacketParams{
@@ -1673,17 +1654,6 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 		IsKeyFrame: false,
 	}
 	extPkt, _ = testutils.GetTestExtPacketVP8(params, vp8)
-	expectedTP = TranslationParams{
-		rtp: TranslationParamsRTP{
-			snOrdering:        SequenceNumberOrderingContiguous,
-			extSequenceNumber: 23336,
-			extTimestamp:      0xabcdef,
-		},
-	}
-	actualTP, err = f.GetTranslationParams(extPkt, 0)
-	require.NoError(t, err)
-	require.Equal(t, expectedTP, actualTP)
-
 	expectedVP8 = &buffer.VP8{
 		FirstByte:  25,
 		I:          true,
@@ -1701,12 +1671,18 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 	}
 	marshalledVP8, err = expectedVP8.Marshal()
 	require.NoError(t, err)
-	shouldForward, incomingHeaderSize, outgoingHeaderSize, err = f.TranslateCodecHeader(extPkt, &actualTP.rtp, buf)
+	expectedTP = TranslationParams{
+		rtp: TranslationParamsRTP{
+			snOrdering:        SequenceNumberOrderingContiguous,
+			extSequenceNumber: 23336,
+			extTimestamp:      0xabcdef,
+		},
+		codecBytes:         marshalledVP8,
+		incomingHeaderSize: 6,
+	}
+	actualTP, err = f.GetTranslationParams(extPkt, 0)
 	require.NoError(t, err)
-	require.True(t, shouldForward)
-	require.Equal(t, 6, incomingHeaderSize)
-	require.Equal(t, 6, outgoingHeaderSize)
-	require.Equal(t, marshalledVP8, buf[:outgoingHeaderSize])
+	require.Equal(t, expectedTP, actualTP)
 
 	// padding only packet after a gap should be forwarded
 	params = &testutils.TestExtPacketParams{
@@ -1776,19 +1752,6 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 	}
 	extPkt, _ = testutils.GetTestExtPacketVP8(params, vp8)
 
-	expectedTP = TranslationParams{
-		isSwitching: true,
-		rtp: TranslationParamsRTP{
-			snOrdering:        SequenceNumberOrderingContiguous,
-			extSequenceNumber: 23339,
-			extTimestamp:      0xabcdf0,
-		},
-	}
-	actualTP, err = f.GetTranslationParams(extPkt, 1)
-	require.NoError(t, err)
-	require.Equal(t, expectedTP, actualTP)
-	require.Equal(t, f.lastSSRC, params.SSRC)
-
 	expectedVP8 = &buffer.VP8{
 		FirstByte:  25,
 		I:          true,
@@ -1806,12 +1769,20 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 	}
 	marshalledVP8, err = expectedVP8.Marshal()
 	require.NoError(t, err)
-	shouldForward, incomingHeaderSize, outgoingHeaderSize, err = f.TranslateCodecHeader(extPkt, &actualTP.rtp, buf)
+	expectedTP = TranslationParams{
+		isSwitching: true,
+		rtp: TranslationParamsRTP{
+			snOrdering:        SequenceNumberOrderingContiguous,
+			extSequenceNumber: 23339,
+			extTimestamp:      0xabcdf0,
+		},
+		codecBytes:         marshalledVP8,
+		incomingHeaderSize: 5,
+	}
+	actualTP, err = f.GetTranslationParams(extPkt, 1)
 	require.NoError(t, err)
-	require.True(t, shouldForward)
-	require.Equal(t, 5, incomingHeaderSize)
-	require.Equal(t, 6, outgoingHeaderSize)
-	require.Equal(t, marshalledVP8, buf[:outgoingHeaderSize])
+	require.Equal(t, expectedTP, actualTP)
+	require.Equal(t, f.lastSSRC, params.SSRC)
 }
 
 func TestForwarderGetSnTsForPadding(t *testing.T) {

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -1455,8 +1455,8 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 			extSequenceNumber: 23333,
 			extTimestamp:      0xabcdef,
 		},
-		codecBytes:         marshalledVP8,
 		incomingHeaderSize: 6,
+		codecBytes:         marshalledVP8,
 		marker:             true,
 	}
 	actualTP, err = f.GetTranslationParams(extPkt, 0)
@@ -1534,8 +1534,8 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 			extSequenceNumber: 23334,
 			extTimestamp:      0xabcdef,
 		},
-		codecBytes:         marshalledVP8,
 		incomingHeaderSize: 6,
+		codecBytes:         marshalledVP8,
 	}
 	actualTP, err = f.GetTranslationParams(extPkt, 0)
 	require.NoError(t, err)
@@ -1588,8 +1588,8 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 			extSequenceNumber: 23335,
 			extTimestamp:      0xabcdef,
 		},
-		codecBytes:         marshalledVP8,
 		incomingHeaderSize: 6,
+		codecBytes:         marshalledVP8,
 	}
 	actualTP, err = f.GetTranslationParams(extPkt, 0)
 	require.NoError(t, err)
@@ -1676,8 +1676,8 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 			extSequenceNumber: 23336,
 			extTimestamp:      0xabcdef,
 		},
-		codecBytes:         marshalledVP8,
 		incomingHeaderSize: 6,
+		codecBytes:         marshalledVP8,
 	}
 	actualTP, err = f.GetTranslationParams(extPkt, 0)
 	require.NoError(t, err)
@@ -1775,8 +1775,8 @@ func TestForwarderGetTranslationParamsVideo(t *testing.T) {
 			extSequenceNumber: 23339,
 			extTimestamp:      0xabcdf0,
 		},
-		codecBytes:         marshalledVP8,
 		incomingHeaderSize: 5,
+		codecBytes:         marshalledVP8,
 	}
 	actualTP, err = f.GetTranslationParams(extPkt, 1)
 	require.NoError(t, err)


### PR DESCRIPTION
It was possible for probe packets to get in between RTP munging and codec munging and throw off sequence number while dropping packets. Affected only VP8 as it does codec munging.