### PR TITLE
Fix header size calculation in stats.

### DIFF
--- a/pkg/sfu/pacer/leaky_bucket.go
+++ b/pkg/sfu/pacer/leaky_bucket.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/frostbyte73/core"
 	"github.com/gammazero/deque"
 	"github.com/livekit/livekit-server/pkg/sfu/sendsidebwe"
 	"github.com/livekit/protocol/logger"
@@ -32,11 +33,11 @@ type LeakyBucket struct {
 
 	logger logger.Logger
 
-	lock      sync.RWMutex
-	packets   deque.Deque[Packet]
-	interval  time.Duration
-	bitrate   int
-	isStopped bool
+	lock     sync.RWMutex
+	packets  deque.Deque[Packet]
+	interval time.Duration
+	bitrate  int
+	stop     core.Fuse
 }
 
 func NewLeakyBucket(logger logger.Logger, sendSideBWE *sendsidebwe.SendSideBWE, interval time.Duration, bitrate int) *LeakyBucket {
@@ -67,23 +68,17 @@ func (l *LeakyBucket) SetBitrate(bitrate int) {
 }
 
 func (l *LeakyBucket) Stop() {
-	l.lock.Lock()
-	if l.isStopped {
-		l.lock.Unlock()
-		return
-	}
-
-	l.isStopped = true
-	l.lock.Unlock()
+	l.stop.Break()
 }
 
-func (l *LeakyBucket) Enqueue(p Packet) {
-	l.lock.Lock()
-	defer l.lock.Unlock()
+func (l *LeakyBucket) Enqueue(p Packet) (int, int) {
+	headerSize, payloadSize := l.Base.Prepare(&p)
 
-	if !l.isStopped {
-		l.packets.PushBack(p)
-	}
+	l.lock.Lock()
+	l.packets.PushBack(p)
+	l.lock.Unlock()
+
+	return headerSize, payloadSize
 }
 
 func (l *LeakyBucket) sendWorker() {
@@ -121,12 +116,11 @@ func (l *LeakyBucket) sendWorker() {
 		}
 
 		for {
-			l.lock.Lock()
-			if l.isStopped {
-				l.lock.Unlock()
+			if l.stop.IsBroken() {
 				return
 			}
 
+			l.lock.Lock()
 			if l.packets.Len() == 0 {
 				l.lock.Unlock()
 				// allow overshoot in next interval with shortage in this interval

--- a/pkg/sfu/pacer/pacer.go
+++ b/pkg/sfu/pacer/pacer.go
@@ -29,6 +29,7 @@ type ExtensionData struct {
 
 type Packet struct {
 	Header             *rtp.Header
+	HeaderSize         int // calculated and set inside Pacer
 	Extensions         []ExtensionData
 	Payload            []byte
 	IsRTX              bool
@@ -40,7 +41,7 @@ type Packet struct {
 }
 
 type Pacer interface {
-	Enqueue(p Packet)
+	Enqueue(p Packet) (int, int)
 	Stop()
 
 	SetInterval(interval time.Duration)

--- a/pkg/sfu/pacer/pass_through.go
+++ b/pkg/sfu/pacer/pass_through.go
@@ -32,8 +32,10 @@ func NewPassThrough(logger logger.Logger, sendSideBWE *sendsidebwe.SendSideBWE) 
 func (p *PassThrough) Stop() {
 }
 
-func (p *PassThrough) Enqueue(pkt Packet) {
+func (p *PassThrough) Enqueue(pkt Packet) (int, int) {
+	headerSize, payloadSize := p.Base.Prepare(&pkt)
 	p.Base.SendPacket(&pkt)
+	return headerSize, payloadSize
 }
 
 // ------------------------------------------------


### PR DESCRIPTION
With pacer inserting some extensions, the header size used in stats (and more impoetantly when probing for bandwidth estimation and metering the bytes to control the probes) was incorrect. The size was effectively was that of incoming extensions. It would have been close enough though.

Anyhow, a bit of history
- initially was planning on packaging all the necessary fields into pacer packet and pacer would callback after sending, but that was not great for a couple of reasons
  - had to send in a bunch of useless data (as far as pacer is concerned) into pacer.
  - callback every packet (this is not bad, just a function call which happens in the foward path too, but had to lug around the above data).
- in the forward path, there is a very edge case issue when calling stats update after pacer.Enqueue() - details in https://github.com/livekit/livekit/pull/2085, but that is a rare case.

Because of those reasons, the update was placed in the forward path before enqueue, but did not notice the header size issue till now.

As a compromise, `pacer.Enqueue` returns the headerSize and payloadSize. It uses a dummy header to calculate size. Real extension will be added just before sending packet on the wire. pion/rtp replaces extension if one is already present. So, the dummy would be replaced by the real one before sending on the wire.
https://github.com/pion/rtp/blob/a21194ecfb5362261a0dc4af1f68e4a8944df345/packet.go#L398

This does introduce back the second rare edge case, but that is very rare and even if it happens, not catastrophic.