### PR TITLE
Split ICE candidate queue.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -191,7 +191,7 @@ type ParticipantImpl struct {
 	*UpTrackManager
 	*SubscriptionManager
 
-	icQueue atomic.Pointer[webrtc.ICECandidate]
+	icQueue [2]atomic.Pointer[webrtc.ICECandidate]
 
 	// keeps track of unpublished tracks in order to reuse trackID
 	unpublishedTracks []*livekit.TrackInfo

--- a/pkg/sfu/utils/wraparound.go
+++ b/pkg/sfu/utils/wraparound.go
@@ -157,7 +157,7 @@ func (w *WrapAround[T, ET]) GetExtendedHighest() ET {
 }
 
 func (w *WrapAround[T, ET]) updateExtendedHighest() {
-	w.extendedHighest = getExtendedHighest(w.cycles, w.highest)
+	w.extendedHighest = getExtended(w.cycles, w.highest)
 }
 
 func (w *WrapAround[T, ET]) maybeAdjustStart(val T) (result WrapAroundUpdateResult[ET]) {
@@ -172,7 +172,7 @@ func (w *WrapAround[T, ET]) maybeAdjustStart(val T) (result WrapAroundUpdateResu
 			cycles -= w.fullRange
 		}
 		result.PreExtendedHighest = w.extendedHighest
-		result.ExtendedVal = getExtendedHighest(cycles, val)
+		result.ExtendedVal = getExtended(cycles, val)
 		return
 	}
 
@@ -201,7 +201,7 @@ func (w *WrapAround[T, ET]) maybeAdjustStart(val T) (result WrapAroundUpdateResu
 		}
 	}
 	result.PreExtendedHighest = w.extendedHighest
-	result.ExtendedVal = getExtendedHighest(cycles, val)
+	result.ExtendedVal = getExtended(cycles, val)
 	return
 }
 
@@ -211,6 +211,6 @@ func (w *WrapAround[T, ET]) isWrapBack(earlier T, later T) bool {
 
 // ------------------------------------
 
-func getExtendedHighest[T number, ET extendedNumber](cycles ET, val T) ET {
+func getExtended[T number, ET extendedNumber](cycles ET, val T) ET {
 	return cycles + ET(val)
 }


### PR DESCRIPTION
Shared ICE candidate queue meant only one of PUBLISHER/SUBSCRIBER pc got final candidate notification. Split the queue.