### PR TITLE
allow configuring non-host PC nominate delay

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -86,6 +86,10 @@ type RTCConfig struct {
 
 	StrictACKs bool `yaml:"strict_acks,omitempty"`
 
+	ICEPrflxAcceptanceWait *time.Duration `yaml:"ice_prflx_acceptance_wait,omitempty"`
+	ICESrflxAcceptanceWait *time.Duration `yaml:"ice_srflx_acceptance_wait,omitempty"`
+	ICERelayAcceptanceWait *time.Duration `yaml:"ice_relay_acceptance_wait,omitempty"`
+
 	// Deprecated: use PacketBufferSizeVideo and PacketBufferSizeAudio
 	PacketBufferSize int `yaml:"packet_buffer_size,omitempty"`
 	// Number of packets to buffer for NACK - video

--- a/pkg/rtc/config.go
+++ b/pkg/rtc/config.go
@@ -70,6 +70,16 @@ func NewWebRTCConfig(conf *config.Config) (*WebRTCConfig, error) {
 	// we don't want to use active TCP on a server, clients should be dialing
 	webRTCConfig.SettingEngine.DisableActiveTCP(true)
 
+	if rtcConf.ICESrflxAcceptanceWait != nil {
+		webRTCConfig.SettingEngine.SetSrflxAcceptanceMinWait(*rtcConf.ICESrflxAcceptanceWait)
+	}
+	if rtcConf.ICEPrflxAcceptanceWait != nil {
+		webRTCConfig.SettingEngine.SetPrflxAcceptanceMinWait(*rtcConf.ICEPrflxAcceptanceWait)
+	}
+	if rtcConf.ICERelayAcceptanceWait != nil {
+		webRTCConfig.SettingEngine.SetRelayAcceptanceMinWait(*rtcConf.ICERelayAcceptanceWait)
+	}
+
 	if rtcConf.PacketBufferSize == 0 {
 		rtcConf.PacketBufferSize = 500
 	}


### PR DESCRIPTION
Currently, when the server is the controlling ice agent, it waits for some time before it accepts srflx or prflx candidates. When using an SFU, it is common for clients to not have a host candidate, and by reducing these values we achieved around 1s reduction in the start session time and calls were established much quicker. I believe it is a good idea to reduce these values to even 0 when running an SFU so that clients without a dedicated public IP (which covers the majority of clients) could connect quickly.