### PR TITLE
Log ICE reconnected.

### DIFF
--- a/pkg/rtc/transportmanager.go
+++ b/pkg/rtc/transportmanager.go
@@ -482,15 +482,15 @@ func (t *TransportManager) SubscriberAsPrimary() bool {
 	return t.params.SubscriberAsPrimary
 }
 
-func (t *TransportManager) GetICEConnectionDetails() []*types.ICEConnectionDetails {
-	details := make([]*types.ICEConnectionDetails, 0, 2)
+func (t *TransportManager) GetICEConnectionInfo() []*types.ICEConnectionInfo {
+	infos := make([]*types.ICEConnectionInfo, 0, 2)
 	for _, pc := range []*PCTransport{t.publisher, t.subscriber} {
-		cd := pc.GetICEConnectionDetails()
-		if cd.HasCandidates() {
-			details = append(details, cd.Clone())
+		info := pc.GetICEConnectionInfo()
+		if info.HasCandidates() {
+			infos = append(infos, info)
 		}
 	}
-	return details
+	return infos
 }
 
 func (t *TransportManager) getTransport(isPrimary bool) *PCTransport {

--- a/pkg/rtc/types/ice.go
+++ b/pkg/rtc/types/ice.go
@@ -47,43 +47,49 @@ type ICECandidateExtended struct {
 	Trickle  bool
 }
 
-type ICEConnectionDetails struct {
+// --------------------------------------------
+
+type ICEConnectionInfo struct {
 	Local     []*ICECandidateExtended
 	Remote    []*ICECandidateExtended
 	Transport livekit.SignalTarget
 	Type      ICEConnectionType
-	lock      sync.Mutex
-	logger    logger.Logger
+}
+
+func (i *ICEConnectionInfo) HasCandidates() bool {
+	return len(i.Local) > 0 || len(i.Remote) > 0
+}
+
+// --------------------------------------------
+
+type ICEConnectionDetails struct {
+	ICEConnectionInfo
+	lock   sync.Mutex
+	logger logger.Logger
 }
 
 func NewICEConnectionDetails(transport livekit.SignalTarget, l logger.Logger) *ICEConnectionDetails {
 	d := &ICEConnectionDetails{
-		Transport: transport,
-		Type:      ICEConnectionTypeUnknown,
-		logger:    l,
+		ICEConnectionInfo: ICEConnectionInfo{
+			Transport: transport,
+			Type:      ICEConnectionTypeUnknown,
+		},
+		logger: l,
 	}
 	return d
 }
 
-func (d *ICEConnectionDetails) HasCandidates() bool {
+func (d *ICEConnectionDetails) GetInfo() *ICEConnectionInfo {
 	d.lock.Lock()
 	defer d.lock.Unlock()
-	return len(d.Local) > 0 || len(d.Remote) > 0
-}
-
-// Clone returns a copy of the ICEConnectionDetails, where fields can be read without locking
-func (d *ICEConnectionDetails) Clone() *ICEConnectionDetails {
-	d.lock.Lock()
-	defer d.lock.Unlock()
-	clone := &ICEConnectionDetails{
+	info := &ICEConnectionInfo{
 		Transport: d.Transport,
 		Type:      d.Type,
-		logger:    d.logger,
 		Local:     make([]*ICECandidateExtended, 0, len(d.Local)),
 		Remote:    make([]*ICECandidateExtended, 0, len(d.Remote)),
 	}
 	for _, c := range d.Local {
-		clone.Local = append(clone.Local, &ICECandidateExtended{
+		info.Local = append(info.Local, &ICECandidateExtended{
 			Local:    c.Local,
 			Filtered: c.Filtered,
 			Selected: c.Selected,
@@ -91,14 +97,14 @@ func (d *ICEConnectionDetails) Clone() *ICEConnectionDetails {
 		})
 	}
 	for _, c := range d.Remote {
-		clone.Remote = append(clone.Remote, &ICECandidateExtended{
+		info.Remote = append(info.Remote, &ICECandidateExtended{
 			Remote:   c.Remote,
 			Filtered: c.Filtered,
 			Selected: c.Selected,
 			Trickle:  c.Trickle,
 		})
 	}
-	return clone
+	return info
 }
 
 func (d *ICEConnectionDetails) AddLocalCandidate(c *webrtc.ICECandidate, filtered, trickle bool) {

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -321,7 +321,7 @@ type LocalParticipant interface {
 	GetBufferFactory() *buffer.Factory
 	GetPlayoutDelayConfig() *livekit.PlayoutDelay
 	GetPendingTrack(trackID livekit.TrackID) *livekit.TrackInfo
-	GetICEConnectionDetails() []*ICEConnectionDetails
+	GetICEConnectionInfo() []*ICEConnectionInfo
 	HasConnected() bool
 	GetEnabledPublishCodecs() []*livekit.Codec
 

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -306,15 +306,15 @@ type FakeLocalParticipant struct {
 	getICEConfigReturnsOnCall map[int]struct {
 		result1 *livekit.ICEConfig
 	}
-	GetICEConnectionDetailsStub        func() []*types.ICEConnectionDetails
-	getICEConnectionDetailsMutex       sync.RWMutex
-	getICEConnectionDetailsArgsForCall []struct {
+	GetICEConnectionInfoStub        func() []*types.ICEConnectionInfo
+	getICEConnectionInfoMutex       sync.RWMutex
+	getICEConnectionInfoArgsForCall []struct {
 	}
-	getICEConnectionDetailsReturns struct {
-		result1 []*types.ICEConnectionDetails
+	getICEConnectionInfoReturns struct {
+		result1 []*types.ICEConnectionInfo
 	}
-	getICEConnectionDetailsReturnsOnCall map[int]struct {
-		result1 []*types.ICEConnectionDetails
+	getICEConnectionInfoReturnsOnCall map[int]struct {
+		result1 []*types.ICEConnectionInfo
 	}
 	GetLoggerStub        func() logger.Logger
 	getLoggerMutex       sync.RWMutex
@@ -2568,15 +2568,15 @@ func (fake *FakeLocalParticipant) GetICEConfigReturnsOnCall(i int, result1 *live
 	}{result1}
 }
 
-func (fake *FakeLocalParticipant) GetICEConnectionDetails() []*types.ICEConnectionDetails {
-	fake.getICEConnectionDetailsMutex.Lock()
-	ret, specificReturn := fake.getICEConnectionDetailsReturnsOnCall[len(fake.getICEConnectionDetailsArgsForCall)]
-	fake.getICEConnectionDetailsArgsForCall = append(fake.getICEConnectionDetailsArgsForCall, struct {
+func (fake *FakeLocalParticipant) GetICEConnectionInfo() []*types.ICEConnectionInfo {
+	fake.getICEConnectionInfoMutex.Lock()
+	ret, specificReturn := fake.getICEConnectionInfoReturnsOnCall[len(fake.getICEConnectionInfoArgsForCall)]
+	fake.getICEConnectionInfoArgsForCall = append(fake.getICEConnectionInfoArgsForCall, struct {
 	}{})
-	stub := fake.GetICEConnectionDetailsStub
-	fakeReturns := fake.getICEConnectionDetailsReturns
-	fake.recordInvocation("GetICEConnectionDetails", []interface{}{})
-	fake.getICEConnectionDetailsMutex.Unlock()
+	stub := fake.GetICEConnectionInfoStub
+	fakeReturns := fake.getICEConnectionInfoReturns
+	fake.recordInvocation("GetICEConnectionInfo", []interface{}{})
+	fake.getICEConnectionInfoMutex.Unlock()
 	if stub != nil {
 		return stub()
 	}
@@ -2586,38 +2586,38 @@ func (fake *FakeLocalParticipant) GetICEConnectionDetails() []*types.ICEConnecti
 	return fakeReturns.result1
 }
 
-func (fake *FakeLocalParticipant) GetICEConnectionDetailsCallCount() int {
-	fake.getICEConnectionDetailsMutex.RLock()
-	defer fake.getICEConnectionDetailsMutex.RUnlock()
-	return len(fake.getICEConnectionDetailsArgsForCall)
+func (fake *FakeLocalParticipant) GetICEConnectionInfoCallCount() int {
+	fake.getICEConnectionInfoMutex.RLock()
+	defer fake.getICEConnectionInfoMutex.RUnlock()
+	return len(fake.getICEConnectionInfoArgsForCall)
 }
 
-func (fake *FakeLocalParticipant) GetICEConnectionDetailsCalls(stub func() []*types.ICEConnectionDetails) {
-	fake.getICEConnectionDetailsMutex.Lock()
-	defer fake.getICEConnectionDetailsMutex.Unlock()
-	fake.GetICEConnectionDetailsStub = stub
+func (fake *FakeLocalParticipant) GetICEConnectionInfoCalls(stub func() []*types.ICEConnectionInfo) {
+	fake.getICEConnectionInfoMutex.Lock()
+	defer fake.getICEConnectionInfoMutex.Unlock()
+	fake.GetICEConnectionInfoStub = stub
 }
 
-func (fake *FakeLocalParticipant) GetICEConnectionDetailsReturns(result1 []*types.ICEConnectionDetails) {
-	fake.getICEConnectionDetailsMutex.Lock()
-	defer fake.getICEConnectionDetailsMutex.Unlock()
-	fake.GetICEConnectionDetailsStub = nil
-	fake.getICEConnectionDetailsReturns = struct {
-		result1 []*types.ICEConnectionDetails
+func (fake *FakeLocalParticipant) GetICEConnectionInfoReturns(result1 []*types.ICEConnectionInfo) {
+	fake.getICEConnectionInfoMutex.Lock()
+	defer fake.getICEConnectionInfoMutex.Unlock()
+	fake.GetICEConnectionInfoStub = nil
+	fake.getICEConnectionInfoReturns = struct {
+		result1 []*types.ICEConnectionInfo
 	}{result1}
 }
 
-func (fake *FakeLocalParticipant) GetICEConnectionDetailsReturnsOnCall(i int, result1 []*types.ICEConnectionDetails) {
-	fake.getICEConnectionDetailsMutex.Lock()
-	defer fake.getICEConnectionDetailsMutex.Unlock()
-	fake.GetICEConnectionDetailsStub = nil
-	if fake.getICEConnectionDetailsReturnsOnCall == nil {
-		fake.getICEConnectionDetailsReturnsOnCall = make(map[int]struct {
-			result1 []*types.ICEConnectionDetails
+func (fake *FakeLocalParticipant) GetICEConnectionInfoReturnsOnCall(i int, result1 []*types.ICEConnectionInfo) {
+	fake.getICEConnectionInfoMutex.Lock()
+	defer fake.getICEConnectionInfoMutex.Unlock()
+	fake.GetICEConnectionInfoStub = nil
+	if fake.getICEConnectionInfoReturnsOnCall == nil {
+		fake.getICEConnectionInfoReturnsOnCall = make(map[int]struct {
+			result1 []*types.ICEConnectionInfo
 		})
 	}
-	fake.getICEConnectionDetailsReturnsOnCall[i] = struct {
-		result1 []*types.ICEConnectionDetails
+	fake.getICEConnectionInfoReturnsOnCall[i] = struct {
+		result1 []*types.ICEConnectionInfo
 	}{result1}
 }
 
@@ -6969,8 +6969,8 @@ func (fake *FakeLocalParticipant) Invocations() map[string][][]interface{} {
 	defer fake.getEnabledPublishCodecsMutex.RUnlock()
 	fake.getICEConfigMutex.RLock()
 	defer fake.getICEConfigMutex.RUnlock()
-	fake.getICEConnectionDetailsMutex.RLock()
-	defer fake.getICEConnectionDetailsMutex.RUnlock()
+	fake.getICEConnectionInfoMutex.RLock()
+	defer fake.getICEConnectionInfoMutex.RUnlock()
 	fake.getLoggerMutex.RLock()
 	defer fake.getLoggerMutex.RUnlock()
 	fake.getPacerMutex.RLock()

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -196,7 +196,9 @@ type refInfo struct {
 }
 
 func (r refInfo) MarshalLogObject(e zapcore.ObjectEncoder) error {
-	e.AddObject("senderReport", buffer.WrappedRTCPSenderReportStateLogger{r.senderReport})
+	e.AddObject("senderReport", buffer.WrappedRTCPSenderReportStateLogger{
+		RTCPSenderReportState: r.senderReport,
+	})
 	e.AddUint64("tsOffset", r.tsOffset)
 	e.AddBool("isTSOffsetValid", r.isTSOffsetValid)
 	return nil


### PR DESCRIPTION
To increase visibility of ICE reconnect, logging reconnected at Infow level. Otherwise, it is hard to see if an ICE restart finished successfully.

Also, cleaning up ICEConnectionDetails a bit. Just separate out read-only fields into its own struct and use it for read-only export.