### PR TITLE
Fix cloud-media panic: runtime error: slice bounds out of range [:-1]

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -150,10 +150,19 @@ func (w wrappedICECandidatePairLogger) MarshalLogObject(e zapcore.ObjectEncoder)
 	if w.pair.Remote != nil {
 		e.AddString("remoteProtocol", w.pair.Remote.Protocol.String())
 		e.AddString("remoteCandidateType", w.pair.Remote.Typ.String())
-		e.AddString("remoteAdddress", w.pair.Remote.Address[:len(w.pair.Remote.Address)-3]+"...")
+
+		remoteAdddress := w.pair.Remote.Address
+		if l := len(remoteAdddress); l > 3 {
+			remoteAdddress = remoteAdddress[:l-3] + "..."
+		}
+		e.AddString("remoteAdddress", remoteAdddress)
 		e.AddUint16("remotePort", w.pair.Remote.Port)
 		if w.pair.Remote.RelatedAddress != "" {
-			e.AddString("relatedAdddress", w.pair.Remote.RelatedAddress[:len(w.pair.Remote.RelatedAddress)-3]+"...")
+			relatedAdddress := w.pair.Remote.RelatedAddress
+			if l := len(relatedAdddress); l > 3 {
+				relatedAdddress = relatedAdddress[:l-3] + "..."
+			}
+			e.AddString("relatedAdddress", relatedAdddress)
 			e.AddUint16("relatedPort", w.pair.Remote.RelatedPort)
 		}
 	}


### PR DESCRIPTION
This PR tries to fix recent panic on production (fra):
```                                                                                                                                                                                                                                         
cloud-media goroutine 1123224 [running]:                                                                                                                                                                                                                                                                     
cloud-media github.com/livekit/livekit-server/pkg/rtc.wrappedICECandidatePairLogger.MarshalLogObject({0xc0741cc000?}, {0x2af01e0, 0xc00948e480})                                                                                                                                                             
cloud-media     /go/pkg/mod/github.com/livekit/livekit-server@v1.8.1-0.20241025132723-49b75e94a6dd/pkg/rtc/transport.go:156 +0x417                                                                                                                                                                           
cloud-media go.uber.org/zap/zapcore.(*jsonEncoder).AppendObject(0xc00948e480, {0x7f9fe202ad58, 0xc006fe94e0})                                                                                                                                                                                                
cloud-media     /go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/json_encoder.go:225 +0x25a                                                                                                                                                                                                                       
...
```