### PR TITLE
Check sender report against media path.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_receiver.go
+++ b/pkg/sfu/buffer/rtpstats_receiver.go
@@ -113,6 +113,7 @@ type RTPStatsReceiver struct {
 	propagationDelaySpike              time.Duration
 
 	clockSkewCount              int
+	clockSkewMediaPathCount     int
 	outOfOrderSenderReportCount int
 	largeJumpCount              int
 	largeJumpNegativeCount      int
@@ -318,24 +319,7 @@ func (r *RTPStatsReceiver) Update(
 	return
 }
 
-func (r *RTPStatsReceiver) SetRtcpSenderReportData(srData *RTCPSenderReportData) bool {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-
-	if srData == nil || !r.initialized {
-		return false
-	}
-
-	// prevent against extreme case of anachronous sender reports
-	if r.srNewest != nil && r.srNewest.NTPTimestamp > srData.NTPTimestamp {
-		r.logger.Infow(
-			"received sender report, anachronous, dropping",
-			"current", srData,
-			"rtpStats", lockedRTPStatsReceiverLogEncoder{r},
-		)
-		return false
-	}
-
+func (r *RTPStatsReceiver) getExtendedSenderReport(srData *RTCPSenderReportData) *RTCPSenderReportData {
 	tsCycles := uint64(0)
 	if r.srNewest != nil {
 		// use time since last sender report to ensure long gaps where the time stamp might
@@ -374,55 +358,104 @@ func (r *RTPStatsReceiver) SetRtcpSenderReportData(srData *RTCPSenderReportData)
 		}
 	}
 
-	srDataCopy := *srData
-	srDataCopy.RTPTimestampExt = uint64(srDataCopy.RTPTimestamp) + tsCycles
+	srDataExt := *srData
+	srDataExt.RTPTimestampExt = uint64(srDataExt.RTPTimestamp) + tsCycles
+	return &srDataExt
+}
 
-	if r.srNewest != nil && srDataCopy.RTPTimestampExt < r.srNewest.RTPTimestampExt {
+func (r *RTPStatsReceiver) checkOutOfOrderSenderReport(srData *RTCPSenderReportData) bool {
+	if r.srNewest != nil && srData.RTPTimestampExt < r.srNewest.RTPTimestampExt {
 		// This can happen when a track is replaced with a null and then restored -
 		// i. e. muting replacing with null and unmute restoring the original track.
 		// Or it could be due bad report generation.
 		// In any case, ignore out-of-order reports.
-		if r.outOfOrderSenderReportCount%10 == 0 {
+		r.outOfOrderSenderReportCount++
+		if (r.outOfOrderSenderReportCount-1)%10 == 0 {
 			r.logger.Infow(
 				"received sender report, out-of-order, skipping",
-				"current", &srDataCopy,
+				"current", srData,
 				"count", r.outOfOrderSenderReportCount,
 				"rtpStats", lockedRTPStatsReceiverLogEncoder{r},
 			)
 		}
-		r.outOfOrderSenderReportCount++
-		return false
+		return true
 	}
 
-	if r.srNewest != nil {
-		timeSinceLast := srData.NTPTimestamp.Time().Sub(r.srNewest.NTPTimestamp.Time()).Seconds()
-		rtpDiffSinceLast := srDataCopy.RTPTimestampExt - r.srNewest.RTPTimestampExt
-		calculatedClockRateFromLast := float64(rtpDiffSinceLast) / timeSinceLast
+	return false
+}
 
-		timeSinceFirst := srData.NTPTimestamp.Time().Sub(r.srFirst.NTPTimestamp.Time()).Seconds()
-		rtpDiffSinceFirst := srDataCopy.RTPTimestampExt - r.srFirst.RTPTimestampExt
-		calculatedClockRateFromFirst := float64(rtpDiffSinceFirst) / timeSinceFirst
+func (r *RTPStatsReceiver) checkRTPClockSkewForSenderReport(srData *RTCPSenderReportData) {
+	if r.srNewest == nil {
+		return
+	}
 
-		if (timeSinceLast > 0.2 && math.Abs(float64(r.params.ClockRate)-calculatedClockRateFromLast) > 0.2*float64(r.params.ClockRate)) ||
-			(timeSinceFirst > 0.2 && math.Abs(float64(r.params.ClockRate)-calculatedClockRateFromFirst) > 0.2*float64(r.params.ClockRate)) {
-			if r.clockSkewCount%100 == 0 {
-				r.logger.Infow(
-					"received sender report, clock skew",
-					"current", &srDataCopy,
-					"timeSinceFirst", timeSinceFirst,
-					"rtpDiffSinceFirst", rtpDiffSinceFirst,
-					"calculatedFirst", calculatedClockRateFromFirst,
-					"timeSinceLast", timeSinceLast,
-					"rtpDiffSinceLast", rtpDiffSinceLast,
-					"calculatedLast", calculatedClockRateFromLast,
-					"count", r.clockSkewCount,
-					"rtpStats", lockedRTPStatsReceiverLogEncoder{r},
-				)
-			}
-			r.clockSkewCount++
+	timeSinceLast := srData.NTPTimestamp.Time().Sub(r.srNewest.NTPTimestamp.Time()).Seconds()
+	rtpDiffSinceLast := srData.RTPTimestampExt - r.srNewest.RTPTimestampExt
+	calculatedClockRateFromLast := float64(rtpDiffSinceLast) / timeSinceLast
+
+	timeSinceFirst := srData.NTPTimestamp.Time().Sub(r.srFirst.NTPTimestamp.Time()).Seconds()
+	rtpDiffSinceFirst := srData.RTPTimestampExt - r.srFirst.RTPTimestampExt
+	calculatedClockRateFromFirst := float64(rtpDiffSinceFirst) / timeSinceFirst
+
+	if (timeSinceLast > 0.2 && math.Abs(float64(r.params.ClockRate)-calculatedClockRateFromLast) > 0.2*float64(r.params.ClockRate)) ||
+		(timeSinceFirst > 0.2 && math.Abs(float64(r.params.ClockRate)-calculatedClockRateFromFirst) > 0.2*float64(r.params.ClockRate)) {
+		r.clockSkewCount++
+		if (r.clockSkewCount-1)%100 == 0 {
+			r.logger.Infow(
+				"received sender report, clock skew",
+				"current", srData,
+				"timeSinceFirst", timeSinceFirst,
+				"rtpDiffSinceFirst", rtpDiffSinceFirst,
+				"calculatedFirst", calculatedClockRateFromFirst,
+				"timeSinceLast", timeSinceLast,
+				"rtpDiffSinceLast", rtpDiffSinceLast,
+				"calculatedLast", calculatedClockRateFromLast,
+				"count", r.clockSkewCount,
+				"rtpStats", lockedRTPStatsReceiverLogEncoder{r},
+			)
 		}
 	}
+}
 
+func (r *RTPStatsReceiver) checkRTPClockSkewAgainstMediaPathForSenderReport(srData *RTCPSenderReportData) {
+	if r.highestTime == 0 {
+		return
+	}
+
+	timeSinceSR := time.Since(srData.AtAdjusted)
+	extNowTSSR := srData.RTPTimestampExt + uint64(timeSinceSR.Nanoseconds()*int64(r.params.ClockRate)/1e9)
+
+	timeSinceHighest := time.Since(time.Unix(0, r.highestTime))
+	extNowTSHighest := r.timestamp.GetExtendedHighest() + uint64(timeSinceHighest.Nanoseconds()*int64(r.params.ClockRate)/1e9)
+	diffHighest := extNowTSSR - extNowTSHighest
+
+	timeSinceFirst := time.Since(time.Unix(0, r.firstTime))
+	extNowTSFirst := r.timestamp.GetExtendedStart() + uint64(timeSinceFirst.Nanoseconds()*int64(r.params.ClockRate)/1e9)
+	diffFirst := extNowTSSR - extNowTSFirst
+
+	// is it more than 5 seconds off?
+	if uint32(math.Abs(float64(int64(diffHighest)))) > 5*r.params.ClockRate || uint32(math.Abs(float64(int64(diffFirst)))) > 5*r.params.ClockRate {
+		r.clockSkewMediaPathCount++
+		if (r.clockSkewMediaPathCount-1)%100 == 0 {
+			r.logger.Infow(
+				"received sender report, clock skew against media path",
+				"current", srData,
+				"timeSinceSR", timeSinceSR,
+				"extNowTSSR", extNowTSSR,
+				"timeSinceHighest", timeSinceHighest,
+				"extNowTSHighest", extNowTSHighest,
+				"diffHighest", int64(diffHighest),
+				"timeSinceFirst", timeSinceFirst,
+				"extNowTSFirst", extNowTSFirst,
+				"diffFirst", int64(diffFirst),
+				"count", r.clockSkewMediaPathCount,
+				"rtpStats", lockedRTPStatsReceiverLogEncoder{r},
+			)
+		}
+	}
+}
+
+func (r *RTPStatsReceiver) updatePropagationDelayAndRecordSenderReport(srData *RTCPSenderReportData) {
 	var propagationDelay time.Duration
 	var deltaPropagationDelay time.Duration
 	getPropagationFields := func() []interface{} {
@@ -432,7 +465,7 @@ func (r *RTPStatsReceiver) SetRtcpSenderReportData(srData *RTCPSenderReportData)
 			"deltaHighCount", r.propagationDelayDeltaHighCount,
 			"sinceDeltaHighStart", time.Since(r.propagationDelayDeltaHighStartTime).String(),
 			"propagationDelaySpike", r.propagationDelaySpike.String(),
-			"current", &srDataCopy,
+			"current", srData,
 			"rtpStats", lockedRTPStatsReceiverLogEncoder{r},
 		}
 	}
@@ -449,10 +482,10 @@ func (r *RTPStatsReceiver) SetRtcpSenderReportData(srData *RTCPSenderReportData)
 		resetDelta()
 	}
 
-	ntpTime := srDataCopy.NTPTimestamp.Time()
-	propagationDelay = srDataCopy.At.Sub(ntpTime)
+	ntpTime := srData.NTPTimestamp.Time()
+	propagationDelay = srData.At.Sub(ntpTime)
 	if r.srFirst == nil {
-		r.srFirst = &srDataCopy
+		r.srFirst = srData
 		initPropagationDelay(propagationDelay)
 		r.logger.Debugw("initializing propagation delay", getPropagationFields()...)
 	} else {
@@ -495,15 +528,44 @@ func (r *RTPStatsReceiver) SetRtcpSenderReportData(srData *RTCPSenderReportData)
 			if deltaPropagationDelay < cPropagationDelayDeltaLongTermAdaptationThreshold {
 				// do not adapt to large +ve spikes, can happen when channel is congested and reports are delivered very late
 				// if the spike is in fact a path change, it will persist and handled by path change detection above
-				sinceLastReport := srDataCopy.NTPTimestamp.Time().Sub(r.srNewest.NTPTimestamp.Time())
+				sinceLastReport := srData.NTPTimestamp.Time().Sub(r.srNewest.NTPTimestamp.Time())
 				adaptationFactor := min(1.0, float64(sinceLastReport)/float64(cPropagationDelayDeltaHighResetWait))
 				r.longTermDeltaPropagationDelay += time.Duration(adaptationFactor * float64(deltaPropagationDelay-r.longTermDeltaPropagationDelay))
 			}
 		}
 	}
 	// adjust receive time to estimated propagation delay
-	srDataCopy.AtAdjusted = ntpTime.Add(r.propagationDelay)
-	r.srNewest = &srDataCopy
+	srData.AtAdjusted = ntpTime.Add(r.propagationDelay)
+	r.srNewest = srData
+}
+
+func (r *RTPStatsReceiver) SetRtcpSenderReportData(srData *RTCPSenderReportData) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if srData == nil || !r.initialized {
+		return false
+	}
+
+	// prevent against extreme case of anachronous sender reports
+	if r.srNewest != nil && r.srNewest.NTPTimestamp > srData.NTPTimestamp {
+		r.logger.Infow(
+			"received sender report, anachronous, dropping",
+			"current", srData,
+			"rtpStats", lockedRTPStatsReceiverLogEncoder{r},
+		)
+		return false
+	}
+
+	srDataExt := r.getExtendedSenderReport(srData)
+
+	if r.checkOutOfOrderSenderReport(srDataExt) {
+		return false
+	}
+
+	r.checkRTPClockSkewForSenderReport(srDataExt)
+	r.updatePropagationDelayAndRecordSenderReport(srDataExt)
+	r.checkRTPClockSkewAgainstMediaPathForSenderReport(srDataExt)
 
 	if err, loggingFields := r.maybeAdjustFirstPacketTime(r.srNewest, 0, r.timestamp.GetExtendedStart()); err != nil {
 		r.logger.Infow(err.Error(), append(loggingFields, "rtpStats", lockedRTPStatsReceiverLogEncoder{r})...)

--- a/pkg/sfu/buffer/rtpstats_sender.go
+++ b/pkg/sfu/buffer/rtpstats_sender.go
@@ -548,7 +548,8 @@ func (r *RTPStatsSender) UpdateFromReceiverReport(rr rtcp.ReceptionReport) (rtt 
 			if r.lastRRTime.IsZero() {
 				timeSinceLastRR = time.Since(r.startTime)
 			}
-			if r.metadataCacheOverflowCount%10 == 0 {
+			r.metadataCacheOverflowCount++
+			if (r.metadataCacheOverflowCount-1)%10 == 0 {
 				r.logger.Infow(
 					"metadata cache overflow",
 					"timeSinceLastRR", timeSinceLastRR.String(),
@@ -561,7 +562,6 @@ func (r *RTPStatsSender) UpdateFromReceiverReport(rr rtcp.ReceptionReport) (rtt 
 					"rtpStats", lockedRTPStatsSenderLogEncoder{r},
 				)
 			}
-			r.metadataCacheOverflowCount++
 		}
 		s.extLastRRSN = extReceivedRRSN
 	}
@@ -656,7 +656,8 @@ func (r *RTPStatsSender) GetRtcpSenderReport(ssrc uint32, publisherSRData *RTCPS
 		rtpDiffSinceLastReport := nowRTPExt - r.srNewest.RTPTimestampExt
 		windowClockRate := float64(rtpDiffSinceLastReport) / timeSinceLastReport.Seconds()
 		if timeSinceLastReport.Seconds() > 0.2 && math.Abs(float64(r.params.ClockRate)-windowClockRate) > 0.2*float64(r.params.ClockRate) {
-			if r.clockSkewCount%100 == 0 {
+			r.clockSkewCount++
+			if (r.clockSkewCount-1)%100 == 0 {
 				fields := append(
 					getFields(),
 					"timeSinceLastReport", timeSinceLastReport.String(),
@@ -666,7 +667,6 @@ func (r *RTPStatsSender) GetRtcpSenderReport(ssrc uint32, publisherSRData *RTCPS
 				)
 				r.logger.Infow("sending sender report, clock skew", fields...)
 			}
-			r.clockSkewCount++
 		}
 	}
 


### PR DESCRIPTION
Seeing cases (mostly across relay) of large first packet time adjustment getting ignored. From data, it looks like the first packet is extremely delayed (some times of the order of minutes) which does not make sense.

Adding some checks against media path, i. e. compare RTP timestamp from sender report against expected RTP timestamp based on media path arrivals and log deviations more than 5 seconds.

Another puzzling case. Trying to understand more.

Also, refactoring SetRtcpSenderReportData() function as it was getting unwieldy.