### PR TITLE
Fix forced rollover of RTP time stamp.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_receiver.go
+++ b/pkg/sfu/buffer/rtpstats_receiver.go
@@ -145,6 +145,9 @@ func (r *RTPStatsReceiver) getTSRolloverCount(diffNano int64, ts uint32) int {
 
 	excess := int((diffNano - r.tsRolloverThreshold*2) * int64(r.params.ClockRate) / 1e9)
 	roc := excess / (1 << 32)
+	if roc < 0 {
+		roc = 0
+	}
 	if r.timestamp.GetHighest() > ts {
 		roc++
 	}

--- a/pkg/sfu/utils/wraparound.go
+++ b/pkg/sfu/utils/wraparound.go
@@ -120,7 +120,7 @@ func (w *WrapAround[T, ET]) UndoUpdate(result WrapAroundUpdateResult[ET]) {
 }
 
 func (w *WrapAround[T, ET]) Rollover(val T, numCycles int) (result WrapAroundUpdateResult[ET]) {
-	if !w.initialized || numCycles == 0 {
+	if !w.initialized || numCycles < 0 {
 		return w.Update(val)
 	}
 

--- a/pkg/sfu/utils/wraparound_test.go
+++ b/pkg/sfu/utils/wraparound_test.go
@@ -476,10 +476,11 @@ func TestWrapAroundUint16Rollover(t *testing.T) {
 			highest:         10,
 			extendedHighest: 10,
 		},
-		// zero cycles - should just do an update
+		// negative cycles - should just do an update
 		{
-			name:  "zero",
-			input: 8,
+			name:      "zero",
+			input:     8,
+			numCycles: -1,
 			updated: WrapAroundUpdateResult[uint32]{
 				IsUnhandled: true,
 				// the following fields are not valid when `IsUnhandled = true`, but code fills it in


### PR DESCRIPTION
Was erroneously forcing a rollover when the timestamp jump actually has room to accommodate large jumps. For example, before pause ts = 10, then eight hour pause, restart ts = 10  + (8 * 00 * 60 * 90000) = 2592000010 (at 90000 clock rate for video). In normal processing, it will look like out-of-order as the difference 2592000000 is more than half the 32-bit range. But, forcing a roll over is incorrect.

Fix by calculating excess over the full range and then account for wrap around.