### PR TITLE
Reset DD tracker layers when muted.

### DIFF
--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -545,9 +545,7 @@ func (s *StreamAllocator) maybePostEventAllocateTrack(downTrack *sfu.DownTrack) 
 	shouldPost := false
 	s.videoTracksMu.Lock()
 	if track := s.videoTracks[livekit.TrackID(downTrack.ID())]; track != nil {
-		if track.SetDirty(true) {
-			shouldPost = true
-		}
+		shouldPost = track.SetDirty(true)
 	}
 	s.videoTracksMu.Unlock()
 

--- a/pkg/sfu/streamtracker/streamtracker_dd.go
+++ b/pkg/sfu/streamtracker/streamtracker_dd.go
@@ -136,7 +136,9 @@ func (s *StreamTrackerDependencyDescriptor) SetPaused(paused bool) {
 		s.resetLocked()
 
 		notifyStatus = StreamStatusStopped
-		notifyFns = s.onStatusChanged[:]
+		for _, f := range s.onStatusChanged {
+			notifyFns = append(notifyFns, f)
+		}
 	} else {
 		s.lastBitrateReport = time.Now()
 		go s.worker(s.generation.Inc())

--- a/pkg/sfu/streamtracker/streamtracker_dd.go
+++ b/pkg/sfu/streamtracker/streamtracker_dd.go
@@ -136,9 +136,7 @@ func (s *StreamTrackerDependencyDescriptor) SetPaused(paused bool) {
 		s.resetLocked()
 
 		notifyStatus = StreamStatusStopped
-		for _, f := range s.onStatusChanged {
-			notifyFns = append(notifyFns, f)
-		}
+		notifyFns = append(notifyFns, s.onStatusChanged[:]...)
 	} else {
 		s.lastBitrateReport = time.Now()
 		go s.worker(s.generation.Inc())

--- a/pkg/sfu/streamtracker/streamtracker_dd.go
+++ b/pkg/sfu/streamtracker/streamtracker_dd.go
@@ -117,6 +117,9 @@ func (s *StreamTrackerDependencyDescriptor) resetLocked() {
 			s.bitrate[i][j] = 0
 		}
 	}
+
+	s.maxSpatialLayer = buffer.InvalidLayerSpatial
+	s.maxTemporalLayer = buffer.InvalidLayerTemporal
 }
 
 func (s *StreamTrackerDependencyDescriptor) SetPaused(paused bool) {
@@ -126,8 +129,14 @@ func (s *StreamTrackerDependencyDescriptor) SetPaused(paused bool) {
 		return
 	}
 	s.paused = paused
+
+	var notifyFns []func(status StreamStatus)
+	var notifyStatus StreamStatus
 	if !paused {
 		s.resetLocked()
+
+		notifyStatus = StreamStatusStopped
+		notifyFns = s.onStatusChanged[:]
 	} else {
 		s.lastBitrateReport = time.Now()
 		go s.worker(s.generation.Inc())
@@ -135,6 +144,11 @@ func (s *StreamTrackerDependencyDescriptor) SetPaused(paused bool) {
 	}
 	s.lock.Unlock()
 
+	for _, fn := range notifyFns {
+		if fn != nil {
+			fn(notifyStatus)
+		}
+	}
 }
 
 func (s *StreamTrackerDependencyDescriptor) Observe(temporalLayer int32, pktSize int, payloadSize int, hasMarker bool, ts uint32, ddVal *buffer.ExtDependencyDescriptor) {


### PR DESCRIPTION
@cnderrauber, I think this is okay to do, but please let me know if there are gotchas in there.

Track resume on publisher unmute has an issue when congested. The sequence is
- VP9 (DD based track to be correct) starts.
- Stream tracker detects available layers.
- Subscriber starts forwarding.
- Subscriber congested.
- Publisher mutes.
- Publisher unmutes.
- Subscriber still congested.
- Stream tracker does not provide signals to restart the forwarder. DD tracker and non-DD tracker behave differently here. When not congested, the forwarder will just speculatively allocate the most optimistic case, but not when congested.