### PR TITLE
Send telemetry events on track feature updates.

### DIFF
--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -673,23 +673,29 @@ func (t *MediaTrackReceiver) UpdateAudioTrack(update *livekit.UpdateLocalAudioTr
 	}
 
 	t.lock.Lock()
-	t.trackInfo.AudioFeatures = update.Features
-	t.trackInfo.Stereo = false
-	t.trackInfo.DisableDtx = false
+	clonedInfo := proto.Clone(t.trackInfo).(*livekit.TrackInfo)
+	clonedInfo.AudioFeatures = update.Features
+	clonedInfo.Stereo = false
+	clonedInfo.DisableDtx = false
 	for _, feature := range update.Features {
 		switch feature {
 		case livekit.AudioTrackFeature_TF_STEREO:
-			t.trackInfo.Stereo = true
+			clonedInfo.Stereo = true
 		case livekit.AudioTrackFeature_TF_NO_DTX:
-			t.trackInfo.DisableDtx = true
+			clonedInfo.DisableDtx = true
 		}
 	}
-	ti := t.trackInfoCloneLocked()
+	if proto.Equal(t.trackInfo, clonedInfo) {
+		t.lock.Unlock()
+		return
+	}
+
+	t.trackInfo = clonedInfo
 	t.lock.Unlock()
 
 	t.updateTrackInfoOfReceivers()
 
-	t.params.Telemetry.TrackPublishedUpdate(context.Background(), t.PublisherID(), ti)
+	t.params.Telemetry.TrackPublishedUpdate(context.Background(), t.PublisherID(), clonedInfo)
 }
 
 func (t *MediaTrackReceiver) UpdateVideoTrack(update *livekit.UpdateLocalVideoTrack) {
@@ -698,14 +704,20 @@ func (t *MediaTrackReceiver) UpdateVideoTrack(update *livekit.UpdateLocalVideoTr
 	}
 
 	t.lock.Lock()
-	t.trackInfo.Width = update.Width
-	t.trackInfo.Height = update.Height
-	ti := t.trackInfoCloneLocked()
+	clonedInfo := proto.Clone(t.trackInfo).(*livekit.TrackInfo)
+	clonedInfo.Width = update.Width
+	clonedInfo.Height = update.Height
+	if proto.Equal(t.trackInfo, clonedInfo) {
+		t.lock.Unlock()
+		return
+	}
+
+	t.trackInfo = clonedInfo
 	t.lock.Unlock()
 
 	t.updateTrackInfoOfReceivers()
 
-	t.params.Telemetry.TrackPublishedUpdate(context.Background(), t.PublisherID(), ti)
+	t.params.Telemetry.TrackPublishedUpdate(context.Background(), t.PublisherID(), clonedInfo)
 }
 
 func (t *MediaTrackReceiver) TrackInfo() *livekit.TrackInfo {

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -684,9 +684,12 @@ func (t *MediaTrackReceiver) UpdateAudioTrack(update *livekit.UpdateLocalAudioTr
 			t.trackInfo.DisableDtx = true
 		}
 	}
+	ti := t.trackInfoCloneLocked()
 	t.lock.Unlock()
 
 	t.updateTrackInfoOfReceivers()
+
+	t.params.Telemetry.TrackPublishedUpdate(context.Background(), t.PublisherID(), ti)
 }
 
 func (t *MediaTrackReceiver) UpdateVideoTrack(update *livekit.UpdateLocalVideoTrack) {
@@ -697,9 +700,12 @@ func (t *MediaTrackReceiver) UpdateVideoTrack(update *livekit.UpdateLocalVideoTr
 	t.lock.Lock()
 	t.trackInfo.Width = update.Width
 	t.trackInfo.Height = update.Height
+	ti := t.trackInfoCloneLocked()
 	t.lock.Unlock()
 
 	t.updateTrackInfoOfReceivers()
+
+	t.params.Telemetry.TrackPublishedUpdate(context.Background(), t.PublisherID(), ti)
 }
 
 func (t *MediaTrackReceiver) TrackInfo() *livekit.TrackInfo {
@@ -709,11 +715,15 @@ func (t *MediaTrackReceiver) TrackInfo() *livekit.TrackInfo {
 	return t.trackInfo
 }
 
+func (t *MediaTrackReceiver) trackInfoCloneLocked() *livekit.TrackInfo {
+	return proto.Clone(t.trackInfo).(*livekit.TrackInfo)
+}
+
 func (t *MediaTrackReceiver) TrackInfoClone() *livekit.TrackInfo {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 
-	return proto.Clone(t.trackInfo).(*livekit.TrackInfo)
+	return t.trackInfoCloneLocked()
 }
 
 func (t *MediaTrackReceiver) NotifyMaxLayerChange(maxLayer int32) {


### PR DESCRIPTION
@shishirng @davidzhao This is more like a draft PR to solicit ideas.

On track feature update, I have added code in this PR to notify analytics using `TrackPublisherdUpdate`. But, that is not quite right. Currently, that event is used to notify max layer changes using a synthesised `TrackInfo`. So, using that on feature update will report incorrect max layer.

Wanted to discuss options
- Make a new event (any suggestion for names) which will just send the latest `TrackInfo` (the full structure)
- Re-use `TrackPublished`, but I am guessing that will cause issues where events will look like multiple publishes happened.

Suggestions please.