### PR TITLE
Freeze update on congested probe.

### DIFF
--- a/pkg/sfu/streamallocator/probe_controller.go
+++ b/pkg/sfu/streamallocator/probe_controller.go
@@ -225,8 +225,8 @@ func (p *ProbeController) MaybeFinalizeProbe() (ccutils.ProbeClusterInfo, bool) 
 	return p.pci, true
 }
 
-func (p *ProbeController) ProbeCongestionSignal(isCongestionClearing bool) {
-	if !isCongestionClearing {
+func (p *ProbeController) ProbeCongestionSignal(isCongesting bool) {
+	if isCongesting {
 		// wait longer till next probe
 		p.probeInterval = time.Duration(p.probeInterval.Seconds()*p.params.Config.BackoffFactor) * time.Second
 		if p.probeInterval > p.params.Config.MaxInterval {

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -695,13 +695,13 @@ func (s *StreamAllocator) handleSignalEstimate(event Event) {
 func (s *StreamAllocator) handleSignalPeriodicPing(Event) {
 	// finalize any probe that may have finished/aborted
 	if pci, ok := s.probeController.MaybeFinalizeProbe(); ok {
-		isCongestionClearing, channelCapacity := s.params.BWE.ProbeClusterDone(pci)
+		isCongesting, channelCapacity := s.params.BWE.ProbeClusterDone(pci)
 		s.params.Logger.Debugw(
 			"stream allocator: probe result",
-			"isCongestionClearing", isCongestionClearing,
+			"isCongesting", isCongesting,
 			"channelCapacity", channelCapacity,
 		)
-		if isCongestionClearing {
+		if !isCongesting {
 			if channelCapacity > s.committedChannelCapacity {
 				s.committedChannelCapacity = channelCapacity
 			}
@@ -709,7 +709,7 @@ func (s *StreamAllocator) handleSignalPeriodicPing(Event) {
 			s.maybeBoostDeficientTracks()
 		}
 
-		s.probeController.ProbeCongestionSignal(isCongestionClearing)
+		s.probeController.ProbeCongestionSignal(isCongesting)
 	}
 
 	// probe if necessary and timing is right


### PR DESCRIPTION
Reverting back to pre-refactor behaviour. Was trying to avoid doing special treatment when in probe, but REMB values are hard to predict and the NACKs as well.

So, freeze updates when congesting in probe till the probe is done. Otherwise, further changes while probe is finalising sometimes causes an invalid signal and tracks are not up allocated.