### PR TITLE
Try up-allocation on neutral trend.

### DIFF
--- a/pkg/sfu/bwe/remotebwe/channel_observer.go
+++ b/pkg/sfu/bwe/remotebwe/channel_observer.go
@@ -48,6 +48,7 @@ func (c channelTrend) String() string {
 }
 
 // ------------------------------------------------
+
 type channelCongestionReason int
 
 const (

--- a/pkg/sfu/bwe/remotebwe/channel_observer.go
+++ b/pkg/sfu/bwe/remotebwe/channel_observer.go
@@ -196,7 +196,7 @@ func (c *channelObserver) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	}
 
 	e.AddString("name", c.params.Name)
-	e.AddString("estimate", c.estimateTrend.String())
+	e.AddObject("estimate", c.estimateTrend)
 	e.AddObject("nack", c.nackTracker)
 
 	channelTrend, channelCongestionReason := c.GetTrend()

--- a/pkg/sfu/bwe/remotebwe/probe_controller.go
+++ b/pkg/sfu/bwe/remotebwe/probe_controller.go
@@ -61,7 +61,7 @@ var (
 	DefaultProbeControllerConfig = ProbeControllerConfig{
 		ProbeRegulator: ccutils.DefaultProbeRegulatorConfig,
 
-		SettleWaitNumRTT: 10,
+		SettleWaitNumRTT: 5,
 		SettleWaitMin:    500 * time.Millisecond,
 		SettleWaitMax:    10 * time.Second,
 	}

--- a/pkg/sfu/bwe/remotebwe/remote_bwe.go
+++ b/pkg/sfu/bwe/remotebwe/remote_bwe.go
@@ -320,10 +320,10 @@ func (r *RemoteBWE) ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool) {
 		"probeClusterInfo", pci,
 	)
 
-	probeSignal := ccutils.ProbeSignalClearing
+	probeSignal := ccutils.ProbeSignalNotCongesting
 	if probeCongestionState != bwe.CongestionStateNone {
 		probeSignal = ccutils.ProbeSignalCongesting
-	} else if trend, _ := pco.GetTrend(); !pco.HasEnoughEstimateSamples() || trend == channelTrendNeutral {
+	} else if !pco.HasEnoughEstimateSamples() {
 		probeSignal = ccutils.ProbeSignalInconclusive
 	} else {
 		highestEstimate := pco.GetHighestEstimate()

--- a/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
@@ -94,7 +94,7 @@ func (p ProbeSignalConfig) ProbeSignal(ppg *probePacketGroup) (ccutils.ProbeSign
 	}
 
 	if pqd < p.DQRMaxDelay.Microseconds() {
-		return ccutils.ProbeSignalClearing, ts.AcknowledgedBitrate()
+		return ccutils.ProbeSignalNotCongesting, ts.AcknowledgedBitrate()
 	}
 
 	return ccutils.ProbeSignalInconclusive, ts.AcknowledgedBitrate()
@@ -521,7 +521,7 @@ func (c *congestionDetector) ProbeClusterFinalize() (ccutils.ProbeSignal, int64,
 	)
 
 	probeSignal, estimatedAvailableChannelCapacity := c.params.Config.ProbeSignal.ProbeSignal(c.probePacketGroup)
-	if probeSignal == ccutils.ProbeSignalClearing && estimatedAvailableChannelCapacity > c.estimatedAvailableChannelCapacity {
+	if probeSignal == ccutils.ProbeSignalNotCongesting && estimatedAvailableChannelCapacity > c.estimatedAvailableChannelCapacity {
 		c.estimatedAvailableChannelCapacity = estimatedAvailableChannelCapacity
 	}
 

--- a/pkg/sfu/bwe/sendsidebwe/probe_packet_group.go
+++ b/pkg/sfu/bwe/sendsidebwe/probe_packet_group.go
@@ -40,7 +40,8 @@ var (
 			MinPackets:        16384,
 			MaxWindowDuration: time.Minute,
 		},
-		SettleWaitNumRTT: 10,
+
+		SettleWaitNumRTT: 5,
 		SettleWaitMin:    500 * time.Millisecond,
 		SettleWaitMax:    10 * time.Second,
 	}

--- a/pkg/sfu/ccutils/probe_signal.go
+++ b/pkg/sfu/ccutils/probe_signal.go
@@ -23,7 +23,7 @@ type ProbeSignal int
 const (
 	ProbeSignalInconclusive ProbeSignal = iota
 	ProbeSignalCongesting
-	ProbeSignalClearing
+	ProbeSignalNotCongesting
 )
 
 func (p ProbeSignal) String() string {
@@ -32,8 +32,8 @@ func (p ProbeSignal) String() string {
 		return "INCONCLUSIVE"
 	case ProbeSignalCongesting:
 		return "CONGESTING"
-	case ProbeSignalClearing:
-		return "CLEARING"
+	case ProbeSignalNotCongesting:
+		return "NOT_CONGESTING"
 	default:
 		return fmt.Sprintf("%d", int(p))
 	}


### PR DESCRIPTION
Some probes end up with neutral trend due to getting much estimates of same value. It is okay to try up-allocating in those cases. Otherwise, the stream allocator some times gets stuck and does not up-allocate at all as all probes end up neutral.

Changing the name of the signal to `NotCongesting` to signify it is either neutral or clearing.