### PR TITLE
Use lower case mime type in dynacast.

### DIFF
--- a/pkg/rtc/dynacast/dynacastmanager.go
+++ b/pkg/rtc/dynacast/dynacastmanager.go
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rtc
+package dynacast
 
 import (
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/bep/debounce"
+	"golang.org/x/exp/maps"
 
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
@@ -157,6 +159,7 @@ func (d *DynacastManager) getOrCreateDynacastQuality(mime string) *DynacastQuali
 		return nil
 	}
 
+	mime = strings.ToLower(mime)
 	if dq := d.dynacastQuality[mime]; dq != nil {
 		return dq
 	}
@@ -165,8 +168,8 @@ func (d *DynacastManager) getOrCreateDynacastQuality(mime string) *DynacastQuali
 		MimeType: mime,
 		Logger:   d.params.Logger,
 	})
-	dq.OnSubscribedMaxQualityChange(func(maxQuality livekit.VideoQuality) {
-		d.updateMaxQualityForMime(mime, maxQuality)
+	dq.OnSubscribedMaxQualityChange(func(mimeType string, maxQuality livekit.VideoQuality) {
+		d.updateMaxQualityForMime(mimeType, maxQuality)
 	})
 	dq.Start()
 
@@ -176,12 +179,7 @@ func (d *DynacastManager) getOrCreateDynacastQuality(mime string) *DynacastQuali
 }
 
 func (d *DynacastManager) getDynacastQualitiesLocked() []*DynacastQuality {
-	dqs := make([]*DynacastQuality, 0, len(d.dynacastQuality))
-	for _, dq := range d.dynacastQuality {
-		dqs = append(dqs, dq)
-	}
-
-	return dqs
+	return maps.Values(d.dynacastQuality)
 }
 
 func (d *DynacastManager) updateMaxQualityForMime(mime string, maxQuality livekit.VideoQuality) {

--- a/pkg/rtc/dynacast/dynacastmanager_test.go
+++ b/pkg/rtc/dynacast/dynacastmanager_test.go
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rtc
+package dynacast
 
 import (
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -54,7 +55,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 
 		expectedSubscribedQualities := []*livekit.SubscribedCodec{
 			{
-				Codec: webrtc.MimeTypeVP8,
+				Codec: strings.ToLower(webrtc.MimeTypeVP8),
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: false},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: false},
@@ -62,7 +63,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 				},
 			},
 			{
-				Codec: webrtc.MimeTypeAV1,
+				Codec: strings.ToLower(webrtc.MimeTypeAV1),
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: true},
@@ -94,8 +95,8 @@ func TestSubscribedMaxQuality(t *testing.T) {
 		})
 
 		dm.maxSubscribedQuality = map[string]livekit.VideoQuality{
-			webrtc.MimeTypeVP8: livekit.VideoQuality_LOW,
-			webrtc.MimeTypeAV1: livekit.VideoQuality_LOW,
+			strings.ToLower(webrtc.MimeTypeVP8): livekit.VideoQuality_LOW,
+			strings.ToLower(webrtc.MimeTypeAV1): livekit.VideoQuality_LOW,
 		}
 		dm.NotifySubscriberMaxQuality("s1", webrtc.MimeTypeVP8, livekit.VideoQuality_HIGH)
 		dm.NotifySubscriberMaxQuality("s2", webrtc.MimeTypeVP8, livekit.VideoQuality_MEDIUM)
@@ -103,7 +104,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 
 		expectedSubscribedQualities := []*livekit.SubscribedCodec{
 			{
-				Codec: webrtc.MimeTypeVP8,
+				Codec: strings.ToLower(webrtc.MimeTypeVP8),
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: true},
@@ -111,7 +112,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 				},
 			},
 			{
-				Codec: webrtc.MimeTypeAV1,
+				Codec: strings.ToLower(webrtc.MimeTypeAV1),
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: true},
@@ -131,7 +132,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 
 		expectedSubscribedQualities = []*livekit.SubscribedCodec{
 			{
-				Codec: webrtc.MimeTypeVP8,
+				Codec: strings.ToLower(webrtc.MimeTypeVP8),
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: true},
@@ -139,7 +140,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 				},
 			},
 			{
-				Codec: webrtc.MimeTypeAV1,
+				Codec: strings.ToLower(webrtc.MimeTypeAV1),
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: true},
@@ -161,7 +162,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 
 		expectedSubscribedQualities = []*livekit.SubscribedCodec{
 			{
-				Codec: webrtc.MimeTypeVP8,
+				Codec: strings.ToLower(webrtc.MimeTypeVP8),
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: false},
@@ -169,7 +170,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 				},
 			},
 			{
-				Codec: webrtc.MimeTypeAV1,
+				Codec: strings.ToLower(webrtc.MimeTypeAV1),
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: false},
@@ -201,7 +202,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 
 		expectedSubscribedQualities = []*livekit.SubscribedCodec{
 			{
-				Codec: webrtc.MimeTypeVP8,
+				Codec: strings.ToLower(webrtc.MimeTypeVP8),
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: false},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: false},
@@ -209,7 +210,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 				},
 			},
 			{
-				Codec: webrtc.MimeTypeAV1,
+				Codec: strings.ToLower(webrtc.MimeTypeAV1),
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: false},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: false},
@@ -229,7 +230,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 
 		expectedSubscribedQualities = []*livekit.SubscribedCodec{
 			{
-				Codec: webrtc.MimeTypeVP8,
+				Codec: strings.ToLower(webrtc.MimeTypeVP8),
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: false},
@@ -237,7 +238,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 				},
 			},
 			{
-				Codec: webrtc.MimeTypeAV1,
+				Codec: strings.ToLower(webrtc.MimeTypeAV1),
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: false},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: false},
@@ -260,7 +261,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 
 		expectedSubscribedQualities = []*livekit.SubscribedCodec{
 			{
-				Codec: webrtc.MimeTypeVP8,
+				Codec: strings.ToLower(webrtc.MimeTypeVP8),
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: true},
@@ -268,7 +269,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 				},
 			},
 			{
-				Codec: webrtc.MimeTypeAV1,
+				Codec: strings.ToLower(webrtc.MimeTypeAV1),
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: true},

--- a/pkg/rtc/dynacast/dynacastquality.go
+++ b/pkg/rtc/dynacast/dynacastquality.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rtc
+package dynacast
 
 import (
 	"sync"
@@ -43,7 +43,7 @@ type DynacastQuality struct {
 	maxSubscribedQuality     livekit.VideoQuality
 	maxQualityTimer          *time.Timer
 
-	onSubscribedMaxQualityChange func(maxSubscribedQuality livekit.VideoQuality)
+	onSubscribedMaxQualityChange func(mimeType string, maxSubscribedQuality livekit.VideoQuality)
 }
 
 func NewDynacastQuality(params DynacastQualityParams) *DynacastQuality {
@@ -66,7 +66,7 @@ func (d *DynacastQuality) Stop() {
 	d.stopMaxQualityTimer()
 }
 
-func (d *DynacastQuality) OnSubscribedMaxQualityChange(f func(maxSubscribedQuality livekit.VideoQuality)) {
+func (d *DynacastQuality) OnSubscribedMaxQualityChange(f func(mimeType string, maxSubscribedQuality livekit.VideoQuality)) {
 	d.onSubscribedMaxQualityChange = f
 }
 
@@ -148,7 +148,7 @@ func (d *DynacastQuality) updateQualityChange(force bool) {
 	d.lock.Unlock()
 
 	if onSubscribedMaxQualityChange != nil {
-		onSubscribedMaxQualityChange(maxSubscribedQuality)
+		onSubscribedMaxQualityChange(d.params.MimeType, maxSubscribedQuality)
 	}
 }
 

--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -29,6 +29,7 @@ import (
 	"github.com/livekit/protocol/logger"
 
 	"github.com/livekit/livekit-server/pkg/config"
+	"github.com/livekit/livekit-server/pkg/rtc/dynacast"
 	"github.com/livekit/livekit-server/pkg/rtc/types"
 	"github.com/livekit/livekit-server/pkg/sfu"
 	"github.com/livekit/livekit-server/pkg/sfu/buffer"
@@ -48,7 +49,7 @@ type MediaTrack struct {
 	*MediaTrackReceiver
 	*MediaLossProxy
 
-	dynacastManager *DynacastManager
+	dynacastManager *dynacast.DynacastManager
 
 	lock sync.RWMutex
 
@@ -107,7 +108,7 @@ func NewMediaTrack(params MediaTrackParams, ti *livekit.TrackInfo) *MediaTrack {
 	}
 
 	if ti.Type == livekit.TrackType_VIDEO {
-		t.dynacastManager = NewDynacastManager(DynacastManagerParams{
+		t.dynacastManager = dynacast.NewDynacastManager(dynacast.DynacastManagerParams{
 			DynacastPauseDelay: params.VideoConfig.DynacastPauseDelay,
 			Logger:             params.Logger,
 		})


### PR DESCRIPTION
Seeing instances of both lower case and upper case mime in dynacast manager which created duplicate entries.

Also, move the dyncast files to a package.

TODO: Need to do audit and come up with a consistent way to always use lower case for mime type.