### PR TITLE
Support passing SIP headers.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1
 	github.com/livekit/mediatransportutil v0.0.0-20240730083616-559fa5ece598
-	github.com/livekit/protocol v1.21.1-0.20240910150033-0614c86dc888
+	github.com/livekit/protocol v1.21.1-0.20240913074525-1f5de7d620c4
 	github.com/livekit/psrpc v0.5.3-0.20240616012458-ac39c8549a0a
 	github.com/mackerelio/go-osstat v0.2.5
 	github.com/magefile/mage v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkD
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20240730083616-559fa5ece598 h1:yLlkHk2feSLHstD9n4VKg7YEBR4rLODTI4WE8gNBEnQ=
 github.com/livekit/mediatransportutil v0.0.0-20240730083616-559fa5ece598/go.mod h1:jwKUCmObuiEDH0iiuJHaGMXwRs3RjrB4G6qqgkr/5oE=
-github.com/livekit/protocol v1.21.1-0.20240910150033-0614c86dc888 h1:976vtgdLdIaeoTMq9ABiNPr8pnelxFh9twTku2cd8tQ=
-github.com/livekit/protocol v1.21.1-0.20240910150033-0614c86dc888/go.mod h1:AFuwk3+uIWFeO5ohKjx5w606Djl940+wktaZ441VoCI=
+github.com/livekit/protocol v1.21.1-0.20240913074525-1f5de7d620c4 h1:JhLovaAv+UxOTYpjQxN3IRV3kuJFb9f3LZmg/KqvHkc=
+github.com/livekit/protocol v1.21.1-0.20240913074525-1f5de7d620c4/go.mod h1:AFuwk3+uIWFeO5ohKjx5w606Djl940+wktaZ441VoCI=
 github.com/livekit/psrpc v0.5.3-0.20240616012458-ac39c8549a0a h1:EQAHmcYEGlc6V517cQ3Iy0+jHgP6+tM/B4l2vGuLpQo=
 github.com/livekit/psrpc v0.5.3-0.20240616012458-ac39c8549a0a/go.mod h1:CQUBSPfYYAaevg1TNCc6/aYsa8DJH4jSRFdCeSZk5u0=
 github.com/mackerelio/go-osstat v0.2.5 h1:+MqTbZUhoIt4m8qzkVoXUJg1EuifwlAJSk4Yl2GXh+o=

--- a/pkg/service/interfaces.go
+++ b/pkg/service/interfaces.go
@@ -90,7 +90,7 @@ type SIPStore interface {
 	ListSIPTrunk(ctx context.Context) ([]*livekit.SIPTrunkInfo, error)
 	ListSIPInboundTrunk(ctx context.Context) ([]*livekit.SIPInboundTrunkInfo, error)
 	ListSIPOutboundTrunk(ctx context.Context) ([]*livekit.SIPOutboundTrunkInfo, error)
-	DeleteSIPTrunk(ctx context.Context, info *livekit.SIPTrunkInfo) error
+	DeleteSIPTrunk(ctx context.Context, sipTrunkID string) error
 
 	StoreSIPDispatchRule(ctx context.Context, info *livekit.SIPDispatchRuleInfo) error
 	LoadSIPDispatchRule(ctx context.Context, sipDispatchRuleID string) (*livekit.SIPDispatchRuleInfo, error)

--- a/pkg/service/ioservice_sip.go
+++ b/pkg/service/ioservice_sip.go
@@ -26,7 +26,7 @@ import (
 
 // matchSIPTrunk finds a SIP Trunk definition matching the request.
 // Returns nil if no rules matched or an error if there are conflicting definitions.
-func (s *IOInfoService) matchSIPTrunk(ctx context.Context, calling, called string) (*livekit.SIPInboundTrunkInfo, error) {
+func (s *IOInfoService) matchSIPTrunk(ctx context.Context, trunkID, calling, called string) (*livekit.SIPInboundTrunkInfo, error) {
 	trunks, err := s.ss.ListSIPInboundTrunk(ctx)
 	if err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func (s *IOInfoService) matchSIPDispatchRule(ctx context.Context, trunk *livekit
 func (s *IOInfoService) EvaluateSIPDispatchRules(ctx context.Context, req *rpc.EvaluateSIPDispatchRulesRequest) (*rpc.EvaluateSIPDispatchRulesResponse, error) {
 	log := logger.GetLogger()
 	log = log.WithValues("toUser", req.CalledNumber, "fromUser", req.CallingNumber)
-	trunk, err := s.matchSIPTrunk(ctx, req.CallingNumber, req.CalledNumber)
+	trunk, err := s.matchSIPTrunk(ctx, req.SipTrunkId, req.CallingNumber, req.CalledNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (s *IOInfoService) EvaluateSIPDispatchRules(ctx context.Context, req *rpc.E
 		return nil, err
 	}
 	log.Debugw("SIP dispatch rule matched", "sipRule", best.SipDispatchRuleId)
-	resp, err := sip.EvaluateDispatchRule(trunkID, best, req)
+	resp, err := sip.EvaluateDispatchRule("", trunk, best, req)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func (s *IOInfoService) EvaluateSIPDispatchRules(ctx context.Context, req *rpc.E
 func (s *IOInfoService) GetSIPTrunkAuthentication(ctx context.Context, req *rpc.GetSIPTrunkAuthenticationRequest) (*rpc.GetSIPTrunkAuthenticationResponse, error) {
 	log := logger.GetLogger()
 	log = log.WithValues("toUser", req.To, "fromUser", req.From)
-	trunk, err := s.matchSIPTrunk(ctx, req.From, req.To)
+	trunk, err := s.matchSIPTrunk(ctx, "", req.From, req.To)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/redisstore_sip.go
+++ b/pkg/service/redisstore_sip.go
@@ -105,17 +105,13 @@ func (s *RedisStore) LoadSIPOutboundTrunk(ctx context.Context, id string) (*live
 	return nil, ErrSIPTrunkNotFound
 }
 
-func (s *RedisStore) deleteSIPTrunk(ctx context.Context, id string) error {
+func (s *RedisStore) DeleteSIPTrunk(ctx context.Context, id string) error {
 	tx := s.rc.TxPipeline()
 	tx.HDel(s.ctx, SIPTrunkKey, id)
 	tx.HDel(s.ctx, SIPInboundTrunkKey, id)
 	tx.HDel(s.ctx, SIPOutboundTrunkKey, id)
 	_, err := tx.Exec(ctx)
 	return err
-}
-
-func (s *RedisStore) DeleteSIPTrunk(ctx context.Context, info *livekit.SIPTrunkInfo) error {
-	return s.deleteSIPTrunk(ctx, info.SipTrunkId)
 }
 
 func (s *RedisStore) listSIPLegacyTrunk(ctx context.Context) ([]*livekit.SIPTrunkInfo, error) {

--- a/pkg/service/redisstore_sip_test.go
+++ b/pkg/service/redisstore_sip_test.go
@@ -216,9 +216,9 @@ func TestSIPStoreTrunk(t *testing.T) {
 	require.True(t, proto.Equal(outT, listOut[1]))
 
 	// Deletion. Should not return error if not exists.
-	err = rs.DeleteSIPTrunk(ctx, &livekit.SIPTrunkInfo{SipTrunkId: oldID})
+	err = rs.DeleteSIPTrunk(ctx, oldID)
 	require.NoError(t, err)
-	err = rs.DeleteSIPTrunk(ctx, &livekit.SIPTrunkInfo{SipTrunkId: oldID})
+	err = rs.DeleteSIPTrunk(ctx, oldID)
 	require.NoError(t, err)
 
 	// Other objects are still there.
@@ -231,9 +231,9 @@ func TestSIPStoreTrunk(t *testing.T) {
 	require.True(t, proto.Equal(outT, outT2))
 
 	// Delete the rest
-	err = rs.DeleteSIPTrunk(ctx, &livekit.SIPTrunkInfo{SipTrunkId: inID})
+	err = rs.DeleteSIPTrunk(ctx, inID)
 	require.NoError(t, err)
-	err = rs.DeleteSIPTrunk(ctx, &livekit.SIPTrunkInfo{SipTrunkId: outID})
+	err = rs.DeleteSIPTrunk(ctx, outID)
 	require.NoError(t, err)
 
 	// Check everything is deleted.

--- a/pkg/service/servicefakes/fake_sipstore.go
+++ b/pkg/service/servicefakes/fake_sipstore.go
@@ -22,11 +22,11 @@ type FakeSIPStore struct {
 	deleteSIPDispatchRuleReturnsOnCall map[int]struct {
 		result1 error
 	}
-	DeleteSIPTrunkStub        func(context.Context, *livekit.SIPTrunkInfo) error
+	DeleteSIPTrunkStub        func(context.Context, string) error
 	deleteSIPTrunkMutex       sync.RWMutex
 	deleteSIPTrunkArgsForCall []struct {
 		arg1 context.Context
-		arg2 *livekit.SIPTrunkInfo
+		arg2 string
 	}
 	deleteSIPTrunkReturns struct {
 		result1 error
@@ -256,12 +256,12 @@ func (fake *FakeSIPStore) DeleteSIPDispatchRuleReturnsOnCall(i int, result1 erro
 	}{result1}
 }
 
-func (fake *FakeSIPStore) DeleteSIPTrunk(arg1 context.Context, arg2 *livekit.SIPTrunkInfo) error {
+func (fake *FakeSIPStore) DeleteSIPTrunk(arg1 context.Context, arg2 string) error {
 	fake.deleteSIPTrunkMutex.Lock()
 	ret, specificReturn := fake.deleteSIPTrunkReturnsOnCall[len(fake.deleteSIPTrunkArgsForCall)]
 	fake.deleteSIPTrunkArgsForCall = append(fake.deleteSIPTrunkArgsForCall, struct {
 		arg1 context.Context
-		arg2 *livekit.SIPTrunkInfo
+		arg2 string
 	}{arg1, arg2})
 	stub := fake.DeleteSIPTrunkStub
 	fakeReturns := fake.deleteSIPTrunkReturns
@@ -282,13 +282,13 @@ func (fake *FakeSIPStore) DeleteSIPTrunkCallCount() int {
 	return len(fake.deleteSIPTrunkArgsForCall)
 }
 
-func (fake *FakeSIPStore) DeleteSIPTrunkCalls(stub func(context.Context, *livekit.SIPTrunkInfo) error) {
+func (fake *FakeSIPStore) DeleteSIPTrunkCalls(stub func(context.Context, string) error) {
 	fake.deleteSIPTrunkMutex.Lock()
 	defer fake.deleteSIPTrunkMutex.Unlock()
 	fake.DeleteSIPTrunkStub = stub
 }
 
-func (fake *FakeSIPStore) DeleteSIPTrunkArgsForCall(i int) (context.Context, *livekit.SIPTrunkInfo) {
+func (fake *FakeSIPStore) DeleteSIPTrunkArgsForCall(i int) (context.Context, string) {
 	fake.deleteSIPTrunkMutex.RLock()
 	defer fake.deleteSIPTrunkMutex.RUnlock()
 	argsForCall := fake.deleteSIPTrunkArgsForCall[i]

--- a/pkg/service/sip.go
+++ b/pkg/service/sip.go
@@ -159,6 +159,38 @@ func (s *SIPService) CreateSIPOutboundTrunk(ctx context.Context, req *livekit.Cr
 	return info, nil
 }
 
+func (s *SIPService) GetSIPInboundTrunk(ctx context.Context, req *livekit.GetSIPInboundTrunkRequest) (*livekit.GetSIPInboundTrunkResponse, error) {
+	if err := EnsureSIPAdminPermission(ctx); err != nil {
+		return nil, twirpAuthError(err)
+	}
+	if s.store == nil {
+		return nil, ErrSIPNotConnected
+	}
+
+	trunk, err := s.store.LoadSIPInboundTrunk(ctx, req.SipTrunkId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &livekit.GetSIPInboundTrunkResponse{Trunk: trunk}, nil
+}
+
+func (s *SIPService) GetSIPOutboundTrunk(ctx context.Context, req *livekit.GetSIPOutboundTrunkRequest) (*livekit.GetSIPOutboundTrunkResponse, error) {
+	if err := EnsureSIPAdminPermission(ctx); err != nil {
+		return nil, twirpAuthError(err)
+	}
+	if s.store == nil {
+		return nil, ErrSIPNotConnected
+	}
+
+	trunk, err := s.store.LoadSIPOutboundTrunk(ctx, req.SipTrunkId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &livekit.GetSIPOutboundTrunkResponse{Trunk: trunk}, nil
+}
+
 func (s *SIPService) ListSIPTrunk(ctx context.Context, req *livekit.ListSIPTrunkRequest) (*livekit.ListSIPTrunkResponse, error) {
 	if err := EnsureSIPAdminPermission(ctx); err != nil {
 		return nil, twirpAuthError(err)
@@ -215,16 +247,11 @@ func (s *SIPService) DeleteSIPTrunk(ctx context.Context, req *livekit.DeleteSIPT
 		return nil, ErrSIPNotConnected
 	}
 
-	info, err := s.store.LoadSIPTrunk(ctx, req.SipTrunkId)
-	if err != nil {
+	if err := s.store.DeleteSIPTrunk(ctx, req.SipTrunkId); err != nil {
 		return nil, err
 	}
 
-	if err = s.store.DeleteSIPTrunk(ctx, info); err != nil {
-		return nil, err
-	}
-
-	return info, nil
+	return &livekit.SIPTrunkInfo{SipTrunkId: req.SipTrunkId}, nil
 }
 
 func (s *SIPService) CreateSIPDispatchRule(ctx context.Context, req *livekit.CreateSIPDispatchRuleRequest) (*livekit.SIPDispatchRuleInfo, error) {
@@ -356,5 +383,5 @@ func (s *SIPService) CreateSIPParticipantRequest(ctx context.Context, req *livek
 		)
 		return nil, err
 	}
-	return rpc.NewCreateSIPParticipantRequest(callID, wsUrl, token, req, trunk)
+	return rpc.NewCreateSIPParticipantRequest("", callID, "", wsUrl, token, req, trunk)
 }


### PR DESCRIPTION
Support new SIP protocol and allow passing and handling SIP headers.

Also, make `DeleteSIPTrunk` errors consistent with Cloud.

Requires https://github.com/livekit/protocol/pull/805

