### PR TITLE
don't send unknown signal message to rust sdk with protocol 9

### DIFF
--- a/pkg/rtc/clientinfo.go
+++ b/pkg/rtc/clientinfo.go
@@ -92,6 +92,15 @@ func (c ClientInfo) ComplyWithCodecOrderInSDPAnswer() bool {
 	return !((c.isLinux() || c.isAndroid()) && c.isFirefox())
 }
 
+// Rust SDK can't decode unknown signal message (TrackSubscribed and ErrorResponse)
+func (c ClientInfo) SupportTrackSubscribedEvent() bool {
+	return !(c.ClientInfo.GetSdk() == livekit.ClientInfo_RUST && c.ClientInfo.GetProtocol() < 10)
+}
+
+func (c ClientInfo) SupportErrorResponse() bool {
+	return c.SupportTrackSubscribedEvent()
+}
+
 // compareVersion compares a semver against the current client SDK version
 // returning 1 if current version is greater than version
 // 0 if they are the same, and -1 if it's an earlier version

--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -198,7 +198,7 @@ func (p *ParticipantImpl) SendRefreshToken(token string) error {
 }
 
 func (p *ParticipantImpl) SendErrorResponse(errorResponse *livekit.ErrorResponse) error {
-	if errorResponse.RequestId == 0 {
+	if errorResponse.RequestId == 0 || !p.params.ClientInfo.SupportErrorResponse() {
 		return nil
 	}
 
@@ -299,6 +299,9 @@ func (p *ParticipantImpl) sendTrackUnpublished(trackID livekit.TrackID) {
 }
 
 func (p *ParticipantImpl) sendTrackHasBeenSubscribed(trackID livekit.TrackID) {
+	if !p.params.ClientInfo.SupportTrackSubscribedEvent() {
+		return
+	}
 	_ = p.writeMessage(&livekit.SignalResponse{
 		Message: &livekit.SignalResponse_TrackSubscribed{
 			TrackSubscribed: &livekit.TrackSubscribed{


### PR DESCRIPTION
rust sdk can't handle unknown message (ErrorResponse and TrackSubscribed)