### PR TITLE
fix remaining mimeType comparisons case insensitive, improve receiver mapping

### DIFF
--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -469,7 +469,7 @@ func (t *MediaTrackReceiver) AddSubscriber(sub types.LocalParticipant) (types.Su
 		codec := receiver.Codec()
 		var found bool
 		for _, pc := range potentialCodecs {
-			if codec.MimeType == pc.MimeType {
+			if strings.EqualFold(codec.MimeType, pc.MimeType) {
 				found = true
 				break
 			}

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -16,6 +16,7 @@ package rtc
 
 import (
 	"errors"
+	"strings"
 	"sync"
 
 	"github.com/pion/rtcp"
@@ -258,7 +259,7 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 			Stereo: info.Stereo,
 			Red:    !info.DisableRed,
 		}
-		if addTrackParams.Red && (len(codecs) == 1 && codecs[0].MimeType == webrtc.MimeTypeOpus) {
+		if addTrackParams.Red && (len(codecs) == 1 && strings.EqualFold(codecs[0].MimeType, webrtc.MimeTypeOpus)) {
 			addTrackParams.Red = false
 		}
 
@@ -354,7 +355,7 @@ func (t *MediaTrackSubscriptions) GetAllSubscribersForMime(mime string) []liveki
 
 	subs := make([]livekit.ParticipantID, 0, len(t.subscribedTracks))
 	for id, subTrack := range t.subscribedTracks {
-		if subTrack.DownTrack().Codec().MimeType != mime {
+		if !strings.EqualFold(subTrack.DownTrack().Codec().MimeType, mime) {
 			continue
 		}
 

--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -90,7 +90,7 @@ func (r *WrappedReceiver) StreamID() string {
 func (r *WrappedReceiver) DetermineReceiver(codec webrtc.RTPCodecCapability) {
 	r.determinedCodec = codec
 	for _, receiver := range r.receivers {
-		if c := receiver.Codec(); c.MimeType == codec.MimeType {
+		if c := receiver.Codec(); strings.EqualFold(c.MimeType, codec.MimeType) {
 			r.TrackReceiver = receiver
 			break
 		} else if strings.EqualFold(c.MimeType, sfu.MimeTypeAudioRed) && strings.EqualFold(codec.MimeType, webrtc.MimeTypeOpus) {


### PR DESCRIPTION
When using gstreamer with livekitwebrtcsrc/sink, it's likely gstreamer internals trigger a mimeType of `audio/OPUS`. Fix few missing cases to use strings.EqualFold like the rest of the code

Example error message from v1.4.3
```
{"level":"error","ts":1714583047.6396463,"logger":"livekit","caller":"rtc/wrappedreceiver.go:93","msg":"can't determine receiver for codec","room":"1e189cd1-be72-4be9-a2fd-c176a36d5603","roomID":"RM_np7G97y45nYr","participant":"ingest","pID":"PA_JKLk4t74denc","remote":false,"trackID":"TR_AMPhzFHhevk8St","relayed":false,"codec":"audio/OPUS","stacktrace":"github.com/livekit/livekit-server/pkg/rtc.(*WrappedReceiver).DetermineReceiver\n\t/workspace/pkg/rtc/wrappedreceiver.go:93\ngithub.com/livekit/livekit-server/pkg/rtc.(*MediaTrackSubscriptions).AddSubscriber.func1\n\t/workspace/pkg/rtc/mediatracksubscriptions.go:136\ngithub.com/livekit/livekit-server/pkg/sfu.(*DownTrack).Bind\n\t/workspace/pkg/sfu/downtrack.go:376\ngithub.com/pion/webrtc/v3.(*RTPSender).Send\n\t/go/pkg/mod/github.com/pion/webrtc/v3@v3.2.8/rtpsender.go:308\ngithub.com/pion/webrtc/v3.(*PeerConnection).startRTPSenders\n\t/go/pkg/mod/github.com/pion/webrtc/v3@v3.2.8/peerconnection.go:1458\ngithub.com/pion/webrtc/v3.(*PeerConnection).SetRemoteDescription\n\t/go/pkg/mod/github.com/pion/webrtc/v3@v3.2.8/peerconnection.go:1169\ngithub.com/livekit/livekit-server/pkg/rtc.(*PCTransport).setRemoteDescription\n\t/workspace/pkg/rtc/transport.go:1758\ngithub.com/livekit/livekit-server/pkg/rtc.(*PCTransport).handleRemoteAnswerReceived\n\t/workspace/pkg/rtc/transport.go:1867\ngithub.com/livekit/livekit-server/pkg/rtc.(*PCTransport).handleRemoteDescriptionReceived\n\t/workspace/pkg/rtc/transport.go:1727\ngithub.com/livekit/livekit-server/pkg/rtc.(*PCTransport).handleEvent\n\t/workspace/pkg/rtc/transport.go:1400\ngithub.com/livekit/livekit-server/pkg/rtc.(*PCTransport).processEvents\n\t/workspace/pkg/rtc/transport.go:1373"}
```