### PR TITLE
Fix incorrect computation of SecondsSinceNodeStatsUpdate

### DIFF
--- a/pkg/routing/node.go
+++ b/pkg/routing/node.go
@@ -157,5 +157,5 @@ func (l *LocalNodeImpl) SecondsSinceNodeStatsUpdate() float64 {
 	l.lock.RLock()
 	defer l.lock.RUnlock()
 
-	return time.Since(time.Unix(0, l.node.Stats.UpdatedAt)).Seconds()
+	return time.Since(time.Unix(l.node.Stats.UpdatedAt, 0)).Seconds()
 }


### PR DESCRIPTION
Stats.UpdatedAt is in seconds, but we were loading as nanosecs