### PR TITLE
Do not add tracker for invalid layers.

### DIFF
--- a/pkg/sfu/streamtrackermanager.go
+++ b/pkg/sfu/streamtrackermanager.go
@@ -168,6 +168,10 @@ func (s *StreamTrackerManager) AddDependencyDescriptorTrackers() {
 }
 
 func (s *StreamTrackerManager) AddTracker(layer int32) streamtracker.StreamTrackerWorker {
+	if layer < 0 || int(layer) >= len(s.trackers) {
+		return nil
+	}
+
 	var tracker streamtracker.StreamTrackerWorker
 	s.lock.Lock()
 	tracker = s.trackers[layer]


### PR DESCRIPTION
Previously, the bit rate interval config was checked first. That would have returned `!ok` for invalid layers. A recent change to prevent duplicate tracker addition re-arranged the code and the tracker array was accessed out-of-bounds.

Unclear why an invalid layer is passed in. Need to investigate that.