### PR TITLE
Recreate stats worker on resume if needed.

### DIFF
--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -696,8 +696,6 @@ func (r *RoomManager) rtcSessionWorker(room *rtc.Room, participant types.LocalPa
 				pLogger.Errorw("could not refresh token", err, "connID", requestSource.ConnectionID())
 			}
 		case obj := <-requestSource.ReadChan():
-			// In single node mode, the request source is directly tied to the signal message channel
-			// this means ICE restart isn't possible in single node mode
 			if obj == nil {
 				if room.GetParticipantRequestSource(participant.Identity()) == requestSource {
 					participant.HandleSignalSourceClose()

--- a/pkg/service/rtcservice.go
+++ b/pkg/service/rtcservice.go
@@ -276,6 +276,12 @@ func (s *RTCService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		signalStats.ResolveRoom(join.GetRoom())
 		signalStats.ResolveParticipant(join.GetParticipant())
 	}
+	if pi.Reconnect && pi.ID != "" {
+		signalStats.ResolveParticipant(&livekit.ParticipantInfo{
+			Sid:      string(pi.ID),
+			Identity: string(pi.Identity),
+		})
+	}
 
 	closedByClient := atomic.NewBool(false)
 	done := make(chan struct{})

--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -80,13 +80,14 @@ func (t *telemetryService) ParticipantJoined(
 	shouldSendEvent bool,
 ) {
 	t.enqueue(func() {
-		_, found := t.getOrCreateWorker(
+		worker, found := t.getOrCreateWorker(
 			ctx,
 			livekit.RoomID(room.Sid),
 			livekit.RoomName(room.Name),
 			livekit.ParticipantID(participant.Sid),
 			livekit.ParticipantIdentity(participant.Identity),
 		)
+		worker.AddRef()
 		if !found {
 			prometheus.IncrementParticipantRtcConnected(1)
 			prometheus.AddParticipant()

--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -86,6 +86,7 @@ func (t *telemetryService) ParticipantJoined(
 			livekit.RoomName(room.Name),
 			livekit.ParticipantID(participant.Sid),
 			livekit.ParticipantIdentity(participant.Identity),
+			false,
 		)
 		if !found {
 			prometheus.IncrementParticipantRtcConnected(1)
@@ -124,6 +125,7 @@ func (t *telemetryService) ParticipantActive(
 			livekit.RoomName(room.Name),
 			livekit.ParticipantID(participant.Sid),
 			livekit.ParticipantIdentity(participant.Identity),
+			false,
 		)
 		if !found {
 			// need to also account for participant count
@@ -154,21 +156,15 @@ func (t *telemetryService) ParticipantResumed(
 		// the corresponding participant's stats worker.
 		//
 		// So, on a successful resume, create the worker if needed.
-		worker, found := t.getOrCreateWorker(
+		_, found := t.getOrCreateWorker(
 			ctx,
 			livekit.RoomID(room.Sid),
 			livekit.RoomName(room.Name),
 			livekit.ParticipantID(participant.Sid),
 			livekit.ParticipantIdentity(participant.Identity),
+			true,
 		)
 		if !found {
-			// a worker was created, check if there is a closed worker and transfer connected state to new worker
-			if closedWorker := t.getClosedWorker(livekit.ParticipantID(participant.Sid)); closedWorker != nil {
-				if closedWorker.IsConnected() {
-					worker.SetConnected()
-				}
-			}
-
 			prometheus.AddParticipant()
 		}
 

--- a/pkg/telemetry/statsworker.go
+++ b/pkg/telemetry/statsworker.go
@@ -43,8 +43,6 @@ type StatsWorker struct {
 	outgoingPerTrack map[livekit.TrackID][]*livekit.AnalyticsStat
 	incomingPerTrack map[livekit.TrackID][]*livekit.AnalyticsStat
 	closedAt         time.Time
-
-	refCount int
 }
 
 func newStatsWorker(
@@ -119,31 +117,9 @@ func (s *StatsWorker) Flush(now time.Time) bool {
 	return closed
 }
 
-func (s *StatsWorker) AddRef() {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	s.refCount++
-}
-
 func (s *StatsWorker) Close() bool {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-
-	if s.refCount > 0 {
-		s.refCount--
-		if s.refCount != 0 {
-			return false
-		}
-	} else {
-		logger.Warnw(
-			"stats worker ref count is already 0", nil,
-			"room", s.roomName,
-			"roomID", s.roomID,
-			"participant", s.participantIdentity,
-			"pID", s.participantID,
-		)
-	}
 
 	ok := s.closedAt.IsZero()
 	if ok {

--- a/pkg/telemetry/statsworker.go
+++ b/pkg/telemetry/statsworker.go
@@ -43,6 +43,8 @@ type StatsWorker struct {
 	outgoingPerTrack map[livekit.TrackID][]*livekit.AnalyticsStat
 	incomingPerTrack map[livekit.TrackID][]*livekit.AnalyticsStat
 	closedAt         time.Time
+
+	refCount int
 }
 
 func newStatsWorker(
@@ -117,9 +119,31 @@ func (s *StatsWorker) Flush(now time.Time) bool {
 	return closed
 }
 
+func (s *StatsWorker) AddRef() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.refCount++
+}
+
 func (s *StatsWorker) Close() bool {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+
+	if s.refCount > 0 {
+		s.refCount--
+		if s.refCount != 0 {
+			return false
+		}
+	} else {
+		logger.Warnw(
+			"stats worker ref count is already 0", nil,
+			"room", s.roomName,
+			"roomID", s.roomID,
+			"participant", s.participantIdentity,
+			"pID", s.participantID,
+		)
+	}
 
 	ok := s.closedAt.IsZero()
 	if ok {

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -143,9 +143,12 @@ func (t *telemetryService) FlushStats() {
 					prev = *p
 					p = &prev.next
 				}
+				*p = worker.next
 				t.workersMu.Unlock()
+			} else {
+				prev.next = worker.next
 			}
-			prev.next = worker.next
+
 			worker.next = reap
 			reap = worker
 		} else {

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -143,12 +143,9 @@ func (t *telemetryService) FlushStats() {
 					prev = *p
 					p = &prev.next
 				}
-				*p = worker.next
 				t.workersMu.Unlock()
-			} else {
-				prev.next = worker.next
 			}
-
+			prev.next = worker.next
 			worker.next = reap
 			reap = worker
 		} else {

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -218,6 +218,17 @@ func (t *telemetryService) getOrCreateWorker(
 	return worker, false
 }
 
+func (t *telemetryService) getClosedWorker(participantID livekit.ParticipantID) *StatsWorker {
+	t.workersMu.Lock()
+	defer t.workersMu.Unlock()
+
+	if worker, ok := t.workers[participantID]; ok && worker.Closed() {
+		return worker
+	}
+
+	return nil
+}
+
 func (t *telemetryService) LocalRoomState(ctx context.Context, info *livekit.AnalyticsNodeRooms) {
 	t.enqueue(func() {
 		t.SendNodeRoomStates(ctx, info)


### PR DESCRIPTION
NOTE: Don't like this much, but wanted to open this to get some :eyes: on this and get feedback.
UPDATE ON NOTE ABOVE: Maybe, `ParticipantResumed` should create a new worker? I think that would be needed in cloud case also and that would happen on the controller. Currently, I am guessing we lose track of signal bytes on a resume. Okay, I will change the code to do that.

There are two entities, one for counting signal bytes and another for media stats. They both send `ParticipantJoined` and `ParticipantLeft` events.

In the case of a participant resume, as the old web socket connection is closed, that triggers a signal stats counter close. That would call `ParticipantLeft` and that would close the stats worker.

And `ParticipantResumed` event does not create a new worker.

The closed stats worker got reaped in `FlushStats` after three minutes.

So, all events after that did not have a worker and hence went unreported including missing participant_left webhook because it relied on checking if a participant was ever connected and that needed to check the worker state.

Using a ref count to keep track of join/leaves. And not close the worker until ref count goes down to 0.