### PR TITLE
Set SenderReport to nil on seeding if empty.

### DIFF
--- a/pkg/sfu/buffer/rtpstats_receiver.go
+++ b/pkg/sfu/buffer/rtpstats_receiver.go
@@ -26,7 +26,6 @@ import (
 	"github.com/livekit/livekit-server/pkg/sfu/utils"
 	"github.com/livekit/mediatransportutil"
 	"github.com/livekit/protocol/livekit"
-	"github.com/livekit/protocol/logger"
 	protoutils "github.com/livekit/protocol/utils"
 )
 
@@ -429,7 +428,7 @@ func (r *RTPStatsReceiver) checkOutOfOrderSenderReport(srData *livekit.RTCPSende
 		if (r.outOfOrderSenderReportCount-1)%10 == 0 {
 			r.logger.Infow(
 				"received sender report, out-of-order, skipping",
-				"current", logger.Proto(srData),
+				"current", WrappedRTCPSenderReportStateLogger{srData},
 				"count", r.outOfOrderSenderReportCount,
 				"rtpStats", lockedRTPStatsReceiverLogEncoder{r},
 			)
@@ -459,7 +458,7 @@ func (r *RTPStatsReceiver) checkRTPClockSkewForSenderReport(srData *livekit.RTCP
 		if (r.clockSkewCount-1)%100 == 0 {
 			r.logger.Infow(
 				"received sender report, clock skew",
-				"current", logger.Proto(srData),
+				"current", WrappedRTCPSenderReportStateLogger{srData},
 				"timeSinceFirst", timeSinceFirst,
 				"rtpDiffSinceFirst", rtpDiffSinceFirst,
 				"calculatedFirst", calculatedClockRateFromFirst,
@@ -495,7 +494,7 @@ func (r *RTPStatsReceiver) checkRTPClockSkewAgainstMediaPathForSenderReport(srDa
 		if (r.clockSkewMediaPathCount-1)%100 == 0 {
 			r.logger.Infow(
 				"received sender report, clock skew against media path",
-				"current", logger.Proto(srData),
+				"current", WrappedRTCPSenderReportStateLogger{srData},
 				"timeSinceSR", timeSinceSR,
 				"extNowTSSR", extNowTSSR,
 				"timeSinceHighest", timeSinceHighest,
@@ -724,10 +723,10 @@ func (r lockedRTPStatsReceiverLogEncoder) MarshalLogObject(e zapcore.ObjectEncod
 	e.AddObject("propagationDelayEstimator", r.propagationDelayEstimator)
 
 	packetDrift, ntpReportDrift, receivedReportDrift, rebasedReportDrift := r.getDrift(extStartTS, extHighestTS)
-	e.AddObject("packetDrift", logger.Proto(packetDrift))
-	e.AddObject("ntpReportDrift", logger.Proto(ntpReportDrift))
-	e.AddObject("receivedReportDrift", logger.Proto(receivedReportDrift))
-	e.AddObject("rebasedReportDrift", logger.Proto(rebasedReportDrift))
+	e.AddObject("packetDrift", wrappedRTPDriftLogger{packetDrift})
+	e.AddObject("ntpReportDrift", wrappedRTPDriftLogger{ntpReportDrift})
+	e.AddObject("receivedReportDrift", wrappedRTPDriftLogger{receivedReportDrift})
+	e.AddObject("rebasedReportDrift", wrappedRTPDriftLogger{rebasedReportDrift})
 	return nil
 }
 


### PR DESCRIPTION
With protobuf marshalling/unmarshalling, the default struct was getting used and nil checks for non existence were failing. That means the right layers were not reported active on migration.

Also, restore the wrapped loggers as some fields needs some conversion before logging.