### PR TITLE
Broadcast attributes update

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -461,6 +461,9 @@ func (p *ParticipantImpl) SetMetadata(metadata string) {
 }
 
 func (p *ParticipantImpl) SetAttributes(attrs map[string]string) error {
+	if len(attrs) == 0 {
+		return nil
+	}
 	p.lock.Lock()
 	grants := p.grants.Load().Clone()
 	if grants.Attributes == nil {
@@ -491,6 +494,7 @@ func (p *ParticipantImpl) SetAttributes(attrs map[string]string) error {
 	}
 
 	p.grants.Store(grants)
+	p.requireBroadcast = true // already checked above
 	p.dirty.Store(true)
 
 	onParticipantUpdate := p.onParticipantUpdate


### PR DESCRIPTION
Not sure if it matters (it didn't affect SIP tests), but I noticed that attribute updates do not set the broadcast flag as metadata updates do. 