### PR TITLE
chore: add check to skip launching TrackEgress for Egress participants

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -1222,7 +1222,7 @@ func (r *Room) onTrackPublished(participant types.LocalParticipant, track types.
 			}()
 		}
 	}
-	if r.internal != nil && r.internal.TrackEgress != nil {
+	if participant.Kind() != livekit.ParticipantInfo_EGRESS && r.internal != nil && r.internal.TrackEgress != nil {
 		go func() {
 			if err := StartTrackEgress(
 				context.Background(),


### PR DESCRIPTION
Egress participants don't publish, so there is no functionality change