### PR TITLE
Do not force rollover if ts rollover is not active.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_receiver.go
+++ b/pkg/sfu/buffer/rtpstats_receiver.go
@@ -259,18 +259,25 @@ func (r *RTPStatsReceiver) Update(
 
 		// it is possible that sequence number has rolled over too
 		if gapSN < 0 && gapTS > 0 && payloadSize > 0 {
-			// not possible to know how many cycles of sequence number roll over could have happened,
-			// use 1 to ensure that it at least does not go backwards
-			resSN = r.sequenceNumber.Rollover(sequenceNumber, 1)
-			if resSN.IsUnhandled {
-				flowState.IsNotHandled = true
-				return
-			}
+			if tsRolloverCount >= 0 {
+				// not possible to know how many cycles of sequence number roll over could have happened,
+				// use 1 to ensure that it at least does not go backwards
+				resSN = r.sequenceNumber.Rollover(sequenceNumber, 1)
+				if resSN.IsUnhandled {
+					flowState.IsNotHandled = true
+					return
+				}
 
-			r.logger.Warnw(
-				"forcing sequence number rollover", nil,
-				getLoggingFields()...,
-			)
+				r.logger.Warnw(
+					"forcing sequence number rollover", nil,
+					getLoggingFields()...,
+				)
+			} else {
+				r.logger.Warnw(
+					"forcing sequence number rollover skipped", nil,
+					getLoggingFields()...,
+				)
+			}
 		}
 	}
 	gapSN = int64(resSN.ExtendedVal - resSN.PreExtendedHighest)


### PR DESCRIPTION
There are cases of small negative sequence number jump and small positive time stamp jump. Those should not force rollover. Maybe, they should be dropped, but just logging for now till we learn more.