### PR TITLE
TWCC probing

### DIFF
--- a/pkg/sfu/bwe/bwe.go
+++ b/pkg/sfu/bwe/bwe.go
@@ -61,29 +61,6 @@ func (c CongestionState) String() string {
 
 // ------------------------------------------------
 
-type ProbeSignal int
-
-const (
-	ProbeSignalInconclusive ProbeSignal = iota
-	ProbeSignalCongesting
-	ProbeSignalClearing
-)
-
-func (p ProbeSignal) String() string {
-	switch p {
-	case ProbeSignalInconclusive:
-		return "INCONCLUSIVE"
-	case ProbeSignalCongesting:
-		return "CONGESTING"
-	case ProbeSignalClearing:
-		return "CLEARING"
-	default:
-		return fmt.Sprintf("%d", int(p))
-	}
-}
-
-// ------------------------------------------------
-
 var (
 	ErrProbeClusterStateMismatch = errors.New("mismatched probe cluster state")
 )
@@ -119,7 +96,7 @@ type BWE interface {
 	ProbeDuration() time.Duration
 	ProbeClusterStarting(pci ccutils.ProbeClusterInfo)
 	ProbeClusterDone(pci ccutils.ProbeClusterInfo)
-	ProbeClusterFinalize() (ProbeSignal, int64, bool, error)
+	ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool, error)
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/bwe/bwe.go
+++ b/pkg/sfu/bwe/bwe.go
@@ -17,9 +17,17 @@ package bwe
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/livekit/livekit-server/pkg/sfu/ccutils"
 	"github.com/pion/rtcp"
+)
+
+// ------------------------------------------------
+
+const (
+	DefaultRTT         = float64(0.070) // 70 ms
+	RTTSmoothingFactor = float64(0.5)
 )
 
 // ------------------------------------------------
@@ -77,7 +85,7 @@ func (p ProbeSignal) String() string {
 // ------------------------------------------------
 
 var (
-	ErrProbeClusterMismatch = errors.New("mismatched probe cluster id")
+	ErrProbeClusterStateMismatch = errors.New("mismatched probe cluster state")
 )
 
 type BWE interface {
@@ -105,10 +113,13 @@ type BWE interface {
 
 	HandleTWCCFeedback(report *rtcp.TransportLayerCC)
 
-	CongestionState() CongestionState
+	UpdateRTT(rtt float64)
 
+	CanProbe() bool
+	ProbeDuration() time.Duration
 	ProbeClusterStarting(pci ccutils.ProbeClusterInfo)
-	ProbeClusterDone(pci ccutils.ProbeClusterInfo) (ProbeSignal, int64, error)
+	ProbeClusterDone(pci ccutils.ProbeClusterInfo)
+	ProbeClusterFinalize() (ProbeSignal, int64, bool, error)
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/bwe/bwe.go
+++ b/pkg/sfu/bwe/bwe.go
@@ -15,7 +15,6 @@
 package bwe
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -61,10 +60,6 @@ func (c CongestionState) String() string {
 
 // ------------------------------------------------
 
-var (
-	ErrProbeClusterStateMismatch = errors.New("mismatched probe cluster state")
-)
-
 type BWE interface {
 	SetBWEListener(bweListner BWEListener)
 
@@ -96,7 +91,7 @@ type BWE interface {
 	ProbeDuration() time.Duration
 	ProbeClusterStarting(pci ccutils.ProbeClusterInfo)
 	ProbeClusterDone(pci ccutils.ProbeClusterInfo)
-	ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool, error)
+	ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool)
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/bwe/bwe.go
+++ b/pkg/sfu/bwe/bwe.go
@@ -15,6 +15,7 @@
 package bwe
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/livekit/livekit-server/pkg/sfu/ccutils"
@@ -75,6 +76,10 @@ func (p ProbeSignal) String() string {
 
 // ------------------------------------------------
 
+var (
+	ErrProbeClusterMismatch = errors.New("mismatched probe cluster id")
+)
+
 type BWE interface {
 	SetBWEListener(bweListner BWEListener)
 
@@ -103,7 +108,7 @@ type BWE interface {
 	CongestionState() CongestionState
 
 	ProbeClusterStarting(pci ccutils.ProbeClusterInfo)
-	ProbeClusterDone(pci ccutils.ProbeClusterInfo) (ProbeSignal, int64)
+	ProbeClusterDone(pci ccutils.ProbeClusterInfo) (ProbeSignal, int64, error)
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/bwe/null_bwe.go
+++ b/pkg/sfu/bwe/null_bwe.go
@@ -15,6 +15,8 @@
 package bwe
 
 import (
+	"time"
+
 	"github.com/livekit/livekit-server/pkg/sfu/ccutils"
 	"github.com/pion/rtcp"
 )
@@ -48,14 +50,22 @@ func (n *NullBWE) HandleREMB(
 
 func (n *NullBWE) HandleTWCCFeedback(_report *rtcp.TransportLayerCC) {}
 
-func (n *NullBWE) CongestionState() CongestionState {
-	return CongestionStateNone
+func (n *NullBWE) UpdateRTT(rtt float64) {}
+
+func (n *NullBWE) CanProbe() bool {
+	return false
+}
+
+func (n *NullBWE) ProbeDuration() time.Duration {
+	return 0
 }
 
 func (n *NullBWE) ProbeClusterStarting(_pci ccutils.ProbeClusterInfo) {}
 
-func (n *NullBWE) ProbeClusterDone(_pci ccutils.ProbeClusterInfo) (ProbeSignal, int64, error) {
-	return ProbeSignalInconclusive, 0, nil
+func (n *NullBWE) ProbeClusterDone(_pci ccutils.ProbeClusterInfo) {}
+
+func (n *NullBWE) ProbeClusterFinalize() (ProbeSignal, int64, bool, error) {
+	return ProbeSignalInconclusive, 0, false, nil
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/bwe/null_bwe.go
+++ b/pkg/sfu/bwe/null_bwe.go
@@ -64,8 +64,8 @@ func (n *NullBWE) ProbeClusterStarting(_pci ccutils.ProbeClusterInfo) {}
 
 func (n *NullBWE) ProbeClusterDone(_pci ccutils.ProbeClusterInfo) {}
 
-func (n *NullBWE) ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool, error) {
-	return ccutils.ProbeSignalInconclusive, 0, false, nil
+func (n *NullBWE) ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool) {
+	return ccutils.ProbeSignalInconclusive, 0, false
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/bwe/null_bwe.go
+++ b/pkg/sfu/bwe/null_bwe.go
@@ -64,8 +64,8 @@ func (n *NullBWE) ProbeClusterStarting(_pci ccutils.ProbeClusterInfo) {}
 
 func (n *NullBWE) ProbeClusterDone(_pci ccutils.ProbeClusterInfo) {}
 
-func (n *NullBWE) ProbeClusterFinalize() (ProbeSignal, int64, bool, error) {
-	return ProbeSignalInconclusive, 0, false, nil
+func (n *NullBWE) ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool, error) {
+	return ccutils.ProbeSignalInconclusive, 0, false, nil
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/bwe/null_bwe.go
+++ b/pkg/sfu/bwe/null_bwe.go
@@ -54,8 +54,8 @@ func (n *NullBWE) CongestionState() CongestionState {
 
 func (n *NullBWE) ProbeClusterStarting(_pci ccutils.ProbeClusterInfo) {}
 
-func (n *NullBWE) ProbeClusterDone(_pci ccutils.ProbeClusterInfo) (ProbeSignal, int64) {
-	return ProbeSignalInconclusive, 0
+func (n *NullBWE) ProbeClusterDone(_pci ccutils.ProbeClusterInfo) (ProbeSignal, int64, error) {
+	return ProbeSignalInconclusive, 0, nil
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/bwe/remotebwe/probe_controller.go
+++ b/pkg/sfu/bwe/remotebwe/probe_controller.go
@@ -140,9 +140,9 @@ func (p *probeController) ProbeClusterDone(pci ccutils.ProbeClusterInfo) {
 	p.setState(probeControllerStateHangover)
 }
 
-func (p *probeController) MaybeFinalizeProbe() (ccutils.ProbeClusterInfo, bool, error) {
+func (p *probeController) MaybeFinalizeProbe() (ccutils.ProbeClusterInfo, bool) {
 	if p.state != probeControllerStateHangover {
-		return ccutils.ProbeClusterInfoInvalid, false, bwe.ErrProbeClusterStateMismatch
+		return ccutils.ProbeClusterInfoInvalid, false
 	}
 
 	settleWait := time.Duration(float64(p.params.Config.SettleWaitNumRTT) * p.rtt * float64(time.Second))
@@ -153,11 +153,11 @@ func (p *probeController) MaybeFinalizeProbe() (ccutils.ProbeClusterInfo, bool, 
 		settleWait = p.params.Config.SettleWaitMax
 	}
 	if time.Since(p.stateSwitchedAt) < settleWait {
-		return ccutils.ProbeClusterInfoInvalid, false, nil
+		return ccutils.ProbeClusterInfoInvalid, false
 	}
 
 	p.setState(probeControllerStateNone)
-	return p.pci, true, nil
+	return p.pci, true
 }
 
 func (p *probeController) setState(state probeControllerState) {

--- a/pkg/sfu/bwe/remotebwe/remote_bwe.go
+++ b/pkg/sfu/bwe/remotebwe/remote_bwe.go
@@ -260,7 +260,7 @@ func (r *RemoteBWE) CanProbe() bool {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	return r.probeController.CanProbe()
+	return r.congestionState == bwe.CongestionStateNone && r.probeController.CanProbe()
 }
 
 func (r *RemoteBWE) ProbeDuration() time.Duration {
@@ -312,7 +312,7 @@ func (r *RemoteBWE) ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool) {
 	r.newChannelObserver()
 
 	r.params.Logger.Debugw(
-		"remote bwe: probe done",
+		"remote bwe: probe finalized",
 		"lastReceived", r.lastReceivedEstimate,
 		"expectedBandwidthUsage", r.lastExpectedBandwidthUsage,
 		"channel", pco,

--- a/pkg/sfu/bwe/remotebwe/remote_bwe.go
+++ b/pkg/sfu/bwe/remotebwe/remote_bwe.go
@@ -294,13 +294,13 @@ func (r *RemoteBWE) ProbeClusterDone(pci ccutils.ProbeClusterInfo) {
 	r.probeController.ProbeClusterDone(pci)
 }
 
-func (r *RemoteBWE) ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool, error) {
+func (r *RemoteBWE) ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	pci, isFinalized, err := r.probeController.MaybeFinalizeProbe()
-	if err != nil || !isFinalized {
-		return ccutils.ProbeSignalInconclusive, 0, isFinalized, err
+	pci, isFinalized := r.probeController.MaybeFinalizeProbe()
+	if !isFinalized {
+		return ccutils.ProbeSignalInconclusive, 0, isFinalized
 	}
 
 	// switch to a non-probe channel observer on probe end,
@@ -333,7 +333,7 @@ func (r *RemoteBWE) ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool, er
 	}
 
 	r.probeController.ProbeSignal(probeSignal, pci.CreatedAt)
-	return probeSignal, r.committedChannelCapacity, true, nil
+	return probeSignal, r.committedChannelCapacity, true
 }
 
 func (r *RemoteBWE) newChannelObserver() {

--- a/pkg/sfu/bwe/remotebwe/remote_bwe.go
+++ b/pkg/sfu/bwe/remotebwe/remote_bwe.go
@@ -294,13 +294,13 @@ func (r *RemoteBWE) ProbeClusterDone(pci ccutils.ProbeClusterInfo) {
 	r.probeController.ProbeClusterDone(pci)
 }
 
-func (r *RemoteBWE) ProbeClusterFinalize() (bwe.ProbeSignal, int64, bool, error) {
+func (r *RemoteBWE) ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
 	pci, isFinalized, err := r.probeController.MaybeFinalizeProbe()
 	if err != nil || !isFinalized {
-		return bwe.ProbeSignalInconclusive, 0, isFinalized, err
+		return ccutils.ProbeSignalInconclusive, 0, isFinalized, err
 	}
 
 	// switch to a non-probe channel observer on probe end,
@@ -320,11 +320,11 @@ func (r *RemoteBWE) ProbeClusterFinalize() (bwe.ProbeSignal, int64, bool, error)
 		"probeClusterInfo", pci,
 	)
 
-	probeSignal := bwe.ProbeSignalClearing
+	probeSignal := ccutils.ProbeSignalClearing
 	if probeCongestionState != bwe.CongestionStateNone {
-		probeSignal = bwe.ProbeSignalCongesting
+		probeSignal = ccutils.ProbeSignalCongesting
 	} else if trend, _ := pco.GetTrend(); !pco.HasEnoughEstimateSamples() || trend == channelTrendNeutral {
-		probeSignal = bwe.ProbeSignalInconclusive
+		probeSignal = ccutils.ProbeSignalInconclusive
 	} else {
 		highestEstimate := pco.GetHighestEstimate()
 		if highestEstimate > r.committedChannelCapacity {
@@ -332,7 +332,7 @@ func (r *RemoteBWE) ProbeClusterFinalize() (bwe.ProbeSignal, int64, bool, error)
 		}
 	}
 
-	r.probeController.ProbeSignal(probeSignal)
+	r.probeController.ProbeSignal(probeSignal, pci.CreatedAt)
 	return probeSignal, r.committedChannelCapacity, true, nil
 }
 

--- a/pkg/sfu/bwe/remotebwe/remote_bwe.go
+++ b/pkg/sfu/bwe/remotebwe/remote_bwe.go
@@ -27,25 +27,22 @@ import (
 // ---------------------------------------------------------------------------
 
 type RemoteBWEConfig struct {
-	NackRatioAttenuator     float64               `yaml:"nack_ratio_attenuator,omitempty"`
-	ExpectedUsageThreshold  float64               `yaml:"expected_usage_threshold,omitempty"`
-	ChannelObserverProbe    ChannelObserverConfig `yaml:"channel_observer_probe,omitempty"`
-	ChannelObserverNonProbe ChannelObserverConfig `yaml:"channel_observer_non_probe,omitempty"`
-	CongestedMinDuration    time.Duration         `yaml:"congested_min_duration,omitempty"`
-
-	PeriodicCheckInterval          time.Duration `yaml:"periodic_check_interval,omitempty"`
-	PeriodicCheckIntervalCongested time.Duration `yaml:"periodic_check_interval_congested,omitempty"`
+	NackRatioAttenuator       float64               `yaml:"nack_ratio_attenuator,omitempty"`
+	ExpectedUsageThreshold    float64               `yaml:"expected_usage_threshold,omitempty"`
+	ChannelObserverProbe      ChannelObserverConfig `yaml:"channel_observer_probe,omitempty"`
+	ChannelObserverNonProbe   ChannelObserverConfig `yaml:"channel_observer_non_probe,omitempty"`
+	CongestedHangoverDuration time.Duration         `yaml:"congested_hangover_duration,omitempty"`
+	ProbeController           ProbeControllerConfig `yaml:"probe_controller,omitempty"`
 }
 
 var (
 	DefaultRemoteBWEConfig = RemoteBWEConfig{
-		NackRatioAttenuator:            0.4,
-		ExpectedUsageThreshold:         0.95,
-		ChannelObserverProbe:           defaultChannelObserverConfigProbe,
-		ChannelObserverNonProbe:        defaultChannelObserverConfigNonProbe,
-		CongestedMinDuration:           3 * time.Second,
-		PeriodicCheckInterval:          2 * time.Second,
-		PeriodicCheckIntervalCongested: 200 * time.Millisecond,
+		NackRatioAttenuator:       0.4,
+		ExpectedUsageThreshold:    0.95,
+		ChannelObserverProbe:      defaultChannelObserverConfigProbe,
+		ChannelObserverNonProbe:   defaultChannelObserverConfigNonProbe,
+		CongestedHangoverDuration: 3 * time.Second,
+		ProbeController:           DefaultProbeControllerConfig,
 	}
 )
 
@@ -67,8 +64,7 @@ type RemoteBWE struct {
 	lastExpectedBandwidthUsage int64
 	committedChannelCapacity   int64
 
-	isInProbe bool
-	pci       ccutils.ProbeClusterInfo
+	probeController *probeController
 
 	channelObserver *channelObserver
 
@@ -109,11 +105,15 @@ func (r *RemoteBWE) Reset() {
 	r.lastExpectedBandwidthUsage = 0
 	r.committedChannelCapacity = 100_000_000
 
-	r.isInProbe = false
-	r.newChannelObserver()
-
 	r.congestionState = bwe.CongestionStateNone
 	r.congestionStateSwitchedAt = mono.Now()
+
+	r.probeController = newProbeController(probeControllerParams{
+		Config: r.params.Config.ProbeController,
+		Logger: r.params.Logger,
+	})
+
+	r.newChannelObserver()
 }
 
 func (r *RemoteBWE) HandleREMB(
@@ -128,7 +128,7 @@ func (r *RemoteBWE) HandleREMB(
 
 	// in probe, freeze channel observer state if probe causes congestion till the probe is done,
 	// this is to ensure that probe result is not a success and an unsuccessful probe will not up allocate any tracks
-	if r.isInProbe && r.congestionState != bwe.CongestionStateNone {
+	if r.congestionState != bwe.CongestionStateNone && r.probeController.IsInProbe() {
 		r.lock.Unlock()
 		return
 	}
@@ -146,11 +146,11 @@ func (r *RemoteBWE) HandleREMB(
 	}
 }
 
-func (r *RemoteBWE) CongestionState() bwe.CongestionState {
-	r.lock.RLock()
-	defer r.lock.RUnlock()
+func (r *RemoteBWE) UpdateRTT(rtt float64) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
 
-	return r.congestionState
+	r.probeController.UpdateRTT(rtt)
 }
 
 func (r *RemoteBWE) congestionDetectionStateMachine() (bool, bwe.CongestionState, int64) {
@@ -164,7 +164,7 @@ func (r *RemoteBWE) congestionDetectionStateMachine() (bool, bwe.CongestionState
 	switch r.congestionState {
 	case bwe.CongestionStateNone:
 		if trend == channelTrendCongesting {
-			if r.isInProbe || r.estimateAvailableChannelCapacity(reason) {
+			if r.probeController.IsInProbe() || r.estimateAvailableChannelCapacity(reason) {
 				// when in probe, if congested, stays there will probe is done,
 				// the estimate stays at pre-probe level
 				newState = bwe.CongestionStateCongested
@@ -186,7 +186,7 @@ func (r *RemoteBWE) congestionDetectionStateMachine() (bool, bwe.CongestionState
 			if r.estimateAvailableChannelCapacity(reason) {
 				newState = bwe.CongestionStateCongested
 			}
-		} else if time.Since(r.congestionStateSwitchedAt) >= r.params.Config.CongestedMinDuration {
+		} else if time.Since(r.congestionStateSwitchedAt) >= r.params.Config.CongestedHangoverDuration {
 			newState = bwe.CongestionStateNone
 		}
 	}
@@ -256,6 +256,20 @@ func (r *RemoteBWE) updateCongestionState(state bwe.CongestionState, reason chan
 	r.congestionStateSwitchedAt = mono.Now()
 }
 
+func (r *RemoteBWE) CanProbe() bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.probeController.CanProbe()
+}
+
+func (r *RemoteBWE) ProbeDuration() time.Duration {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.probeController.ProbeDuration()
+}
+
 func (r *RemoteBWE) ProbeClusterStarting(pci ccutils.ProbeClusterInfo) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
@@ -269,17 +283,24 @@ func (r *RemoteBWE) ProbeClusterStarting(pci ccutils.ProbeClusterInfo) {
 		"channel", r.channelObserver,
 	)
 
-	r.isInProbe = true
-	r.pci = pci
+	r.probeController.ProbeClusterStarting(pci)
 	r.newChannelObserver()
 }
 
-func (r *RemoteBWE) ProbeClusterDone(pci ccutils.ProbeClusterInfo) (bwe.ProbeSignal, int64, error) {
+func (r *RemoteBWE) ProbeClusterDone(pci ccutils.ProbeClusterInfo) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	if pci.Id != r.pci.Id {
-		return bwe.ProbeSignalInconclusive, 0, bwe.ErrProbeClusterMismatch
+	r.probeController.ProbeClusterDone(pci)
+}
+
+func (r *RemoteBWE) ProbeClusterFinalize() (bwe.ProbeSignal, int64, bool, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	pci, isFinalized, err := r.probeController.MaybeFinalizeProbe()
+	if err != nil || !isFinalized {
+		return bwe.ProbeSignalInconclusive, 0, isFinalized, err
 	}
 
 	// switch to a non-probe channel observer on probe end,
@@ -287,7 +308,6 @@ func (r *RemoteBWE) ProbeClusterDone(pci ccutils.ProbeClusterInfo) (bwe.ProbeSig
 	pco := r.channelObserver
 	probeCongestionState := r.congestionState
 
-	r.isInProbe = false
 	r.congestionState = bwe.CongestionStateNone
 	r.newChannelObserver()
 
@@ -297,26 +317,27 @@ func (r *RemoteBWE) ProbeClusterDone(pci ccutils.ProbeClusterInfo) (bwe.ProbeSig
 		"expectedBandwidthUsage", r.lastExpectedBandwidthUsage,
 		"channel", pco,
 		"isSignalValid", pco.HasEnoughEstimateSamples(),
+		"probeClusterInfo", pci,
 	)
 
+	probeSignal := bwe.ProbeSignalClearing
 	if probeCongestionState != bwe.CongestionStateNone {
-		return bwe.ProbeSignalCongesting, r.committedChannelCapacity, nil
+		probeSignal = bwe.ProbeSignalCongesting
+	} else if trend, _ := pco.GetTrend(); !pco.HasEnoughEstimateSamples() || trend == channelTrendNeutral {
+		probeSignal = bwe.ProbeSignalInconclusive
+	} else {
+		highestEstimate := pco.GetHighestEstimate()
+		if highestEstimate > r.committedChannelCapacity {
+			r.committedChannelCapacity = highestEstimate
+		}
 	}
 
-	trend, _ := pco.GetTrend()
-	if !pco.HasEnoughEstimateSamples() || trend == channelTrendNeutral {
-		return bwe.ProbeSignalInconclusive, r.committedChannelCapacity, nil
-	}
-
-	highestEstimate := pco.GetHighestEstimate()
-	if highestEstimate > r.committedChannelCapacity {
-		r.committedChannelCapacity = highestEstimate
-	}
-	return bwe.ProbeSignalClearing, r.committedChannelCapacity, nil
+	r.probeController.ProbeSignal(probeSignal)
+	return probeSignal, r.committedChannelCapacity, true, nil
 }
 
 func (r *RemoteBWE) newChannelObserver() {
-	if r.isInProbe {
+	if r.probeController.IsInProbe() {
 		r.channelObserver = newChannelObserver(
 			channelObserverParams{
 				Name:   "probe",

--- a/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
@@ -371,13 +371,6 @@ func (c *congestionDetector) HandleTWCCFeedback(report *rtcp.TransportLayerCC) {
 	}
 }
 
-func (c *congestionDetector) CongestionState() bwe.CongestionState {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-
-	return c.congestionState
-}
-
 func (c *congestionDetector) ProbeClusterStarting(pci ccutils.ProbeClusterInfo) {
 	/* RAJA-TODO
 	r.lock.Lock()
@@ -397,7 +390,7 @@ func (c *congestionDetector) ProbeClusterStarting(pci ccutils.ProbeClusterInfo) 
 	*/
 }
 
-func (c *congestionDetector) ProbeClusterDone(_pci ccutils.ProbeClusterInfo) (bwe.ProbeSignal, int64, error) {
+func (c *congestionDetector) ProbeClusterDone(pci ccutils.ProbeClusterInfo) {
 	/* RAjA-TODO
 	r.lock.Lock()
 	defer r.lock.Unlock()
@@ -434,7 +427,6 @@ func (c *congestionDetector) ProbeClusterDone(_pci ccutils.ProbeClusterInfo) (bw
 	}
 	return bwe.ProbeSignalClearing, r.committedChannelCapacity
 	*/
-	return bwe.ProbeSignalClearing, 0, nil
 }
 
 func (c *congestionDetector) prunePacketGroups() {

--- a/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
@@ -64,8 +64,8 @@ var (
 // -------------------------------------------------------------------------------
 
 type ProbeSignalConfig struct {
-	MinBytesRatio    float64 `yaml:"min_bytes_ratio,imitempty"`
-	MinDurationRatio float64 `yaml:"min_duration_ratio,imitempty"`
+	MinBytesRatio    float64 `yaml:"min_bytes_ratio,omitempty"`
+	MinDurationRatio float64 `yaml:"min_duration_ratio,omitempty"`
 
 	JQRMinDelay time.Duration `yaml:"jqr_min_delay,omitempty"`
 	DQRMaxDelay time.Duration `yaml:"dqr_max_delay,omitempty"`

--- a/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
@@ -463,7 +463,7 @@ func (c *congestionDetector) CanProbe() bool {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	return c.probeRegulator.CanProbe()
+	return c.congestionState == bwe.CongestionStateNone && c.probePacketGroup == nil && c.probeRegulator.CanProbe()
 }
 
 func (c *congestionDetector) ProbeDuration() time.Duration {
@@ -514,7 +514,7 @@ func (c *congestionDetector) ProbeClusterFinalize() (ccutils.ProbeSignal, int64,
 
 	isSignalValid := c.params.Config.ProbeSignal.IsValid(pci)
 	c.params.Logger.Debugw(
-		"send side bwe: probe done",
+		"send side bwe: probe finalized",
 		"isSignalValid", isSignalValid,
 		"probeClusterInfo", pci,
 		"probePacketGroup", c.probePacketGroup,

--- a/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
@@ -499,17 +499,17 @@ func (c *congestionDetector) ProbeClusterDone(pci ccutils.ProbeClusterInfo) {
 	}
 }
 
-func (c *congestionDetector) ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool, error) {
+func (c *congestionDetector) ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
 	if c.probePacketGroup == nil {
-		return ccutils.ProbeSignalInconclusive, 0, false, bwe.ErrProbeClusterStateMismatch
+		return ccutils.ProbeSignalInconclusive, 0, false
 	}
 
 	pci, isFinalized := c.probePacketGroup.MaybeFinalizeProbe(c.packetTracker.ProbeMaxSequenceNumber(), c.rtt)
 	if !isFinalized {
-		return ccutils.ProbeSignalInconclusive, 0, isFinalized, nil
+		return ccutils.ProbeSignalInconclusive, 0, isFinalized
 	}
 
 	isSignalValid := c.params.Config.ProbeSignal.IsValid(pci)
@@ -527,7 +527,7 @@ func (c *congestionDetector) ProbeClusterFinalize() (ccutils.ProbeSignal, int64,
 
 	c.probeRegulator.ProbeSignal(probeSignal, pci.CreatedAt)
 	c.probePacketGroup = nil
-	return probeSignal, c.estimatedAvailableChannelCapacity, true, nil
+	return probeSignal, c.estimatedAvailableChannelCapacity, true
 }
 
 func (c *congestionDetector) prunePacketGroups() {

--- a/pkg/sfu/bwe/sendsidebwe/packet_group.go
+++ b/pkg/sfu/bwe/sendsidebwe/packet_group.go
@@ -42,6 +42,14 @@ var (
 		MinPackets:        20,
 		MaxWindowDuration: 500 * time.Millisecond,
 	}
+
+	/* RAJA-REMOVE
+	// large numbers to treat a probe packet group as one
+	DefaultPacketGroupConfigProbe = PacketGroupConfig{
+		MinPackets:        16384,
+		MaxWindowDuration: time.Minute,
+	}
+	*/
 )
 
 // -------------------------------------------------------------

--- a/pkg/sfu/bwe/sendsidebwe/packet_group.go
+++ b/pkg/sfu/bwe/sendsidebwe/packet_group.go
@@ -42,14 +42,6 @@ var (
 		MinPackets:        20,
 		MaxWindowDuration: 500 * time.Millisecond,
 	}
-
-	/* RAJA-REMOVE
-	// large numbers to treat a probe packet group as one
-	DefaultPacketGroupConfigProbe = PacketGroupConfig{
-		MinPackets:        16384,
-		MaxWindowDuration: time.Minute,
-	}
-	*/
 )
 
 // -------------------------------------------------------------

--- a/pkg/sfu/bwe/sendsidebwe/packet_tracker.go
+++ b/pkg/sfu/bwe/sendsidebwe/packet_tracker.go
@@ -76,7 +76,7 @@ func (p *packetTracker) RecordPacketSendAndGetSequenceNumber(
 		probeClusterId: probeClusterId,
 		isProbe:        isProbe,
 	}
-	// SSBWE-REMOVE p.params.Logger.Infow("packet sent", "packetInfo", pi) // SSBWE-REMOVE
+	// SSBWE-REMOVE p.params.Logger.Infow("send side bwe: packet sent", "packetInfo", pi) // SSBWE-REMOVE
 
 	p.sequenceNumber++
 
@@ -85,7 +85,7 @@ func (p *packetTracker) RecordPacketSendAndGetSequenceNumber(
 		p.piLastRecv = nil
 	}
 
-	if p.probeClusterId != ccutils.ProbeClusterIdInvalid && pi.sequenceNumber > p.probeMaxSequenceNumber {
+	if p.probeClusterId != ccutils.ProbeClusterIdInvalid && p.probeClusterId == pi.probeClusterId && pi.sequenceNumber > p.probeMaxSequenceNumber {
 		p.probeMaxSequenceNumber = pi.sequenceNumber
 	}
 
@@ -152,17 +152,18 @@ func (p *packetTracker) ProbeClusterStarting(probeClusterId ccutils.ProbeCluster
 	p.probeClusterId = probeClusterId
 }
 
-func (p *packetTracker) ProbeClusterDone(probeClusterId ccutils.ProbeClusterId) (uint64, bool) {
+func (p *packetTracker) ProbeClusterDone(probeClusterId ccutils.ProbeClusterId) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
 	if p.probeClusterId == probeClusterId {
 		p.probeClusterId = ccutils.ProbeClusterIdInvalid
-		probeMaxSequenceNumber := p.probeMaxSequenceNumber
-		p.probeMaxSequenceNumber = 0
-
-		return probeMaxSequenceNumber, probeMaxSequenceNumber != 0
 	}
+}
 
-	return 0, false
+func (p *packetTracker) ProbeMaxSequenceNumber() uint64 {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	return p.probeMaxSequenceNumber
 }

--- a/pkg/sfu/bwe/sendsidebwe/packet_tracker.go
+++ b/pkg/sfu/bwe/sendsidebwe/packet_tracker.go
@@ -76,7 +76,7 @@ func (p *packetTracker) RecordPacketSendAndGetSequenceNumber(
 		probeClusterId: probeClusterId,
 		isProbe:        isProbe,
 	}
-	// SSBWE-REMOVE p.params.Logger.Infow("send side bwe: packet sent", "packetInfo", pi) // SSBWE-REMOVE
+	//p.params.Logger.Infow("send side bwe: packet sent", "packetInfo", pi) // SSBWE-REMOVE
 
 	p.sequenceNumber++
 

--- a/pkg/sfu/bwe/sendsidebwe/packet_tracker.go
+++ b/pkg/sfu/bwe/sendsidebwe/packet_tracker.go
@@ -41,6 +41,9 @@ type packetTracker struct {
 
 	baseRecvTime int64
 	piLastRecv   *packetInfo
+
+	probeClusterId         ccutils.ProbeClusterId
+	probeMaxSequenceNumber uint64
 }
 
 func newPacketTracker(params packetTrackerParams) *packetTracker {
@@ -80,6 +83,10 @@ func (p *packetTracker) RecordPacketSendAndGetSequenceNumber(
 	// extreme case of wrap around before receiving any feedback
 	if pi == p.piLastRecv {
 		p.piLastRecv = nil
+	}
+
+	if p.probeClusterId != ccutils.ProbeClusterIdInvalid && pi.sequenceNumber > p.probeMaxSequenceNumber {
+		p.probeMaxSequenceNumber = pi.sequenceNumber
 	}
 
 	return uint16(pi.sequenceNumber)
@@ -136,4 +143,26 @@ func (p *packetTracker) getPacketInfoExisting(sn uint16) *packetInfo {
 	}
 
 	return nil
+}
+
+func (p *packetTracker) ProbeClusterStarting(probeClusterId ccutils.ProbeClusterId) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.probeClusterId = probeClusterId
+}
+
+func (p *packetTracker) ProbeClusterDone(probeClusterId ccutils.ProbeClusterId) (uint64, bool) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.probeClusterId == probeClusterId {
+		p.probeClusterId = ccutils.ProbeClusterIdInvalid
+		probeMaxSequenceNumber := p.probeMaxSequenceNumber
+		p.probeMaxSequenceNumber = 0
+
+		return probeMaxSequenceNumber, probeMaxSequenceNumber != 0
+	}
+
+	return 0, false
 }

--- a/pkg/sfu/bwe/sendsidebwe/probe_packet_group.go
+++ b/pkg/sfu/bwe/sendsidebwe/probe_packet_group.go
@@ -1,0 +1,76 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sendsidebwe
+
+import (
+	"time"
+
+	"github.com/livekit/livekit-server/pkg/sfu/ccutils"
+	"github.com/livekit/protocol/logger"
+	"go.uber.org/zap/zapcore"
+)
+
+// -------------------------------------------------------------
+
+var (
+	// large numbers to treat a probe packet group as one
+	DefaultPacketGroupConfigProbe = PacketGroupConfig{
+		MinPackets:        16384,
+		MaxWindowDuration: time.Minute,
+	}
+)
+
+// -------------------------------------------------------------
+
+type probePacketGroupParams struct {
+	ProbeClusterInfo ccutils.ProbeClusterInfo
+	Config           PacketGroupConfig
+	WeightedLoss     WeightedLossConfig
+	Logger           logger.Logger
+}
+
+type probePacketGroup struct {
+	params probePacketGroupParams
+	*packetGroup
+}
+
+func newProbePacketGroup(params probePacketGroupParams) *probePacketGroup {
+	return &probePacketGroup{
+		params: params,
+		packetGroup: newPacketGroup(packetGroupParams{
+			Config:       params.Config,
+			WeightedLoss: params.WeightedLoss,
+			Logger:       params.Logger,
+		}, 0),
+	}
+}
+
+func (p *probePacketGroup) Add(pi *packetInfo, sendDelta, recvDelta int64, isLost bool) error {
+	if pi.probeClusterId != p.params.ProbeClusterInfo.Id {
+		return nil
+	}
+
+	return p.packetGroup.Add(pi, sendDelta, recvDelta, isLost)
+}
+
+func (p *probePacketGroup) MarshalLogObject(e zapcore.ObjectEncoder) error {
+	if p == nil {
+		return nil
+	}
+
+	e.AddObject("probeClusterInfo", p.params.ProbeClusterInfo)
+	e.AddObject("packetGroup", p.packetGroup)
+	return nil
+}

--- a/pkg/sfu/bwe/sendsidebwe/send_side_bwe.go
+++ b/pkg/sfu/bwe/sendsidebwe/send_side_bwe.go
@@ -103,6 +103,16 @@ func (s *SendSideBWE) Stop() {
 	s.congestionDetector.Stop()
 }
 
+func (s *SendSideBWE) RecordPacketSendAndGetSequenceNumber(
+	atMicro int64,
+	size int,
+	isRTX bool,
+	probeClusterId ccutils.ProbeClusterId,
+	isProbe bool,
+) uint16 {
+	return s.congestionDetector.RecordPacketSendAndGetSequenceNumber(atMicro, size, isRTX, probeClusterId, isProbe)
+}
+
 func (s *SendSideBWE) HandleTWCCFeedback(report *rtcp.TransportLayerCC) {
 	s.congestionDetector.HandleTWCCFeedback(report)
 }

--- a/pkg/sfu/bwe/sendsidebwe/send_side_bwe.go
+++ b/pkg/sfu/bwe/sendsidebwe/send_side_bwe.go
@@ -127,7 +127,7 @@ func (s *SendSideBWE) ProbeClusterDone(pci ccutils.ProbeClusterInfo) {
 	s.congestionDetector.ProbeClusterDone(pci)
 }
 
-func (s *SendSideBWE) ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool, error) {
+func (s *SendSideBWE) ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool) {
 	return s.congestionDetector.ProbeClusterFinalize()
 }
 

--- a/pkg/sfu/bwe/sendsidebwe/send_side_bwe.go
+++ b/pkg/sfu/bwe/sendsidebwe/send_side_bwe.go
@@ -15,6 +15,8 @@
 package sendsidebwe
 
 import (
+	"time"
+
 	"github.com/livekit/livekit-server/pkg/sfu/bwe"
 	"github.com/livekit/livekit-server/pkg/sfu/ccutils"
 	"github.com/livekit/protocol/logger"
@@ -105,12 +107,28 @@ func (s *SendSideBWE) HandleTWCCFeedback(report *rtcp.TransportLayerCC) {
 	s.congestionDetector.HandleTWCCFeedback(report)
 }
 
+func (s *SendSideBWE) UpdateRTT(rtt float64) {
+	s.congestionDetector.UpdateRTT(rtt)
+}
+
+func (s *SendSideBWE) CanProbe() bool {
+	return s.congestionDetector.CanProbe()
+}
+
+func (s *SendSideBWE) ProbeDuration() time.Duration {
+	return s.congestionDetector.ProbeDuration()
+}
+
 func (s *SendSideBWE) ProbeClusterStarting(pci ccutils.ProbeClusterInfo) {
 	s.congestionDetector.ProbeClusterStarting(pci)
 }
 
 func (s *SendSideBWE) ProbeClusterDone(pci ccutils.ProbeClusterInfo) {
 	s.congestionDetector.ProbeClusterDone(pci)
+}
+
+func (s *SendSideBWE) ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool, error) {
+	return s.congestionDetector.ProbeClusterFinalize()
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/bwe/sendsidebwe/send_side_bwe.go
+++ b/pkg/sfu/bwe/sendsidebwe/send_side_bwe.go
@@ -16,6 +16,7 @@ package sendsidebwe
 
 import (
 	"github.com/livekit/livekit-server/pkg/sfu/bwe"
+	"github.com/livekit/livekit-server/pkg/sfu/ccutils"
 	"github.com/livekit/protocol/logger"
 	"github.com/pion/rtcp"
 )
@@ -106,6 +107,14 @@ func (s *SendSideBWE) HandleTWCCFeedback(report *rtcp.TransportLayerCC) {
 
 func (s *SendSideBWE) CongestionState() bwe.CongestionState {
 	return s.congestionDetector.CongestionState()
+}
+
+func (s *SendSideBWE) ProbeClusterStarting(pci ccutils.ProbeClusterInfo) {
+	s.congestionDetector.ProbeClusterStarting(pci)
+}
+
+func (s *SendSideBWE) ProbeClusterDone(pci ccutils.ProbeClusterInfo) (bwe.ProbeSignal, int64, error) {
+	return s.congestionDetector.ProbeClusterDone(pci)
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/bwe/sendsidebwe/send_side_bwe.go
+++ b/pkg/sfu/bwe/sendsidebwe/send_side_bwe.go
@@ -105,16 +105,12 @@ func (s *SendSideBWE) HandleTWCCFeedback(report *rtcp.TransportLayerCC) {
 	s.congestionDetector.HandleTWCCFeedback(report)
 }
 
-func (s *SendSideBWE) CongestionState() bwe.CongestionState {
-	return s.congestionDetector.CongestionState()
-}
-
 func (s *SendSideBWE) ProbeClusterStarting(pci ccutils.ProbeClusterInfo) {
 	s.congestionDetector.ProbeClusterStarting(pci)
 }
 
-func (s *SendSideBWE) ProbeClusterDone(pci ccutils.ProbeClusterInfo) (bwe.ProbeSignal, int64, error) {
-	return s.congestionDetector.ProbeClusterDone(pci)
+func (s *SendSideBWE) ProbeClusterDone(pci ccutils.ProbeClusterInfo) {
+	s.congestionDetector.ProbeClusterDone(pci)
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/bwe/sendsidebwe/traffic_stats.go
+++ b/pkg/sfu/bwe/sendsidebwe/traffic_stats.go
@@ -86,6 +86,11 @@ func (ts *trafficStats) Duration() int64 {
 }
 
 func (ts *trafficStats) AcknowledgedBitrate() int64 {
+	duration := ts.Duration()
+	if duration == 0 {
+		return 0
+	}
+
 	ackedBitrate := int64(ts.ackedBytes) * 8 * 1e6 / ts.Duration()
 	return int64(float64(ackedBitrate) * ts.CapturedTrafficRatio())
 }

--- a/pkg/sfu/bwe/sendsidebwe/traffic_stats.go
+++ b/pkg/sfu/bwe/sendsidebwe/traffic_stats.go
@@ -53,6 +53,7 @@ type trafficStats struct {
 	ackedPackets int
 	ackedBytes   int
 	lostPackets  int
+	lostBytes    int
 }
 
 func newTrafficStats(params trafficStatsParams) *trafficStats {
@@ -73,6 +74,11 @@ func (ts *trafficStats) Merge(rhs *trafficStats) {
 	ts.ackedPackets += rhs.ackedPackets
 	ts.ackedBytes += rhs.ackedBytes
 	ts.lostPackets += rhs.lostPackets
+	ts.lostBytes += rhs.lostBytes
+}
+
+func (ts *trafficStats) NumBytes() int {
+	return ts.ackedBytes + ts.lostBytes
 }
 
 func (ts *trafficStats) Duration() int64 {

--- a/pkg/sfu/bwe/sendsidebwe/traffic_stats.go
+++ b/pkg/sfu/bwe/sendsidebwe/traffic_stats.go
@@ -112,10 +112,10 @@ func (ts *trafficStats) WeightedLoss() float64 {
 	pps := totalPackets * 1e6 / float64(ts.Duration())
 
 	// Log10 is used to give higher weight for the same loss ratio at higher packet rates,
-	// for e.g. with a penalty factor of 0.25
-	//    - 10% loss at 20 pps = 0.1 * log10(20) * 0.25 = 0.032
-	//    - 10% loss at 100 pps = 0.1 * log10(100) * 0.25 = 0.05
-	//    - 10% loss at 1000 pps = 0.1 * log10(1000) * 0.25 = 0.075
+	// for e.g.
+	//    - 10% loss at 20 pps = 0.1 * log10(20) = 0.130
+	//    - 10% loss at 100 pps = 0.1 * log10(100) = 0.2
+	//    - 10% loss at 1000 pps = 0.1 * log10(1000) = 0.3
 	return lossRatio * math.Log10(pps)
 }
 

--- a/pkg/sfu/bwe/sendsidebwe/twcc_feedback.go
+++ b/pkg/sfu/bwe/sendsidebwe/twcc_feedback.go
@@ -66,7 +66,7 @@ func newTWCCFeedback(params twccFeedbackParams) *twccFeedback {
 }
 
 func (t *twccFeedback) ProcessReport(report *rtcp.TransportLayerCC, at time.Time) (int64, bool) {
-	// SSBWE-REMOVE t.params.Logger.Infow("send side bwe: TWCC feedback", "report", report.String()) // SSBWE-REMOVE
+	// t.params.Logger.Infow("send side bwe: TWCC feedback", "report", report.String()) // SSBWE-REMOVE
 	t.numReports++
 	if t.lastFeedbackTime.IsZero() {
 		t.lastFeedbackTime = at
@@ -99,7 +99,7 @@ func (t *twccFeedback) ProcessReport(report *rtcp.TransportLayerCC, at time.Time
 
 	if !isOutOfOrder {
 		sinceLast := at.Sub(t.lastFeedbackTime)
-		// SSBWE-REMOVE t.params.Logger.Infow("send side bwe: report received", "at", at, "sinceLast", sinceLast, "pktCount", report.FbPktCount) // SSBWE-REMOVE
+		// t.params.Logger.Infow("send side bwe: report received", "at", at, "sinceLast", sinceLast, "pktCount", report.FbPktCount) // SSBWE-REMOVE
 		if t.estimatedFeedbackInterval == 0 {
 			t.estimatedFeedbackInterval = sinceLast
 		} else {

--- a/pkg/sfu/bwe/sendsidebwe/twcc_feedback.go
+++ b/pkg/sfu/bwe/sendsidebwe/twcc_feedback.go
@@ -66,7 +66,7 @@ func newTWCCFeedback(params twccFeedbackParams) *twccFeedback {
 }
 
 func (t *twccFeedback) ProcessReport(report *rtcp.TransportLayerCC, at time.Time) (int64, bool) {
-	// SSBWE-REMOVE t.params.Logger.Infow("TWCC feedback", "report", report.String()) // SSBWE-REMOVE
+	// SSBWE-REMOVE t.params.Logger.Infow("send side bwe: TWCC feedback", "report", report.String()) // SSBWE-REMOVE
 	t.numReports++
 	if t.lastFeedbackTime.IsZero() {
 		t.lastFeedbackTime = at
@@ -99,7 +99,7 @@ func (t *twccFeedback) ProcessReport(report *rtcp.TransportLayerCC, at time.Time
 
 	if !isOutOfOrder {
 		sinceLast := at.Sub(t.lastFeedbackTime)
-		// SSBWE-REMOVE t.params.Logger.Infow("report received", "at", at, "sinceLast", sinceLast, "pktCount", report.FbPktCount) // SSBWE-REMOVE
+		// SSBWE-REMOVE t.params.Logger.Infow("send side bwe: report received", "at", at, "sinceLast", sinceLast, "pktCount", report.FbPktCount) // SSBWE-REMOVE
 		if t.estimatedFeedbackInterval == 0 {
 			t.estimatedFeedbackInterval = sinceLast
 		} else {

--- a/pkg/sfu/ccutils/probe_regulator.go
+++ b/pkg/sfu/ccutils/probe_regulator.go
@@ -1,0 +1,106 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ccutils
+
+import (
+	"time"
+
+	"github.com/livekit/protocol/logger"
+	"github.com/livekit/protocol/utils/mono"
+)
+
+// ------------------------------------------------
+
+type ProbeRegulatorConfig struct {
+	BaseInterval  time.Duration `yaml:"base_interval,omitempty"`
+	BackoffFactor float64       `yaml:"backoff_factor,omitempty"`
+	MaxInterval   time.Duration `yaml:"max_interval,omitempty"`
+
+	MinDuration            time.Duration `yaml:"min_duration,omitempty"`
+	MaxDuration            time.Duration `yaml:"max_duration,omitempty"`
+	DurationIncreaseFactor float64       `yaml:"duration_increase_factor,omitempty"`
+}
+
+var (
+	DefaultProbeRegulatorConfig = ProbeRegulatorConfig{
+		BaseInterval:  3 * time.Second,
+		BackoffFactor: 1.5,
+		MaxInterval:   2 * time.Minute,
+
+		MinDuration:            200 * time.Millisecond,
+		MaxDuration:            20 * time.Second,
+		DurationIncreaseFactor: 1.5,
+	}
+)
+
+// ---------------------------------------------------------------------------
+
+type ProbeRegulatorParams struct {
+	Config ProbeRegulatorConfig
+	Logger logger.Logger
+}
+
+type ProbeRegulator struct {
+	params ProbeRegulatorParams
+
+	probeInterval       time.Duration
+	probeDuration       time.Duration
+	nextProbeEarliestAt time.Time
+}
+
+func NewProbeRegulator(params ProbeRegulatorParams) *ProbeRegulator {
+	return &ProbeRegulator{
+		params:              params,
+		probeInterval:       params.Config.BaseInterval,
+		probeDuration:       params.Config.MinDuration,
+		nextProbeEarliestAt: mono.Now(),
+	}
+}
+
+func (p *ProbeRegulator) CanProbe() bool {
+	return mono.Now().After(p.nextProbeEarliestAt)
+}
+
+func (p *ProbeRegulator) ProbeDuration() time.Duration {
+	return p.probeDuration
+}
+
+func (p *ProbeRegulator) ProbeSignal(probeSignal ProbeSignal, baseTime time.Time) {
+	if probeSignal == ProbeSignalCongesting {
+		// wait longer till next probe
+		p.probeInterval = time.Duration(p.probeInterval.Seconds()*p.params.Config.BackoffFactor) * time.Second
+		if p.probeInterval > p.params.Config.MaxInterval {
+			p.probeInterval = p.params.Config.MaxInterval
+		}
+
+		// revert back to starting with shortest probe
+		p.probeDuration = p.params.Config.MinDuration
+	} else {
+		// probe can be started again after minimal interval as previous congestion signal indicated congestion clearing
+		p.probeInterval = p.params.Config.BaseInterval
+
+		// can do longer probe after a good probe
+		p.probeDuration = time.Duration(float64(p.probeDuration.Milliseconds())*p.params.Config.DurationIncreaseFactor) * time.Millisecond
+		if p.probeDuration > p.params.Config.MaxDuration {
+			p.probeDuration = p.params.Config.MaxDuration
+		}
+	}
+
+	if baseTime.IsZero() {
+		p.nextProbeEarliestAt = mono.Now().Add(p.probeInterval)
+	} else {
+		p.nextProbeEarliestAt = baseTime.Add(p.probeInterval)
+	}
+}

--- a/pkg/sfu/ccutils/probe_signal.go
+++ b/pkg/sfu/ccutils/probe_signal.go
@@ -1,0 +1,40 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ccutils
+
+import "fmt"
+
+// ------------------------------------------------
+
+type ProbeSignal int
+
+const (
+	ProbeSignalInconclusive ProbeSignal = iota
+	ProbeSignalCongesting
+	ProbeSignalClearing
+)
+
+func (p ProbeSignal) String() string {
+	switch p {
+	case ProbeSignalInconclusive:
+		return "INCONCLUSIVE"
+	case ProbeSignalCongesting:
+		return "CONGESTING"
+	case ProbeSignalClearing:
+		return "CLEARING"
+	default:
+		return fmt.Sprintf("%d", int(p))
+	}
+}

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -628,6 +628,10 @@ func (d *DownTrack) SetProbeClusterId(probeClusterId ccutils.ProbeClusterId) {
 	d.probeClusterId.Store(uint32(probeClusterId))
 }
 
+func (d *DownTrack) SwapProbeClusterId(match ccutils.ProbeClusterId, swap ccutils.ProbeClusterId) {
+	d.probeClusterId.CompareAndSwap(uint32(match), uint32(swap))
+}
+
 // ID is the unique identifier for this Track. This should be unique for the
 // stream, but doesn't have to globally unique. A common example would be 'audio' or 'video'
 // and StreamID would be 'desktop' or 'webcam'

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -694,9 +694,8 @@ func (s *StreamAllocator) handleSignalEstimate(event Event) {
 
 func (s *StreamAllocator) handleSignalPeriodicPing(Event) {
 	// finalize any probe that may have finished/aborted
-	if probeSignal, channelCapacity, isFinalized, err := s.params.BWE.ProbeClusterFinalize(); err != nil {
-		s.params.Logger.Warnw("stream allocator: probe result failed", err)
-	} else if isFinalized {
+	if s.activeProbeClusterId !=  ccutils.ProbeClusterIdInvalid {
+	if probeSignal, channelCapacity, isFinalized := s.params.BWE.ProbeClusterFinalize(); isFinalized {
 		s.params.Logger.Debugw(
 			"stream allocator: probe result",
 			"probeClusterId", s.activeProbeClusterId,
@@ -714,6 +713,7 @@ func (s *StreamAllocator) handleSignalPeriodicPing(Event) {
 			s.maybeBoostDeficientTracks()
 		}
 	}
+}
 
 	// probe if necessary and timing is right
 	if s.state == streamAllocatorStateDeficient {

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -706,7 +706,7 @@ func (s *StreamAllocator) handleSignalPeriodicPing(Event) {
 
 		s.activeProbeClusterId = ccutils.ProbeClusterIdInvalid
 
-		if probeSignal != bwe.ProbeSignalCongesting {
+		if probeSignal != ccutils.ProbeSignalCongesting {
 			if channelCapacity > s.committedChannelCapacity {
 				s.committedChannelCapacity = channelCapacity
 			}

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -694,26 +694,26 @@ func (s *StreamAllocator) handleSignalEstimate(event Event) {
 
 func (s *StreamAllocator) handleSignalPeriodicPing(Event) {
 	// finalize any probe that may have finished/aborted
-	if s.activeProbeClusterId !=  ccutils.ProbeClusterIdInvalid {
-	if probeSignal, channelCapacity, isFinalized := s.params.BWE.ProbeClusterFinalize(); isFinalized {
-		s.params.Logger.Debugw(
-			"stream allocator: probe result",
-			"probeClusterId", s.activeProbeClusterId,
-			"probeSignal", probeSignal,
-			"channelCapacity", channelCapacity,
-		)
+	if s.activeProbeClusterId != ccutils.ProbeClusterIdInvalid {
+		if probeSignal, channelCapacity, isFinalized := s.params.BWE.ProbeClusterFinalize(); isFinalized {
+			s.params.Logger.Debugw(
+				"stream allocator: probe result",
+				"probeClusterId", s.activeProbeClusterId,
+				"probeSignal", probeSignal,
+				"channelCapacity", channelCapacity,
+			)
 
-		s.activeProbeClusterId = ccutils.ProbeClusterIdInvalid
+			s.activeProbeClusterId = ccutils.ProbeClusterIdInvalid
 
-		if probeSignal != ccutils.ProbeSignalCongesting {
-			if channelCapacity > s.committedChannelCapacity {
-				s.committedChannelCapacity = channelCapacity
+			if probeSignal != ccutils.ProbeSignalCongesting {
+				if channelCapacity > s.committedChannelCapacity {
+					s.committedChannelCapacity = channelCapacity
+				}
+
+				s.maybeBoostDeficientTracks()
 			}
-
-			s.maybeBoostDeficientTracks()
 		}
 	}
-}
 
 	// probe if necessary and timing is right
 	if s.state == streamAllocatorStateDeficient {

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -157,16 +157,20 @@ const (
 )
 
 type StreamAllocatorConfig struct {
-	ProbeMode                        ProbeMode             `yaml:"probe_mode,omitempty"`
-	MinChannelCapacity               int64                 `yaml:"min_channel_capacity,omitempty"`
-	ProbeController                  ProbeControllerConfig `yaml:"probe_controller,omitempty"`
-	DisableEstimationUnmanagedTracks bool                  `yaml:"disable_etimation_unmanaged_tracks,omitempty"`
+	ProbeMode                        ProbeMode `yaml:"probe_mode,omitempty"`
+	MinChannelCapacity               int64     `yaml:"min_channel_capacity,omitempty"`
+	DisableEstimationUnmanagedTracks bool      `yaml:"disable_etimation_unmanaged_tracks,omitempty"`
+
+	ProbeOveragePct int64 `yaml:"probe_overage_pct,omitempty"`
+	ProbeMinBps     int64 `yaml:"probe_min_bps,omitempty"`
 }
 
 var (
 	DefaultStreamAllocatorConfig = StreamAllocatorConfig{
-		ProbeMode:       ProbeModePadding,
-		ProbeController: DefaultProbeControllerConfig,
+		ProbeMode: ProbeModePadding,
+
+		ProbeOveragePct: 120,
+		ProbeMinBps:     200_000,
 	}
 )
 
@@ -193,8 +197,7 @@ type StreamAllocator struct {
 	committedChannelCapacity  int64
 	overriddenChannelCapacity int64
 
-	probeController *ProbeController
-	prober          *ccutils.Prober
+	prober *ccutils.Prober
 
 	// STREAM-ALLOCATOR-DATA rateMonitor     *RateMonitor
 
@@ -203,8 +206,9 @@ type StreamAllocator struct {
 	isAllocateAllPending bool
 	rembTrackingSSRC     uint32
 
-	state     streamAllocatorState
-	isHolding bool
+	state                streamAllocatorState
+	isHolding            bool
+	activeProbeClusterId ccutils.ProbeClusterId
 
 	eventsQueue *utils.TypedOpsQueue[Event]
 
@@ -219,8 +223,9 @@ func NewStreamAllocator(params StreamAllocatorParams, enabled bool, allowPause b
 		enabled:    enabled,
 		allowPause: allowPause,
 		// STREAM-ALLOCATOR-DATA rateMonitor: NewRateMonitor(),
-		videoTracks: make(map[livekit.TrackID]*Track),
-		state:       streamAllocatorStateStable,
+		videoTracks:          make(map[livekit.TrackID]*Track),
+		state:                streamAllocatorStateStable,
+		activeProbeClusterId: ccutils.ProbeClusterIdInvalid,
 		eventsQueue: utils.NewTypedOpsQueue[Event](utils.OpsQueueParams{
 			Name:    "stream-allocator",
 			MinSize: 64,
@@ -232,11 +237,6 @@ func NewStreamAllocator(params StreamAllocatorParams, enabled bool, allowPause b
 	s.prober = ccutils.NewProber(ccutils.ProberParams{
 		Listener: s,
 		Logger:   params.Logger,
-	})
-
-	s.probeController = NewProbeController(ProbeControllerParams{
-		Config: s.params.Config.ProbeController,
-		Logger: params.Logger,
 	})
 
 	s.params.BWE.SetBWEListener(s)
@@ -298,7 +298,7 @@ func (s *StreamAllocator) AddTrack(downTrack *sfu.DownTrack, params AddTrackPara
 	}
 
 	downTrack.SetStreamAllocatorListener(s)
-	downTrack.SetProbeClusterId(s.prober.GetActiveClusterId())
+	downTrack.SetProbeClusterId(s.activeProbeClusterId)
 
 	s.maybePostEventAllocateTrack(downTrack)
 }
@@ -694,24 +694,24 @@ func (s *StreamAllocator) handleSignalEstimate(event Event) {
 
 func (s *StreamAllocator) handleSignalPeriodicPing(Event) {
 	// finalize any probe that may have finished/aborted
-	if pci, ok := s.probeController.MaybeFinalizeProbe(); ok {
-		if probeSignal, channelCapacity, err := s.params.BWE.ProbeClusterDone(pci); err != nil {
-			s.params.Logger.Warnw("stream allocator: probe result failed", err, "probeClusterInfo", pci)
-		} else {
-			s.params.Logger.Debugw(
-				"stream allocator: probe result",
-				"probeSignal", probeSignal,
-				"channelCapacity", channelCapacity,
-			)
-			if probeSignal != bwe.ProbeSignalCongesting {
-				if channelCapacity > s.committedChannelCapacity {
-					s.committedChannelCapacity = channelCapacity
-				}
+	if probeSignal, channelCapacity, isFinalized, err := s.params.BWE.ProbeClusterFinalize(); err != nil {
+		s.params.Logger.Warnw("stream allocator: probe result failed", err)
+	} else if isFinalized {
+		s.params.Logger.Debugw(
+			"stream allocator: probe result",
+			"probeClusterId", s.activeProbeClusterId,
+			"probeSignal", probeSignal,
+			"channelCapacity", channelCapacity,
+		)
 
-				s.maybeBoostDeficientTracks()
+		s.activeProbeClusterId = ccutils.ProbeClusterIdInvalid
+
+		if probeSignal != bwe.ProbeSignalCongesting {
+			if channelCapacity > s.committedChannelCapacity {
+				s.committedChannelCapacity = channelCapacity
 			}
 
-			s.probeController.ProbeSignal(probeSignal)
+			s.maybeBoostDeficientTracks()
 		}
 	}
 
@@ -725,7 +725,7 @@ func (s *StreamAllocator) handleSignalPeriodicPing(Event) {
 
 		if s.params.RTTGetter != nil {
 			if rtt, ok := s.params.RTTGetter(); ok {
-				s.probeController.UpdateRTT(rtt)
+				s.params.BWE.UpdateRTT(rtt)
 			}
 		}
 	}
@@ -738,7 +738,8 @@ func (s *StreamAllocator) handleSignalPeriodicPing(Event) {
 
 func (s *StreamAllocator) handleSignalProbeClusterSwitch(event Event) {
 	pci := event.Data.(ccutils.ProbeClusterInfo)
-	s.probeController.ProbeClusterStarting(pci)
+	s.activeProbeClusterId = pci.Id
+
 	s.params.BWE.ProbeClusterStarting(pci)
 
 	s.params.Pacer.StartProbeCluster(pci)
@@ -773,7 +774,7 @@ func (s *StreamAllocator) handleSignalPacerProbeObserverClusterComplete(event Ev
 		t.DownTrack().SwapProbeClusterId(pci.Id, ccutils.ProbeClusterIdInvalid)
 	}
 
-	s.probeController.ProbeClusterDone(pci)
+	s.params.BWE.ProbeClusterDone(pci)
 	s.prober.ClusterDone(pci)
 }
 
@@ -858,7 +859,7 @@ func (s *StreamAllocator) handleSignalCongestionStateChange(event Event) {
 	}
 
 	if cscd.congestionState == bwe.CongestionStateCongested {
-		if s.probeController.GetActiveProbeClusterId() != ccutils.ProbeClusterIdInvalid {
+		if s.activeProbeClusterId != ccutils.ProbeClusterIdInvalid {
 			s.params.Logger.Infow(
 				"stream allocator: channel congestion detected, not updating channel capacity in active probe",
 				"old(bps)", s.committedChannelCapacity,
@@ -898,8 +899,6 @@ func (s *StreamAllocator) setState(state streamAllocatorState) {
 	// restart everything when state is STABLE
 	if state == streamAllocatorStateStable {
 		s.maybeStopProbe()
-
-		s.probeController.Reset()
 
 		s.params.BWE.Reset()
 	}
@@ -1072,12 +1071,13 @@ func (s *StreamAllocator) allocateTrack(track *Track) {
 }
 
 func (s *StreamAllocator) maybeStopProbe() {
-	activeProbeClusterId := s.probeController.GetActiveProbeClusterId()
-	if activeProbeClusterId != ccutils.ProbeClusterIdInvalid {
-		pci := s.params.Pacer.EndProbeCluster(activeProbeClusterId)
-		s.probeController.ProbeClusterDone(pci)
-		s.prober.Reset(pci)
+	if s.activeProbeClusterId == ccutils.ProbeClusterIdInvalid {
+		return
 	}
+
+	pci := s.params.Pacer.EndProbeCluster(s.activeProbeClusterId)
+	s.params.BWE.ProbeClusterDone(pci)
+	s.prober.Reset(pci)
 }
 
 func (s *StreamAllocator) maybeBoostDeficientTracks() {
@@ -1304,7 +1304,7 @@ func (s *StreamAllocator) maybeProbe() {
 		return
 	}
 
-	if s.params.BWE.CongestionState() != bwe.CongestionStateNone || !s.probeController.CanProbe() {
+	if !s.params.BWE.CanProbe() {
 		return
 	}
 
@@ -1329,7 +1329,7 @@ func (s *StreamAllocator) maybeProbeWithMedia() {
 		updateStreamStateChange(track, allocation, update)
 		s.maybeSendUpdate(update)
 
-		s.probeController.Reset()
+		s.params.BWE.Reset()
 		break
 	}
 }
@@ -1342,14 +1342,25 @@ func (s *StreamAllocator) maybeProbeWithPadding() {
 			continue
 		}
 
-		pcg, ok := s.probeController.MaybeInitiateProbe(s.committedChannelCapacity, transition.BandwidthDelta, s.getExpectedBandwidthUsage())
-		if ok {
-			pci := s.prober.AddCluster(ccutils.ProbeClusterModeUniform, pcg)
-			s.params.Logger.Debugw(
-				"stream allocator: starting probe",
-				"probeClusterInfo", pci,
-			)
+		// overshoot a bit to account for noise (in measurement/estimate etc)
+		desiredIncreaseBps := (transition.BandwidthDelta * s.params.Config.ProbeOveragePct) / 100
+		if desiredIncreaseBps < s.params.Config.ProbeMinBps {
+			desiredIncreaseBps = s.params.Config.ProbeMinBps
 		}
+		expectedBandwidthUsage := s.getExpectedBandwidthUsage()
+		pci := s.prober.AddCluster(
+			ccutils.ProbeClusterModeUniform,
+			ccutils.ProbeClusterGoal{
+				AvailableBandwidthBps: int(s.committedChannelCapacity),
+				ExpectedUsageBps:      int(expectedBandwidthUsage),
+				DesiredBps:            int(expectedBandwidthUsage + desiredIncreaseBps),
+				Duration:              s.params.BWE.ProbeDuration(),
+			},
+		)
+		s.params.Logger.Debugw(
+			"stream allocator: adding probe",
+			"probeClusterInfo", pci,
+		)
 		break
 	}
 }


### PR DESCRIPTION
Hopefully the last of the big refactors.

- Probe controller is attached to BWE. As finalising probe is BWE dependent, it is moved to BWE.
- Split out probe regulator, i.e the module which says when to run probes and put in ccutils. May make separate config of that for RemoteBWE and SendSideBWE, but same for now.

Will tweak probe behaviour of TWCC as I do more testing.