### PR TITLE
Record packet/octet count in sender report.

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -210,7 +210,7 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.Tra
 			case *rtcp.SourceDescription:
 			case *rtcp.SenderReport:
 				if pkt.SSRC == uint32(track.SSRC()) {
-					buff.SetSenderReportData(pkt.RTPTime, pkt.NTPTime)
+					buff.SetSenderReportData(pkt.RTPTime, pkt.NTPTime, pkt.PacketCount, pkt.OctetCount)
 				}
 			case *rtcp.ExtendedReport:
 			rttFromXR:

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -952,12 +952,14 @@ func (b *Buffer) buildReceptionReport() *rtcp.ReceptionReport {
 	return b.rtpStats.GetRtcpReceptionReport(b.mediaSSRC, proxyLoss, b.rrSnapshotId)
 }
 
-func (b *Buffer) SetSenderReportData(rtpTime uint32, ntpTime uint64) {
+func (b *Buffer) SetSenderReportData(rtpTime uint32, ntpTime uint64, packets uint32, octets uint32) {
 	b.RLock()
 	srData := &RTCPSenderReportData{
 		RTPTimestamp: rtpTime,
 		NTPTimestamp: mediatransportutil.NtpTime(ntpTime),
 		At:           time.Now(),
+		Packets:      packets,
+		Octets:       octets,
 	}
 
 	didSet := false

--- a/pkg/sfu/buffer/rtpstats_base.go
+++ b/pkg/sfu/buffer/rtpstats_base.go
@@ -118,6 +118,8 @@ type RTCPSenderReportData struct {
 	NTPTimestamp    mediatransportutil.NtpTime
 	At              time.Time
 	AtAdjusted      time.Time
+	Packets         uint32
+	Octets          uint32
 }
 
 func (r *RTCPSenderReportData) PropagationDelay(passThrough bool) time.Duration {
@@ -133,12 +135,14 @@ func (r *RTCPSenderReportData) ToString() string {
 		return ""
 	}
 
-	return fmt.Sprintf("ntp: %s, rtp: %d, extRtp: %d, at: %s, atAdj: %s",
+	return fmt.Sprintf("ntp: %s, rtp: %d, extRtp: %d, at: %s, atAdj: %s, p: %d, o: %d",
 		r.NTPTimestamp.Time().String(),
 		r.RTPTimestamp,
 		r.RTPTimestampExt,
 		r.At.String(),
 		r.AtAdjusted.String(),
+		r.Packets,
+		r.Octets,
 	)
 }
 
@@ -152,6 +156,8 @@ func (r *RTCPSenderReportData) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	e.AddUint64("RTPTimestampExt", r.RTPTimestampExt)
 	e.AddTime("At", r.At)
 	e.AddTime("AtAdjusted", r.AtAdjusted)
+	e.AddUint32("Packets", r.Packets)
+	e.AddUint32("Octets", r.Octets)
 	return nil
 }
 

--- a/pkg/sfu/buffer/rtpstats_sender.go
+++ b/pkg/sfu/buffer/rtpstats_sender.go
@@ -628,12 +628,16 @@ func (r *RTPStatsSender) GetRtcpSenderReport(ssrc uint32, publisherSRData *RTCPS
 		nowRTPExt = publisherSRData.RTPTimestampExt - tsOffset + uint64(timeSincePublisherSRAdjusted.Nanoseconds()*int64(r.params.ClockRate)/1e9)
 	}
 
+	packetCount := uint32(r.getTotalPacketsPrimary(r.extStartSN, r.extHighestSN) + r.packetsDuplicate + r.packetsPadding)
+	octetCount := uint32(r.bytes + r.bytesDuplicate + r.bytesPadding)
 	srData := &RTCPSenderReportData{
 		NTPTimestamp:    nowNTP,
 		RTPTimestamp:    uint32(nowRTPExt),
 		RTPTimestampExt: nowRTPExt,
 		At:              now,
 		AtAdjusted:      now,
+		Packets:         packetCount,
+		Octets:          octetCount,
 	}
 
 	getFields := func() []interface{} {
@@ -686,8 +690,8 @@ func (r *RTPStatsSender) GetRtcpSenderReport(ssrc uint32, publisherSRData *RTCPS
 		SSRC:        ssrc,
 		NTPTime:     uint64(nowNTP),
 		RTPTime:     uint32(nowRTPExt),
-		PacketCount: uint32(r.getTotalPacketsPrimary(r.extStartSN, r.extHighestSN) + r.packetsDuplicate + r.packetsPadding),
-		OctetCount:  uint32(r.bytes + r.bytesDuplicate + r.bytesPadding),
+		PacketCount: packetCount,
+		OctetCount:  octetCount,
 	}
 }
 


### PR DESCRIPTION
Seeing cases of huge jumps in sender erport rtp time stamp (of the order of minutes) a few hundred ms after start of track. Only less than 20 packets have been published at that time as seen by server. Adding these to sender report to check if client thinks it has sent much more.