### PR TITLE
Set FEC enabled properly in connection stats module.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2750,31 +2750,6 @@ func (p *ParticipantImpl) SupportsTransceiverReuse() bool {
 	return p.ProtocolVersion().SupportsTransceiverReuse() && !p.SupportsSyncStreamID()
 }
 
-func codecsFromMediaDescription(m *sdp.MediaDescription) (out []sdp.Codec, err error) {
-	s := &sdp.SessionDescription{
-		MediaDescriptions: []*sdp.MediaDescription{m},
-	}
-
-	for _, payloadStr := range m.MediaName.Formats {
-		payloadType, err := strconv.ParseUint(payloadStr, 10, 8)
-		if err != nil {
-			return nil, err
-		}
-
-		codec, err := s.GetCodecForPayloadType(uint8(payloadType))
-		if err != nil {
-			if payloadType == 0 {
-				continue
-			}
-			return nil, err
-		}
-
-		out = append(out, codec)
-	}
-
-	return out, nil
-}
-
 func (p *ParticipantImpl) SendDataPacket(kind livekit.DataPacket_Kind, encoded []byte) error {
 	if p.State() != livekit.ParticipantInfo_ACTIVE {
 		return ErrDataChannelUnavailable
@@ -2927,4 +2902,31 @@ func (p *ParticipantImpl) HandleMetrics(senderParticipantID livekit.ParticipantI
 	}
 
 	return p.TransportManager.SendDataPacket(livekit.DataPacket_RELIABLE, dpData)
+}
+
+// ----------------------------------------------
+
+func codecsFromMediaDescription(m *sdp.MediaDescription) (out []sdp.Codec, err error) {
+	s := &sdp.SessionDescription{
+		MediaDescriptions: []*sdp.MediaDescription{m},
+	}
+
+	for _, payloadStr := range m.MediaName.Formats {
+		payloadType, err := strconv.ParseUint(payloadStr, 10, 8)
+		if err != nil {
+			return nil, err
+		}
+
+		codec, err := s.GetCodecForPayloadType(uint8(payloadType))
+		if err != nil {
+			if payloadType == 0 {
+				continue
+			}
+			return nil, err
+		}
+
+		out = append(out, codec)
+	}
+
+	return out, nil
 }

--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pion/webrtc/v3"
 	"go.uber.org/atomic"
+	"golang.org/x/exp/slices"
 
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
@@ -126,9 +127,7 @@ func (r *WrappedReceiver) DetermineReceiver(codec webrtc.RTPCodecCapability) boo
 }
 
 func (r *WrappedReceiver) Codecs() []webrtc.RTPCodecParameters {
-	codecs := make([]webrtc.RTPCodecParameters, len(r.codecs))
-	copy(codecs, r.codecs)
-	return codecs
+	return slices.Clone(r.codecs)
 }
 
 func (r *WrappedReceiver) DeleteDownTrack(participantID livekit.ParticipantID) {

--- a/pkg/sfu/connectionquality/connectionstats_test.go
+++ b/pkg/sfu/connectionquality/connectionstats_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pion/webrtc/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/livekit/livekit-server/pkg/sfu/buffer"
@@ -60,8 +61,6 @@ func TestConnectionQuality(t *testing.T) {
 	trp := newTestReceiverProvider()
 	t.Run("quality scorer operation", func(t *testing.T) {
 		cs := NewConnectionStats(ConnectionStatsParams{
-			MimeType:           "audio/opus",
-			IsFECEnabled:       false,
 			IncludeRTT:         true,
 			IncludeJitter:      true,
 			EnableBitrateScore: true,
@@ -71,7 +70,7 @@ func TestConnectionQuality(t *testing.T) {
 
 		duration := 5 * time.Second
 		now := time.Now()
-		cs.StartAt(&livekit.TrackInfo{Type: livekit.TrackType_AUDIO}, now.Add(-duration))
+		cs.StartAt(webrtc.MimeTypeOpus, false, now.Add(-duration))
 		cs.UpdateMuteAt(false, now.Add(-1*time.Second))
 
 		// no data and not enough unmute time should return default state which is EXCELLENT quality
@@ -477,8 +476,6 @@ func TestConnectionQuality(t *testing.T) {
 
 	t.Run("quality scorer dependent rtt", func(t *testing.T) {
 		cs := NewConnectionStats(ConnectionStatsParams{
-			MimeType:         "audio/opus",
-			IsFECEnabled:     false,
 			IncludeRTT:       false,
 			IncludeJitter:    true,
 			ReceiverProvider: trp,
@@ -487,7 +484,7 @@ func TestConnectionQuality(t *testing.T) {
 
 		duration := 5 * time.Second
 		now := time.Now()
-		cs.StartAt(&livekit.TrackInfo{Type: livekit.TrackType_AUDIO}, now.Add(-duration))
+		cs.StartAt(webrtc.MimeTypeOpus, false, now.Add(-duration))
 		cs.UpdateMuteAt(false, now.Add(-1*time.Second))
 
 		// RTT does not knock quality down because it is dependent and hence not taken into account
@@ -512,8 +509,6 @@ func TestConnectionQuality(t *testing.T) {
 
 	t.Run("quality scorer dependent jitter", func(t *testing.T) {
 		cs := NewConnectionStats(ConnectionStatsParams{
-			MimeType:         "audio/opus",
-			IsFECEnabled:     false,
 			IncludeRTT:       true,
 			IncludeJitter:    false,
 			ReceiverProvider: trp,
@@ -522,7 +517,7 @@ func TestConnectionQuality(t *testing.T) {
 
 		duration := 5 * time.Second
 		now := time.Now()
-		cs.StartAt(&livekit.TrackInfo{Type: livekit.TrackType_AUDIO}, now.Add(-duration))
+		cs.StartAt(webrtc.MimeTypeOpus, false, now.Add(-duration))
 		cs.UpdateMuteAt(false, now.Add(-1*time.Second))
 
 		// Jitter does not knock quality down because it is dependent and hence not taken into account
@@ -684,8 +679,6 @@ func TestConnectionQuality(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				cs := NewConnectionStats(ConnectionStatsParams{
-					MimeType:         tc.mimeType,
-					IsFECEnabled:     tc.isFECEnabled,
 					IncludeRTT:       true,
 					IncludeJitter:    true,
 					ReceiverProvider: trp,
@@ -694,7 +687,7 @@ func TestConnectionQuality(t *testing.T) {
 
 				duration := 5 * time.Second
 				now := time.Now()
-				cs.StartAt(&livekit.TrackInfo{Type: livekit.TrackType_AUDIO}, now.Add(-duration))
+				cs.StartAt(tc.mimeType, tc.isFECEnabled, now.Add(-duration))
 
 				for _, eq := range tc.expectedQualities {
 					trp.setStreams(map[uint32]*buffer.StreamStatsWithLayers{
@@ -784,8 +777,6 @@ func TestConnectionQuality(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				cs := NewConnectionStats(ConnectionStatsParams{
-					MimeType:           "video/vp8",
-					IsFECEnabled:       false,
 					IncludeRTT:         true,
 					IncludeJitter:      true,
 					EnableBitrateScore: true,
@@ -795,7 +786,7 @@ func TestConnectionQuality(t *testing.T) {
 
 				duration := 5 * time.Second
 				now := time.Now()
-				cs.StartAt(&livekit.TrackInfo{Type: livekit.TrackType_VIDEO}, now)
+				cs.StartAt(webrtc.MimeTypeVP8, false, now)
 
 				for _, tr := range tc.transitions {
 					cs.AddBitrateTransitionAt(tr.bitrate, now.Add(tr.offset))
@@ -879,8 +870,6 @@ func TestConnectionQuality(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				cs := NewConnectionStats(ConnectionStatsParams{
-					MimeType:         "video/vp8",
-					IsFECEnabled:     false,
 					IncludeRTT:       true,
 					IncludeJitter:    true,
 					ReceiverProvider: trp,
@@ -889,7 +878,7 @@ func TestConnectionQuality(t *testing.T) {
 
 				duration := 5 * time.Second
 				now := time.Now()
-				cs.StartAt(&livekit.TrackInfo{Type: livekit.TrackType_VIDEO}, now)
+				cs.StartAt(webrtc.MimeTypeVP8, false, now)
 
 				for _, tr := range tc.transitions {
 					cs.AddLayerTransitionAt(tr.distance, now.Add(tr.offset))

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -481,7 +481,7 @@ func (d *DownTrack) Bind(t webrtc.TrackLocalContext) (webrtc.RTPCodecParameters,
 		if strings.EqualFold(matchedUpstreamCodec.MimeType, MimeTypeAudioRed) {
 			d.isRED = true
 			for _, c := range d.upstreamCodecs {
-				isFECEnabled = strings.Contains(strings.ToLower(c.SDPFmtpLine), "fec")
+				isFECEnabled = strings.Contains(strings.ToLower(c.SDPFmtpLine), "useinbandfec=1")
 
 				// assume upstream primary codec is opus since we only support it for audio now
 				if strings.EqualFold(c.MimeType, webrtc.MimeTypeOpus) {

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -229,6 +229,7 @@ func NewWebRTCReceiver(
 	})
 	w.connectionStats.Start(
 		w.codec.MimeType,
+		// TODO: technically not correct to declare FEC on when RED. Need the primary codec's fmtp line to check.
 		strings.EqualFold(w.codec.MimeType, MimeTypeAudioRed) || strings.Contains(strings.ToLower(w.codec.SDPFmtpLine), "fec"),
 	)
 

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -230,7 +230,7 @@ func NewWebRTCReceiver(
 	w.connectionStats.Start(
 		w.codec.MimeType,
 		// TODO: technically not correct to declare FEC on when RED. Need the primary codec's fmtp line to check.
-		strings.EqualFold(w.codec.MimeType, MimeTypeAudioRed) || strings.Contains(strings.ToLower(w.codec.SDPFmtpLine), "fec"),
+		strings.EqualFold(w.codec.MimeType, MimeTypeAudioRed) || strings.Contains(strings.ToLower(w.codec.SDPFmtpLine), "useinbandfec=1"),
 	)
 
 	w.streamTrackerManager = NewStreamTrackerManager(logger, trackInfo, w.isSVC, w.codec.ClockRate, trackersConfig)

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -219,8 +219,6 @@ func NewWebRTCReceiver(
 	})
 
 	w.connectionStats = connectionquality.NewConnectionStats(connectionquality.ConnectionStatsParams{
-		MimeType:         w.codec.MimeType,
-		IsFECEnabled:     strings.EqualFold(w.codec.MimeType, webrtc.MimeTypeOpus) && strings.Contains(strings.ToLower(w.codec.SDPFmtpLine), "fec"),
 		ReceiverProvider: w,
 		Logger:           w.logger.WithValues("direction", "up"),
 	})
@@ -229,7 +227,10 @@ func NewWebRTCReceiver(
 			w.onStatsUpdate(w, stat)
 		}
 	})
-	w.connectionStats.Start(trackInfo)
+	w.connectionStats.Start(
+		w.codec.MimeType,
+		strings.EqualFold(w.codec.MimeType, MimeTypeAudioRed) || strings.Contains(strings.ToLower(w.codec.SDPFmtpLine), "fec"),
+	)
 
 	w.streamTrackerManager = NewStreamTrackerManager(logger, trackInfo, w.isSVC, w.codec.ClockRate, trackersConfig)
 	w.streamTrackerManager.SetListener(w)
@@ -417,7 +418,6 @@ func (w *WebRTCReceiver) AddDownTrack(track TrackSender) error {
 		w.logger.Infow("subscriberID already exists, replacing downtrack", "subscriberID", track.SubscriberID())
 	}
 
-	track.TrackInfoAvailable()
 	track.UpTrackMaxPublishedLayerChange(w.streamTrackerManager.GetMaxPublishedLayer())
 	track.UpTrackMaxTemporalLayerSeenChange(w.streamTrackerManager.GetMaxTemporalLayerSeen())
 

--- a/pkg/sfu/redprimaryreceiver.go
+++ b/pkg/sfu/redprimaryreceiver.go
@@ -107,8 +107,6 @@ func (r *RedPrimaryReceiver) AddDownTrack(track TrackSender) error {
 		r.logger.Infow("subscriberID already exists, replacing downtrack", "subscriberID", track.SubscriberID())
 	}
 
-	track.TrackInfoAvailable()
-
 	r.downTrackSpreader.Store(track)
 	r.logger.Debugw("red primary receiver downtrack added", "subscriberID", track.SubscriberID())
 	return nil

--- a/pkg/sfu/redreceiver.go
+++ b/pkg/sfu/redreceiver.go
@@ -98,8 +98,6 @@ func (r *RedReceiver) AddDownTrack(track TrackSender) error {
 		r.logger.Infow("subscriberID already exists, replacing downtrack", "subscriberID", track.SubscriberID())
 	}
 
-	track.TrackInfoAvailable()
-
 	r.downTrackSpreader.Store(track)
 	r.logger.Debugw("red receiver downtrack added", "subscriberID", track.SubscriberID())
 	return nil


### PR DESCRIPTION
With RED, the FEC indication is in primary codec.

Also, clean up some bits that were not necessary (TrackInfoAvailable is not needed)

TODO: There are still a couple of things to figure out
- If codec is RED, Opus is added as second codec synthetically using https://github.com/livekit/livekit/blob/33098337fc17705bbdb3283c7a7034aa6b2f3745/pkg/rtc/mediaengine.go#L31 which hard codecs FEC enabled. Ideally, we should get the primary codec parameters from SDP offer.
- The WebRTCReceiver does not have information about primary codec. For now, just setting FEC to true when RED is enabled. It is okay as it just affects when we declare quality drops, but ideally the primary codec should be retrieved from SDP offer.