### PR TITLE
Skip divide-by-0.

### DIFF
--- a/pkg/sfu/rtpstats/rtpstats_base_lite.go
+++ b/pkg/sfu/rtpstats/rtpstats_base_lite.go
@@ -345,7 +345,9 @@ func (r *rtpStatsBaseLite) marshalLogObject(e zapcore.ObjectEncoder, packetsExpe
 
 	e.AddUint64("packetsLost", r.packetsLost)
 	e.AddFloat64("packetsLostRate", float64(r.packetsLost)/elapsedSeconds)
-	e.AddFloat32("packetLostPercentage", float32(r.packetsLost)/float32(packetsExpected)*100.0)
+	if packetsExpected != 0 {
+		e.AddFloat32("packetLostPercentage", float32(r.packetsLost)/float32(packetsExpected)*100.0)
+	}
 
 	hasLoss := false
 	first := true
@@ -396,7 +398,10 @@ func (r *rtpStatsBaseLite) toProto(packetsExpected, packetsSeenMinusPadding, pac
 	bitrate := float64(r.bytes) * 8.0 / elapsed
 
 	packetLostRate := float64(packetsLost) / elapsed
-	packetLostPercentage := float32(packetsLost) / float32(packetsExpected) * 100.0
+	packetLostPercentage := float32(0)
+	if packetsExpected != 0 {
+		packetLostPercentage = float32(packetsLost) / float32(packetsExpected) * 100.0
+	}
 
 	p := &livekit.RTPStats{
 		StartTime:            timestamppb.New(r.startTime),

--- a/pkg/sfu/rtpstats/rtpstats_sender.go
+++ b/pkg/sfu/rtpstats/rtpstats_sender.go
@@ -1036,7 +1036,9 @@ func (r lockedRTPStatsSenderLogEncoder) MarshalLogObject(e zapcore.ObjectEncoder
 	e.AddUint64("extHighestSNFromRR", r.extHighestSNFromRR)
 	e.AddUint64("packetsLostFromRR", r.packetsLostFromRR)
 	e.AddFloat64("packetsLostFromRRRate", float64(r.packetsLostFromRR)/elapsedSeconds)
-	e.AddFloat32("packetLostFromRRPercentage", float32(r.packetsLostFromRR)/float32(packetsExpected)*100.0)
+	if packetsExpected != 0 {
+		e.AddFloat32("packetLostFromRRPercentage", float32(r.packetsLostFromRR)/float32(packetsExpected)*100.0)
+	}
 	e.AddFloat64("jitterFromRR", r.jitterFromRR)
 	e.AddFloat64("maxJitterFromRR", r.maxJitterFromRR)
 


### PR DESCRIPTION
Does not crash, but does a NaN. Avoid that.