### PR TITLE
Use a safety net OnClose to remove track from peer connection.

### DIFF
--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -289,6 +289,18 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 	// negotiation isn't required if we've replaced track
 	subTrack.SetNeedsNegotiation(!replacedTrack)
 	subTrack.SetRTPSender(sender)
+	// it is possible that subscribed track is closed before subscription manager sets
+	// the `OnClose` callback. That handler in subscription manager removes the track
+	// from the peer connection.
+	//
+	// But, the subscription could be removed early if the published track is closed
+	// while adding subscription. In those cases, subscription manager would not have set
+	// the `OnClose` callback. So, set it here to handle cases of early close.
+	subTrack.OnClose(func(_willBeResumed bool) {
+		if err := sub.RemoveTrackFromSubscriber(sender); err != nil {
+			t.params.Logger.Warnw("could not remove track from peer connection", err)
+		}
+	})
 
 	downTrack.SetTransceiver(transceiver)
 

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -296,9 +296,11 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 	// But, the subscription could be removed early if the published track is closed
 	// while adding subscription. In those cases, subscription manager would not have set
 	// the `OnClose` callback. So, set it here to handle cases of early close.
-	subTrack.OnClose(func(_willBeResumed bool) {
-		if err := sub.RemoveTrackFromSubscriber(sender); err != nil {
-			t.params.Logger.Warnw("could not remove track from peer connection", err)
+	subTrack.OnClose(func(willBeResumed bool) {
+		if !willBeResumed {
+			if err := sub.RemoveTrackFromSubscriber(sender); err != nil {
+				t.params.Logger.Warnw("could not remove track from peer connection", err)
+			}
 		}
 	})
 


### PR DESCRIPTION
It is possible that the published track gets closed when a subscriber is being added. In those cases, the subscription is removed early, i. e. subscription manager does not get a SubscribedTrack to work with.

Typically, subscription manager registers an `OnClose` on returned `SubscribedTrack` and when that subscribed track is closed, the `OnClose` handler removes the track from the peer connection.

In the early close case, subscription manager does not have a chance to do that and the added track is left in the peer connection.

A subsequent re-publish of the same track adds a new m-section to the SDP with the same track ID and that causea a msid collision when client tries to `setRemoteDescription`.

While there may be more things to look at (see below for more commentary), using a simple approach first of registering an `OnClose` on `SubscribedTrack` which can remove the track from the peer connection if necessary. In the normal path, subscription manager will register `OnClose` which will overwrite the temporary `OnClose` registration.

Longer commentary
-----------------
Track re-publish very quickly needs more scrutiny. As there are a few goroutines involved, need to check if there can be race/collisions.

- `closeSubscribedTrack` uses a go routine if track is not expected to resume.
- `downTrackClosed` (callback from down track close) runs in a go rourtine.
- `SubscribedTrack` `OnClose` is run in a goroutine.

I think subscription manager reconcile should eventually resolve, but something to look out for.