### PR TITLE
Rollover sequence number when time stamp is moving forward.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_receiver_test.go
+++ b/pkg/sfu/buffer/rtpstats_receiver_test.go
@@ -190,7 +190,7 @@ func Test_RTPStatsReceiver_Update(t *testing.T) {
 	require.Equal(t, uint64(9), r.packetsLost)
 
 	// out-of-order should decrement number of lost packets
-	packet = getPacket(sequenceNumber-6, timestamp-45000, 1000)
+	packet = getPacket(sequenceNumber-6, timestamp-18000, 1000)
 	flowState = r.Update(
 		time.Now().UnixNano(),
 		packet.Header.SequenceNumber,


### PR DESCRIPTION
Seeing large gaps in sequence number due to potential network issues. In that gap, the sequence number could roll over.

Using packet time jumps to figure out if a roll over could have happened and force roll over the sequence number to ensure that it does not flow backwards.