### PR TITLE
Simplify probe sleep calculations.

### DIFF
--- a/pkg/sfu/ccutils/prober.go
+++ b/pkg/sfu/ccutils/prober.go
@@ -289,6 +289,7 @@ func (p *Prober) run() {
 		sleepDuration := cluster.Process()
 		if sleepDuration == 0 {
 			p.popFrontCluster(cluster)
+			continue
 		}
 
 		ticker.Reset(sleepDuration)


### PR DESCRIPTION
Splitting into buckets made it problematic around the boundaries and it was ugly code too. Simplify and set up probes with sleep after each probe to get the desired interval/rate.