### PR TITLE
Buffer reliable data packets for users transitioning from JOINED to A…

### DIFF
--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -449,6 +449,11 @@ type LocalParticipant interface {
 	GetDisableSenderReportPassThrough() bool
 
 	HandleMetrics(senderParticipantID livekit.ParticipantID, batch *livekit.MetricsBatch) error
+
+	// reliable data packets may be lost for participants in active transition from JOINED to ACTIVE state
+	// these methods allow the participant to buffer these packets for later delivery just after reaching ACTIVE state
+	StoreReliableDataPacketForLaterDelivery(dpData *livekit.DataPacket)
+	DeliverStoredReliableDataPackets()
 }
 
 // Room is a container of participants, and can provide room-level actions

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -7210,6 +7210,14 @@ func (fake *FakeLocalParticipant) WriteSubscriberRTCPReturnsOnCall(i int, result
 	}{result1}
 }
 
+func (fake *FakeLocalParticipant) DeliverStoredReliableDataPackets() {
+	fake.recordInvocation("DeliverStoredReliableDataPackets", []interface{}{})
+}
+
+func (fake *FakeLocalParticipant) StoreReliableDataPacketForLaterDelivery(arg1 *livekit.DataPacket) {
+	fake.recordInvocation("StoreReliableDataPacketForLaterDelivery", []interface{}{arg1})
+}
+
 func (fake *FakeLocalParticipant) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()


### PR DESCRIPTION
…CTIVE state and deliver when reaching ACTIVE state.

Related issue: [3049](https://github.com/livekit/livekit/issues/3049)