### PR TITLE
Reduce threshold of out-of-order very old packet detection.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_receiver.go
+++ b/pkg/sfu/buffer/rtpstats_receiver.go
@@ -33,7 +33,7 @@ const (
 	// number of seconds the current report RTP timestamp can be off from expected RTP timestamp
 	cReportSlack = float64(60.0)
 
-	cTSJumpTooHighFactor = 100
+	cTSJumpTooHighFactor = float64(1.5)
 )
 
 // ---------------------------------------------------------------------
@@ -230,7 +230,7 @@ func (r *RTPStatsReceiver) Update(
 		//  Use a threshold against expected to ignore these.
 		if gapSN < 0 && gapTS > 0 {
 			expectedTSJump = timeSinceHighest * int64(r.params.ClockRate) / 1e9
-			if gapTS > expectedTSJump*cTSJumpTooHighFactor {
+			if gapTS > int64(float64(expectedTSJump)*cTSJumpTooHighFactor) {
 				r.sequenceNumber.UndoUpdate(resSN)
 				r.timestamp.UndoUpdate(resTS)
 				r.logger.Warnw(


### PR DESCRIPTION
There are cases where the very first packet on resume is an out-of-order packet. In that case, the gap in both sequence number and time stamp is a small(ish) negative number. With a high threshold to declare very old packet, the condition does not trip and the packet gets through and treated as a packet that has rolled over.

It should be fine to have smaller threshold (in fact, it is probably okay to have something a little over 1.0 too) as the expected jump is calculated based on elapsed time since last packet receive and new packets should be coming in with a diff close to that. So, a factor of just over 1.0 to prevent false triggers should be fine. Using 1.5 for now.