### PR TITLE
Loss based congestion signal detector.

### DIFF
--- a/pkg/sfu/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/sendsidebwe/congestion_detector.go
@@ -284,7 +284,6 @@ func (c *congestionDetector) isCongestionSignalTriggered() (bool, string, bool, 
 	congestedTriggered := false
 	congestedReason := ""
 
-	// RAJA-TODO, maybe send in contributing groups so that details of those can be logged
 	qd := &congestionSignalCalculator[int64]{
 		thresholdMin: c.params.Config.JQRMinDelay.Microseconds(),
 		thresholdMax: c.params.Config.DQRMaxDelay.Microseconds(),

--- a/pkg/sfu/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/sendsidebwe/congestion_detector.go
@@ -302,7 +302,7 @@ func (c *congestionDetector) isCongestionSignalTriggered() (bool, string, bool, 
 			continue
 		}
 
-		// `queueing delay` and `loss` based congestion signals are determined indepdently,
+		// `queueing delay` and `loss` based congestion signals are determined independently,
 		// i. e. one packet group triggering `queueing delay` and another group triggering
 		// `loss` will not combine to trigger the aggregate congestion signal
 		sendDuration := pg.SendDuration()

--- a/pkg/sfu/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/sendsidebwe/congestion_detector.go
@@ -20,16 +20,54 @@ type CongestionSignalConfig struct {
 }
 
 var (
-	DefaultEarlyWarningCongestionSignalConfig = CongestionSignalConfig{
+	DefaultQueuingDelayEarlyWarningCongestionSignalConfig = CongestionSignalConfig{
 		MinNumberOfGroups: 1,
 		MinDuration:       100 * time.Millisecond,
 	}
 
-	DefaultCongestedCongestionSignalConfig = CongestionSignalConfig{
+	DefaultLossEarlyWarningCongestionSignalConfig = CongestionSignalConfig{
+		MinNumberOfGroups: 2,
+		MinDuration:       200 * time.Millisecond,
+	}
+
+	DefaultQueuingDelayCongestedCongestionSignalConfig = CongestionSignalConfig{
 		MinNumberOfGroups: 3,
 		MinDuration:       300 * time.Millisecond,
 	}
+
+	DefaultLossCongestedCongestionSignalConfig = CongestionSignalConfig{
+		MinNumberOfGroups: 5,
+		MinDuration:       600 * time.Millisecond,
+	}
 )
+
+// -------------------------------------------------------------------------------
+
+type congestionSignalCalculator[T int64 | float64] struct {
+	thresholdMin T
+	thresholdMax T
+	isSealed     bool
+	numGroups    int
+	duration     int64
+}
+
+func (c *congestionSignalCalculator[T]) processSample(val T, duration int64) {
+	if c.isSealed {
+		return
+	}
+
+	if val < c.thresholdMin {
+		c.isSealed = true
+		return
+	}
+
+	c.numGroups++
+	c.duration += duration
+}
+
+func (c *congestionSignalCalculator[T]) isTriggered(config CongestionSignalConfig) bool {
+	return c.numGroups >= config.MinNumberOfGroups && c.duration >= config.MinDuration.Microseconds()
+}
 
 // -------------------------------------------------------------------------------
 
@@ -40,10 +78,16 @@ type CongestionDetectorConfig struct {
 	JQRMinDelay time.Duration `yaml:"jqr_min_delay,omitempty"`
 	DQRMaxDelay time.Duration `yaml:"dqr_max_delay,omitempty"`
 
-	EarlyWarning         CongestionSignalConfig `yaml:"early_warning,omitempty"`
-	EarlyWarningHangover time.Duration          `yaml:"early_warning_hangover,omitempty"`
-	Congested            CongestionSignalConfig `yaml:"congested,omitempty"`
-	CongestedHangover    time.Duration          `yaml:"congested_hangover,omitempty"`
+	JQRMinLoss float64 `yaml:"jqr_min_loss,omitempty"`
+	DQRMaxLoss float64 `yaml:"dqr_max_loss,omitempty"`
+
+	QueuingDelayEarlyWarning CongestionSignalConfig `yaml:"queuing_delay_early_warning,omitempty"`
+	LossEarlyWarning         CongestionSignalConfig `yaml:"loss_early_warning,omitempty"`
+	EarlyWarningHangover     time.Duration          `yaml:"early_warning_hangover,omitempty"`
+
+	QueuingDelayCongested CongestionSignalConfig `yaml:"queuing_delay_congested,omitempty"`
+	LossCongested         CongestionSignalConfig `yaml:"loss_congested,omitempty"`
+	CongestedHangover     time.Duration          `yaml:"congested_hangover,omitempty"`
 
 	RateMeasurementWindowFullnessMin float64       `yaml:"rate_measurement_window_fullness_min,omitempty"`
 	RateMeasurementWindowDurationMin time.Duration `yaml:"rate_measurement_window_duration_min,omitempty"`
@@ -70,9 +114,13 @@ var (
 		PacketGroupMaxAge:                30 * time.Second,
 		JQRMinDelay:                      15 * time.Millisecond,
 		DQRMaxDelay:                      5 * time.Millisecond,
-		EarlyWarning:                     DefaultEarlyWarningCongestionSignalConfig,
+		JQRMinLoss:                       0.15,
+		DQRMaxLoss:                       0.05,
+		QueuingDelayEarlyWarning:         DefaultQueuingDelayEarlyWarningCongestionSignalConfig,
+		LossEarlyWarning:                 DefaultLossEarlyWarningCongestionSignalConfig,
 		EarlyWarningHangover:             500 * time.Millisecond,
-		Congested:                        DefaultCongestedCongestionSignalConfig,
+		QueuingDelayCongested:            DefaultQueuingDelayCongestedCongestionSignalConfig,
+		LossCongested:                    DefaultLossCongestedCongestionSignalConfig,
 		CongestedHangover:                3 * time.Second,
 		RateMeasurementWindowFullnessMin: 0.8,
 		RateMeasurementWindowDurationMin: 800 * time.Millisecond,
@@ -151,12 +199,14 @@ func (c *congestionDetector) GetCongestionState() CongestionState {
 	return c.congestionState
 }
 
-func (c *congestionDetector) updateCongestionState(state CongestionState) {
+func (c *congestionDetector) updateCongestionState(state CongestionState, reason string, oldestContributingGroup int) {
 	c.lock.Lock()
 	c.params.Logger.Infow(
 		"congestion state change",
 		"from", c.congestionState,
 		"to", state,
+		"reason", reason,
+		"contributingGroups", logger.ObjectSlice(c.packetGroups[oldestContributingGroup:]),
 		"estimatedAvailableChannelCapacity", c.estimatedAvailableChannelCapacity,
 	)
 
@@ -221,51 +271,80 @@ func (c *congestionDetector) prunePacketGroups() {
 	}
 }
 
-func (c *congestionDetector) isCongestionSignalTriggered() (bool, bool) {
+func (c *congestionDetector) isCongestionSignalTriggered() (bool, string, bool, string, int) {
 	earlyWarningTriggered := false
-	congestedTriggered := false
+	earlyWarningReason := ""
 
-	numGroups := 0
-	duration := int64(0)
-	for idx := len(c.packetGroups) - 1; idx >= 0; idx-- {
+	congestedTriggered := false
+	congestedReason := ""
+
+	// RAJA-TODO, maybe send in contributing groups so that details of those can be logged
+	qd := &congestionSignalCalculator[int64]{
+		thresholdMin: c.params.Config.JQRMinDelay.Microseconds(),
+		thresholdMax: c.params.Config.DQRMaxDelay.Microseconds(),
+	}
+	loss := &congestionSignalCalculator[float64]{
+		thresholdMin: c.params.Config.JQRMinLoss,
+		thresholdMax: c.params.Config.DQRMaxLoss,
+	}
+
+	var idx int
+	for idx = len(c.packetGroups) - 1; idx >= 0; idx-- {
 		pg := c.packetGroups[idx]
-		pqd, ok := pg.PropagatedQueuingDelay()
-		if !ok {
+		pqd, pqdOk := pg.PropagatedQueuingDelay()
+		lr, lrOk := pg.LossRatio()
+		if !pqdOk && !lrOk {
 			continue
 		}
 
-		if pqd > c.params.Config.JQRMinDelay.Microseconds() {
-			// JQR group builds up congestion signal
-			numGroups++
-			duration += pg.SendDuration()
-		}
-
+		// `queueing delay` and `loss` based congestion signals are determined indepdently,
+		// i. e. one packet group triggering `queueing delay` and another group triggering
+		// `loss` will not combine to trigger the aggregate congestion signal
+		//
+		// JQR group builds up congestion signal
 		// INDETERMINATE group is treated as a no-op
+		// any DQR group breaks the continuity
 
-		if pqd < c.params.Config.DQRMaxDelay.Microseconds() {
-			// any DQR group breaks the continuity
-			return earlyWarningTriggered, congestedTriggered
+		sendDuration := pg.SendDuration()
+		if pqdOk {
+			qd.processSample(pqd, sendDuration)
+		}
+		if lrOk {
+			loss.processSample(lr, sendDuration)
 		}
 
-		if numGroups >= c.params.Config.EarlyWarning.MinNumberOfGroups && duration >= c.params.Config.EarlyWarning.MinDuration.Microseconds() {
+		if !earlyWarningTriggered && qd.isTriggered(c.params.Config.QueuingDelayEarlyWarning) {
 			earlyWarningTriggered = true
+			earlyWarningReason = "queuing-delay"
 		}
-		if numGroups >= c.params.Config.Congested.MinNumberOfGroups && duration >= c.params.Config.Congested.MinDuration.Microseconds() {
+		if !earlyWarningTriggered && loss.isTriggered(c.params.Config.LossEarlyWarning) {
+			earlyWarningTriggered = true
+			earlyWarningReason = "loss"
+		}
+
+		if !congestedTriggered && qd.isTriggered(c.params.Config.QueuingDelayCongested) {
 			congestedTriggered = true
+			congestedReason = "queuing-delay"
 		}
+		if !congestedTriggered && loss.isTriggered(c.params.Config.LossCongested) {
+			congestedTriggered = true
+			congestedReason = "loss"
+		}
+
 		if earlyWarningTriggered && congestedTriggered {
 			break
 		}
 	}
 
-	return earlyWarningTriggered, congestedTriggered
+	return earlyWarningTriggered, earlyWarningReason, congestedTriggered, congestedReason, idx
 }
 
 func (c *congestionDetector) congestionDetectionStateMachine() {
 	state := c.GetCongestionState()
 	newState := state
+	reason := ""
 
-	earlyWarningTriggered, congestedTriggered := c.isCongestionSignalTriggered()
+	earlyWarningTriggered, earlyWarningReason, congestedTriggered, congestedReason, oldestContributingGroup := c.isCongestionSignalTriggered()
 
 	switch state {
 	case CongestionStateNone:
@@ -274,11 +353,13 @@ func (c *congestionDetector) congestionDetectionStateMachine() {
 		}
 		if earlyWarningTriggered {
 			newState = CongestionStateEarlyWarning
+			reason = earlyWarningReason
 		}
 
 	case CongestionStateEarlyWarning:
 		if congestedTriggered {
 			newState = CongestionStateCongested
+			reason = congestedReason
 		} else if !earlyWarningTriggered {
 			newState = CongestionStateEarlyWarningHangover
 		}
@@ -289,6 +370,7 @@ func (c *congestionDetector) congestionDetectionStateMachine() {
 		}
 		if earlyWarningTriggered {
 			newState = CongestionStateEarlyWarning
+			reason = earlyWarningReason
 		} else if time.Since(c.congestionStateSwitchedAt) >= c.params.Config.EarlyWarningHangover {
 			newState = CongestionStateNone
 		}
@@ -304,6 +386,7 @@ func (c *congestionDetector) congestionDetectionStateMachine() {
 		}
 		if earlyWarningTriggered {
 			newState = CongestionStateEarlyWarning
+			reason = earlyWarningReason
 		} else if time.Since(c.congestionStateSwitchedAt) >= c.params.Config.CongestedHangover {
 			newState = CongestionStateNone
 		}
@@ -314,7 +397,7 @@ func (c *congestionDetector) congestionDetectionStateMachine() {
 	// update after running the above estimate as state change callback includes the estimated available channel capacity
 	if newState != state {
 		c.congestionStateSwitchedAt = mono.Now()
-		c.updateCongestionState(newState)
+		c.updateCongestionState(newState, reason, oldestContributingGroup)
 	}
 }
 


### PR DESCRIPTION
It uses the same approach of thresholding + duration to detect region of operation and further derive early warning/congested states. A gutter is used for indeterminate region just like the queuing delay based case.

The two approaches (queuing delay and loss) are treated independently, i. e. packet groups have to satify the same type of condition (queuing delay OR loss) to build up congestion.

The aggregate congestion signal is triggered if either one triggers.

Maybe, there is a way to accept hybrid signalling (i. e. each group satisfying either threhsold adds up to congestion signal detection), but needs more experimentation. For now, keeping them separate.