### PR TITLE
Ignore really old packets.

### DIFF
--- a/pkg/sfu/utils/wraparound.go
+++ b/pkg/sfu/utils/wraparound.go
@@ -111,6 +111,14 @@ func (w *WrapAround[T, ET]) Update(val T) (result WrapAroundUpdateResult[ET]) {
 	return
 }
 
+func (w *WrapAround[T, ET]) UndoUpdate(result WrapAroundUpdateResult[ET]) {
+	if !w.initialized || result.PreExtendedHighest <= result.ExtendedVal {
+		return
+	}
+
+	w.ResetHighest(result.PreExtendedHighest)
+}
+
 func (w *WrapAround[T, ET]) Rollover(val T, numCycles int) (result WrapAroundUpdateResult[ET]) {
 	if !w.initialized || numCycles == 0 {
 		return w.Update(val)

--- a/pkg/sfu/utils/wraparound.go
+++ b/pkg/sfu/utils/wraparound.go
@@ -112,7 +112,7 @@ func (w *WrapAround[T, ET]) Update(val T) (result WrapAroundUpdateResult[ET]) {
 }
 
 func (w *WrapAround[T, ET]) UndoUpdate(result WrapAroundUpdateResult[ET]) {
-	if !w.initialized || result.PreExtendedHighest <= result.ExtendedVal {
+	if !w.initialized || result.PreExtendedHighest >= result.ExtendedVal {
 		return
 	}
 


### PR DESCRIPTION
There are cases where really old packets (time stamp is way back, but sequence number looks like it is moving forward) which cause the sequence number to update incorrectly. Drop those packets are they are very old.