### PR TITLE
Indicate if track is expectd to be resumed in `onClose` callback.

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -411,13 +411,13 @@ func (t *MediaTrack) Restart() {
 	}
 }
 
-func (t *MediaTrack) Close(willBeResumed bool) {
+func (t *MediaTrack) Close(isExpectedToResume bool) {
 	t.MediaTrackReceiver.SetClosing()
 	if t.dynacastManager != nil {
 		t.dynacastManager.Close()
 	}
-	t.MediaTrackReceiver.ClearAllReceivers(willBeResumed)
-	t.MediaTrackReceiver.Close()
+	t.MediaTrackReceiver.ClearAllReceivers(isExpectedToResume)
+	t.MediaTrackReceiver.Close(isExpectedToResume)
 }
 
 func (t *MediaTrack) SetMuted(muted bool) {

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2125,7 +2125,7 @@ func (p *ParticipantImpl) addMediaTrack(signalCid string, sdpCid string, ti *liv
 	}
 
 	trackID := livekit.TrackID(ti.Sid)
-	mt.AddOnClose(func() {
+	mt.AddOnClose(func(_isExpectedToRsume bool) {
 		if p.supervisor != nil {
 			p.supervisor.ClearPublishedTrack(trackID, mt)
 		}

--- a/pkg/rtc/subscribedtrack.go
+++ b/pkg/rtc/subscribedtrack.go
@@ -139,9 +139,9 @@ func (t *SubscribedTrack) Bound(err error) {
 }
 
 // for DownTrack callback to notify us that it's closed
-func (t *SubscribedTrack) Close(willBeResumed bool) {
+func (t *SubscribedTrack) Close(isExpectedToResume bool) {
 	if onClose := t.onClose.Load(); onClose != nil {
-		go onClose.(func(bool))(willBeResumed)
+		go onClose.(func(bool))(isExpectedToResume)
 	}
 }
 

--- a/pkg/rtc/subscriptionmanager_test.go
+++ b/pkg/rtc/subscriptionmanager_test.go
@@ -214,11 +214,11 @@ func TestUnsubscribe(t *testing.T) {
 	st, err := res.Track.AddSubscriber(sm.params.Participant)
 	require.NoError(t, err)
 	s.subscribedTrack = st
-	st.OnClose(func(willBeResumed bool) {
-		sm.handleSubscribedTrackClose(s, willBeResumed)
+	st.OnClose(func(isExpectedToResume bool) {
+		sm.handleSubscribedTrackClose(s, isExpectedToResume)
 	})
-	res.Track.(*typesfakes.FakeMediaTrack).RemoveSubscriberCalls(func(pID livekit.ParticipantID, willBeResumed bool) {
-		setTestSubscribedTrackClosed(t, st, willBeResumed)
+	res.Track.(*typesfakes.FakeMediaTrack).RemoveSubscriberCalls(func(pID livekit.ParticipantID, isExpectedToResume bool) {
+		setTestSubscribedTrackClosed(t, st, isExpectedToResume)
 	})
 
 	sm.lock.Lock()
@@ -279,18 +279,18 @@ func TestSubscribeStatusChanged(t *testing.T) {
 		return !s1.needsSubscribe() && !s2.needsSubscribe()
 	}, subSettleTimeout, subCheckInterval, "track1 and track2 should be subscribed")
 	st1 := s1.getSubscribedTrack()
-	st1.OnClose(func(willBeResumed bool) {
-		sm.handleSubscribedTrackClose(s1, willBeResumed)
+	st1.OnClose(func(isExpectedToResume bool) {
+		sm.handleSubscribedTrackClose(s1, isExpectedToResume)
 	})
 	st2 := s2.getSubscribedTrack()
-	st2.OnClose(func(willBeResumed bool) {
-		sm.handleSubscribedTrackClose(s2, willBeResumed)
+	st2.OnClose(func(isExpectedToResume bool) {
+		sm.handleSubscribedTrackClose(s2, isExpectedToResume)
 	})
-	st1.MediaTrack().(*typesfakes.FakeMediaTrack).RemoveSubscriberCalls(func(pID livekit.ParticipantID, willBeResumed bool) {
-		setTestSubscribedTrackClosed(t, st1, willBeResumed)
+	st1.MediaTrack().(*typesfakes.FakeMediaTrack).RemoveSubscriberCalls(func(pID livekit.ParticipantID, isExpectedToResume bool) {
+		setTestSubscribedTrackClosed(t, st1, isExpectedToResume)
 	})
-	st2.MediaTrack().(*typesfakes.FakeMediaTrack).RemoveSubscriberCalls(func(pID livekit.ParticipantID, willBeResumed bool) {
-		setTestSubscribedTrackClosed(t, st2, willBeResumed)
+	st2.MediaTrack().(*typesfakes.FakeMediaTrack).RemoveSubscriberCalls(func(pID livekit.ParticipantID, isExpectedToResume bool) {
+		setTestSubscribedTrackClosed(t, st2, isExpectedToResume)
 	})
 
 	require.Eventually(t, func() bool {
@@ -533,9 +533,9 @@ func setTestSubscribedTrackBound(t *testing.T, st types.SubscribedTrack) {
 	}
 }
 
-func setTestSubscribedTrackClosed(t *testing.T, st types.SubscribedTrack, willBeResumed bool) {
+func setTestSubscribedTrackClosed(t *testing.T, st types.SubscribedTrack, isExpectedToResume bool) {
 	fst, ok := st.(*typesfakes.FakeSubscribedTrack)
 	require.True(t, ok)
 
-	fst.OnCloseArgsForCall(0)(willBeResumed)
+	fst.OnCloseArgsForCall(0)(isExpectedToResume)
 }

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -261,7 +261,7 @@ type Participant interface {
 	IsPublisher() bool
 	GetPublishedTrack(trackID livekit.TrackID) MediaTrack
 	GetPublishedTracks() []MediaTrack
-	RemovePublishedTrack(track MediaTrack, willBeResumed bool, shouldClose bool)
+	RemovePublishedTrack(track MediaTrack, isExpectedToResume bool, shouldClose bool)
 
 	GetAudioLevel() (smoothedLevel float64, active bool)
 
@@ -466,15 +466,15 @@ type MediaTrack interface {
 
 	GetAudioLevel() (level float64, active bool)
 
-	Close(willBeResumed bool)
+	Close(isExpectedToResume bool)
 	IsOpen() bool
 
 	// callbacks
-	AddOnClose(func())
+	AddOnClose(func(isExpectedToResume bool))
 
 	// subscribers
 	AddSubscriber(participant LocalParticipant) (SubscribedTrack, error)
-	RemoveSubscriber(participantID livekit.ParticipantID, willBeResumed bool)
+	RemoveSubscriber(participantID livekit.ParticipantID, isExpectedToResume bool)
 	IsSubscriber(subID livekit.ParticipantID) bool
 	RevokeDisallowedSubscribers(allowedSubscriberIdentities []livekit.ParticipantIdentity) []livekit.ParticipantIdentity
 	GetAllSubscribers() []livekit.ParticipantID
@@ -487,7 +487,7 @@ type MediaTrack interface {
 	GetTemporalLayerForSpatialFps(spatial int32, fps uint32, mime string) int32
 
 	Receivers() []sfu.TrackReceiver
-	ClearAllReceivers(willBeResumed bool)
+	ClearAllReceivers(isExpectedToResume bool)
 
 	IsEncrypted() bool
 }
@@ -514,8 +514,8 @@ type LocalMediaTrack interface {
 type SubscribedTrack interface {
 	AddOnBind(f func(error))
 	IsBound() bool
-	Close(willBeResumed bool)
-	OnClose(f func(willBeResumed bool))
+	Close(isExpectedToResume bool)
+	OnClose(f func(isExpectedToResume bool))
 	ID() livekit.TrackID
 	PublisherID() livekit.ParticipantID
 	PublisherIdentity() livekit.ParticipantIdentity

--- a/pkg/rtc/types/typesfakes/fake_local_media_track.go
+++ b/pkg/rtc/types/typesfakes/fake_local_media_track.go
@@ -10,10 +10,10 @@ import (
 )
 
 type FakeLocalMediaTrack struct {
-	AddOnCloseStub        func(func())
+	AddOnCloseStub        func(func(isExpectedToResume bool))
 	addOnCloseMutex       sync.RWMutex
 	addOnCloseArgsForCall []struct {
-		arg1 func()
+		arg1 func(isExpectedToResume bool)
 	}
 	AddSubscriberStub        func(types.LocalParticipant) (types.SubscribedTrack, error)
 	addSubscriberMutex       sync.RWMutex
@@ -351,10 +351,10 @@ type FakeLocalMediaTrack struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeLocalMediaTrack) AddOnClose(arg1 func()) {
+func (fake *FakeLocalMediaTrack) AddOnClose(arg1 func(isExpectedToResume bool)) {
 	fake.addOnCloseMutex.Lock()
 	fake.addOnCloseArgsForCall = append(fake.addOnCloseArgsForCall, struct {
-		arg1 func()
+		arg1 func(isExpectedToResume bool)
 	}{arg1})
 	stub := fake.AddOnCloseStub
 	fake.recordInvocation("AddOnClose", []interface{}{arg1})
@@ -370,13 +370,13 @@ func (fake *FakeLocalMediaTrack) AddOnCloseCallCount() int {
 	return len(fake.addOnCloseArgsForCall)
 }
 
-func (fake *FakeLocalMediaTrack) AddOnCloseCalls(stub func(func())) {
+func (fake *FakeLocalMediaTrack) AddOnCloseCalls(stub func(func(isExpectedToResume bool))) {
 	fake.addOnCloseMutex.Lock()
 	defer fake.addOnCloseMutex.Unlock()
 	fake.AddOnCloseStub = stub
 }
 
-func (fake *FakeLocalMediaTrack) AddOnCloseArgsForCall(i int) func() {
+func (fake *FakeLocalMediaTrack) AddOnCloseArgsForCall(i int) func(isExpectedToResume bool) {
 	fake.addOnCloseMutex.RLock()
 	defer fake.addOnCloseMutex.RUnlock()
 	argsForCall := fake.addOnCloseArgsForCall[i]

--- a/pkg/rtc/types/typesfakes/fake_media_track.go
+++ b/pkg/rtc/types/typesfakes/fake_media_track.go
@@ -10,10 +10,10 @@ import (
 )
 
 type FakeMediaTrack struct {
-	AddOnCloseStub        func(func())
+	AddOnCloseStub        func(func(isExpectedToResume bool))
 	addOnCloseMutex       sync.RWMutex
 	addOnCloseArgsForCall []struct {
-		arg1 func()
+		arg1 func(isExpectedToResume bool)
 	}
 	AddSubscriberStub        func(types.LocalParticipant) (types.SubscribedTrack, error)
 	addSubscriberMutex       sync.RWMutex
@@ -287,10 +287,10 @@ type FakeMediaTrack struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeMediaTrack) AddOnClose(arg1 func()) {
+func (fake *FakeMediaTrack) AddOnClose(arg1 func(isExpectedToResume bool)) {
 	fake.addOnCloseMutex.Lock()
 	fake.addOnCloseArgsForCall = append(fake.addOnCloseArgsForCall, struct {
-		arg1 func()
+		arg1 func(isExpectedToResume bool)
 	}{arg1})
 	stub := fake.AddOnCloseStub
 	fake.recordInvocation("AddOnClose", []interface{}{arg1})
@@ -306,13 +306,13 @@ func (fake *FakeMediaTrack) AddOnCloseCallCount() int {
 	return len(fake.addOnCloseArgsForCall)
 }
 
-func (fake *FakeMediaTrack) AddOnCloseCalls(stub func(func())) {
+func (fake *FakeMediaTrack) AddOnCloseCalls(stub func(func(isExpectedToResume bool))) {
 	fake.addOnCloseMutex.Lock()
 	defer fake.addOnCloseMutex.Unlock()
 	fake.AddOnCloseStub = stub
 }
 
-func (fake *FakeMediaTrack) AddOnCloseArgsForCall(i int) func() {
+func (fake *FakeMediaTrack) AddOnCloseArgsForCall(i int) func(isExpectedToResume bool) {
 	fake.addOnCloseMutex.RLock()
 	defer fake.addOnCloseMutex.RUnlock()
 	argsForCall := fake.addOnCloseArgsForCall[i]

--- a/pkg/rtc/types/typesfakes/fake_subscribed_track.go
+++ b/pkg/rtc/types/typesfakes/fake_subscribed_track.go
@@ -81,10 +81,10 @@ type FakeSubscribedTrack struct {
 	needsNegotiationReturnsOnCall map[int]struct {
 		result1 bool
 	}
-	OnCloseStub        func(func(willBeResumed bool))
+	OnCloseStub        func(func(isExpectedToResume bool))
 	onCloseMutex       sync.RWMutex
 	onCloseArgsForCall []struct {
-		arg1 func(willBeResumed bool)
+		arg1 func(isExpectedToResume bool)
 	}
 	PublisherIDStub        func() livekit.ParticipantID
 	publisherIDMutex       sync.RWMutex
@@ -557,10 +557,10 @@ func (fake *FakeSubscribedTrack) NeedsNegotiationReturnsOnCall(i int, result1 bo
 	}{result1}
 }
 
-func (fake *FakeSubscribedTrack) OnClose(arg1 func(willBeResumed bool)) {
+func (fake *FakeSubscribedTrack) OnClose(arg1 func(isExpectedToResume bool)) {
 	fake.onCloseMutex.Lock()
 	fake.onCloseArgsForCall = append(fake.onCloseArgsForCall, struct {
-		arg1 func(willBeResumed bool)
+		arg1 func(isExpectedToResume bool)
 	}{arg1})
 	stub := fake.OnCloseStub
 	fake.recordInvocation("OnClose", []interface{}{arg1})
@@ -576,13 +576,13 @@ func (fake *FakeSubscribedTrack) OnCloseCallCount() int {
 	return len(fake.onCloseArgsForCall)
 }
 
-func (fake *FakeSubscribedTrack) OnCloseCalls(stub func(func(willBeResumed bool))) {
+func (fake *FakeSubscribedTrack) OnCloseCalls(stub func(func(isExpectedToResume bool))) {
 	fake.onCloseMutex.Lock()
 	defer fake.onCloseMutex.Unlock()
 	fake.OnCloseStub = stub
 }
 
-func (fake *FakeSubscribedTrack) OnCloseArgsForCall(i int) func(willBeResumed bool) {
+func (fake *FakeSubscribedTrack) OnCloseArgsForCall(i int) func(isExpectedToResume bool) {
 	fake.onCloseMutex.RLock()
 	defer fake.onCloseMutex.RUnlock()
 	argsForCall := fake.onCloseArgsForCall[i]

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -296,7 +296,7 @@ type DownTrack struct {
 	onStatsUpdate               func(dt *DownTrack, stat *livekit.AnalyticsStat)
 	onMaxSubscribedLayerChanged func(dt *DownTrack, layer int32)
 	onRttUpdate                 func(dt *DownTrack, rtt uint32)
-	onCloseHandler              func(willBeResumed bool)
+	onCloseHandler              func(isExpectedToResume bool)
 
 	createdAt int64
 }
@@ -1169,14 +1169,14 @@ func (d *DownTrack) UpTrackBitrateReport(availableLayers []int32, bitrates Bitra
 }
 
 // OnCloseHandler method to be called on remote tracked removed
-func (d *DownTrack) OnCloseHandler(fn func(willBeResumed bool)) {
+func (d *DownTrack) OnCloseHandler(fn func(isExpectedToResume bool)) {
 	d.cbMu.Lock()
 	defer d.cbMu.Unlock()
 
 	d.onCloseHandler = fn
 }
 
-func (d *DownTrack) getOnCloseHandler() func(willBeResumed bool) {
+func (d *DownTrack) getOnCloseHandler() func(isExpectedToResume bool) {
 	d.cbMu.RLock()
 	defer d.cbMu.RUnlock()
 


### PR DESCRIPTION
That is the main change. Changed variable name to `isExpectedToResume` everywhere to be consistent.

Planning to use the callback value in relays to determine if the down track should be closed or switched to a different up track.