### PR TITLE
(Attempted) Simplify time stamp calculation on switches.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_base.go
+++ b/pkg/sfu/buffer/rtpstats_base.go
@@ -529,6 +529,11 @@ func (r *rtpStatsBase) maybeAdjustFirstPacketTime(srData *RTCPSenderReportData, 
 			"adjustment", r.firstTime.Sub(firstTime).String(),
 			"extNowTS", extNowTS,
 			"extStartTS", extStartTS,
+			"srData", srData,
+			"timeSinceReceive", timeSinceReceive.String(),
+			"timeSinceFirst", timeSinceFirst.String(),
+			"samplesDiff", samplesDiff,
+			"samplesDuration", samplesDuration,
 		}
 	}
 

--- a/pkg/sfu/buffer/rtpstats_receiver.go
+++ b/pkg/sfu/buffer/rtpstats_receiver.go
@@ -212,18 +212,21 @@ func (r *RTPStatsReceiver) Update(
 		flowState.ExtSequenceNumber = resSN.ExtendedVal
 		flowState.ExtTimestamp = resTS.ExtendedVal
 	} else { // in-order
-		if gapSN >= cNumSequenceNumbers/2 {
+		if gapSN >= cNumSequenceNumbers/2 || resTS.ExtendedVal < resTS.PreExtendedHighest {
 			r.logger.Warnw(
-				"large sequence number gap", nil,
+				"large sequence number gap OR time reversed", nil,
 				"extStartSN", r.sequenceNumber.GetExtendedStart(),
 				"extHighestSN", r.sequenceNumber.GetExtendedHighest(),
 				"extStartTS", r.timestamp.GetExtendedStart(),
 				"extHighestTS", r.timestamp.GetExtendedHighest(),
 				"firstTime", r.firstTime.String(),
 				"highestTime", r.highestTime.String(),
-				"prev", resSN.PreExtendedHighest,
-				"curr", resSN.ExtendedVal,
-				"gap", gapSN,
+				"prevSN", resSN.PreExtendedHighest,
+				"currSN", resSN.ExtendedVal,
+				"gapSN", gapSN,
+				"prevTS", resTS.PreExtendedHighest,
+				"currTS", resTS.ExtendedVal,
+				"gapTS", resTS.ExtendedVal-resTS.PreExtendedHighest,
 				"packetTime", packetTime.String(),
 				"sequenceNumber", sequenceNumber,
 				"timestamp", timestamp,

--- a/pkg/sfu/buffer/rtpstats_sender.go
+++ b/pkg/sfu/buffer/rtpstats_sender.go
@@ -33,6 +33,8 @@ const (
 	cSenderReportInitialWait = time.Second
 )
 
+// -------------------------------------------------------------------
+
 type snInfoFlag byte
 
 const (
@@ -625,7 +627,7 @@ func (r *RTPStatsSender) GetExpectedRTPTimestamp(at time.Time) (expectedTSExt ui
 	defer r.lock.RUnlock()
 
 	if !r.initialized {
-		err = errors.New("uninitilaized")
+		err = errors.New("uninitialized")
 		return
 	}
 

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1640,7 +1640,7 @@ func (f *Forwarder) processSourceSwitch(extPkt *buffer.ExtPacket, layer int32) e
 		}
 	}
 
-	// adjust extReTS to current packet's timestamp mapped to that of reference layer's
+	// adjust extRefTS to current packet's timestamp mapped to that of reference layer's
 	extRefTS = (extRefTS & 0xFFFF_FFFF_0000_0000) + uint64(refTS)
 	lastTS := uint32(extLastTS)
 	if (refTS-lastTS) < 1<<31 && refTS < lastTS {
@@ -1690,7 +1690,7 @@ func (f *Forwarder) processSourceSwitch(extPkt *buffer.ExtPacket, layer int32) e
 		// timestamp should be used as things will catch up to real time when channel capacity
 		// increases and pacer starts sending at faster rate.
 		//
-		// But, the challenege is distinguishing between the two cases. As a compromise, the difference
+		// But, the challenge is distinguishing between the two cases. As a compromise, the difference
 		// between extExpectedTS and extRefTS is thresholded. Difference below the threshold is treated as Case 2
 		// and above as Case 1.
 		//
@@ -1754,8 +1754,6 @@ func (f *Forwarder) processSourceSwitch(extPkt *buffer.ExtPacket, layer int32) e
 		// nominal increase
 		extNextTS = extLastTS + 1
 	}
-	f.rtpMunger.UpdateSnTsOffsets(extPkt, 1, extNextTS-extLastTS)
-	f.codecMunger.UpdateOffsets(extPkt)
 	f.logger.Debugw(
 		"next timestamp on switch",
 		"switchingAt", switchingAt.String(),
@@ -1771,6 +1769,9 @@ func (f *Forwarder) processSourceSwitch(extPkt *buffer.ExtPacket, layer int32) e
 		"extIncomingSN", extPkt.ExtSequenceNumber,
 		"extIncomingTS", extPkt.ExtTimestamp,
 	)
+
+	f.rtpMunger.UpdateSnTsOffsets(extPkt, 1, extNextTS-extLastTS)
+	f.codecMunger.UpdateOffsets(extPkt)
 	return nil
 }
 

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1779,7 +1779,6 @@ func (f *Forwarder) processSourceSwitch(extPkt *buffer.ExtPacket, layer int32) e
 func (f *Forwarder) getTranslationParamsCommon(extPkt *buffer.ExtPacket, layer int32, tp *TranslationParams) (bool, error) {
 	if f.lastSSRC != extPkt.Packet.SSRC {
 		if err := f.processSourceSwitch(extPkt, layer); err != nil {
-			f.logger.Warnw("source switch failed", err) // RAJA-REMOVE
 			tp.shouldDrop = true
 			return false, nil
 		}


### PR DESCRIPTION
Was attempting to simplify time stamp calculation on a resume (on unmute etc.). I was hoping that using expected time stamp should be enough. But, ran into cases where the expected was ahead by 70 - 80 ms and subsequent layer switches did not happen due to switch point being too behind. I need to spend more time trying to simplify this.

In the mean time, doing
- Some clean up (will leave notes in line)
- logging a bit more about time stamp going backwards, seems like this might be happening with react native clients.