### PR TITLE
Log ICE connection info on failure.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1334,7 +1334,7 @@ type AnyTransportHandler struct {
 	p *ParticipantImpl
 }
 
-func (h AnyTransportHandler) OnFailed(isShortLived bool) {
+func (h AnyTransportHandler) OnFailed(_isShortLived bool, _ici *types.ICEConnectionInfo) {
 	h.p.onAnyTransportFailed()
 }
 

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net"
 	"slices"
 	"sort"
 	"strings"
@@ -54,6 +55,8 @@ const (
 	dataForwardLoadBalanceThreshold = 20
 
 	simulateDisconnectSignalTimeout = 5 * time.Second
+
+	minIPTruncateLen = 8
 )
 
 var (
@@ -1837,7 +1840,28 @@ func connectionDetailsFields(infos []*types.ICEConnectionInfo) []interface{} {
 			if c.Trickle {
 				cStr += "[trickle]"
 			}
-			cStr += " " + c.Remote.String()
+			remoteAddress := c.Remote.Address()
+			ipAddr := net.ParseIP(remoteAddress)
+			isPrivate := false
+			if ipAddr != nil {
+				isPrivate = ipAddr.IsPrivate()
+			}
+			if !isPrivate && len(remoteAddress) > minIPTruncateLen {
+				remoteAddress = remoteAddress[:len(remoteAddress)-3] + "..."
+			}
+			cStr += " " + fmt.Sprintf("%s %s %s:%d", c.Remote.NetworkType(), c.Remote.Type(), c.Remote.Address(), c.Remote.Port())
+			if relatedAddress := c.Remote.RelatedAddress(); relatedAddress != nil {
+				ipAddr = net.ParseIP(relatedAddress.Address)
+				if ipAddr != nil {
+					isPrivate = ipAddr.IsPrivate()
+				}
+
+				relatedAddressAddress := relatedAddress.Address
+				if !isPrivate && len(relatedAddressAddress) > minIPTruncateLen {
+					relatedAddressAddress = relatedAddressAddress[:len(relatedAddressAddress)-3] + "..."
+				}
+				cStr += " " + fmt.Sprintf(" related %s:%d", relatedAddressAddress, relatedAddress.Port)
+			}
 			candidates = append(candidates, cStr)
 		}
 		if len(candidates) > 0 {

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -640,7 +640,7 @@ func (t *PCTransport) handleConnectionFailed(forceShortConn bool) {
 		}
 	}
 
-	t.params.Handler.OnFailed(isShort)
+	t.params.Handler.OnFailed(isShort, t.GetICEConnectionInfo())
 }
 
 func (t *PCTransport) onICEConnectionStateChange(state webrtc.ICEConnectionState) {

--- a/pkg/rtc/transport/handler.go
+++ b/pkg/rtc/transport/handler.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pion/webrtc/v3"
 
+	"github.com/livekit/livekit-server/pkg/rtc/types"
 	"github.com/livekit/livekit-server/pkg/sfu/streamallocator"
 	"github.com/livekit/protocol/livekit"
 )
@@ -36,7 +37,7 @@ type Handler interface {
 	OnICECandidate(c *webrtc.ICECandidate, target livekit.SignalTarget) error
 	OnInitialConnected()
 	OnFullyEstablished()
-	OnFailed(isShortLived bool)
+	OnFailed(isShortLived bool, iceConnectionInfo *types.ICEConnectionInfo)
 	OnTrack(track *webrtc.TrackRemote, rtpReceiver *webrtc.RTPReceiver)
 	OnDataPacket(kind livekit.DataPacket_Kind, data []byte)
 	OnDataSendError(err error)

--- a/pkg/rtc/transport/transportfakes/fake_handler.go
+++ b/pkg/rtc/transport/transportfakes/fake_handler.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/livekit/livekit-server/pkg/rtc/transport"
+	"github.com/livekit/livekit-server/pkg/rtc/types"
 	"github.com/livekit/livekit-server/pkg/sfu/streamallocator"
 	"github.com/livekit/protocol/livekit"
 	webrtc "github.com/pion/webrtc/v3"
@@ -33,10 +34,11 @@ type FakeHandler struct {
 	onDataSendErrorArgsForCall []struct {
 		arg1 error
 	}
-	OnFailedStub        func(bool)
+	OnFailedStub        func(bool, *types.ICEConnectionInfo)
 	onFailedMutex       sync.RWMutex
 	onFailedArgsForCall []struct {
 		arg1 bool
+		arg2 *types.ICEConnectionInfo
 	}
 	OnFullyEstablishedStub        func()
 	onFullyEstablishedMutex       sync.RWMutex
@@ -230,16 +232,17 @@ func (fake *FakeHandler) OnDataSendErrorArgsForCall(i int) error {
 	return argsForCall.arg1
 }
 
-func (fake *FakeHandler) OnFailed(arg1 bool) {
+func (fake *FakeHandler) OnFailed(arg1 bool, arg2 *types.ICEConnectionInfo) {
 	fake.onFailedMutex.Lock()
 	fake.onFailedArgsForCall = append(fake.onFailedArgsForCall, struct {
 		arg1 bool
-	}{arg1})
+		arg2 *types.ICEConnectionInfo
+	}{arg1, arg2})
 	stub := fake.OnFailedStub
-	fake.recordInvocation("OnFailed", []interface{}{arg1})
+	fake.recordInvocation("OnFailed", []interface{}{arg1, arg2})
 	fake.onFailedMutex.Unlock()
 	if stub != nil {
-		fake.OnFailedStub(arg1)
+		fake.OnFailedStub(arg1, arg2)
 	}
 }
 
@@ -249,17 +252,17 @@ func (fake *FakeHandler) OnFailedCallCount() int {
 	return len(fake.onFailedArgsForCall)
 }
 
-func (fake *FakeHandler) OnFailedCalls(stub func(bool)) {
+func (fake *FakeHandler) OnFailedCalls(stub func(bool, *types.ICEConnectionInfo)) {
 	fake.onFailedMutex.Lock()
 	defer fake.onFailedMutex.Unlock()
 	fake.OnFailedStub = stub
 }
 
-func (fake *FakeHandler) OnFailedArgsForCall(i int) bool {
+func (fake *FakeHandler) OnFailedArgsForCall(i int) (bool, *types.ICEConnectionInfo) {
 	fake.onFailedMutex.RLock()
 	defer fake.onFailedMutex.RUnlock()
 	argsForCall := fake.onFailedArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeHandler) OnFullyEstablished() {


### PR DESCRIPTION
- Truncate public remote IP
- Log only on short connection to avoid logging too much