### PR TITLE
Remove check for rust on TrackSubscribed

### DIFF
--- a/pkg/rtc/clientinfo.go
+++ b/pkg/rtc/clientinfo.go
@@ -92,13 +92,9 @@ func (c ClientInfo) ComplyWithCodecOrderInSDPAnswer() bool {
 	return !((c.isLinux() || c.isAndroid()) && c.isFirefox())
 }
 
-// Rust SDK can't decode unknown signal message (TrackSubscribed and ErrorResponse)
-func (c ClientInfo) SupportTrackSubscribedEvent() bool {
-	return !(c.ClientInfo.GetSdk() == livekit.ClientInfo_RUST && c.ClientInfo.GetProtocol() < 10)
-}
-
+// Rust SDK can't decode unknown signal message (ErrorResponse)
 func (c ClientInfo) SupportErrorResponse() bool {
-	return c.SupportTrackSubscribedEvent()
+	return !(c.ClientInfo.GetSdk() == livekit.ClientInfo_RUST && c.ClientInfo.GetProtocol() < 10)
 }
 
 // compareVersion compares a semver against the current client SDK version

--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -313,9 +313,6 @@ func (p *ParticipantImpl) sendTrackUnpublished(trackID livekit.TrackID) {
 }
 
 func (p *ParticipantImpl) sendTrackHasBeenSubscribed(trackID livekit.TrackID) {
-	if !p.params.ClientInfo.SupportTrackSubscribedEvent() {
-		return
-	}
 	_ = p.writeMessage(&livekit.SignalResponse{
 		Message: &livekit.SignalResponse_TrackSubscribed{
 			TrackSubscribed: &livekit.TrackSubscribed{


### PR DESCRIPTION
a new PR for rust-sdks adds support for `TrackSubscribed`, see https://github.com/livekit/rust-sdks/pull/394