### PR TITLE
fix republish failed

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -71,6 +71,7 @@ type pendingTrackInfo struct {
 	trackInfos []*livekit.TrackInfo
 	migrated   bool
 	createdAt  time.Time
+	queued     bool
 }
 
 type pendingRemoteTrack struct {
@@ -1962,7 +1963,7 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 	}
 	if p.getPublishedTrackBySignalCid(req.Cid) != nil || p.getPublishedTrackBySdpCid(req.Cid) != nil || p.pendingTracks[req.Cid] != nil {
 		if p.pendingTracks[req.Cid] == nil {
-			p.pendingTracks[req.Cid] = &pendingTrackInfo{trackInfos: []*livekit.TrackInfo{ti}, createdAt: time.Now()}
+			p.pendingTracks[req.Cid] = &pendingTrackInfo{trackInfos: []*livekit.TrackInfo{ti}, createdAt: time.Now(), queued: true}
 		} else {
 			p.pendingTracks[req.Cid].trackInfos = append(p.pendingTracks[req.Cid].trackInfos, ti)
 		}
@@ -2077,7 +2078,7 @@ func (p *ParticipantImpl) mediaTrackReceived(track *webrtc.TrackRemote, rtpRecei
 	var pubTime time.Duration
 	mt, ok := p.getPublishedTrackBySdpCid(track.ID()).(*MediaTrack)
 	if !ok {
-		signalCid, ti, migrated, createdAt := p.getPendingTrack(track.ID(), ToProtoTrackKind(track.Kind()))
+		signalCid, ti, migrated, createdAt := p.getPendingTrack(track.ID(), ToProtoTrackKind(track.Kind()), true)
 		if ti == nil {
 			p.pendingTracksLock.Unlock()
 			return nil, false
@@ -2230,6 +2231,9 @@ func (p *ParticipantImpl) addMediaTrack(signalCid string, sdpCid string, ti *liv
 	p.pendingTracks[signalCid].trackInfos = p.pendingTracks[signalCid].trackInfos[1:]
 	if len(p.pendingTracks[signalCid].trackInfos) == 0 {
 		delete(p.pendingTracks, signalCid)
+	} else {
+		p.pendingTracks[signalCid].queued = true
+		p.pendingTracks[signalCid].createdAt = time.Now()
 	}
 
 	trackID := livekit.TrackID(ti.Sid)
@@ -2251,10 +2255,12 @@ func (p *ParticipantImpl) addMediaTrack(signalCid string, sdpCid string, ti *liv
 		p.pendingTracksLock.Lock()
 		if pti := p.pendingTracks[signalCid]; pti != nil {
 			p.sendTrackPublished(signalCid, pti.trackInfos[0])
+			pti.queued = false
 		} else {
 			p.unpublishedTracks = append(p.unpublishedTracks, ti)
 		}
 		p.pendingTracksLock.Unlock()
+		p.handlePendingRemoteTracks()
 
 		p.dirty.Store(true)
 
@@ -2309,7 +2315,7 @@ func (p *ParticipantImpl) onUpTrackManagerClose() {
 	p.pubRTCPQueue.Stop()
 }
 
-func (p *ParticipantImpl) getPendingTrack(clientId string, kind livekit.TrackType) (string, *livekit.TrackInfo, bool, time.Time) {
+func (p *ParticipantImpl) getPendingTrack(clientId string, kind livekit.TrackType, skipQueued bool) (string, *livekit.TrackInfo, bool, time.Time) {
 	signalCid := clientId
 	pendingInfo := p.pendingTracks[clientId]
 	if pendingInfo == nil {
@@ -2343,7 +2349,7 @@ func (p *ParticipantImpl) getPendingTrack(clientId string, kind livekit.TrackTyp
 	}
 
 	// if still not found, we are done
-	if pendingInfo == nil {
+	if pendingInfo == nil || (skipQueued && pendingInfo.queued) {
 		return signalCid, nil, false, time.Time{}
 	}
 

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -71,7 +71,11 @@ type pendingTrackInfo struct {
 	trackInfos []*livekit.TrackInfo
 	migrated   bool
 	createdAt  time.Time
-	queued     bool
+
+	// indicates if this track is queued for publishing to avoid a track has been published
+	// before the previous track is unpublished(closed) because client is allowed to neogtiate
+	// webrtc track before AddTrackRequest return to speed up the publishing process
+	queued bool
 }
 
 type pendingRemoteTrack struct {

--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -286,7 +286,7 @@ func TestMuteSetting(t *testing.T) {
 			Muted: true,
 		})
 
-		_, ti, _, _ := p.getPendingTrack("cid", livekit.TrackType_AUDIO)
+		_, ti, _, _ := p.getPendingTrack("cid", livekit.TrackType_AUDIO, false)
 		require.NotNil(t, ti)
 		require.True(t, ti.Muted)
 	})

--- a/pkg/rtc/participant_sdp.go
+++ b/pkg/rtc/participant_sdp.go
@@ -45,7 +45,7 @@ func (p *ParticipantImpl) setCodecPreferencesOpusRedForPublisher(offer webrtc.Se
 		}
 
 		p.pendingTracksLock.RLock()
-		_, info, _, _ := p.getPendingTrack(streamID, livekit.TrackType_AUDIO)
+		_, info, _, _ := p.getPendingTrack(streamID, livekit.TrackType_AUDIO, false)
 		// if RED is disabled for this track, don't prefer RED codec in offer
 		disableRed := info != nil && info.DisableRed
 		p.pendingTracksLock.RUnlock()
@@ -131,7 +131,7 @@ func (p *ParticipantImpl) setCodecPreferencesVideoForPublisher(offer webrtc.Sess
 		if mt != nil {
 			info = mt.ToProto()
 		} else {
-			_, info, _, _ = p.getPendingTrack(streamID, livekit.TrackType_VIDEO)
+			_, info, _, _ = p.getPendingTrack(streamID, livekit.TrackType_VIDEO, false)
 		}
 
 		if info == nil {
@@ -227,7 +227,7 @@ func (p *ParticipantImpl) configurePublisherAnswer(answer webrtc.SessionDescript
 					track, _ := p.getPublishedTrackBySdpCid(streamID).(*MediaTrack)
 					if track == nil {
 						p.pendingTracksLock.RLock()
-						_, ti, _, _ = p.getPendingTrack(streamID, livekit.TrackType_AUDIO)
+						_, ti, _, _ = p.getPendingTrack(streamID, livekit.TrackType_AUDIO, false)
 						p.pendingTracksLock.RUnlock()
 					} else {
 						ti = track.ToProto()


### PR DESCRIPTION
parallel negotiation would cause remote webrtc track consume pending republished track then failed.