### PR TITLE
One shot signalling mode fixes

### DIFF
--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -309,6 +309,7 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 	//   but it is not detrimental to set this, needs clean up when participants modes are separated out better.
 	subTrack.SetNeedsNegotiation(!replacedTrack)
 	subTrack.SetRTPSender(sender)
+
 	// it is possible that subscribed track is closed before subscription manager sets
 	// the `OnClose` callback. That handler in subscription manager removes the track
 	// from the peer connection.

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2955,6 +2955,10 @@ func (p *ParticipantImpl) SupportsSyncStreamID() bool {
 }
 
 func (p *ParticipantImpl) SupportsTransceiverReuse() bool {
+	if p.params.UseOneShotSignallingMode {
+		return p.ProtocolVersion().SupportsTransceiverReuse()
+	}
+
 	return p.ProtocolVersion().SupportsTransceiverReuse() && !p.SupportsSyncStreamID()
 }
 

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -912,7 +912,6 @@ func (p *ParticipantImpl) GetAnswer() (webrtc.SessionDescription, error) {
 		return answer, err
 	}
 
-	p.pubLogger.Debugw("got answer", "transport", livekit.SignalTarget_PUBLISHER, "answer", answer)
 	answer = p.configurePublisherAnswer(answer)
 	p.pubLogger.Debugw("returning answer", "transport", livekit.SignalTarget_PUBLISHER, "answer", answer)
 	return answer, nil

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -912,6 +912,7 @@ func (p *ParticipantImpl) GetAnswer() (webrtc.SessionDescription, error) {
 		return answer, err
 	}
 
+	p.pubLogger.Debugw("got answer", "transport", livekit.SignalTarget_PUBLISHER, "answer", answer)
 	answer = p.configurePublisherAnswer(answer)
 	p.pubLogger.Debugw("returning answer", "transport", livekit.SignalTarget_PUBLISHER, "answer", answer)
 	return answer, nil

--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -645,6 +645,7 @@ func (m *SubscriptionManager) subscribeSynchronous(trackID livekit.TrackID) erro
 		m.subscriptions[trackID] = sub
 	}
 	m.lock.Unlock()
+	sub.setDesired(true)
 
 	subTrack, err := track.AddSubscriber(m.params.Participant)
 	if err != nil && !errors.Is(err, errAlreadySubscribed) {

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -809,7 +809,13 @@ func (t *PCTransport) AddTrack(trackLocal webrtc.TrackLocal, params types.AddTra
 	}
 
 	for _, transceiver := range t.pc.GetTransceivers() {
-		t.params.Logger.Debugw("DBG, add track transceiver", "mid", transceiver.Mid(), "hasReceiver", transceiver.Receiver() != nil, "hasSender", transceiver.Sender() != nil) // REMOVE
+		t.params.Logger.Debugw(
+			"DBG, add track transceiver",
+			"mid", transceiver.Mid(),
+			"hasReceiver", transceiver.Receiver() != nil,
+			"hasSender", transceiver.Sender() != nil,
+			"direction", transceiver.Direction(),
+		) // REMOVE
 	}
 
 	configureAudioTransceiver(transceiver, params.Stereo, !params.Red || !t.params.ClientInfo.SupportsAudioRED())
@@ -1110,7 +1116,13 @@ func (t *PCTransport) GetAnswer() (webrtc.SessionDescription, error) {
 	cld := t.pc.CurrentLocalDescription()
 	t.params.Logger.Debugw("DBG, currentLocalDescription", "currentLocalDescription", cld) // REMOVE
 	for _, transceiver := range t.pc.GetTransceivers() {
-		t.params.Logger.Debugw("DBG, transceiver", "mid", transceiver.Mid(), "hasReceiver", transceiver.Receiver() != nil, "hasSender", transceiver.Sender() != nil) // REMOVE
+		t.params.Logger.Debugw(
+			"DBG, transceiver",
+			"mid", transceiver.Mid(),
+			"hasReceiver", transceiver.Receiver() != nil,
+			"hasSender", transceiver.Sender() != nil,
+			"direction", transceiver.Direction(),
+		) // REMOVE
 	}
 
 	// add local candidates to ICE connection details

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -1088,11 +1088,13 @@ func (t *PCTransport) GetAnswer() (webrtc.SessionDescription, error) {
 	if prd == nil || prd.Type != webrtc.SDPTypeOffer {
 		return webrtc.SessionDescription{}, ErrNoRemoteDescription
 	}
+	t.params.Logger.Debugw("DBG, pendingRemoteDescription", "pendingRemoteDescription", prd) // REMOVE
 
 	answer, err := t.pc.CreateAnswer(nil)
 	if err != nil {
 		return webrtc.SessionDescription{}, err
 	}
+	t.params.Logger.Debugw("DBG, answer", "answer", answer) // REMOVE
 
 	if err = t.pc.SetLocalDescription(answer); err != nil {
 		return webrtc.SessionDescription{}, err
@@ -1102,6 +1104,10 @@ func (t *PCTransport) GetAnswer() (webrtc.SessionDescription, error) {
 	<-webrtc.GatheringCompletePromise(t.pc)
 
 	cld := t.pc.CurrentLocalDescription()
+	t.params.Logger.Debugw("DBG, currentLocalDescription", "currentLocalDescription", prd) // REMOVE
+	for _, transceiver := range t.pc.GetTransceivers() {
+		t.params.Logger.Debugw("DBG, transceiver", "mid", transceiver.Mid(), "hasReceiver", transceiver.Receiver() != nil, "hasSender", transceiver.Sender() != nil) // REMOVE
+	}
 
 	// add local candidates to ICE connection details
 	parsed, err := cld.Unmarshal()

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -808,16 +808,6 @@ func (t *PCTransport) AddTrack(trackLocal webrtc.TrackLocal, params types.AddTra
 		return
 	}
 
-	for _, transceiver := range t.pc.GetTransceivers() {
-		t.params.Logger.Debugw(
-			"DBG, add track transceiver",
-			"mid", transceiver.Mid(),
-			"hasReceiver", transceiver.Receiver() != nil,
-			"hasSender", transceiver.Sender() != nil,
-			"direction", transceiver.Direction(),
-		) // REMOVE
-	}
-
 	configureAudioTransceiver(transceiver, params.Stereo, !params.Red || !t.params.ClientInfo.SupportsAudioRED())
 	return
 }
@@ -1098,13 +1088,11 @@ func (t *PCTransport) GetAnswer() (webrtc.SessionDescription, error) {
 	if prd == nil || prd.Type != webrtc.SDPTypeOffer {
 		return webrtc.SessionDescription{}, ErrNoRemoteDescription
 	}
-	t.params.Logger.Debugw("DBG, pendingRemoteDescription", "pendingRemoteDescription", prd) // REMOVE
 
 	answer, err := t.pc.CreateAnswer(nil)
 	if err != nil {
 		return webrtc.SessionDescription{}, err
 	}
-	t.params.Logger.Debugw("DBG, answer", "answer", answer) // REMOVE
 
 	if err = t.pc.SetLocalDescription(answer); err != nil {
 		return webrtc.SessionDescription{}, err
@@ -1114,16 +1102,6 @@ func (t *PCTransport) GetAnswer() (webrtc.SessionDescription, error) {
 	<-webrtc.GatheringCompletePromise(t.pc)
 
 	cld := t.pc.CurrentLocalDescription()
-	t.params.Logger.Debugw("DBG, currentLocalDescription", "currentLocalDescription", cld) // REMOVE
-	for _, transceiver := range t.pc.GetTransceivers() {
-		t.params.Logger.Debugw(
-			"DBG, transceiver",
-			"mid", transceiver.Mid(),
-			"hasReceiver", transceiver.Receiver() != nil,
-			"hasSender", transceiver.Sender() != nil,
-			"direction", transceiver.Direction(),
-		) // REMOVE
-	}
 
 	// add local candidates to ICE connection details
 	parsed, err := cld.Unmarshal()

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -808,6 +808,10 @@ func (t *PCTransport) AddTrack(trackLocal webrtc.TrackLocal, params types.AddTra
 		return
 	}
 
+	for _, transceiver := range t.pc.GetTransceivers() {
+		t.params.Logger.Debugw("DBG, add track transceiver", "mid", transceiver.Mid(), "hasReceiver", transceiver.Receiver() != nil, "hasSender", transceiver.Sender() != nil) // REMOVE
+	}
+
 	configureAudioTransceiver(transceiver, params.Stereo, !params.Red || !t.params.ClientInfo.SupportsAudioRED())
 	return
 }
@@ -1104,7 +1108,7 @@ func (t *PCTransport) GetAnswer() (webrtc.SessionDescription, error) {
 	<-webrtc.GatheringCompletePromise(t.pc)
 
 	cld := t.pc.CurrentLocalDescription()
-	t.params.Logger.Debugw("DBG, currentLocalDescription", "currentLocalDescription", prd) // REMOVE
+	t.params.Logger.Debugw("DBG, currentLocalDescription", "currentLocalDescription", cld) // REMOVE
 	for _, transceiver := range t.pc.GetTransceivers() {
 		t.params.Logger.Debugw("DBG, transceiver", "mid", transceiver.Mid(), "hasReceiver", transceiver.Receiver() != nil, "hasSender", transceiver.Sender() != nil) // REMOVE
 	}


### PR DESCRIPTION
- set desired to ensure unsubscribe does not happen in reconcile
- sync streams is not applicable, this was preventing transceiver re-use when enabled.