### PR TITLE
Fix prober listener.

### DIFF
--- a/pkg/sfu/ccutils/prober.go
+++ b/pkg/sfu/ccutils/prober.go
@@ -430,6 +430,7 @@ func newCluster(
 	c := &Cluster{
 		id:          id,
 		mode:        mode,
+		listener:    listener,
 		minDuration: minDuration,
 		maxDuration: maxDuration,
 	}


### PR DESCRIPTION
This was stopping active probe and taking longer to recover. Missed in the refactor.