### PR TITLE
Do not propagate RTCP if report is not processed.

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -872,12 +872,13 @@ func (b *Buffer) SetSenderReportData(rtpTime uint32, ntpTime uint64) {
 		At:           time.Now(),
 	}
 
+	didSet := false
 	if b.rtpStats != nil {
-		b.rtpStats.SetRtcpSenderReportData(srData)
+		didSet = b.rtpStats.SetRtcpSenderReportData(srData)
 	}
 	b.RUnlock()
 
-	if b.onRtcpSenderReport != nil {
+	if didSet && b.onRtcpSenderReport != nil {
 		b.onRtcpSenderReport()
 	}
 }

--- a/pkg/sfu/buffer/rtpstats_base.go
+++ b/pkg/sfu/buffer/rtpstats_base.go
@@ -641,6 +641,7 @@ func (r *rtpStatsBase) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	}
 
 	e.AddTime("startTime", r.startTime)
+	e.AddTime("endTime", r.endTime)
 	e.AddTime("firstTime", r.firstTime)
 	e.AddTime("highestTime", r.highestTime)
 


### PR DESCRIPTION
There are cases where RTCP sender report from publisher gets dropped due to various reasons. In those cases, it is not required to propagate RTCP reports. Functionally, there is no problem as the propagation will use the last valid report, but it is redundant.