### PR TITLE
Set down track connected flag in one-shot-signalling mode.

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -1025,7 +1025,7 @@ func (t *PCTransport) clearConnTimer() {
 
 func (t *PCTransport) HandleRemoteDescription(sd webrtc.SessionDescription) error {
 	if t.params.UseOneShotSignallingMode {
-		// add remove candidates to ICE connection details
+		// add remote candidates to ICE connection details
 		parsed, err := sd.Unmarshal()
 		if err == nil {
 			addRemoteICECandidates := func(attrs []sdp.Attribute) {


### PR DESCRIPTION
Also, added maintaing ICE candidates for info purposes. And doing analytics events (have to maintain the subscription inside subscriptionmanager to get list of subscribed tracks, so added enough bits from the async path into sync path to get the analytics bits also)