### PR TITLE
Remote BWE tweaks

### DIFF
--- a/pkg/sfu/bwe/remotebwe/channel_observer.go
+++ b/pkg/sfu/bwe/remotebwe/channel_observer.go
@@ -29,15 +29,15 @@ import (
 type channelTrend int
 
 const (
-	channelTrendNeutral channelTrend = iota
+	channelTrendInconclusive channelTrend = iota
 	channelTrendClearing
 	channelTrendCongesting
 )
 
 func (c channelTrend) String() string {
 	switch c {
-	case channelTrendNeutral:
-		return "NEUTRAL"
+	case channelTrendInconclusive:
+		return "INCONCLUSIVE"
 	case channelTrendClearing:
 		return "CLEARING"
 	case channelTrendCongesting:
@@ -181,7 +181,7 @@ func (c *channelObserver) GetTrend() (channelTrend, channelCongestionReason) {
 		return channelTrendClearing, channelCongestionReasonNone
 	}
 
-	return channelTrendNeutral, channelCongestionReasonNone
+	return channelTrendInconclusive, channelCongestionReasonNone
 }
 
 func (c *channelObserver) MarshalLogObject(e zapcore.ObjectEncoder) error {

--- a/pkg/sfu/bwe/remotebwe/remote_bwe.go
+++ b/pkg/sfu/bwe/remotebwe/remote_bwe.go
@@ -127,7 +127,7 @@ func (r *RemoteBWE) HandleREMB(
 	r.lastExpectedBandwidthUsage = expectedBandwidthUsage
 
 	// in probe, freeze channel observer state if probe causes congestion till the probe is done,
-	// this is to ensure that probe result is not marked a success, 
+	// this is to ensure that probe result is not marked a success,
 	// an unsuccessful probe will not up allocate any tracks
 	if r.congestionState != bwe.CongestionStateNone && r.probeController.IsInProbe() {
 		r.lock.Unlock()
@@ -160,7 +160,7 @@ func (r *RemoteBWE) congestionDetectionStateMachine() (bool, bwe.CongestionState
 	trend, reason := r.channelObserver.GetTrend()
 	if trend == channelTrendCongesting && r.congestionState == bwe.CongestionStateNone {
 		r.params.Logger.Debugw("remote bwe, channel congesting", "channel", r.channelObserver)
-	} else  if trend == channelTrendClearing && r.congestionState != bwe.CongestionStateNone {
+	} else if trend == channelTrendClearing && r.congestionState != bwe.CongestionStateNone {
 		r.params.Logger.Debugw("remote bwe, channel congestion relieving", "channel", r.channelObserver)
 	}
 
@@ -221,7 +221,7 @@ func (r *RemoteBWE) estimateAvailableChannelCapacity(reason channelCongestionRea
 	}
 
 	r.params.Logger.Infow(
-		"remote bwe: channel congestion detected, applying channel capacity update")
+		"remote bwe: channel congestion detected, applying channel capacity update",
 		"reason", reason,
 		"old(bps)", r.committedChannelCapacity,
 		"new(bps)", estimateToCommit,
@@ -335,7 +335,7 @@ func (r *RemoteBWE) newChannelObserver() {
 			Config: r.params.Config.ChannelObserverProbe,
 		}
 	} else {
-		params  = channelObserverParams{
+		params = channelObserverParams{
 			Name:   "non-probe",
 			Config: r.params.Config.ChannelObserverNonProbe,
 		}

--- a/pkg/sfu/ccutils/trenddetector.go
+++ b/pkg/sfu/ccutils/trenddetector.go
@@ -27,15 +27,15 @@ import (
 type TrendDirection int
 
 const (
-	TrendDirectionNeutral TrendDirection = iota
+	TrendDirectionInconclusive TrendDirection = iota
 	TrendDirectionUpward
 	TrendDirectionDownward
 )
 
 func (t TrendDirection) String() string {
 	switch t {
-	case TrendDirectionNeutral:
-		return "NEUTRAL"
+	case TrendDirectionInconclusive:
+		return "INCONCLUSIVE"
 	case TrendDirectionUpward:
 		return "UPWARD"
 	case TrendDirectionDownward:
@@ -104,7 +104,7 @@ func NewTrendDetector[T trendDetectorNumber](params TrendDetectorParams) *TrendD
 	return &TrendDetector[T]{
 		params:    params,
 		startTime: time.Now(),
-		direction: TrendDirectionNeutral,
+		direction: TrendDirectionInconclusive,
 	}
 }
 
@@ -236,14 +236,14 @@ func (t *TrendDetector[T]) prune() {
 
 func (t *TrendDetector[T]) updateDirection() {
 	if len(t.samples) < t.params.Config.RequiredSamplesMin {
-		t.direction = TrendDirectionNeutral
+		t.direction = TrendDirectionInconclusive
 		return
 	}
 
 	// using Kendall's Tau to find trend
 	kt := t.kendallsTau()
 
-	t.direction = TrendDirectionNeutral
+	t.direction = TrendDirectionInconclusive
 	switch {
 	case kt > 0 && len(t.samples) >= t.params.Config.RequiredSamples:
 		t.direction = TrendDirectionUpward


### PR DESCRIPTION
- Do not refresh channel observer on estimate update. Let the history continue and update state. That works better to detect perceived end of congestion.
- Rename `NEUTRAL` -> `INCONCLUSIVE`
- Do not see in probe channel observer, let is start fresh. As end of congestion is detected by preserving history above, this can start fresh and determine probe behaviour.