### PR TITLE
Handle cases of long mute/rollover of time stamp.

### DIFF
--- a/pkg/sfu/audio/audiolevel.go
+++ b/pkg/sfu/audio/audiolevel.go
@@ -100,7 +100,7 @@ func (l *AudioLevel) Observe(level uint8, durationMs uint32, arrivalTime int64) 
 	}
 }
 
-// returns current soothed audio level
+// returns current smoothed audio level
 func (l *AudioLevel) GetLevel(now int64) (float64, bool) {
 	l.lock.Lock()
 	defer l.lock.Unlock()

--- a/pkg/sfu/audio/audiolevel.go
+++ b/pkg/sfu/audio/audiolevel.go
@@ -17,7 +17,6 @@ package audio
 import (
 	"math"
 	"sync"
-	"time"
 )
 
 const (
@@ -46,7 +45,7 @@ type AudioLevel struct {
 	loudestObservedLevel uint8
 	activeDuration       uint32 // ms
 	observedDuration     uint32 // ms
-	lastObservedAt       time.Time
+	lastObservedAt       int64
 }
 
 func NewAudioLevel(params AudioLevelParams) *AudioLevel {
@@ -67,7 +66,7 @@ func NewAudioLevel(params AudioLevelParams) *AudioLevel {
 }
 
 // Observes a new frame
-func (l *AudioLevel) Observe(level uint8, durationMs uint32, arrivalTime time.Time) {
+func (l *AudioLevel) Observe(level uint8, durationMs uint32, arrivalTime int64) {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 
@@ -102,7 +101,7 @@ func (l *AudioLevel) Observe(level uint8, durationMs uint32, arrivalTime time.Ti
 }
 
 // returns current soothed audio level
-func (l *AudioLevel) GetLevel(now time.Time) (float64, bool) {
+func (l *AudioLevel) GetLevel(now int64) (float64, bool) {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 
@@ -111,8 +110,8 @@ func (l *AudioLevel) GetLevel(now time.Time) (float64, bool) {
 	return l.smoothedLevel, l.smoothedLevel >= l.activeThreshold
 }
 
-func (l *AudioLevel) resetIfStaleLocked(arrivalTime time.Time) {
-	if arrivalTime.Sub(l.lastObservedAt).Milliseconds() < int64(2*l.params.ObserveDuration) {
+func (l *AudioLevel) resetIfStaleLocked(arrivalTime int64) {
+	if (arrivalTime-l.lastObservedAt)/1e6 < int64(2*l.params.ObserveDuration) {
 		return
 	}
 

--- a/pkg/sfu/audio/audiolevel_test.go
+++ b/pkg/sfu/audio/audiolevel_test.go
@@ -34,13 +34,13 @@ func TestAudioLevel(t *testing.T) {
 		clock := time.Now()
 		a := createAudioLevel(defaultActiveLevel, defaultPercentile, defaultObserveDuration)
 
-		_, noisy := a.GetLevel(clock)
+		_, noisy := a.GetLevel(clock.UnixNano())
 		require.False(t, noisy)
 
 		observeSamples(a, 28, 5, clock)
 		clock = clock.Add(5 * 20 * time.Millisecond)
 
-		_, noisy = a.GetLevel(clock)
+		_, noisy = a.GetLevel(clock.UnixNano())
 		require.False(t, noisy)
 	})
 
@@ -51,7 +51,7 @@ func TestAudioLevel(t *testing.T) {
 		observeSamples(a, 35, 100, clock)
 		clock = clock.Add(100 * 20 * time.Millisecond)
 
-		_, noisy := a.GetLevel(clock)
+		_, noisy := a.GetLevel(clock.UnixNano())
 		require.False(t, noisy)
 	})
 
@@ -66,7 +66,7 @@ func TestAudioLevel(t *testing.T) {
 		observeSamples(a, 35, 1, clock)
 		clock = clock.Add(20 * time.Millisecond)
 
-		_, noisy := a.GetLevel(clock)
+		_, noisy := a.GetLevel(clock.UnixNano())
 		require.False(t, noisy)
 	})
 
@@ -81,7 +81,7 @@ func TestAudioLevel(t *testing.T) {
 		observeSamples(a, 29, 8, clock)
 		clock = clock.Add(8 * 20 * time.Millisecond)
 
-		level, noisy := a.GetLevel(clock)
+		level, noisy := a.GetLevel(clock.UnixNano())
 		require.True(t, noisy)
 		require.Greater(t, level, ConvertAudioLevel(float64(defaultActiveLevel)))
 		require.Less(t, level, ConvertAudioLevel(float64(25)))
@@ -93,14 +93,14 @@ func TestAudioLevel(t *testing.T) {
 
 		observeSamples(a, 25, 100, clock)
 		clock = clock.Add(100 * 20 * time.Millisecond)
-		level, noisy := a.GetLevel(clock)
+		level, noisy := a.GetLevel(clock.UnixNano())
 		require.True(t, noisy)
 		require.Greater(t, level, ConvertAudioLevel(float64(defaultActiveLevel)))
 		require.Less(t, level, ConvertAudioLevel(float64(20)))
 
 		// let enough time pass to make the samples stale
 		clock = clock.Add(1500 * time.Millisecond)
-		level, noisy = a.GetLevel(clock)
+		level, noisy = a.GetLevel(clock.UnixNano())
 		require.Equal(t, float64(0.0), level)
 		require.False(t, noisy)
 	})
@@ -116,6 +116,6 @@ func createAudioLevel(activeLevel uint8, minPercentile uint8, observeDuration ui
 
 func observeSamples(a *AudioLevel, level uint8, count int, baseTime time.Time) {
 	for i := 0; i < count; i++ {
-		a.Observe(level, 20, baseTime.Add(+time.Duration(i*20)*time.Millisecond))
+		a.Observe(level, 20, baseTime.Add(+time.Duration(i*20)*time.Millisecond).UnixNano())
 	}
 }

--- a/pkg/sfu/buffer/rtpstats_receiver_test.go
+++ b/pkg/sfu/buffer/rtpstats_receiver_test.go
@@ -61,7 +61,7 @@ func Test_RTPStatsReceiver(t *testing.T) {
 		for i := 0; i < packetsPerFrame; i++ {
 			packet := getPacket(sequenceNumber, timestamp, packetSize)
 			r.Update(
-				time.Now(),
+				time.Now().UnixNano(),
 				packet.Header.SequenceNumber,
 				packet.Header.Timestamp,
 				packet.Header.Marker,
@@ -97,7 +97,7 @@ func Test_RTPStatsReceiver_Update(t *testing.T) {
 	timestamp := uint32(rand.Float64() * float64(1<<32))
 	packet := getPacket(sequenceNumber, timestamp, 1000)
 	flowState := r.Update(
-		time.Now(),
+		time.Now().UnixNano(),
 		packet.Header.SequenceNumber,
 		packet.Header.Timestamp,
 		packet.Header.Marker,
@@ -117,7 +117,7 @@ func Test_RTPStatsReceiver_Update(t *testing.T) {
 	timestamp += 3000
 	packet = getPacket(sequenceNumber, timestamp, 1000)
 	flowState = r.Update(
-		time.Now(),
+		time.Now().UnixNano(),
 		packet.Header.SequenceNumber,
 		packet.Header.Timestamp,
 		packet.Header.Marker,
@@ -134,7 +134,7 @@ func Test_RTPStatsReceiver_Update(t *testing.T) {
 	// out-of-order, would cause a restart which is disallowed
 	packet = getPacket(sequenceNumber-10, timestamp-30000, 1000)
 	flowState = r.Update(
-		time.Now(),
+		time.Now().UnixNano(),
 		packet.Header.SequenceNumber,
 		packet.Header.Timestamp,
 		packet.Header.Marker,
@@ -154,7 +154,7 @@ func Test_RTPStatsReceiver_Update(t *testing.T) {
 	// duplicate of the above out-of-order packet, but would not be handled as it causes a restart
 	packet = getPacket(sequenceNumber-10, timestamp-30000, 1000)
 	flowState = r.Update(
-		time.Now(),
+		time.Now().UnixNano(),
 		packet.Header.SequenceNumber,
 		packet.Header.Timestamp,
 		packet.Header.Marker,
@@ -176,7 +176,7 @@ func Test_RTPStatsReceiver_Update(t *testing.T) {
 	timestamp += 30000
 	packet = getPacket(sequenceNumber, timestamp, 1000)
 	flowState = r.Update(
-		time.Now(),
+		time.Now().UnixNano(),
 		packet.Header.SequenceNumber,
 		packet.Header.Timestamp,
 		packet.Header.Marker,
@@ -192,7 +192,7 @@ func Test_RTPStatsReceiver_Update(t *testing.T) {
 	// out-of-order should decrement number of lost packets
 	packet = getPacket(sequenceNumber-6, timestamp-45000, 1000)
 	flowState = r.Update(
-		time.Now(),
+		time.Now().UnixNano(),
 		packet.Header.SequenceNumber,
 		packet.Header.Timestamp,
 		packet.Header.Marker,
@@ -215,7 +215,7 @@ func Test_RTPStatsReceiver_Update(t *testing.T) {
 	timestamp += 6000
 	packet = getPacket(sequenceNumber, timestamp, 1000)
 	flowState = r.Update(
-		time.Now(),
+		time.Now().UnixNano(),
 		packet.Header.SequenceNumber,
 		packet.Header.Timestamp,
 		packet.Header.Marker,
@@ -234,7 +234,7 @@ func Test_RTPStatsReceiver_Update(t *testing.T) {
 	timestamp -= 3000
 	packet = getPacket(sequenceNumber, timestamp, 999)
 	flowState = r.Update(
-		time.Now(),
+		time.Now().UnixNano(),
 		packet.Header.SequenceNumber,
 		packet.Header.Timestamp,
 		packet.Header.Marker,
@@ -251,7 +251,7 @@ func Test_RTPStatsReceiver_Update(t *testing.T) {
 	sequenceNumber += 2
 	packet = getPacket(sequenceNumber, timestamp, 0)
 	flowState = r.Update(
-		time.Now(),
+		time.Now().UnixNano(),
 		packet.Header.SequenceNumber,
 		packet.Header.Timestamp,
 		packet.Header.Marker,

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -905,7 +905,7 @@ func (d *DownTrack) WritePaddingRTP(bytesToSend int, paddingOnMute bool, forceMa
 			&hdr,
 			len(payload),
 			&sendPacketMetadata{
-				packetTime:           time.Now(),
+				packetTime:           time.Now().UnixNano(),
 				extSequenceNumber:    snts[i].extSequenceNumber,
 				extTimestamp:         snts[i].extTimestamp,
 				isPadding:            true,
@@ -1438,7 +1438,7 @@ func (d *DownTrack) writeBlankFrameRTP(duration float32, generation uint32) chan
 				}
 
 				d.sendingPacket(&hdr, len(payload), &sendPacketMetadata{
-					packetTime:        time.Now(),
+					packetTime:        time.Now().UnixNano(),
 					extSequenceNumber: snts[i].extSequenceNumber,
 					extTimestamp:      snts[i].extTimestamp,
 				})
@@ -1801,7 +1801,7 @@ func (d *DownTrack) retransmitPackets(nacks []uint16) {
 			len(payload),
 			&sendPacketMetadata{
 				layer:             int32(epm.layer),
-				packetTime:        time.Now(),
+				packetTime:        time.Now().UnixNano(),
 				extSequenceNumber: epm.extSequenceNumber,
 				extTimestamp:      epm.extTimestamp,
 				isRTX:             true,
@@ -2011,7 +2011,7 @@ func (d *DownTrack) sendSilentFrameOnMuteForOpus() {
 				&hdr,
 				len(payload),
 				&sendPacketMetadata{
-					packetTime:        time.Now(),
+					packetTime:        time.Now().UnixNano(),
 					extSequenceNumber: snts[i].extSequenceNumber,
 					extTimestamp:      snts[i].extTimestamp,
 					// although this is using empty frames, mark as padding as these are used to trigger Pion OnTrack only
@@ -2053,7 +2053,7 @@ func (d *DownTrack) handleRTCPSenderReportData(publisherSRData *buffer.RTCPSende
 
 type sendPacketMetadata struct {
 	layer                int32
-	packetTime           time.Time
+	packetTime           int64
 	extSequenceNumber    uint64
 	extTimestamp         uint64
 	isKeyFrame           bool

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -756,7 +756,7 @@ func (w *WebRTCReceiver) forwardRTP(layer int32) {
 		}
 
 		if writeCount > 0 && w.forwardStats != nil {
-			w.forwardStats.Update(pkt.Arrival, time.Now())
+			w.forwardStats.Update(pkt.Arrival, time.Now().UnixNano())
 		}
 
 		if spatialTracker != nil {

--- a/pkg/sfu/redprimaryreceiver.go
+++ b/pkg/sfu/redprimaryreceiver.go
@@ -73,7 +73,7 @@ func (r *RedPrimaryReceiver) ForwardRTP(pkt *buffer.ExtPacket, spatialLayer int3
 	for i, sendPkt := range pkts {
 		pPkt := *pkt
 		if i != len(pkts)-1 {
-			// patch extended sequence number and time stmap for all but the last packet,
+			// patch extended sequence number and time stamp for all but the last packet,
 			// last packet is the primary payload
 			pPkt.ExtSequenceNumber -= uint64(pkts[len(pkts)-1].SequenceNumber - pkts[i].SequenceNumber)
 			pPkt.ExtTimestamp -= uint64(pkts[len(pkts)-1].Timestamp - pkts[i].Timestamp)

--- a/pkg/sfu/sequencer.go
+++ b/pkg/sfu/sequencer.go
@@ -104,7 +104,7 @@ type sequencer struct {
 func newSequencer(size int, maybeSparse bool, logger logger.Logger) *sequencer {
 	s := &sequencer{
 		size:      size,
-		startTime: time.Now().UnixMilli(),
+		startTime: time.Now().UnixNano(),
 		meta:      make([]packetMeta, size),
 		rtt:       defaultRtt,
 		logger:    logger,
@@ -128,7 +128,7 @@ func (s *sequencer) setRTT(rtt uint32) {
 }
 
 func (s *sequencer) push(
-	packetTime time.Time,
+	packetTime int64,
 	extIncomingSN, extModifiedSN uint64,
 	extModifiedTS uint64,
 	marker bool,
@@ -296,7 +296,7 @@ func (s *sequencer) getExtPacketMetas(seqNo []uint16) []extPacketMeta {
 	snOffset := uint64(0)
 	var err error
 	extPacketMetas := make([]extPacketMeta, 0, len(seqNo))
-	refTime := s.getRefTime(time.Now())
+	refTime := s.getRefTime(time.Now().UnixNano())
 	highestSN := uint16(s.extHighestSN)
 	highestTS := uint32(s.extHighestTS)
 	for _, sn := range seqNo {
@@ -357,8 +357,8 @@ func (s *sequencer) getExtPacketMetas(seqNo []uint16) []extPacketMeta {
 	return extPacketMetas
 }
 
-func (s *sequencer) getRefTime(at time.Time) uint32 {
-	return uint32(at.UnixMilli() - s.startTime)
+func (s *sequencer) getRefTime(at int64) uint32 {
+	return uint32((at - s.startTime) / 1e6)
 }
 
 func (s *sequencer) updateSNOffset() {

--- a/pkg/sfu/sequencer_test.go
+++ b/pkg/sfu/sequencer_test.go
@@ -29,11 +29,11 @@ func Test_sequencer(t *testing.T) {
 	off := uint16(15)
 
 	for i := uint64(1); i < 518; i++ {
-		seq.push(time.Now(), i, i+uint64(off), 123, true, 2, nil, 0, nil, nil)
+		seq.push(time.Now().UnixNano(), i, i+uint64(off), 123, true, 2, nil, 0, nil, nil)
 	}
 	// send the last two out-of-order
-	seq.push(time.Now(), 519, 519+uint64(off), 123, false, 2, nil, 0, nil, nil)
-	seq.push(time.Now(), 518, 518+uint64(off), 123, true, 2, nil, 0, nil, nil)
+	seq.push(time.Now().UnixNano(), 519, 519+uint64(off), 123, false, 2, nil, 0, nil, nil)
+	seq.push(time.Now().UnixNano(), 518, 518+uint64(off), 123, true, 2, nil, 0, nil, nil)
 
 	req := []uint16{57, 58, 62, 63, 513, 514, 515, 516, 517}
 	res := seq.getExtPacketMetas(req)
@@ -63,14 +63,14 @@ func Test_sequencer(t *testing.T) {
 		require.Equal(t, val.extTimestamp, uint64(123))
 	}
 
-	seq.push(time.Now(), 521, 521+uint64(off), 123, true, 1, nil, 0, nil, nil)
+	seq.push(time.Now().UnixNano(), 521, 521+uint64(off), 123, true, 1, nil, 0, nil, nil)
 	m := seq.getExtPacketMetas([]uint16{521 + off})
 	require.Equal(t, 0, len(m))
 	time.Sleep((ignoreRetransmission + 10) * time.Millisecond)
 	m = seq.getExtPacketMetas([]uint16{521 + off})
 	require.Equal(t, 1, len(m))
 
-	seq.push(time.Now(), 505, 505+uint64(off), 123, false, 1, nil, 0, nil, nil)
+	seq.push(time.Now().UnixNano(), 505, 505+uint64(off), 123, false, 1, nil, 0, nil, nil)
 	m = seq.getExtPacketMetas([]uint16{505 + off})
 	require.Equal(t, 0, len(m))
 	time.Sleep((ignoreRetransmission + 10) * time.Millisecond)
@@ -157,7 +157,7 @@ func Test_sequencer_getNACKSeqNo_exclusion(t *testing.T) {
 				} else {
 					if i.seqNo%5 == 0 {
 						n.push(
-							time.Now(),
+							time.Now().UnixNano(),
 							i.seqNo,
 							i.seqNo+tt.fields.offset,
 							123,
@@ -171,7 +171,7 @@ func Test_sequencer_getNACKSeqNo_exclusion(t *testing.T) {
 					} else {
 						if i.seqNo%2 == 0 {
 							n.push(
-								time.Now(),
+								time.Now().UnixNano(),
 								i.seqNo,
 								i.seqNo+tt.fields.offset,
 								123,
@@ -184,7 +184,7 @@ func Test_sequencer_getNACKSeqNo_exclusion(t *testing.T) {
 							)
 						} else {
 							n.push(
-								time.Now(),
+								time.Now().UnixNano(),
 								i.seqNo,
 								i.seqNo+tt.fields.offset,
 								123,
@@ -311,7 +311,7 @@ func Test_sequencer_getNACKSeqNo_no_exclusion(t *testing.T) {
 				} else {
 					if i.seqNo%2 == 0 {
 						n.push(
-							time.Now(),
+							time.Now().UnixNano(),
 							i.seqNo,
 							i.seqNo+tt.fields.offset,
 							123,
@@ -324,7 +324,7 @@ func Test_sequencer_getNACKSeqNo_no_exclusion(t *testing.T) {
 						)
 					} else {
 						n.push(
-							time.Now(),
+							time.Now().UnixNano(),
 							i.seqNo,
 							i.seqNo+tt.fields.offset,
 							123,

--- a/pkg/sfu/testutils/data.go
+++ b/pkg/sfu/testutils/data.go
@@ -66,7 +66,7 @@ func GetTestExtPacket(params *TestExtPacketParams) (*buffer.ExtPacket, error) {
 		VideoLayer:        params.VideoLayer,
 		ExtSequenceNumber: uint64(params.SNCycles<<16) + uint64(params.SequenceNumber),
 		ExtTimestamp:      uint64(params.TSCycles<<32) + uint64(params.Timestamp),
-		Arrival:           params.ArrivalTime,
+		Arrival:           params.ArrivalTime.UnixNano(),
 		Packet:            &packet,
 		KeyFrame:          params.IsKeyFrame,
 		RawPacket:         raw,


### PR DESCRIPTION
There are cases where the track is muted for long enough for timestamp roll over to happen. There are no packets in that window (typically there should be black frames (for video) or silence (for audio)). But, maybe the pause based implementation of mute is causing this.

Anyhow, use time since last packet to gauge how much roll over should have happened and use that to update time stamp. There will be really edge cases where this could also fail (for e. g. packet time is affected by propagation delay, so it could theoretically happen that mute/unmute
+ packet reception could happen exactly around that rollover point and miscalculate, but should be rare).

As this happen per packet on receive side, changing time to `UnixNano()` to make it more efficient to check this.