### PR TITLE
Don't SetCodecPreferences for video transceiver

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -811,7 +811,9 @@ func (t *PCTransport) AddTrack(trackLocal webrtc.TrackLocal, params types.AddTra
 		return
 	}
 
-	configureAudioTransceiver(transceiver, params.Stereo, !params.Red || !t.params.ClientInfo.SupportsAudioRED())
+	if trackLocal.Kind() == webrtc.RTPCodecTypeAudio {
+		configureAudioTransceiver(transceiver, params.Stereo, !params.Red || !t.params.ClientInfo.SupportsAudioRED())
+	}
 	return
 }
 
@@ -827,7 +829,9 @@ func (t *PCTransport) AddTransceiverFromTrack(trackLocal webrtc.TrackLocal, para
 		return
 	}
 
-	configureAudioTransceiver(transceiver, params.Stereo, !params.Red || !t.params.ClientInfo.SupportsAudioRED())
+	if trackLocal.Kind() == webrtc.RTPCodecTypeAudio {
+		configureAudioTransceiver(transceiver, params.Stereo, !params.Red || !t.params.ClientInfo.SupportsAudioRED())
+	}
 
 	return
 }


### PR DESCRIPTION
The SetCodecPrefrences function will save codecs
to the transceiver and if the primary codec is not support by the client, the saved codec will generate rtx codec for the unsupported codec cause corrupted sdp.