### PR TITLE
Sender side snap shot clean up and logging.

### DIFF
--- a/pkg/sfu/rtpstats/rtpstats_sender.go
+++ b/pkg/sfu/rtpstats/rtpstats_sender.go
@@ -572,7 +572,7 @@ func (r *RTPStatsSender) UpdateFromReceiverReport(rr rtcp.ReceptionReport) (rtt 
 
 	r.packetsLostFromRR = uint64(rr.TotalLost)
 	lossDelta := (rr.TotalLost - r.lastRR.TotalLost) & ((1 << 24) - 1)
-	if lossDelta > 0 && lossDelta < (1<<23) && rr.TotalLost < r.lastRR.TotalLost {
+	if lossDelta < (1<<23) && rr.TotalLost < r.lastRR.TotalLost {
 		r.packetsLostFromRR += (1 << 24)
 	}
 


### PR DESCRIPTION
Seeing cases of sender snap shot packet loss much higher the actual packets some times. Tracking a bit more to understand that better.
- Rename variables to indicate what is coming from feed side clearly
- Fixed an issue with wrong init of feed side loss in snapshot
- Just use the loss from receiver report as it can go back (receiver would subtract on receiving out-of-order packet).
- keep track sof reports in a snapshot (this is temporary for debugging/understanding it better and will be removed later)