### PR TITLE
Reduce large sequence number jump threshold for logging.

### DIFF
--- a/pkg/rtc/uptrackmanager.go
+++ b/pkg/rtc/uptrackmanager.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
+	"golang.org/x/exp/maps"
 
 	"github.com/livekit/livekit-server/pkg/rtc/types"
 	"github.com/livekit/protocol/utils"
@@ -147,11 +148,7 @@ func (u *UpTrackManager) GetPublishedTracks() []types.MediaTrack {
 	u.lock.RLock()
 	defer u.lock.RUnlock()
 
-	tracks := make([]types.MediaTrack, 0, len(u.publishedTracks))
-	for _, t := range u.publishedTracks {
-		tracks = append(tracks, t)
-	}
-	return tracks
+	return maps.Values(u.publishedTracks)
 }
 
 func (u *UpTrackManager) UpdateSubscriptionPermission(

--- a/pkg/sfu/buffer/rtpstats_base.go
+++ b/pkg/sfu/buffer/rtpstats_base.go
@@ -37,6 +37,8 @@ const (
 	cFirstPacketTimeAdjustThreshold = 15 * time.Second
 
 	cPassthroughNTPTimestamp = true
+
+	cSequenceNumberLargeJumpThreshold = 1000
 )
 
 // -------------------------------------------------------

--- a/pkg/sfu/buffer/rtpstats_receiver.go
+++ b/pkg/sfu/buffer/rtpstats_receiver.go
@@ -219,7 +219,7 @@ func (r *RTPStatsReceiver) Update(
 		}
 	}
 	if gapSN <= 0 { // duplicate OR out-of-order
-		if -gapSN >= cNumSequenceNumbers/2 {
+		if -gapSN >= cSequenceNumberLargeJumpThreshold {
 			if r.largeJumpNegativeCount%100 == 0 {
 				r.logger.Warnw(
 					"large sequence number gap negative", nil,
@@ -249,7 +249,7 @@ func (r *RTPStatsReceiver) Update(
 		flowState.ExtSequenceNumber = resSN.ExtendedVal
 		flowState.ExtTimestamp = resTS.ExtendedVal
 	} else { // in-order
-		if gapSN >= cNumSequenceNumbers/2 || resTS.ExtendedVal < resTS.PreExtendedHighest {
+		if gapSN >= cSequenceNumberLargeJumpThreshold || resTS.ExtendedVal < resTS.PreExtendedHighest {
 			if r.largeJumpCount%100 == 0 {
 				r.logger.Warnw(
 					"large sequence number gap OR time reversed", nil,
@@ -596,7 +596,7 @@ func (r *RTPStatsReceiver) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	defer r.lock.RUnlock()
 
 	e.AddObject("base", r.rtpStatsBase)
-	e.AddUint64("extendedStartSN", r.sequenceNumber.GetExtendedStart())
+	e.AddUint64("extStartSN", r.sequenceNumber.GetExtendedStart())
 	e.AddUint64("extHighestSN", r.sequenceNumber.GetExtendedHighest())
 	e.AddUint64("extStartTS", r.timestamp.GetExtendedStart())
 	e.AddUint64("extHighestTS", r.timestamp.GetExtendedHighest())

--- a/pkg/sfu/buffer/rtpstats_sender.go
+++ b/pkg/sfu/buffer/rtpstats_sender.go
@@ -316,7 +316,7 @@ func (r *RTPStatsSender) Update(
 			// do not start on a padding only packet
 			return
 		}
-		if -gapSN >= cNumSequenceNumbers/2 {
+		if -gapSN >= cSequenceNumberLargeJumpThreshold {
 			if r.largeJumpNegativeCount%100 == 0 {
 				r.logger.Warnw(
 					"large sequence number gap negative", nil,
@@ -372,7 +372,7 @@ func (r *RTPStatsSender) Update(
 			r.setSnInfo(extSequenceNumber, r.extHighestSN, uint16(pktSize), uint8(hdrSize), uint16(payloadSize), marker, true)
 		}
 	} else { // in-order
-		if gapSN >= cNumSequenceNumbers/2 || extTimestamp < r.extHighestTS {
+		if gapSN >= cSequenceNumberLargeJumpThreshold || extTimestamp < r.extHighestTS {
 			if r.largeJumpCount%100 == 0 {
 				r.logger.Warnw(
 					"large sequence number gap OR time reversed", nil,


### PR DESCRIPTION
Seeing some unexplained large jumps on remotes across relay. Unclear if there was a jump on origin side at some point. Reducing threshold for large jump so that we can catch unexpected jumps more.