### PR TITLE
Do not use LastTS for dummy offset.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1660,14 +1660,17 @@ func (f *Forwarder) processSourceSwitch(extPkt *buffer.ExtPacket, layer int32) e
 				rtpDiff := uint64(timeSinceFirst.Nanoseconds() * int64(f.codec.ClockRate) / 1e9)
 				extExpectedTS = f.extFirstTS + rtpDiff
 				if f.dummyStartTSOffset == 0 {
+					extRefTS = uint64(refTS)
 					f.dummyStartTSOffset = extExpectedTS - extRefTS
 					f.logger.Infow(
 						"calculating dummyStartTSOffset",
 						"preStartTime", f.preStartTime.String(),
 						"extFirstTS", f.extFirstTS,
-						"timeSinceFirst", timeSinceFirst,
+						"timeSinceFirst", timeSinceFirst.String(),
 						"rtpDiff", rtpDiff,
 						"extRefTS", extRefTS,
+						"incomingTS", extPkt.Packet.Timestamp,
+						"referenceLayerSpatial", f.referenceLayerSpatial,
 						"dummyStartTSOffset", f.dummyStartTSOffset,
 					)
 				}

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1589,6 +1589,7 @@ func (f *Forwarder) processSourceSwitch(extPkt *buffer.ExtPacket, layer int32) e
 		return nil
 	} else if f.referenceLayerSpatial == buffer.InvalidLayerSpatial {
 		f.referenceLayerSpatial = layer
+		f.codecMunger.SetLast(extPkt)
 		f.logger.Debugw(
 			"catch up forwarding",
 			"sequenceNumber", extPkt.Packet.SequenceNumber,

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1641,7 +1641,7 @@ func (f *Forwarder) processSourceSwitch(extPkt *buffer.ExtPacket, layer int32) e
 	}
 
 	// adjust extRefTS to current packet's timestamp mapped to that of reference layer's
-	extRefTS = (extRefTS & 0xFFFF_FFFF_0000_0000) + uint64(refTS)
+	extRefTS = (extRefTS & 0xFFFF_FFFF_0000_0000) + uint64(refTS) + f.dummyStartTSOffset
 	lastTS := uint32(extLastTS)
 	if (refTS-lastTS) < 1<<31 && refTS < lastTS {
 		extRefTS += (1 << 32)
@@ -1662,6 +1662,7 @@ func (f *Forwarder) processSourceSwitch(extPkt *buffer.ExtPacket, layer int32) e
 				if f.dummyStartTSOffset == 0 {
 					extRefTS = uint64(refTS)
 					f.dummyStartTSOffset = extExpectedTS - extRefTS
+					extRefTS += f.dummyStartTSOffset
 					f.logger.Infow(
 						"calculating dummyStartTSOffset",
 						"preStartTime", f.preStartTime.String(),
@@ -1677,7 +1678,6 @@ func (f *Forwarder) processSourceSwitch(extPkt *buffer.ExtPacket, layer int32) e
 			}
 		}
 	}
-	extRefTS += f.dummyStartTSOffset
 
 	var extNextTS uint64
 	if f.lastSSRC == 0 {

--- a/pkg/sfu/sequencer.go
+++ b/pkg/sfu/sequencer.go
@@ -237,7 +237,7 @@ func (s *sequencer) pushPadding(extStartSNInclusive uint64, extEndSNInclusive ui
 	s.Lock()
 	defer s.Unlock()
 
-	if s.snRangeMap == nil {
+	if s.snRangeMap == nil || !s.initialized {
 		return
 	}
 


### PR DESCRIPTION
LastTS could be random when using dummy start. That should not be used in calculating offsets.

Also, do not push padding into sequencer before init. Could have happened with dummy start.

NOTE: There is a stall when using dummy start once in a while. Have checked sequence numbers and time stamps and they look fine. But, there are stalls resulting in a PLI some times. It does not happen when the real stream starts after the dummy start. It happens on some subsequent layer switch. This does not happen without dummy start.
UPDATE: I think this is fixed. Will leave inline note about this.