### PR TITLE
Some misc clean up.

### DIFF
--- a/pkg/routing/roommanager.go
+++ b/pkg/routing/roommanager.go
@@ -24,6 +24,8 @@ import (
 	"github.com/livekit/psrpc/pkg/middleware"
 )
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 //counterfeiter:generate . RoomManagerClient
 type RoomManagerClient interface {
 	rpc.TypedRoomManagerClient

--- a/pkg/routing/roommanager.go
+++ b/pkg/routing/roommanager.go
@@ -24,8 +24,6 @@ import (
 	"github.com/livekit/psrpc/pkg/middleware"
 )
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
-
 //counterfeiter:generate . RoomManagerClient
 type RoomManagerClient interface {
 	rpc.TypedRoomManagerClient

--- a/pkg/routing/signal.go
+++ b/pkg/routing/signal.go
@@ -36,8 +36,6 @@ import (
 var ErrSignalWriteFailed = errors.New("signal write failed")
 var ErrSignalMessageDropped = errors.New("signal message dropped")
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
-
 //counterfeiter:generate . SignalClient
 type SignalClient interface {
 	ActiveCount() int

--- a/pkg/routing/signal.go
+++ b/pkg/routing/signal.go
@@ -36,6 +36,8 @@ import (
 var ErrSignalWriteFailed = errors.New("signal write failed")
 var ErrSignalMessageDropped = errors.New("signal message dropped")
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 //counterfeiter:generate . SignalClient
 type SignalClient interface {
 	ActiveCount() int

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1095,10 +1095,12 @@ func (p *ParticipantImpl) MaybeStartMigration(force bool, onStart func()) bool {
 func (p *ParticipantImpl) NotifyMigration() {
 	p.lock.Lock()
 	defer p.lock.Unlock()
+
 	if p.migrationTimer != nil {
 		// already set up
 		return
 	}
+
 	p.setupMigrationTimerLocked()
 }
 

--- a/pkg/service/clients.go
+++ b/pkg/service/clients.go
@@ -27,6 +27,8 @@ import (
 	"github.com/livekit/protocol/utils/guid"
 )
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 //counterfeiter:generate . IOClient
 type IOClient interface {
 	CreateEgress(ctx context.Context, info *livekit.EgressInfo) (*emptypb.Empty, error)

--- a/pkg/service/clients.go
+++ b/pkg/service/clients.go
@@ -27,8 +27,6 @@ import (
 	"github.com/livekit/protocol/utils/guid"
 )
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
-
 //counterfeiter:generate . IOClient
 type IOClient interface {
 	CreateEgress(ctx context.Context, info *livekit.EgressInfo) (*emptypb.Empty, error)

--- a/pkg/service/signal.go
+++ b/pkg/service/signal.go
@@ -31,6 +31,8 @@ import (
 	"github.com/livekit/psrpc/pkg/middleware"
 )
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 //counterfeiter:generate . SessionHandler
 type SessionHandler interface {
 	Logger(ctx context.Context) logger.Logger

--- a/pkg/service/signal.go
+++ b/pkg/service/signal.go
@@ -31,8 +31,6 @@ import (
 	"github.com/livekit/psrpc/pkg/middleware"
 )
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
-
 //counterfeiter:generate . SessionHandler
 type SessionHandler interface {
 	Logger(ctx context.Context) logger.Logger

--- a/pkg/telemetry/analyticsservice.go
+++ b/pkg/telemetry/analyticsservice.go
@@ -29,7 +29,7 @@ import (
 	"github.com/livekit/livekit-server/pkg/routing"
 )
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . AnalyticsService
+//counterfeiter:generate . AnalyticsService
 type AnalyticsService interface {
 	SendStats(ctx context.Context, stats []*livekit.AnalyticsStat)
 	SendEvent(ctx context.Context, events *livekit.AnalyticsEvent)

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -26,7 +26,9 @@ import (
 	"github.com/livekit/protocol/webhook"
 )
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . TelemetryService
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+//counterfeiter:generate . TelemetryService
 type TelemetryService interface {
 	// TrackStats is called periodically for each track in both directions (published/subscribed)
 	TrackStats(key StatsKey, stat *livekit.AnalyticsStat)


### PR DESCRIPTION
- Have been seeing counterfeiter warnings about efficiency for a while with go:generate declaration multiple times in the same package. Address that: https://github.com/maxbrunsfeld/counterfeiter?tab=readme-ov-file#step-2b---add-counterfeitergenerate-directives
- A bit more readability on parameters passed to `sendLeave`