### PR TITLE
Config option to set `nodeID`

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -16,6 +16,10 @@
 # for production setups, this port should be placed behind a load balancer with TLS
 port: 7880
 
+# setting up node_id is optional & debugging purpose. node_id should be unique
+# left it empty so that unique nodeId will be auto generated
+# node_id: ND_unique_id
+
 # when redis is set, LiveKit will automatically operate in a fully distributed fashion
 # clients could connect to any node and be routed to the same room
 redis:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,6 +59,7 @@ var (
 
 type Config struct {
 	Port           uint32                   `yaml:"port,omitempty"`
+	NodeId         *string                  `yaml:"node_id,omitempty"`
 	BindAddresses  []string                 `yaml:"bind_addresses,omitempty"`
 	PrometheusPort uint32                   `yaml:"prometheus_port,omitempty"`
 	RTC            RTCConfig                `yaml:"rtc,omitempty"`

--- a/pkg/routing/node.go
+++ b/pkg/routing/node.go
@@ -28,6 +28,9 @@ type LocalNode *livekit.Node
 
 func NewLocalNode(conf *config.Config) (LocalNode, error) {
 	nodeID := utils.NewGuid(utils.NodePrefix)
+	if conf.NodeId != nil && *conf.NodeId != "" {
+		nodeID = *conf.NodeId
+	}
 	if conf.RTC.NodeIP == "" {
 		return nil, ErrIPNotSet
 	}


### PR DESCRIPTION
Option to set `node_id` manually from config file. During create a meeting we can set [node_id](https://github.com/livekit/protocol/blob/ec704e0cf263bd29557470806c17f03861d5079f/protobufs/livekit_room.proto#L74) but it is hard to find that ID. Having an option to set fixed `node_id` will be helpful in this case. Also this option is optional. 