### PR TITLE
Seed duplicate packets and bytes.

### DIFF
--- a/pkg/sfu/rtpstats/rtpstats_base.go
+++ b/pkg/sfu/rtpstats/rtpstats_base.go
@@ -195,6 +195,7 @@ func (r *rtpStatsBase) seed(from *rtpStatsBase) bool {
 	}
 
 	r.firstTime = from.firstTime
+	r.firstTimeAdjustment = from.firstTimeAdjustment
 	r.highestTime = from.highestTime
 
 	r.lastTransit = from.lastTransit
@@ -202,6 +203,8 @@ func (r *rtpStatsBase) seed(from *rtpStatsBase) bool {
 
 	r.headerBytes = from.headerBytes
 
+	r.packetsDuplicate = from.packetsDuplicate
+	r.bytesDuplicate = from.bytesDuplicate
 	r.headerBytesDuplicate = from.headerBytesDuplicate
 
 	r.packetsPadding = from.packetsPadding
@@ -212,13 +215,6 @@ func (r *rtpStatsBase) seed(from *rtpStatsBase) bool {
 
 	r.jitter = from.jitter
 	r.maxJitter = from.maxJitter
-
-	r.nackAcks = from.nackAcks
-	r.nackMisses = from.nackMisses
-	r.nackRepeated = from.nackRepeated
-
-	r.plis = from.plis
-	r.lastPli = from.lastPli
 
 	r.firs = from.firs
 	r.lastFir = from.lastFir

--- a/pkg/sfu/rtpstats/rtpstats_base_lite.go
+++ b/pkg/sfu/rtpstats/rtpstats_base_lite.go
@@ -125,6 +125,12 @@ func (r *rtpStatsBaseLite) seed(from *rtpStatsBaseLite) bool {
 	r.gapHistogram = from.gapHistogram
 
 	r.nacks = from.nacks
+	r.nackAcks = from.nackAcks
+	r.nackMisses = from.nackMisses
+	r.nackRepeated = from.nackRepeated
+
+	r.plis = from.plis
+	r.lastPli = from.lastPli
 
 	r.nextSnapshotLiteID = from.nextSnapshotLiteID
 	r.snapshotLites = make([]snapshotLite, cap(from.snapshotLites))

--- a/pkg/sfu/rtpstats/rtpstats_sender.go
+++ b/pkg/sfu/rtpstats/rtpstats_sender.go
@@ -203,12 +203,12 @@ func (r *RTPStatsSender) Seed(from *RTPStatsSender) {
 
 	r.snInfos = from.snInfos
 
+	r.layerLockPlis = from.layerLockPlis
+	r.lastLayerLockPli = from.lastLayerLockPli
+
 	r.nextSenderSnapshotID = from.nextSenderSnapshotID
 	r.senderSnapshots = make([]senderSnapshot, cap(from.senderSnapshots))
 	copy(r.senderSnapshots, from.senderSnapshots)
-
-	r.layerLockPlis = from.layerLockPlis
-	r.lastLayerLockPli = from.lastLayerLockPli
 }
 
 func (r *RTPStatsSender) NewSnapshotId() uint32 {


### PR DESCRIPTION
Had missed this before. This could have cause retransmit packets/bytes to be high.