### PR TITLE
Clean up drop ICE candidates.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -158,7 +158,6 @@ type ParticipantParams struct {
 	ForwardStats                   *sfu.ForwardStats
 	DisableSenderReportPassThrough bool
 	MetricConfig                   metric.MetricConfig
-	DropRemoteICECandidates        bool
 }
 
 type ParticipantImpl struct {
@@ -1449,7 +1448,6 @@ func (p *ParticipantImpl) setupTransportManager() error {
 		PublisherHandler:             pth,
 		SubscriberHandler:            sth,
 		DataChannelStats:             p.dataChannelStats,
-		DropRemoteICECandidates:      p.params.DropRemoteICECandidates,
 	}
 	if p.params.SyncStreams && p.params.PlayoutDelay.GetEnabled() && p.params.ClientInfo.isFirefox() {
 		// we will disable playout delay for Firefox if the user is expecting

--- a/pkg/rtc/transportmanager.go
+++ b/pkg/rtc/transportmanager.go
@@ -103,7 +103,6 @@ type TransportManagerParams struct {
 	PublisherHandler             transport.Handler
 	SubscriberHandler            transport.Handler
 	DataChannelStats             *telemetry.BytesTrackStats
-	DropRemoteICECandidates      bool
 }
 
 type TransportManager struct {
@@ -158,7 +157,6 @@ func NewTransportManager(params TransportManagerParams) (*TransportManager, erro
 		ClientInfo:              params.ClientInfo,
 		Transport:               livekit.SignalTarget_PUBLISHER,
 		Handler:                 TransportManagerPublisherTransportHandler{TransportManagerTransportHandler{params.PublisherHandler, t, lgr}},
-		DropRemoteICECandidates: params.DropRemoteICECandidates,
 	})
 	if err != nil {
 		return nil, err
@@ -182,7 +180,6 @@ func NewTransportManager(params TransportManagerParams) (*TransportManager, erro
 		DataChannelMaxBufferedAmount: params.DataChannelMaxBufferedAmount,
 		Transport:                    livekit.SignalTarget_SUBSCRIBER,
 		Handler:                      TransportManagerTransportHandler{params.SubscriberHandler, t, lgr},
-		DropRemoteICECandidates:      params.DropRemoteICECandidates,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
With pion/ice v2.3.37, ICE Lite will accept use-candidate from peer. So, there is no need to drop candidates.

Still leaving the FF change to not use Lite which was added as part of this effort initially due to how FF does nominations. Updated comment to explain why.