### PR TITLE
Negotiate downttrack for subscriber before receiver is ready

### DIFF
--- a/pkg/rtc/mediaengine.go
+++ b/pkg/rtc/mediaengine.go
@@ -28,13 +28,13 @@ const (
 	videoRTXMimeType = "video/rtx"
 )
 
-var opusCodecCapability = webrtc.RTPCodecCapability{
+var OpusCodecCapability = webrtc.RTPCodecCapability{
 	MimeType:    webrtc.MimeTypeOpus,
 	ClockRate:   48000,
 	Channels:    2,
 	SDPFmtpLine: "minptime=10;useinbandfec=1",
 }
-var redCodecCapability = webrtc.RTPCodecCapability{
+var RedCodecCapability = webrtc.RTPCodecCapability{
 	MimeType:    sfu.MimeTypeAudioRed,
 	ClockRate:   48000,
 	Channels:    2,
@@ -46,7 +46,7 @@ var videoRTX = webrtc.RTPCodecCapability{
 }
 
 func registerCodecs(me *webrtc.MediaEngine, codecs []*livekit.Codec, rtcpFeedback RTCPFeedbackConfig, filterOutH264HighProfile bool) error {
-	opusCodec := opusCodecCapability
+	opusCodec := OpusCodecCapability
 	opusCodec.RTCPFeedback = rtcpFeedback.Audio
 	var opusPayload webrtc.PayloadType
 	if IsCodecEnabled(codecs, opusCodec) {
@@ -58,9 +58,9 @@ func registerCodecs(me *webrtc.MediaEngine, codecs []*livekit.Codec, rtcpFeedbac
 			return err
 		}
 
-		if IsCodecEnabled(codecs, redCodecCapability) {
+		if IsCodecEnabled(codecs, RedCodecCapability) {
 			if err := me.RegisterCodec(webrtc.RTPCodecParameters{
-				RTPCodecCapability: redCodecCapability,
+				RTPCodecCapability: RedCodecCapability,
 				PayloadType:        63,
 			}, webrtc.RTPCodecTypeAudio); err != nil {
 				return err

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -170,12 +170,12 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 	// Bind callback can happen from replaceTrack, so set it up early
 	var reusingTransceiver atomic.Bool
 	var dtState sfu.DownTrackState
+	downTrack.OnCodecNegotiated(wr.DetermineReceiver)
 	downTrack.OnBinding(func(err error) {
 		if err != nil {
 			go subTrack.Bound(err)
 			return
 		}
-		wr.DetermineReceiver(downTrack.Codec())
 		if reusingTransceiver.Load() {
 			downTrack.SeedState(dtState)
 		}

--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -621,7 +621,7 @@ func TestPreferAudioCodecForRed(t *testing.T) {
 	me := webrtc.MediaEngine{}
 	me.RegisterDefaultCodecs()
 	require.NoError(t, me.RegisterCodec(webrtc.RTPCodecParameters{
-		RTPCodecCapability: redCodecCapability,
+		RTPCodecCapability: RedCodecCapability,
 		PayloadType:        63,
 	}, webrtc.RTPCodecTypeAudio))
 

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -322,6 +322,18 @@ const (
 	bindStateBound
 )
 
+func (bs bindState) String() string {
+	switch bs {
+	case bindStateUnbound:
+		return "unbound"
+	case bindStateWaitForReceiverReady:
+		return "waitForReceiverReady"
+	case bindStateBound:
+		return "bound"
+	}
+	return "unknown"
+}
+
 // NewDownTrack returns a DownTrack.
 func NewDownTrack(params DowntrackParams) (*DownTrack, error) {
 	codecs := params.Codecs
@@ -570,7 +582,7 @@ func (d *DownTrack) handleReceiverReady() {
 // because a track has been stopped.
 func (d *DownTrack) Unbind(_ webrtc.TrackLocalContext) error {
 	d.bindLock.Lock()
-	d.bindState.Store(bindStateUnbound)
+	d.setBindStateLocked(bindStateUnbound)
 	d.bindLock.Unlock()
 	return nil
 }
@@ -2012,7 +2024,7 @@ func (d *DownTrack) DebugInfo() map[string]interface{} {
 		"StreamID":            d.params.StreamID,
 		"SSRC":                d.ssrc,
 		"MimeType":            d.codec.MimeType,
-		"Bound":               d.bindState.Load(),
+		"BindState":           d.bindState.Load().(bindState),
 		"Muted":               d.forwarder.IsMuted(),
 		"PubMuted":            d.forwarder.IsPubMuted(),
 		"CurrentSpatialLayer": d.forwarder.CurrentLayer().Spatial,

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -85,6 +85,9 @@ type TrackReceiver interface {
 	GetTrackStats() *livekit.RTPStats
 
 	GetMonotonicNowUnixNano() int64
+
+	// AddOnReady adds a function to be called when the receiver is ready
+	AddOnReady(func())
 }
 
 // WebRTCReceiver receives a media track
@@ -839,6 +842,11 @@ func (w *WebRTCReceiver) GetTemporalLayerFpsForSpatial(layer int32) []float32 {
 
 func (w *WebRTCReceiver) GetMonotonicNowUnixNano() int64 {
 	return w.baseTime.Add(time.Since(w.baseTime)).UnixNano()
+}
+
+func (w *WebRTCReceiver) AddOnReady(fn func()) {
+	// webRTCReceiver is always ready after created
+	fn()
 }
 
 // -----------------------------------------------------------

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -86,7 +86,8 @@ type TrackReceiver interface {
 
 	GetMonotonicNowUnixNano() int64
 
-	// AddOnReady adds a function to be called when the receiver is ready
+	// AddOnReady adds a function to be called when the receiver is ready, the callback
+	// could be called immediately if the receiver is ready when the callback is added
 	AddOnReady(func())
 }
 


### PR DESCRIPTION
This change will save 1 round sdp negotiation time for subscribing to simulcast-codec or remote node track