### PR TITLE
fix: connection reset without any closing handshake on clientside

### DIFF
--- a/pkg/service/rtcservice.go
+++ b/pkg/service/rtcservice.go
@@ -317,6 +317,8 @@ func (s *RTCService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			// when the source is terminated, this means Participant.Close had been called and RTC connection is done
 			// we would terminate the signal connection as well
+			closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
+			_ = conn.WriteControl(websocket.CloseMessage, closeMsg, time.Now().Add(time.Second))
 			_ = conn.Close()
 		}()
 		defer func() {


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc6455#section-1.4

The protocol says we should wait for all the remaining messages after sending the first closing handshake. (But this isn't necessary in our case)

Also see: https://github.com/livekit/rust-sdks/pull/332

This PR may be OK to ignore tho. Since only Rust SDK was complaining about it, and I'm now ignoring the error.
