### PR TITLE
Do not error out on invalid packet.

### DIFF
--- a/pkg/sfu/utils/helpers.go
+++ b/pkg/sfu/utils/helpers.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/pion/interceptor"
@@ -54,18 +55,24 @@ func GetHeaderExtensionID(extensions []interceptor.RTPHeaderExtension, extension
 	return 0
 }
 
+var (
+	ErrInvalidRTPVersion      = errors.New("invalid RTP version")
+	ErrRTPPayloadTypeMismatch = errors.New("RTP payload type mismatch")
+	ErrRTPSSRCMismatch        = errors.New("RTP SSRC mismatch")
+)
+
 // ValidateRTPPacket checks for a valid RTP packet and returns an error if fields are incorrect
 func ValidateRTPPacket(pkt *rtp.Packet, expectedPayloadType uint8, expectedSSRC uint32) error {
 	if pkt.Version != 2 {
-		return errors.New("invalid RTP version")
+		return fmt.Errorf("%w, expected: 2, actual: %d", ErrInvalidRTPVersion, pkt.Version)
 	}
 
 	if expectedPayloadType != 0 && pkt.PayloadType != expectedPayloadType {
-		return errors.New("invalid RTP payload type")
+		return fmt.Errorf("%w, expected: %d, actual: %d", ErrRTPPayloadTypeMismatch, expectedPayloadType, pkt.PayloadType)
 	}
 
 	if expectedSSRC != 0 && pkt.SSRC != expectedSSRC {
-		return errors.New("invalid RTP SSRC")
+		return fmt.Errorf("%w, expected: %d, actual: %d", ErrRTPSSRCMismatch, expectedSSRC, pkt.SSRC)
 	}
 
 	return nil


### PR DESCRIPTION
Remove the return when encountering invalid packet. Also, log more sparsely.
Proper error returns from util so that we can selectively drop packets based on error type, for example SSRC mismatches are okay type of thing.