### PR TITLE
Better lock for sender report TS offset.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -599,7 +599,6 @@ func (f *Forwarder) SetRefSenderReport(isSVC bool, layer int32, srData *buffer.R
 	if layer >= 0 && int(layer) < len(f.refInfos) {
 		f.refInfos[layer] = refInfo{srData, 0, false}
 		if layer == refLayer && srData.RTPTimestampExt >= f.lastSwitchExtIncomingTS {
-			f.logger.Infow("setting SR data") // REMOVE
 			f.refInfos[layer].tsOffset = f.rtpMunger.GetTSOffset()
 			f.refInfos[layer].isTSOffsetValid = true
 		}

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -720,6 +720,14 @@ func (w *WebRTCReceiver) forwardRTP(layer int32) {
 				"mime", w.codec.MimeType,
 				"layer", layer,
 				"spatialLayer", spatialLayer,
+				"sn", pkt.Packet.SequenceNumber,
+				"esn", pkt.ExtSequenceNumber,
+				"timestamp", pkt.Packet.Timestamp,
+				"ets", pkt.ExtTimestamp,
+				"payloadSize", len(pkt.Packet.Payload),
+				"rtpVersion", pkt.Packet.Version,
+				"payloadType", pkt.Packet.PayloadType,
+				"ssrc", pkt.Packet.SSRC,
 			)
 		}
 


### PR DESCRIPTION
It is possible that a resume has happened and new time stamp offset calculated. But, a sender report from publisher comes with a time stamp prior to the time stamp which was used for offset calculation. Using that sender report in the forwarding path causes jumps.

Example
- Track forwarding, let us say tsOffset = `a`
- Unmute/layer switch - one of those events happens, a new tsOffset will be calculated, let us say that offset is `b` and it is based on incoming time stmap of `c`.
- A sender report from publisher could arrive with timestamp = `d`.
  - If `d` >= `c`,  the offset `b` is correct and can be applied.
  - But, it is possible that `d` < `c`, in that case, offset `a` should be used and not `b`.

To address this, keep track of incoming extended timestamp at switch point and accept incoming sender reports which have a timestamp >= switch point timestamp.