### PR TITLE
Handle trailing slashes in URL

### DIFF
--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -102,6 +102,7 @@ func NewLivekitServer(conf *config.Config,
 			// allow preflight to be cached for a day
 			MaxAge: 86400,
 		}),
+		negroni.HandlerFunc(RemoveDoubleSlashes),
 	}
 	if keyProvider != nil {
 		middlewares = append(middlewares, NewAPIKeyAuthMiddleware(keyProvider))

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/livekit/protocol/logger"
 )
@@ -38,6 +39,13 @@ func handleError(w http.ResponseWriter, r *http.Request, status int, err error, 
 
 func boolValue(s string) bool {
 	return s == "1" || s == "true"
+}
+
+func RemoveDoubleSlashes(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	if strings.HasPrefix(r.URL.Path, "//") {
+		r.URL.Path = r.URL.Path[1:]
+	}
+	next(w, r)
 }
 
 func IsValidDomain(domain string) bool {

--- a/test/singlenode_test.go
+++ b/test/singlenode_test.go
@@ -376,6 +376,20 @@ func TestSingleNodeCORS(t *testing.T) {
 	require.Equal(t, "testhost.com", res.Header.Get("Access-Control-Allow-Origin"))
 }
 
+func TestSingleNodeDoubleSlash(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+		return
+	}
+	s, finish := setupSingleNodeTest("TestSingleNodeDoubleSlash")
+	defer finish()
+	// client contains trailing slash in URL, causing path to contain double //
+	// without our middleware, this would cause a 302 redirect
+	roomClient = livekit.NewRoomServiceJSONClient(fmt.Sprintf("http://localhost:%d/", s.HTTPPort()), &http.Client{})
+	_, err := roomClient.ListRooms(contextWithToken(listRoomToken()), &livekit.ListRoomsRequest{})
+	require.NoError(t, err)
+}
+
 func TestPingPong(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()


### PR DESCRIPTION
When a user includes a trailing slash in LIVEKIT_URL, it would produce double slashes in the path, i.e. `https://myhost.livekit.cloud//twirp/RoomService.ListRooms`

Currently the server will send a 302 MOVED response, causing Twirp requests to fail.

We now remove the double slash in front within the middleware.