### PR TITLE
Handle large jumps in RTCP sender report timestamp.

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -17,9 +17,9 @@ name: Test
 on:
   workflow_dispatch:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: Set up gotestfmt
         run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@v2.4.1


### PR DESCRIPTION
Seeing cases of RTCP Sender Report spaced apart by more than half the RTP Timestamp range. Maybe a case of laptop going to sleep and waking up. Handle it using time diff from last report and calculating expected timestamp.