### PR TITLE
Version 1.6.1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const Version = "1.6.0"
+const Version = "1.6.1"


### PR DESCRIPTION
 ## Changelog

This release changes the default behavior when creating or updating WHIP ingress. WHIP ingress will now default to disabling transcoding and forwarding media unchanged to the LiveKit subscribers. This behavior can be changed by using the new `enable_transcoding` available in updated SDKs. The behavior of existing ingresses is unchanged.

 ### Added

- Add support for "abs-capture-time" extension.  (#2640)
- Add PropagationDelay API to sender report data (#2646)
- Add support for EnableTranscoding ingress option (#2681)
- Pass new SIP metadata. Update protocol. (#2683)
- Handle UpdateLocalAudioTrack and UpdateLocalVideoTrack. (#2684)
- Forward transcription data packets to the room (#2687)

 ### Fixed

- backwards compatability for IsRecorder (#2647)
- Reduce RED weight in half. (#2648)
- add disconnected chan to participant (#2650)
- add typed ops queue (#2655)
- ICE config cache module. (#2654)
- use typed ops queue in pctransport (#2656)
- Use the ingress state updated_at field to ensure that out of order RPC do not overwrite state (#2657)
- Log ICE candidates to debug TCP connection issues. (#2658)
- Debug logging addition of ICE candidate (#2659)
- fix participant, ensure room name matches (#2660)
- replace keyframe ticker with timer (#2661)
- fix key frame timer (#2662)
- Disable dynamic playout delay for screenshare track (#2663)
- Don't log dd invalid template index (#2664)
- Do codec munging when munging RTP header. (#2665)
- Connection quality LOST only if RTCP is also not available. (#2670)
- Handle large jumps in RTCP sender report timestamp. (#2674)
- Bump golang.org/x/net from 0.22.0 to 0.23.0 (#2673)
- do not capture pointers in ops queue closures (#2675)
- Fix SubParticipant twice when paticipant left (#2672)
- use ttlcache (#2677)
- Detach subscriber datachannel to save memory (#2680)
- Clean up UpdateVideoLayers (#2685)
- Make datachannel optional for publisher (#2686)