### PR TITLE
Log first time adjustment total.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_base.go
+++ b/pkg/sfu/buffer/rtpstats_base.go
@@ -174,8 +174,9 @@ type rtpStatsBase struct {
 	startTime time.Time
 	endTime   time.Time
 
-	firstTime   time.Time
-	highestTime time.Time
+	firstTime           time.Time
+	firstTimeAdjustment time.Duration
+	highestTime         time.Time
 
 	lastTransit            uint64
 	lastJitterExtTimestamp uint64
@@ -551,6 +552,7 @@ func (r *rtpStatsBase) maybeAdjustFirstPacketTime(srData *RTCPSenderReportData, 
 			r.logger.Infow("adjusting first packet time, too big, ignoring", getFields()...)
 		} else {
 			r.logger.Debugw("adjusting first packet time", getFields()...)
+			r.firstTimeAdjustment += r.firstTime.Sub(firstTime)
 			r.firstTime = firstTime
 		}
 	}
@@ -645,6 +647,7 @@ func (r *rtpStatsBase) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	e.AddTime("startTime", r.startTime)
 	e.AddTime("endTime", r.endTime)
 	e.AddTime("firstTime", r.firstTime)
+	e.AddDuration("firstTimeAdjustment", r.firstTimeAdjustment)
 	e.AddTime("highestTime", r.highestTime)
 
 	e.AddUint64("bytes", r.bytes)

--- a/pkg/sfu/buffer/rtpstats_receiver.go
+++ b/pkg/sfu/buffer/rtpstats_receiver.go
@@ -596,10 +596,14 @@ func (r *RTPStatsReceiver) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	defer r.lock.RUnlock()
 
 	e.AddObject("base", r.rtpStatsBase)
+
 	e.AddUint64("extStartSN", r.sequenceNumber.GetExtendedStart())
 	e.AddUint64("extHighestSN", r.sequenceNumber.GetExtendedHighest())
 	e.AddUint64("extStartTS", r.timestamp.GetExtendedStart())
 	e.AddUint64("extHighestTS", r.timestamp.GetExtendedHighest())
+
+	e.AddDuration("propagationDelay", r.propagationDelay)
+	e.AddDuration("longTermDeltaPropagationDelay", r.longTermDeltaPropagationDelay)
 	return nil
 }
 


### PR DESCRIPTION
Seeing cases where the first time is 400ms+ before start time. Possible it is getting that much adjustment, but would be good to see how much total adjustment happens.