### PR TITLE
Support custom RTP header extension

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -141,6 +141,17 @@ rtc:
   # # when this limit is breached, data messages will be dropped till the buffered amount drops below this limit.
   # data_channel_max_buffered_amount: 0
 
+  # # set custom RTP header extensions
+  # publisher_header_extensions:
+  #   audio:
+  #     - http://www.example.org/experiments/rtp-hdrext/header-1
+  #     - http://www.example.org/experiments/rtp-hdrext/header-2
+
+  # subscriber_header_extensions:
+  #   audio:
+  #     - http://www.example.org/experiments/rtp-hdrext/header-1
+  #     - http://www.example.org/experiments/rtp-hdrext/header-2
+
 # when enabled, LiveKit will expose prometheus metrics on :6789/metrics
 # prometheus_port: 6789
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -125,8 +125,15 @@ type RTCConfig struct {
 	DataChannelMaxBufferedAmount uint64 `yaml:"data_channel_max_buffered_amount,omitempty"`
 
 	ForwardStats ForwardStatsConfig `yaml:"forward_stats,omitempty"`
+
+	PublisherHeaderExtensions  HeaderExtensions `yaml:"publisher_header_extensions,omitempty"`
+	SubscriberHeaderExtensions HeaderExtensions `yaml:"subscriber_header_extensions,omitempty"`
 }
 
+type HeaderExtensions struct {
+	Audio []string `yaml:"audio,omitempty"`
+	Video []string `yaml:"video,omitempty"`
+}
 type TURNServer struct {
 	Host       string `yaml:"host,omitempty"`
 	Port       int    `yaml:"port,omitempty"`

--- a/pkg/rtc/config.go
+++ b/pkg/rtc/config.go
@@ -112,6 +112,8 @@ func NewWebRTCConfig(conf *config.Config) (*WebRTCConfig, error) {
 			},
 		},
 	}
+	publisherConfig.RTPHeaderExtension.Audio = append(publisherConfig.RTPHeaderExtension.Audio, rtcConf.PublisherHeaderExtensions.Audio...)
+	publisherConfig.RTPHeaderExtension.Video = append(publisherConfig.RTPHeaderExtension.Video, rtcConf.PublisherHeaderExtensions.Video...)
 
 	// subscriber configuration
 	subscriberConfig := DirectionConfig{
@@ -140,6 +142,8 @@ func NewWebRTCConfig(conf *config.Config) (*WebRTCConfig, error) {
 		subscriberConfig.RTPHeaderExtension.Video = append(subscriberConfig.RTPHeaderExtension.Video, sdp.ABSSendTimeURI)
 		subscriberConfig.RTCPFeedback.Video = append(subscriberConfig.RTCPFeedback.Video, webrtc.RTCPFeedback{Type: webrtc.TypeRTCPFBGoogREMB})
 	}
+	subscriberConfig.RTPHeaderExtension.Video = append(subscriberConfig.RTPHeaderExtension.Video, rtcConf.SubscriberHeaderExtensions.Video...)
+	subscriberConfig.RTPHeaderExtension.Audio = append(subscriberConfig.RTPHeaderExtension.Audio, rtcConf.SubscriberHeaderExtensions.Audio...)
 
 	return &WebRTCConfig{
 		WebRTCConfig: *webRTCConfig,

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -67,6 +67,12 @@ type ExtPacket struct {
 	DependencyDescriptor *ExtDependencyDescriptor
 	AbsCaptureTimeExt    *act.AbsCaptureTime
 	IsOutOfOrder         bool
+	CustomExtensions     map[string]ExtensionData
+}
+
+type ExtensionData struct {
+	URI     string
+	Payload []byte
 }
 
 // Buffer contains all packets
@@ -140,6 +146,8 @@ type Buffer struct {
 	rtxPktBuf           []byte
 
 	absCaptureTimeExtID uint8
+
+	customHeaderExtensions []webrtc.RTPHeaderExtensionParameter
 }
 
 // NewBuffer constructs a new Buffer
@@ -255,6 +263,8 @@ func (b *Buffer) Bind(params webrtc.RTPParameters, codec webrtc.RTPCodecCapabili
 
 		case act.AbsCaptureTimeURI:
 			b.absCaptureTimeExtID = uint8(ext.ID)
+		default:
+			b.customHeaderExtensions = append(b.customHeaderExtensions, ext)
 		}
 	}
 
@@ -843,6 +853,20 @@ func (b *Buffer) getExtPacket(rtpPacket *rtp.Packet, arrivalTime int64, flowStat
 		var actExt act.AbsCaptureTime
 		if err := actExt.Unmarshal(extData); err == nil {
 			ep.AbsCaptureTimeExt = &actExt
+		}
+	}
+
+	if len(b.customHeaderExtensions) > 0 && ep.CustomExtensions == nil {
+		ep.CustomExtensions = make(map[string]ExtensionData)
+	}
+	for _, ext := range b.customHeaderExtensions {
+		extData := rtpPacket.GetExtension(uint8(ext.ID))
+		if extData == nil {
+			continue
+		}
+		ep.CustomExtensions[ext.URI] = ExtensionData{
+			URI:     ext.URI,
+			Payload: extData,
 		}
 	}
 

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -314,6 +314,8 @@ type DownTrack struct {
 	onCodecNegotiated           func(webrtc.RTPCodecCapability)
 
 	createdAt int64
+
+	customHeaderExtensions []webrtc.RTPHeaderExtensionParameter
 }
 
 type bindState int
@@ -710,6 +712,8 @@ func (d *DownTrack) SetRTPHeaderExtensions(rtpHeaderExtensions []webrtc.RTPHeade
 			}
 		case act.AbsCaptureTimeURI:
 			d.absCaptureTimeExtID = ext.ID
+		default:
+			d.customHeaderExtensions = append(d.customHeaderExtensions, ext)
 		}
 	}
 }
@@ -923,6 +927,12 @@ func (d *DownTrack) WriteRTP(extPkt *buffer.ExtPacket, layer int32) error {
 					)
 				}
 			}
+		}
+	}
+
+	for _, ext := range d.customHeaderExtensions {
+		if v, ok := extPkt.CustomExtensions[ext.URI]; ok {
+			extensions = append(extensions, pacer.ExtensionData{ID: uint8(ext.ID), Payload: v.Payload})
 		}
 	}
 


### PR DESCRIPTION
Fix https://github.com/livekit/livekit/issues/3111

Key updates:
1. Implemented configurable custom RTP header extensions.
2. Enhanced SFU forwarding to transmit Publisher's header extensions to Subscriber.