### PR TITLE
Put go version at 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/livekit/livekit-server
 
-go 1.22.0
-
-toolchain go1.22.1
+go 1.22
 
 require (
 	github.com/bep/debounce v1.2.1


### PR DESCRIPTION
Not sure what is causing it to add the minor version and toolchain. Even now, with this, running `go mod tidy` makes those changes. `staticcheck` says invalid Go version.

Manually setting it to 1.22.