### PR TITLE
fix: copy attributes to refresh token

### DIFF
--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -993,6 +993,7 @@ func (r *RoomManager) refreshToken(participant types.LocalParticipant) error {
 		SetIdentity(string(participant.Identity())).
 		SetValidFor(tokenDefaultTTL).
 		SetMetadata(grants.Metadata).
+		SetAttributes(grants.Attributes).
 		AddGrant(grants.Video)
 	jwt, err := token.ToJWT()
 	if err == nil {


### PR DESCRIPTION
otherwise they will be missing on a full reconnect