### PR TITLE
Tri-state probe signal.

### DIFF
--- a/pkg/sfu/bwe/bwe.go
+++ b/pkg/sfu/bwe/bwe.go
@@ -52,6 +52,29 @@ func (c CongestionState) String() string {
 
 // ------------------------------------------------
 
+type ProbeSignal int
+
+const (
+	ProbeSignalInconclusive ProbeSignal = iota
+	ProbeSignalCongesting
+	ProbeSignalClearing
+)
+
+func (p ProbeSignal) String() string {
+	switch p {
+	case ProbeSignalInconclusive:
+		return "INCONCLUSIVE"
+	case ProbeSignalCongesting:
+		return "CONGESTING"
+	case ProbeSignalClearing:
+		return "CLEARING"
+	default:
+		return fmt.Sprintf("%d", int(p))
+	}
+}
+
+// ------------------------------------------------
+
 type BWE interface {
 	SetBWEListener(bweListner BWEListener)
 
@@ -74,7 +97,7 @@ type BWE interface {
 	CongestionState() CongestionState
 
 	ProbeClusterStarting(pci ccutils.ProbeClusterInfo)
-	ProbeClusterDone(pci ccutils.ProbeClusterInfo) (bool, int64)
+	ProbeClusterDone(pci ccutils.ProbeClusterInfo) (ProbeSignal, int64)
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/bwe/null_bwe.go
+++ b/pkg/sfu/bwe/null_bwe.go
@@ -48,8 +48,8 @@ func (n *NullBWE) CongestionState() CongestionState {
 
 func (n *NullBWE) ProbeClusterStarting(_pci ccutils.ProbeClusterInfo) {}
 
-func (n *NullBWE) ProbeClusterDone(_pci ccutils.ProbeClusterInfo) (bool, int64) {
-	return false, 0
+func (n *NullBWE) ProbeClusterDone(_pci ccutils.ProbeClusterInfo) (ProbeSignal, int64) {
+	return ProbeSignalInconclusive, 0
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/streamallocator/probe_controller.go
+++ b/pkg/sfu/streamallocator/probe_controller.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/livekit/livekit-server/pkg/sfu/bwe"
 	"github.com/livekit/livekit-server/pkg/sfu/ccutils"
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/utils/mono"
@@ -225,8 +226,8 @@ func (p *ProbeController) MaybeFinalizeProbe() (ccutils.ProbeClusterInfo, bool) 
 	return p.pci, true
 }
 
-func (p *ProbeController) ProbeCongestionSignal(isCongesting bool) {
-	if isCongesting {
+func (p *ProbeController) ProbeSignal(probeSignal bwe.ProbeSignal) {
+	if probeSignal == bwe.ProbeSignalCongesting {
 		// wait longer till next probe
 		p.probeInterval = time.Duration(p.probeInterval.Seconds()*p.params.Config.BackoffFactor) * time.Second
 		if p.probeInterval > p.params.Config.MaxInterval {

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -695,13 +695,13 @@ func (s *StreamAllocator) handleSignalEstimate(event Event) {
 func (s *StreamAllocator) handleSignalPeriodicPing(Event) {
 	// finalize any probe that may have finished/aborted
 	if pci, ok := s.probeController.MaybeFinalizeProbe(); ok {
-		isCongesting, channelCapacity := s.params.BWE.ProbeClusterDone(pci)
+		probeSignal, channelCapacity := s.params.BWE.ProbeClusterDone(pci)
 		s.params.Logger.Debugw(
 			"stream allocator: probe result",
-			"isCongesting", isCongesting,
+			"probeSignal", probeSignal,
 			"channelCapacity", channelCapacity,
 		)
-		if !isCongesting {
+		if probeSignal != bwe.ProbeSignalCongesting {
 			if channelCapacity > s.committedChannelCapacity {
 				s.committedChannelCapacity = channelCapacity
 			}
@@ -709,7 +709,7 @@ func (s *StreamAllocator) handleSignalPeriodicPing(Event) {
 			s.maybeBoostDeficientTracks()
 		}
 
-		s.probeController.ProbeCongestionSignal(isCongesting)
+		s.probeController.ProbeSignal(probeSignal)
 	}
 
 	// probe if necessary and timing is right


### PR DESCRIPTION
Need tri-state to indicate inconclusive, congesting and clearing. Currently, no special treatment for inconclusive, but for future use. Also, a nicer return makes easier reading.