### PR TITLE
 Skip ICE restart on unestablished peer connection. 

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -1785,19 +1785,19 @@ func (t *PCTransport) handleRemoteAnswerReceived(sd *webrtc.SessionDescription) 
 }
 
 func (t *PCTransport) doICERestart() error {
+	// if restart is requested, but negotiation never started
+	if !t.IsEstablished() {
+		t.params.Logger.Debugw("skipping ICE restart on unestablished peer connection")
+		return nil
+	}
+
 	if t.pc.ConnectionState() == webrtc.PeerConnectionStateClosed {
 		t.params.Logger.Warnw("trying to restart ICE on closed peer connection", nil)
 		return nil
 	}
 
-	iceGatheringState := t.pc.ICEGatheringState()
-	// if restart is requested, but ICE was never started
-	if iceGatheringState == webrtc.ICEGatheringStateNew && t.pc.ICEConnectionState() == webrtc.ICEConnectionStateNew {
-		return nil
-	}
-
 	// if restart is requested, and we are not ready, then continue afterwards
-	if iceGatheringState == webrtc.ICEGatheringStateGathering {
+	if t.pc.ICEGatheringState() == webrtc.ICEGatheringStateGathering {
 		t.params.Logger.Debugw("deferring ICE restart to after gathering")
 		t.restartAfterGathering = true
 		return nil

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -1790,8 +1790,14 @@ func (t *PCTransport) doICERestart() error {
 		return nil
 	}
 
+	iceGatheringState := t.pc.ICEGatheringState()
+	// if restart is requested, but ICE was never started
+	if iceGatheringState == webrtc.ICEGatheringStateNew && t.pc.ICEConnectionState() == webrtc.ICEConnectionStateNew {
+		return nil
+	}
+
 	// if restart is requested, and we are not ready, then continue afterwards
-	if t.pc.ICEGatheringState() == webrtc.ICEGatheringStateGathering {
+	if iceGatheringState == webrtc.ICEGatheringStateGathering {
 		t.params.Logger.Debugw("deferring ICE restart to after gathering")
 		t.restartAfterGathering = true
 		return nil

--- a/pkg/rtc/transport_test.go
+++ b/pkg/rtc/transport_test.go
@@ -315,7 +315,7 @@ func TestFirstAnswerMissedDuringICERestart(t *testing.T) {
 	handlerA.OnOfferCalls(func(sd webrtc.SessionDescription) error {
 		offerCount.Inc()
 
-		// the second offer is a ice restart offer, so we wait transportB complete the ice gathering
+		// the second offer is a ice restart offer, so we wait for transportB to complete ICE gathering
 		if transportB.pc.ICEGatheringState() == webrtc.ICEGatheringStateGathering {
 			require.Eventually(t, func() bool {
 				return transportB.pc.ICEGatheringState() == webrtc.ICEGatheringStateComplete


### PR DESCRIPTION
For publish only participants, the subscriber peer connection is not
negotiated. So, ICE restart was hitting an error while trying to restart
the SUBSCRIBER peer connection.