### PR TITLE
Disable NTP timestamp passthrough as it is causing variance on the sender reports

### DIFF
--- a/pkg/sfu/buffer/rtpstats_base.go
+++ b/pkg/sfu/buffer/rtpstats_base.go
@@ -37,7 +37,7 @@ const (
 	cFirstPacketTimeAdjustWindow    = 2 * time.Minute
 	cFirstPacketTimeAdjustThreshold = 15 * 1e9
 
-	cPassthroughNTPTimestamp = true
+	cPassthroughNTPTimestamp = false
 
 	cSequenceNumberLargeJumpThreshold = 100
 )


### PR DESCRIPTION
Discussion: https://livekit-users.slack.com/archives/C048FRL1N2C/p1720705708072679

Hello LiveKit folks! We've started having A/V sync issues in our streams for a few weeks and have been investigating what's the source of the issue - and seems like an issue with the RTCP Sender Reports coming from livekit. I've isolated the commit that introduces the issue to `91520a36`.

Without the issue (variance around ~20ms):
![image (8)](https://github.com/user-attachments/assets/8a42c880-a657-45a1-aea7-497b164c06cc)

With the issue (variance around ~2s) 
![image (9)](https://github.com/user-attachments/assets/e9083b0f-437e-4e62-9bd6-9fd08a153739)

On the latest version (1.7.0), changing `cPassthroughNTPTimestamp` to `false` seems to revert things back to the old behavior.

For now we'll host livekit oss ourselves with `cPassthroughNTPTimestamp = false` so our service gets back to working.

