### PR TITLE
Remove unsupported environment option

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -143,8 +143,6 @@ rtc:
 
 # when enabled, LiveKit will expose prometheus metrics on :6789/metrics
 # prometheus_port: 6789
-# set a custom environment variable. prometheus metrics will be labeled with this value. defaults to an empty string
-# environment: custom-value
 
 # API key / secret pairs.
 # Keys are used for JWT authentication, server APIs would require a keypair in order to generate access tokens


### PR DESCRIPTION
This option seems to be no longer supported as of 10c8582a6b01c37fb2db7e343b5204c713fbb7cd, and will crash the server if provided in the config.