### PR TITLE
Log only when not nil.

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -1253,7 +1253,9 @@ func (d *DownTrack) GetState() DownTrackState {
 }
 
 func (d *DownTrack) SeedState(state DownTrackState) {
-	d.params.Logger.Debugw("seeding down track state", "state", state)
+	if state.RTPStats != nil || state.ForwarderState != nil {
+		d.params.Logger.Debugw("seeding down track state", "state", state)
+	}
 	if state.RTPStats != nil {
 		d.rtpStats.Seed(state.RTPStats)
 		d.deltaStatsSenderSnapshotId = state.DeltaStatsSenderSnapshotId


### PR DESCRIPTION
Default logging confuses debugging as we call using nil as well to make the call site simpler. And logging a nil makes it look like it is incorrect seeding. `nil` fields do not seed. So, don't log when `nil`.