### PR TITLE
Probe controller refactor

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -468,10 +468,11 @@ func NewPCTransport(params TransportParams) (*PCTransport, error) {
 		}
 
 		t.streamAllocator = streamallocator.NewStreamAllocator(streamallocator.StreamAllocatorParams{
-			Config: params.CongestionControlConfig.StreamAllocator,
-			BWE:    t.bwe,
-			Pacer:  t.pacer,
-			Logger: params.Logger.WithComponent(utils.ComponentCongestionControl),
+			Config:    params.CongestionControlConfig.StreamAllocator,
+			BWE:       t.bwe,
+			Pacer:     t.pacer,
+			RTTGetter: t.GetRTT,
+			Logger:    params.Logger.WithComponent(utils.ComponentCongestionControl),
 		}, params.CongestionControlConfig.Enabled, params.CongestionControlConfig.AllowPause)
 		t.streamAllocator.OnStreamStateChange(params.Handler.OnStreamStateChange)
 		t.streamAllocator.Start()

--- a/pkg/sfu/bwe/bwe.go
+++ b/pkg/sfu/bwe/bwe.go
@@ -17,6 +17,7 @@ package bwe
 import (
 	"fmt"
 
+	"github.com/livekit/livekit-server/pkg/sfu/ccutils"
 	"github.com/pion/rtcp"
 )
 
@@ -51,6 +52,7 @@ func (c CongestionState) String() string {
 
 // ------------------------------------------------
 
+// RAJA-TODO: maybe this can be internal to remote_bwe???
 type ChannelTrend int
 
 const (
@@ -94,9 +96,9 @@ type BWE interface {
 
 	HandleTWCCFeedback(report *rtcp.TransportLayerCC)
 
-	ProbingStart(expectedBandwidthUsage int64)
-	ProbingEnd(isNotFailing bool, isGoalReached bool)
-	GetProbeStatus() (isValidSignal bool, trend ChannelTrend, lowestEstimate int64, highestEstimate int64)
+	ProbeClusterStarting(pci ccutils.ProbeClusterInfo)
+	ProbeClusterDone(pci ccutils.ProbeClusterInfo)
+	GetProbeStatus() (isValidSignal bool, trend ChannelTrend, lowestEstimate int64, highestEstimate int64) // RAJA-REMOVE
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/bwe/bwe.go
+++ b/pkg/sfu/bwe/bwe.go
@@ -52,30 +52,6 @@ func (c CongestionState) String() string {
 
 // ------------------------------------------------
 
-// RAJA-TODO: maybe this can be internal to remote_bwe???
-type ChannelTrend int
-
-const (
-	ChannelTrendNeutral ChannelTrend = iota
-	ChannelTrendClearing
-	ChannelTrendCongesting
-)
-
-func (c ChannelTrend) String() string {
-	switch c {
-	case ChannelTrendNeutral:
-		return "NEUTRAL"
-	case ChannelTrendClearing:
-		return "CLEARING"
-	case ChannelTrendCongesting:
-		return "CONGESTING"
-	default:
-		return fmt.Sprintf("%d", int(c))
-	}
-}
-
-// ------------------------------------------------
-
 type BWE interface {
 	SetBWEListener(bweListner BWEListener)
 
@@ -85,7 +61,6 @@ type BWE interface {
 
 	HandleREMB(
 		receivedEstimate int64,
-		isProbeFinalizing bool,
 		expectedBandwidthUsage int64,
 		sentPackets uint32,
 		repeatedNacks uint32,
@@ -97,8 +72,7 @@ type BWE interface {
 	HandleTWCCFeedback(report *rtcp.TransportLayerCC)
 
 	ProbeClusterStarting(pci ccutils.ProbeClusterInfo)
-	ProbeClusterDone(pci ccutils.ProbeClusterInfo)
-	GetProbeStatus() (isValidSignal bool, trend ChannelTrend, lowestEstimate int64, highestEstimate int64) // RAJA-REMOVE
+	ProbeClusterDone(pci ccutils.ProbeClusterInfo) (bool, int64)
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/bwe/null_bwe.go
+++ b/pkg/sfu/bwe/null_bwe.go
@@ -34,7 +34,6 @@ func (n *NullBWE) RecordPacketSendAndGetSequenceNumber(_atMicro int64, _size int
 
 func (n *NullBWE) HandleREMB(
 	_receivedEstimate int64,
-	_isProbeFinalizing bool,
 	_expectedBandwidthUsage int64,
 	_sentPackets uint32,
 	_repeatedNacks uint32,
@@ -45,11 +44,8 @@ func (n *NullBWE) HandleTWCCFeedback(_report *rtcp.TransportLayerCC) {}
 
 func (n *NullBWE) ProbeClusterStarting(_pci ccutils.ProbeClusterInfo) {}
 
-func (n *NullBWE) ProbeClusterDone(_pci ccutils.ProbeClusterInfo) {}
-
-// RAJA-REMOVE
-func (n *NullBWE) GetProbeStatus() (bool, ChannelTrend, int64, int64) {
-	return false, ChannelTrendNeutral, 0, 0
+func (n *NullBWE) ProbeClusterDone(_pci ccutils.ProbeClusterInfo) (bool, int64) {
+	return false, 0
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/bwe/null_bwe.go
+++ b/pkg/sfu/bwe/null_bwe.go
@@ -15,6 +15,7 @@
 package bwe
 
 import (
+	"github.com/livekit/livekit-server/pkg/sfu/ccutils"
 	"github.com/pion/rtcp"
 )
 
@@ -42,10 +43,11 @@ func (n *NullBWE) HandleREMB(
 
 func (n *NullBWE) HandleTWCCFeedback(_report *rtcp.TransportLayerCC) {}
 
-func (n *NullBWE) ProbingStart(_expectedBandwidthUsage int64) {}
+func (n *NullBWE) ProbeClusterStarting(_pci ccutils.ProbeClusterInfo) {}
 
-func (n *NullBWE) ProbingEnd(_isNotFailing bool, _isGoalReached bool) {}
+func (n *NullBWE) ProbeClusterDone(_pci ccutils.ProbeClusterInfo) {}
 
+// RAJA-REMOVE
 func (n *NullBWE) GetProbeStatus() (bool, ChannelTrend, int64, int64) {
 	return false, ChannelTrendNeutral, 0, 0
 }

--- a/pkg/sfu/ccutils/prober.go
+++ b/pkg/sfu/ccutils/prober.go
@@ -341,6 +341,7 @@ type ProbeClusterResult struct {
 	BytesProbe           int
 	BytesNonProbePrimary int
 	BytesNonProbeRTX     int
+	IsCompleted          bool
 }
 
 func (p ProbeClusterResult) Bytes() int {
@@ -359,6 +360,7 @@ func (p ProbeClusterResult) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	e.AddInt("BytesNonProbePrimary", p.BytesNonProbePrimary)
 	e.AddInt("BytesNonProbeRTX", p.BytesNonProbeRTX)
 	e.AddInt("Bytes", p.Bytes())
+	e.AddBool("IsCompleted", p.IsCompleted)
 	return nil
 }
 

--- a/pkg/sfu/ccutils/prober.go
+++ b/pkg/sfu/ccutils/prober.go
@@ -134,8 +134,8 @@ import (
 )
 
 type ProberListener interface {
-	OnSendProbe(bytesToSend int)
 	OnProbeClusterSwitch(info ProbeClusterInfo)
+	OnSendProbe(bytesToSend int)
 }
 
 type ProberParams struct {

--- a/pkg/sfu/pacer/pacer.go
+++ b/pkg/sfu/pacer/pacer.go
@@ -45,7 +45,7 @@ type Pacer interface {
 	SetBitrate(bitrate int)
 
 	SetPacerProbeObserverListener(listener PacerProbeObserverListener)
-	StartProbeCluster(probeClusterId ccutils.ProbeClusterId, desiredBytes int)
+	StartProbeCluster(pci ccutils.ProbeClusterInfo)
 	EndProbeCluster(probeClusterId ccutils.ProbeClusterId) ccutils.ProbeClusterInfo
 }
 

--- a/pkg/sfu/pacer/probe_observer.go
+++ b/pkg/sfu/pacer/probe_observer.go
@@ -123,6 +123,7 @@ func (po *ProbeObserver) RecordPacket(size int, isRTX bool, probeClusterId ccuti
 	var clusterId ccutils.ProbeClusterId
 	if po.pci.Result.EndTime == 0 && po.pci.Result.Bytes() >= po.pci.Goal.DesiredBytes {
 		po.pci.Result.EndTime = mono.UnixNano()
+		po.pci.Result.IsCompleted = true
 
 		notify = true
 		clusterId = po.pci.Id

--- a/pkg/sfu/pacer/probe_observer.go
+++ b/pkg/sfu/pacer/probe_observer.go
@@ -30,14 +30,8 @@ type ProbeObserver struct {
 
 	isInProbe atomic.Bool
 
-	lock                     sync.Mutex
-	clusterStartTime         int64
-	activeProbeClusterId     ccutils.ProbeClusterId
-	desiredProbeClusterBytes int
-	bytesNonProbePrimary     int
-	bytesNonProbeRTX         int
-	bytesProbe               int
-	isActiveClusterDone      bool
+	lock sync.Mutex
+	pci  ccutils.ProbeClusterInfo
 }
 
 func NewProbeObserver(logger logger.Logger) *ProbeObserver {
@@ -50,12 +44,11 @@ func (po *ProbeObserver) SetPacerProbeObserverListener(listener PacerProbeObserv
 	po.listener = listener
 }
 
-func (po *ProbeObserver) StartProbeCluster(probeClusterId ccutils.ProbeClusterId, desiredBytes int) {
+func (po *ProbeObserver) StartProbeCluster(pci ccutils.ProbeClusterInfo) {
 	if po.isInProbe.Load() {
 		po.logger.Warnw(
 			"ignoring start of a new probe cluster when already active", nil,
-			"probeClusterId", probeClusterId,
-			"desiredBytes", desiredBytes,
+			"probeClusterInfo", pci,
 		)
 		return
 	}
@@ -63,13 +56,10 @@ func (po *ProbeObserver) StartProbeCluster(probeClusterId ccutils.ProbeClusterId
 	po.lock.Lock()
 	defer po.lock.Unlock()
 
-	po.clusterStartTime = mono.UnixNano()
-	po.activeProbeClusterId = probeClusterId
-	po.desiredProbeClusterBytes = desiredBytes
-	po.bytesNonProbePrimary = 0
-	po.bytesNonProbeRTX = 0
-	po.bytesProbe = 0
-	po.isActiveClusterDone = false
+	po.pci = pci
+	po.pci.Result = ccutils.ProbeClusterResult{
+		StartTime: mono.UnixNano(),
+	}
 
 	po.isInProbe.Store(true)
 }
@@ -89,30 +79,23 @@ func (po *ProbeObserver) EndProbeCluster(probeClusterId ccutils.ProbeClusterId) 
 	po.lock.Lock()
 	defer po.lock.Unlock()
 
-	if po.activeProbeClusterId != probeClusterId {
+	if po.pci.Id != probeClusterId {
 		// probe cluster id not active
 		po.logger.Warnw(
 			"ignoring end of a probe cluster of a non-active one", nil,
 			"probeClusterId", probeClusterId,
-			"active", po.activeProbeClusterId,
+			"active", po.pci.Id,
 		)
 		return ccutils.ProbeClusterInfoInvalid
 	}
 
-	clusterInfo := ccutils.ProbeClusterInfo{
-		ProbeClusterId:       po.activeProbeClusterId,
-		DesiredBytes:         po.desiredProbeClusterBytes,
-		StartTime:            po.clusterStartTime,
-		EndTime:              mono.UnixNano(),
-		BytesProbe:           po.bytesProbe,
-		BytesNonProbePrimary: po.bytesNonProbePrimary,
-		BytesNonProbeRTX:     po.bytesNonProbeRTX,
+	if po.pci.Result.EndTime == 0 {
+		po.pci.Result.EndTime = mono.UnixNano()
 	}
 
-	po.activeProbeClusterId = ccutils.ProbeClusterIdInvalid
 	po.isInProbe.Store(false)
 
-	return clusterInfo
+	return po.pci
 }
 
 func (po *ProbeObserver) RecordPacket(size int, isRTX bool, probeClusterId ccutils.ProbeClusterId, isProbe bool) {
@@ -121,28 +104,28 @@ func (po *ProbeObserver) RecordPacket(size int, isRTX bool, probeClusterId ccuti
 	}
 
 	po.lock.Lock()
-	if probeClusterId != po.activeProbeClusterId || po.isActiveClusterDone {
+	if probeClusterId != po.pci.Id || po.pci.Result.EndTime != 0 {
 		po.lock.Unlock()
 		return
 	}
 
 	if isProbe {
-		po.bytesProbe += size
+		po.pci.Result.BytesProbe += size
 	} else {
 		if isRTX {
-			po.bytesNonProbeRTX += size
+			po.pci.Result.BytesNonProbeRTX += size
 		} else {
-			po.bytesNonProbePrimary += size
+			po.pci.Result.BytesNonProbePrimary += size
 		}
 	}
 
 	notify := false
 	var clusterId ccutils.ProbeClusterId
-	if !po.isActiveClusterDone && po.bytesProbe+po.bytesNonProbePrimary+po.bytesNonProbeRTX >= po.desiredProbeClusterBytes {
-		po.isActiveClusterDone = true
+	if po.pci.Result.EndTime == 0 && po.pci.Result.Bytes() >= po.pci.Goal.DesiredBytes {
+		po.pci.Result.EndTime = mono.UnixNano()
 
 		notify = true
-		clusterId = po.activeProbeClusterId
+		clusterId = po.pci.Id
 	}
 	po.lock.Unlock()
 


### PR DESCRIPTION
Please feel free to rubber stamp it as this is ugly to read and I will be doing more tests.

The main idea here is to simplify the probe path and the probe controller. This is beginning to look a bit like what I would like to have for supporting both remote BWE and TWCC.

Basically, the changes are
- let the probe run and bwe report if it observes congestion
- if yes, abort the probe immediately
- if not, let the probe run till completion
- in either case (running to completion or abort), let the probe settle for some RTTs (either to take effect of increased measured channel capacity or self-induced congestion clearing)
- at the end of settling period, ask the BWE module for result of probe (NOTE: this is yet to be implemented in TWCC, basically I wanted to get to this point to implement that, i.e ask BWE for its analysis of the probe period)
- if BWE says things are good, try up allocating some deficient tracks
- if there more tracks deficient, probe again (after a configurable gap)
- if BWE says things are not good, back off probing for a longer interval and try again if channel is in probable (i. e. not congesting) state.