### PR TITLE
Attempt to fix missing participant left webhook.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2392,7 +2392,6 @@ func (p *ParticipantImpl) addMediaTrack(signalCid string, sdpCid string, ti *liv
 			p.supervisor.ClearPublishedTrack(trackID, mt)
 		}
 
-		// not logged when closing
 		p.params.Telemetry.TrackUnpublished(
 			context.Background(),
 			p.ID(),
@@ -2401,7 +2400,6 @@ func (p *ParticipantImpl) addMediaTrack(signalCid string, sdpCid string, ti *liv
 			true,
 		)
 
-		// re-use Track sid
 		p.pendingTracksLock.Lock()
 		if pti := p.pendingTracks[signalCid]; pti != nil {
 			p.sendTrackPublished(signalCid, pti.trackInfos[0])

--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -86,7 +86,6 @@ func (t *telemetryService) ParticipantJoined(
 			livekit.RoomName(room.Name),
 			livekit.ParticipantID(participant.Sid),
 			livekit.ParticipantIdentity(participant.Identity),
-			false,
 		)
 		if !found {
 			prometheus.IncrementParticipantRtcConnected(1)
@@ -125,7 +124,6 @@ func (t *telemetryService) ParticipantActive(
 			livekit.RoomName(room.Name),
 			livekit.ParticipantID(participant.Sid),
 			livekit.ParticipantIdentity(participant.Identity),
-			false,
 		)
 		if !found {
 			// need to also account for participant count
@@ -162,7 +160,6 @@ func (t *telemetryService) ParticipantResumed(
 			livekit.RoomName(room.Name),
 			livekit.ParticipantID(participant.Sid),
 			livekit.ParticipantIdentity(participant.Identity),
-			true,
 		)
 		if !found {
 			prometheus.AddParticipant()

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -197,7 +197,6 @@ func (t *telemetryService) getOrCreateWorker(
 	roomName livekit.RoomName,
 	participantID livekit.ParticipantID,
 	participantIdentity livekit.ParticipantIdentity,
-	transferConnectedState bool,
 ) (*StatsWorker, bool) {
 	t.workersMu.Lock()
 	defer t.workersMu.Unlock()
@@ -208,7 +207,7 @@ func (t *telemetryService) getOrCreateWorker(
 	}
 
 	existingIsConnected := false
-	if ok && transferConnectedState {
+	if ok {
 		existingIsConnected = worker.IsConnected()
 	}
 


### PR DESCRIPTION
On a resume, the signal stats will call `ParticipantLeft`. Although, it explicity says not to send events, it could still close the stats worker.

To handle that, we created a stats worker if needed in `ParticipantResume` notification in this PR
(https://github.com/livekit/livekit/pull/2982), but that is not enough as that event could happen before previous signal connection closes the stats worker.

A new stats worker does get created when `ParticipantJoined` is called by the new signal connection, but it does not transfer connected state. So, when the client leaves, `ParticipantLeft` is not sent.

I am not seeing why we should not transfer connected state always given that it is the same participant SID/session. But, I have a feeling that I am missing some corner case. Please let me know if I am missing something here.