### PR TITLE
Don't wait rtp packet to fire track 

### DIFF
--- a/pkg/rtc/clientinfo.go
+++ b/pkg/rtc/clientinfo.go
@@ -105,12 +105,6 @@ func (c ClientInfo) SupportSctpZeroChecksum() bool {
 	return !(c.isGo() && c.compareVersion("2.1.3") <= 0)
 }
 
-// Go SDK can publish any codec in the negotiated codecs so we can't populate the actual codec by the sdp
-// and should wait for the first rtp packet
-func (c ClientInfo) SupportFireTrackBySdp() bool {
-	return !c.isGo()
-}
-
 // compareVersion compares a semver against the current client SDK version
 // returning 1 if current version is greater than version
 // 0 if they are the same, and -1 if it's an earlier version

--- a/pkg/rtc/clientinfo.go
+++ b/pkg/rtc/clientinfo.go
@@ -105,6 +105,12 @@ func (c ClientInfo) SupportSctpZeroChecksum() bool {
 	return !(c.isGo() && c.compareVersion("2.1.3") <= 0)
 }
 
+// Go SDK can publish any codec in the negotiated codecs so we can't populate the actual codec by the sdp
+// and should wait for the first rtp packet
+func (c ClientInfo) SupportFireTrackBySdp() bool {
+	return !c.isGo()
+}
+
 // compareVersion compares a semver against the current client SDK version
 // returning 1 if current version is greater than version
 // 0 if they are the same, and -1 if it's an earlier version

--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -189,7 +189,7 @@ func (t *MediaTrack) UpdateCodecCid(codecs []*livekit.SimulcastCodec) {
 }
 
 // AddReceiver adds a new RTP receiver to the track, returns true when receiver represents a new codec
-func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track *webrtc.TrackRemote, mid string) bool {
+func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track sfu.TrackRemote, mid string) bool {
 	var newCodec bool
 	ssrc := uint32(track.SSRC())
 	buff, rtcpReader := t.params.BufferFactory.GetBufferPair(ssrc)

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1774,7 +1774,7 @@ func (p *ParticipantImpl) onMediaTrack(rtcTrack *webrtc.TrackRemote, rtpReceiver
 	// track fired by sdp
 	if rtcTrack.Codec().PayloadType == 0 {
 		codecs := rtpReceiver.GetParameters().Codecs
-		if len(codecs) == 0 || (rtcTrack.Kind() == webrtc.RTPCodecTypeVideo && !p.params.ClientInfo.SupportFireTrackBySdp()) {
+		if len(codecs) == 0 || (rtcTrack.Kind() == webrtc.RTPCodecTypeVideo && p.params.ClientInfo.FireTrackByRTPPacket()) {
 			go func() {
 				// wait for the first packet to determine the codec
 				bytes := make([]byte, 1500)

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -260,6 +260,7 @@ type TransportParams struct {
 	AllowPlayoutDelay            bool
 	DataChannelMaxBufferedAmount uint64
 	UseOneShotSignallingMode     bool
+	FireOnTrackBySdp             bool
 }
 
 func newPeerConnection(params TransportParams, onBandwidthEstimator func(estimator cc.BandwidthEstimator)) (*webrtc.PeerConnection, *webrtc.MediaEngine, error) {
@@ -286,6 +287,10 @@ func newPeerConnection(params TransportParams, onBandwidthEstimator func(estimat
 	// Disable close by dtls to avoid peerconnection close too early in migration
 	// https://github.com/pion/webrtc/pull/2961
 	se.DisableCloseByDTLS(true)
+
+	if params.FireOnTrackBySdp {
+		se.SetFireOnTrackBeforeFirstRTP(true)
+	}
 
 	//
 	// Disable SRTP replay protection (https://datatracker.ietf.org/doc/html/rfc3711#page-15).

--- a/pkg/rtc/transportmanager.go
+++ b/pkg/rtc/transportmanager.go
@@ -104,6 +104,7 @@ type TransportManagerParams struct {
 	SubscriberHandler            transport.Handler
 	DataChannelStats             *telemetry.BytesTrackStats
 	UseOneShotSignallingMode     bool
+	FireOnTrackBySdp             bool
 }
 
 type TransportManager struct {
@@ -159,6 +160,7 @@ func NewTransportManager(params TransportManagerParams) (*TransportManager, erro
 		Transport:                livekit.SignalTarget_PUBLISHER,
 		Handler:                  TransportManagerPublisherTransportHandler{TransportManagerTransportHandler{params.PublisherHandler, t, lgr}},
 		UseOneShotSignallingMode: params.UseOneShotSignallingMode,
+		FireOnTrackBySdp:         params.FireOnTrackBySdp,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -491,6 +491,7 @@ func (r *RoomManager) StartSession(
 		ForwardStats:                 r.forwardStats,
 		MetricConfig:                 r.config.Metric,
 		UseOneShotSignallingMode:     useOneShotSignallingMode,
+		FireOnTrackBySdp:             true,
 	})
 	if err != nil {
 		return err

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -151,7 +151,7 @@ type WebRTCReceiver struct {
 
 	bufferMu sync.RWMutex
 	buffers  [buffer.DefaultMaxLayerSpatial + 1]*buffer.Buffer
-	upTracks [buffer.DefaultMaxLayerSpatial + 1]*webrtc.TrackRemote
+	upTracks [buffer.DefaultMaxLayerSpatial + 1]TrackRemote
 	rtt      uint32
 
 	lbThreshold int
@@ -220,7 +220,7 @@ func WithForwardStats(forwardStats *ForwardStats) ReceiverOpts {
 // NewWebRTCReceiver creates a new webrtc track receiver
 func NewWebRTCReceiver(
 	receiver *webrtc.RTPReceiver,
-	track *webrtc.TrackRemote,
+	track TrackRemote,
 	trackInfo *livekit.TrackInfo,
 	logger logger.Logger,
 	onRTCP func([]rtcp.Packet),
@@ -360,7 +360,7 @@ func (w *WebRTCReceiver) Kind() webrtc.RTPCodecType {
 	return w.kind
 }
 
-func (w *WebRTCReceiver) AddUpTrack(track *webrtc.TrackRemote, buff *buffer.Buffer) error {
+func (w *WebRTCReceiver) AddUpTrack(track TrackRemote, buff *buffer.Buffer) error {
 	if w.closed.Load() {
 		return ErrReceiverClosed
 	}

--- a/pkg/sfu/track_remote.go
+++ b/pkg/sfu/track_remote.go
@@ -1,0 +1,35 @@
+package sfu
+
+import "github.com/pion/webrtc/v4"
+
+type TrackRemote interface {
+	ID() string
+	RID() string
+	Msid() string
+	SSRC() webrtc.SSRC
+	StreamID() string
+	Kind() webrtc.RTPCodecType
+	Codec() webrtc.RTPCodecParameters
+}
+
+// TrackRemoteFromSdp represents a remote track that could be created by the sdp.
+// It is a wrapper around the webrtc.TrackRemote and return the Codec from sdp
+// before the first RTP packet is received.
+type TrackRemoteFromSdp struct {
+	*webrtc.TrackRemote
+	sdpCodec webrtc.RTPCodecParameters
+}
+
+func NewTrackRemoteFromSdp(track *webrtc.TrackRemote, codec webrtc.RTPCodecParameters) *TrackRemoteFromSdp {
+	return &TrackRemoteFromSdp{
+		TrackRemote: track,
+		sdpCodec:    codec,
+	}
+}
+
+func (t *TrackRemoteFromSdp) Codec() webrtc.RTPCodecParameters {
+	if t.TrackRemote.PayloadType() == 0 {
+		return t.sdpCodec
+	}
+	return t.TrackRemote.Codec()
+}

--- a/test/singlenode_test.go
+++ b/test/singlenode_test.go
@@ -711,9 +711,16 @@ func TestFireTrackBySdp(t *testing.T) {
 	_, finish := setupSingleNodeTest("TestFireTrackBySdp")
 	defer finish()
 
-	c1 := createRTCClient("c1", defaultServerPort, nil)
+	c1 := createRTCClient("c1", defaultServerPort, &testclient.Options{
+		ClientInfo: &livekit.ClientInfo{
+			Sdk: livekit.ClientInfo_JS,
+		},
+	})
 	c2 := createRTCClient("c2", defaultServerPort, &testclient.Options{
 		AutoSubscribe: true,
+		ClientInfo: &livekit.ClientInfo{
+			Sdk: livekit.ClientInfo_JS,
+		},
 	})
 	waitUntilConnected(t, c1, c2)
 	defer func() {
@@ -740,8 +747,8 @@ func TestFireTrackBySdp(t *testing.T) {
 		t.Log("pub track", pubTrack)
 		tracks := c2.SubscribedTracks()[c1.ID()]
 		for _, track := range tracks {
-			t.Log("sub track", track.ID(), track.PayloadType())
-			if track.PayloadType() == 0 && track.ID() == pubTrack {
+			t.Log("sub track", track.ID(), track.Codec())
+			if track.Codec().PayloadType == 0 && track.ID() == pubTrack {
 				found++
 				break
 			}


### PR DESCRIPTION
Create track from sdp instead of first rtp packet,
it is consistent with the browser behavior and
will accelerate the track publication.
