### PR TITLE
Fix duplicate ParticipantLeft event

### DIFF
--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -161,16 +161,12 @@ func (t *telemetryService) ParticipantLeft(ctx context.Context,
 ) {
 	t.enqueue(func() {
 		isConnected := false
-		hasWorker := false
 		if worker, ok := t.getWorker(livekit.ParticipantID(participant.Sid)); ok {
-			hasWorker = true
 			isConnected = worker.IsConnected()
+			if worker.ClosedAt().IsZero() {
+				prometheus.SubParticipant()
+			}
 			worker.Close()
-		}
-
-		if hasWorker {
-			// signifies we had incremented participant count
-			prometheus.SubParticipant()
 		}
 
 		if isConnected && shouldSendEvent {


### PR DESCRIPTION
Fix #2649. Remove ParticipantLeft event in the signal stats as it will cause duplicate ParticipantLeft that is reported in roommanager and also report signal interruption as ParticipantLeft but participant has chance to reconnect.