### PR TITLE
Publish data and signal bytes once every 30 seconds.

### DIFF
--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -88,7 +88,7 @@ const (
 	jobsQueueMinSize  = 2048
 
 	telemetryStatsUpdateInterval         = time.Second * 30
-	telemetryNonMediaStatsUpdateInterval = time.Minute * 5
+	telemetryNonMediaStatsUpdateInterval = time.Second * 30
 )
 
 type telemetryService struct {


### PR DESCRIPTION
For applications with heavy data usage, accumulating data bytes over 5 minutes and then calculating rate using a much shorter window (like 2 - 5 seconds) makes it looks like there is a massive rate spike.

While this change is not a fix, this should soften the impact.

Need a better way to handle different parts of the system operating at different frequencies. Can use rate in the reporting window, but that will miss the spikes. Maybe that is okay. For example, if the reporting window is 5 minutes and there was a 100 Mbps spike for about 10 seconds of it, it would get smoothed out.