### PR TITLE
Use weighted loss to detect loss based congesiton signal.

### DIFF
--- a/pkg/sfu/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/sendsidebwe/congestion_detector.go
@@ -120,7 +120,7 @@ var (
 		PacketGroupMaxAge:                30 * time.Second,
 		JQRMinDelay:                      15 * time.Millisecond,
 		DQRMaxDelay:                      5 * time.Millisecond,
-		JQRMinLoss:                       0.15,
+		JQRMinLoss:                       0.25,
 		DQRMaxLoss:                       0.05,
 		QueuingDelayEarlyWarning:         DefaultQueuingDelayEarlyWarningCongestionSignalConfig,
 		LossEarlyWarning:                 DefaultLossEarlyWarningCongestionSignalConfig,
@@ -297,8 +297,8 @@ func (c *congestionDetector) isCongestionSignalTriggered() (bool, string, bool, 
 	for idx = len(c.packetGroups) - 1; idx >= 0; idx-- {
 		pg := c.packetGroups[idx]
 		pqd, pqdOk := pg.PropagatedQueuingDelay()
-		lr, lrOk := pg.LossRatio()
-		if !pqdOk && !lrOk {
+		wlr, wlrOk := pg.WeightedLossRatio()
+		if !pqdOk && !wlrOk {
 			continue
 		}
 
@@ -309,8 +309,8 @@ func (c *congestionDetector) isCongestionSignalTriggered() (bool, string, bool, 
 		if pqdOk {
 			qd.processSample(pqd, sendDuration)
 		}
-		if lrOk {
-			loss.processSample(lr, sendDuration)
+		if wlrOk {
+			loss.processSample(wlr, sendDuration)
 		}
 
 		if !earlyWarningTriggered && qd.isTriggered(c.params.Config.QueuingDelayEarlyWarning) {

--- a/pkg/sfu/sendsidebwe/packet_info.go
+++ b/pkg/sfu/sendsidebwe/packet_info.go
@@ -1,3 +1,17 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sendsidebwe
 
 import (

--- a/pkg/sfu/sendsidebwe/packet_tracker.go
+++ b/pkg/sfu/sendsidebwe/packet_tracker.go
@@ -1,3 +1,17 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sendsidebwe
 
 import (

--- a/pkg/sfu/sendsidebwe/packet_tracker.go
+++ b/pkg/sfu/sendsidebwe/packet_tracker.go
@@ -84,6 +84,13 @@ func (p *packetTracker) RecordPacketSendAndGetSequenceNumber(at time.Time, size 
 	return uint16(pi.sequenceNumber)
 }
 
+func (p *packetTracker) BaseSendTime() int64 {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	return p.baseSendTime
+}
+
 func (p *packetTracker) RecordPacketIndicationFromRemote(sn uint16, recvTime int64) (piRecv packetInfo, sendDelta, recvDelta int64) {
 	p.lock.Lock()
 	defer p.lock.Unlock()

--- a/pkg/sfu/sendsidebwe/send_side_bwe.go
+++ b/pkg/sfu/sendsidebwe/send_side_bwe.go
@@ -1,3 +1,17 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sendsidebwe
 
 import (

--- a/pkg/sfu/sendsidebwe/traffic_stats.go
+++ b/pkg/sfu/sendsidebwe/traffic_stats.go
@@ -1,0 +1,97 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sendsidebwe
+
+import "math"
+
+type trafficStats struct {
+	minSendTime  int64
+	duration     int64
+	queuingDelay int64
+	sendDelta    int64
+	recvDelta    int64
+	ackedPackets int
+	ackedBytes   int
+	lostPackets  int
+}
+
+func newTrafficStats() *trafficStats {
+	return &trafficStats{}
+}
+
+func (ts *trafficStats) Merge(rhs trafficStats) {
+	if rhs.minSendTime == 0 || rhs.minSendTime < ts.minSendTime {
+		ts.minSendTime = rhs.minSendTime
+	}
+	ts.duration += rhs.duration
+	ts.queuingDelay += rhs.queuingDelay
+	ts.sendDelta += rhs.sendDelta
+	ts.recvDelta += rhs.recvDelta
+	ts.ackedPackets += rhs.ackedPackets
+	ts.ackedBytes += rhs.ackedBytes
+	ts.lostPackets += rhs.lostPackets
+}
+
+func (ts *trafficStats) Duration() int64 {
+	return ts.duration
+}
+
+func (ts *trafficStats) PropagatedQueuingDelay() int64 {
+	return ts.queuingDelay + ts.sendDelta - ts.recvDelta
+}
+
+func (ts *trafficStats) AcknowledgedBitrate(minPacketsForLossValidity int, lossPenaltyFactor float64) int64 {
+	ackedBitrate := int64(ts.ackedBytes) * 8 * 1e6 / ts.duration
+	return int64(float64(ackedBitrate) * ts.CapturedTrafficRatio(minPacketsForLossValidity, lossPenaltyFactor))
+}
+
+func (ts *trafficStats) CapturedTrafficRatio(minPacketsForLossValidity int, lossPenaltyFactor float64) float64 {
+	if ts.recvDelta == 0 {
+		return 0.0
+	}
+
+	// apply a penalty for lost packets,
+	// tha rationale being packet dropping is a strategy to relieve congestion
+	// and if they were not dropped, they would have increased queuing delay,
+	// as it is not possible to know the reason for the losses,
+	// apply a small penalty to receive delta aggregate to simulate those packets
+	// building up queuing delay.
+	return min(1.0, float64(ts.sendDelta)/float64(ts.recvDelta+ts.lossPenalty(minPacketsForLossValidity, lossPenaltyFactor)))
+}
+
+func (ts *trafficStats) WeightedLoss(minPacketsForLossValidity int, lossPenaltyFactor float64) float64 {
+	totalPackets := float64(ts.lostPackets + ts.ackedPackets)
+	if int(totalPackets) < minPacketsForLossValidity {
+		return 0.0
+	}
+
+	lossRatio := float64(0.0)
+	if totalPackets != 0 {
+		lossRatio = float64(ts.lostPackets) / totalPackets
+	}
+
+	pps := totalPackets * 1e6 / float64(ts.duration)
+
+	// Log10 is used to give higher weight for the same loss ratio at higher packet rates,
+	// for e.g. with a penalty factor of 0.25
+	//    - 10% loss at 20 pps = 0.1 * log10(20) * 0.25 = 0.032
+	//    - 10% loss at 100 pps = 0.1 * log10(100) * 0.25 = 0.05
+	//    - 10% loss at 1000 pps = 0.1 * log10(1000) * 0.25 = 0.075
+	return lossRatio * math.Log10(pps) * lossPenaltyFactor
+}
+
+func (ts *trafficStats) lossPenalty(minPacketsForLossValidity int, lossPenaltyFactor float64) int64 {
+	return int64(float64(ts.recvDelta) * ts.WeightedLoss(minPacketsForLossValidity, lossPenaltyFactor))
+}

--- a/pkg/sfu/sendsidebwe/traffic_stats.go
+++ b/pkg/sfu/sendsidebwe/traffic_stats.go
@@ -116,11 +116,11 @@ func (ts *trafficStats) WeightedLoss() float64 {
 	//    - 10% loss at 20 pps = 0.1 * log10(20) * 0.25 = 0.032
 	//    - 10% loss at 100 pps = 0.1 * log10(100) * 0.25 = 0.05
 	//    - 10% loss at 1000 pps = 0.1 * log10(1000) * 0.25 = 0.075
-	return lossRatio * math.Log10(pps) * ts.params.Config.LossPenaltyFactor
+	return lossRatio * math.Log10(pps)
 }
 
 func (ts *trafficStats) lossPenalty() int64 {
-	return int64(float64(ts.recvDelta) * ts.WeightedLoss())
+	return int64(float64(ts.recvDelta) * ts.WeightedLoss() * ts.params.Config.LossPenaltyFactor)
 }
 
 func (ts *trafficStats) MarshalLogObject(e zapcore.ObjectEncoder) error {

--- a/pkg/sfu/sendsidebwe/twcc_feedback.go
+++ b/pkg/sfu/sendsidebwe/twcc_feedback.go
@@ -1,3 +1,17 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sendsidebwe
 
 import (


### PR DESCRIPTION
Re-doing the loss based congestion which was initially done in https://github.com/livekit/livekit/pull/3168

Thresholding per group is not great for detecting loss based congestion detection as the groups may be small. So, change it to accumulate over early warning/congested configuration windows and do a threshold comparison on the aggregated stats. This has a single threshold now.

Sorry, the PR looks much larger than it should be as I did some refactoring. The loss penalty inside packet group does not work well as max number of packets is 20. So, introduced the `trafficStats` module and doing merging/aggregation in there. Used for acknowledged bitrate calculation, loss based congestion and captured traffic ratio in congested state. All those places aggregate over a longer window which allows calculating packet rate and applying loss penalty based on higher signal.

Also, added License to the new files.