### PR TITLE
Use PPS mode rather than max to adjust packet loss weight.

### DIFF
--- a/pkg/sfu/connectionquality/scorer.go
+++ b/pkg/sfu/connectionquality/scorer.go
@@ -39,6 +39,11 @@ const (
 	cDistanceWeight = float64(35.0) // each spatial layer missed drops a quality level
 
 	cUnmuteTimeThreshold = float64(0.5)
+
+	cPPSQuantization            = float64(2)
+	cPPSMinReadings             = 10
+	cModeCalculationInterval    = 2 * time.Minute
+	cModeCalculationForceFactor = 2
 )
 
 var (
@@ -211,7 +216,10 @@ type qualityScorer struct {
 	pausedAt  time.Time
 	resumedAt time.Time
 
-	maxPPS float64
+	ppsHistogram     [250]int
+	numPPSReadings   int
+	ppsMode          int
+	modeCalculatedAt time.Time
 
 	aggregateBitrate *utils.TimedAggregator[int64]
 	layerDistance    *utils.TimedAggregator[float64]
@@ -227,6 +235,7 @@ func newQualityScorer(params qualityScorerParams) *qualityScorer {
 		layerDistance: utils.NewTimedAggregator[float64](utils.TimedAggregatorParams{
 			CapNegativeValues: true,
 		}),
+		modeCalculatedAt: time.Now().Add(-cModeCalculationInterval),
 	}
 }
 
@@ -455,7 +464,7 @@ func (q *qualityScorer) updateAtLocked(stat *windowStat, at time.Time) {
 		"quality", currCQ,
 		"stat", stat,
 		"packetLossWeight", plw,
-		"maxPPS", q.maxPPS,
+		"modePPS", q.ppsMode*int(cPPSQuantization),
 		"expectedBits", expectedBits,
 		"expectedDistance", expectedDistance,
 	)
@@ -532,23 +541,43 @@ func (q *qualityScorer) getPacketLossWeight(stat *windowStat) float64 {
 		return q.params.PacketLossWeight
 	}
 
-	// packet loss is weighted by comparing against max packet rate seen.
+	// packet loss is weighted by comparing against mode of packet rate seen.
 	// this is to handle situations like DTX in audio and variable bit rate tracks like screen share.
-	// and the effect of loss is not pronounced in those scenarios (audio silence, statis screen share).
+	// and the effect of loss is not pronounced in those scenarios (audio silence, static screen share).
 	// for example, DTX typically uses only 5% of packets of full packet rate. at that rate,
 	// packet loss weight is reduced to ~22% of configured weight (i. e. sqrt(0.05) * configured weight)
 	pps := float64(stat.packets) / stat.duration.Seconds()
-	if pps > q.maxPPS {
-		q.maxPPS = pps
-		q.params.Logger.Debugw("updating maxPPS", "expected", stat.packets, "duration", stat.duration.Seconds(), "pps", pps)
+	ppsQuantized := int(pps/cPPSQuantization + 0.5)
+	if ppsQuantized < len(q.ppsHistogram)-1 {
+		q.ppsHistogram[ppsQuantized]++
+	} else {
+		q.ppsHistogram[len(q.ppsHistogram)-1]++
+	}
+	q.numPPSReadings++
+
+	// calculate mode sparingly, do it under the following conditions
+	//  1. minimum number of readings available (AND)
+	//  2. enough time has elapsed since last calculation
+	if q.numPPSReadings > cPPSMinReadings && time.Since(q.modeCalculatedAt) > cModeCalculationInterval {
+		q.ppsMode = 0
+		for i := 0; i < len(q.ppsHistogram); i++ {
+			if q.ppsHistogram[i] > q.ppsMode {
+				q.ppsMode = i
+			}
+		}
+		q.modeCalculatedAt = time.Now()
+		q.params.Logger.Debugw("updating pps mode", "expected", stat.packets, "duration", stat.duration.Seconds(), "pps", pps, "ppsMode", q.ppsMode)
 	}
 
-	if q.maxPPS == 0 {
+	if q.ppsMode == 0 || q.ppsMode == len(q.ppsHistogram)-1 {
 		return q.params.PacketLossWeight
 	}
 
-	packetRatio := pps / q.maxPPS
-	return packetRatio * packetRatio * q.params.PacketLossWeight
+	packetRatio := pps / (float64(q.ppsMode) * cPPSQuantization)
+	if packetRatio > 1.0 {
+		packetRatio = 1.0
+	}
+	return math.Sqrt(packetRatio) * q.params.PacketLossWeight
 }
 
 func (q *qualityScorer) GetScoreAndQuality() (float32, livekit.ConnectionQuality) {

--- a/pkg/sfu/connectionquality/scorer.go
+++ b/pkg/sfu/connectionquality/scorer.go
@@ -40,10 +40,9 @@ const (
 
 	cUnmuteTimeThreshold = float64(0.5)
 
-	cPPSQuantization            = float64(2)
-	cPPSMinReadings             = 10
-	cModeCalculationInterval    = 2 * time.Minute
-	cModeCalculationForceFactor = 2
+	cPPSQuantization         = float64(2)
+	cPPSMinReadings          = 10
+	cModeCalculationInterval = 2 * time.Minute
 )
 
 var (

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -383,7 +383,7 @@ func NewDownTrack(params DowntrackParams) (*DownTrack, error) {
 
 	d.connectionStats = connectionquality.NewConnectionStats(connectionquality.ConnectionStatsParams{
 		MimeType:       codecs[0].MimeType, // LK-TODO have to notify on codec change
-		IsFECEnabled:   strings.EqualFold(codecs[0].MimeType, webrtc.MimeTypeOpus) && strings.Contains(strings.ToLower(codecs[0].SDPFmtpLine), "fec"),
+		IsFECEnabled:   strings.Contains(strings.ToLower(codecs[0].SDPFmtpLine), "fec"),
 		SenderProvider: d,
 		Logger:         d.params.Logger.WithValues("direction", "down"),
 	})

--- a/pkg/sfu/rtpstats/rtpstats_base.go
+++ b/pkg/sfu/rtpstats/rtpstats_base.go
@@ -470,14 +470,14 @@ func (r *rtpStatsBase) marshalLogObject(
 	e zapcore.ObjectEncoder,
 	packetsExpected, packetsSeenMinusPadding uint64,
 	extStartTS, extHighestTS uint64,
-) error {
+) (float64, error) {
 	if r == nil {
-		return nil
+		return 0, nil
 	}
 
 	elapsedSeconds, err := r.rtpStatsBaseLite.marshalLogObject(e, packetsExpected, packetsSeenMinusPadding)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	e.AddTime("firstTime", time.Unix(0, r.firstTime))
@@ -521,7 +521,7 @@ func (r *rtpStatsBase) marshalLogObject(
 	e.AddObject("ntpReportDrift", wrappedRTPDriftLogger{ntpReportDrift})
 	e.AddObject("receivedReportDrift", wrappedRTPDriftLogger{receivedReportDrift})
 	e.AddObject("rebasedReportDrift", wrappedRTPDriftLogger{rebasedReportDrift})
-	return nil
+	return elapsedSeconds, nil
 }
 
 func (r *rtpStatsBase) toProto(

--- a/pkg/sfu/rtpstats/rtpstats_receiver.go
+++ b/pkg/sfu/rtpstats/rtpstats_receiver.go
@@ -704,7 +704,7 @@ func (r lockedRTPStatsReceiverLogEncoder) MarshalLogObject(e zapcore.ObjectEncod
 
 	extStartSN, extHighestSN := r.sequenceNumber.GetExtendedStart(), r.sequenceNumber.GetExtendedHighest()
 	extStartTS, extHighestTS := r.timestamp.GetExtendedStart(), r.timestamp.GetExtendedHighest()
-	if err := r.rtpStatsBase.marshalLogObject(
+	if _, err := r.rtpStatsBase.marshalLogObject(
 		e,
 		getPacketsExpected(extStartSN, extHighestSN),
 		r.getPacketsSeenMinusPadding(extStartSN, extHighestSN),

--- a/pkg/sfu/rtpstats/rtpstats_sender.go
+++ b/pkg/sfu/rtpstats/rtpstats_sender.go
@@ -1013,13 +1013,15 @@ func (r lockedRTPStatsSenderLogEncoder) MarshalLogObject(e zapcore.ObjectEncoder
 		return nil
 	}
 
-	if err := r.rtpStatsBase.marshalLogObject(
+	packetsExpected := getPacketsExpected(r.extStartSN, r.extHighestSN)
+	elapsedSeconds, err := r.rtpStatsBase.marshalLogObject(
 		e,
-		getPacketsExpected(r.extStartSN, r.extHighestSN),
+		packetsExpected,
 		r.getPacketsSeenMinusPadding(r.extStartSN, r.extHighestSN),
 		r.extStartTS,
 		r.extHighestTS,
-	); err != nil {
+	)
+	if err != nil {
 		return err
 	}
 
@@ -1033,6 +1035,8 @@ func (r lockedRTPStatsSenderLogEncoder) MarshalLogObject(e zapcore.ObjectEncoder
 	e.AddReflected("lastRR", r.lastRR)
 	e.AddUint64("extHighestSNFromRR", r.extHighestSNFromRR)
 	e.AddUint64("packetsLostFromRR", r.packetsLostFromRR)
+	e.AddFloat64("packetsLostFromRRRate", float64(r.packetsLostFromRR)/elapsedSeconds)
+	e.AddFloat32("packetLostFromRRPercentage", float32(r.packetsLostFromRR)/float32(packetsExpected)*100.0)
 	e.AddFloat64("jitterFromRR", r.jitterFromRR)
 	e.AddFloat64("maxJitterFromRR", r.maxJitterFromRR)
 


### PR DESCRIPTION
With maximum, a congestion period followed by a burst biases the weight towards lower values and hence even significant loss was not knocking down quality at times.

Use mode instead of get the most probable packet rate.

In the extreme case of DTX sending only silence packets (when not muted, as muted is treated differently) could set the mode at a low packet rate and a loss during that DTX period could have an outsized impact, but that is an extreme case.