### PR TITLE
Disable close by dtls to fix migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pion/sdp/v3 v3.0.9
 	github.com/pion/transport/v3 v3.0.7
 	github.com/pion/turn/v4 v4.0.0
-	github.com/pion/webrtc/v4 v4.0.4
+	github.com/pion/webrtc/v4 v4.0.5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5
 	github.com/redis/go-redis/v9 v9.7.0

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/pion/transport/v3 v3.0.7 h1:iRbMH05BzSNwhILHoBoAPxoB9xQgOaJk+591KC9P1
 github.com/pion/transport/v3 v3.0.7/go.mod h1:YleKiTZ4vqNxVwh77Z0zytYi7rXHl7j6uPLGhhz9rwo=
 github.com/pion/turn/v4 v4.0.0 h1:qxplo3Rxa9Yg1xXDxxH8xaqcyGUtbHYw4QSCvmFWvhM=
 github.com/pion/turn/v4 v4.0.0/go.mod h1:MuPDkm15nYSklKpN8vWJ9W2M0PlyQZqYt1McGuxG7mA=
-github.com/pion/webrtc/v4 v4.0.4 h1:X+gkoBLKDsR6FliKKQ/VXGBjnMR3yOPcyXEPt3z7Ep0=
-github.com/pion/webrtc/v4 v4.0.4/go.mod h1:LvP8Np5b/sM0uyJIcUPvJcCvhtjHxJwzh2H2PYzE6cQ=
+github.com/pion/webrtc/v4 v4.0.5 h1:8cVPojcv3cQTwVga2vF1rzCNvkiEimnYdCCG7yF317I=
+github.com/pion/webrtc/v4 v4.0.5/go.mod h1:LvP8Np5b/sM0uyJIcUPvJcCvhtjHxJwzh2H2PYzE6cQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1458,10 +1458,6 @@ func (h AnyTransportHandler) OnFailed(_isShortLived bool, _ici *types.ICEConnect
 	h.p.onAnyTransportFailed()
 }
 
-func (h AnyTransportHandler) OnClosed() {
-	h.p.onAnyTransportClosed()
-}
-
 func (h AnyTransportHandler) OnNegotiationFailed() {
 	h.p.onAnyTransportNegotiationFailed()
 }
@@ -2035,10 +2031,6 @@ func (p *ParticipantImpl) onAnyTransportFailed() {
 
 	// detect when participant has actually left.
 	p.setupDisconnectTimer()
-}
-
-func (p *ParticipantImpl) onAnyTransportClosed() {
-	_ = p.Close(false, types.ParticipantCloseReasonPeerConnectionDisconnected, false)
 }
 
 // subscriberRTCPWorker sends SenderReports periodically when the participant is subscribed to

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -285,6 +285,10 @@ func newPeerConnection(params TransportParams, onBandwidthEstimator func(estimat
 	// https://github.com/pion/dtls/pull/474
 	se.SetDTLSEllipticCurves(elliptic.X25519, elliptic.P384, elliptic.P256)
 
+	// Disable close by dtls to avoid peerconnection close too early in migration
+	// https://github.com/pion/webrtc/pull/2961
+	se.DisableCloseByDTLS(true)
+
 	//
 	// Disable SRTP replay protection (https://datatracker.ietf.org/doc/html/rfc3711#page-15).
 	// Needed due to lack of RTX stream support in Pion.
@@ -705,11 +709,6 @@ func (t *PCTransport) onPeerConnectionStateChange(state webrtc.PeerConnectionSta
 	case webrtc.PeerConnectionStateFailed:
 		t.clearConnTimer()
 		t.handleConnectionFailed(false)
-	case webrtc.PeerConnectionStateClosed:
-		// peerconnection closed by client
-		if !t.isClosed.Load() {
-			t.params.Handler.OnClosed()
-		}
 	}
 }
 

--- a/pkg/rtc/transport/handler.go
+++ b/pkg/rtc/transport/handler.go
@@ -38,7 +38,6 @@ type Handler interface {
 	OnInitialConnected()
 	OnFullyEstablished()
 	OnFailed(isShortLived bool, iceConnectionInfo *types.ICEConnectionInfo)
-	OnClosed()
 	OnTrack(track *webrtc.TrackRemote, rtpReceiver *webrtc.RTPReceiver)
 	OnDataPacket(kind livekit.DataPacket_Kind, data []byte)
 	OnDataSendError(err error)

--- a/pkg/rtc/transport/transportfakes/fake_handler.go
+++ b/pkg/rtc/transport/transportfakes/fake_handler.go
@@ -23,10 +23,6 @@ type FakeHandler struct {
 	onAnswerReturnsOnCall map[int]struct {
 		result1 error
 	}
-	OnClosedStub        func()
-	onClosedMutex       sync.RWMutex
-	onClosedArgsForCall []struct {
-	}
 	OnDataPacketStub        func(livekit.DataPacket_Kind, []byte)
 	onDataPacketMutex       sync.RWMutex
 	onDataPacketArgsForCall []struct {
@@ -164,30 +160,6 @@ func (fake *FakeHandler) OnAnswerReturnsOnCall(i int, result1 error) {
 	fake.onAnswerReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
-}
-
-func (fake *FakeHandler) OnClosed() {
-	fake.onClosedMutex.Lock()
-	fake.onClosedArgsForCall = append(fake.onClosedArgsForCall, struct {
-	}{})
-	stub := fake.OnClosedStub
-	fake.recordInvocation("OnClosed", []interface{}{})
-	fake.onClosedMutex.Unlock()
-	if stub != nil {
-		fake.OnClosedStub()
-	}
-}
-
-func (fake *FakeHandler) OnClosedCallCount() int {
-	fake.onClosedMutex.RLock()
-	defer fake.onClosedMutex.RUnlock()
-	return len(fake.onClosedArgsForCall)
-}
-
-func (fake *FakeHandler) OnClosedCalls(stub func()) {
-	fake.onClosedMutex.Lock()
-	defer fake.onClosedMutex.Unlock()
-	fake.OnClosedStub = stub
 }
 
 func (fake *FakeHandler) OnDataPacket(arg1 livekit.DataPacket_Kind, arg2 []byte) {
@@ -619,8 +591,6 @@ func (fake *FakeHandler) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.onAnswerMutex.RLock()
 	defer fake.onAnswerMutex.RUnlock()
-	fake.onClosedMutex.RLock()
-	defer fake.onClosedMutex.RUnlock()
 	fake.onDataPacketMutex.RLock()
 	defer fake.onDataPacketMutex.RUnlock()
 	fake.onDataSendErrorMutex.RLock()


### PR DESCRIPTION
Pion v4 imports new feature that will close
peerconnection on dtls.close to detects
remote peer closed quickly, it breaks the
session migration.