### PR TITLE
Up allocate to available headroom.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1274,17 +1274,12 @@ func (f *Forwarder) AllocateNextHigher(availableChannelCapacity int64, available
 		return f.lastAllocation, false
 	}
 
-	// if targets are still pending, don't increase
-	targetLayer := f.vls.GetTarget()
-	if targetLayer.IsValid() && targetLayer != f.vls.GetCurrent() {
-		return f.lastAllocation, false
-	}
-
 	maxLayer := f.vls.GetMax()
 	maxSeenLayer := f.vls.GetMaxSeen()
 	optimalBandwidthNeeded := getOptimalBandwidthNeeded(f.muted, f.pubMuted, maxSeenLayer.Spatial, brs, maxLayer)
 
 	alreadyAllocated := int64(0)
+	targetLayer := f.vls.GetTarget()
 	if targetLayer.IsValid() {
 		alreadyAllocated = brs[targetLayer.Spatial][targetLayer.Temporal]
 	}

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -726,6 +726,17 @@ func (s *StreamAllocator) handleSignalPeriodicPing(Event) {
 		}
 	}
 
+	// try up allocations in case there is available headroom,
+	// it is possible that a previous up allocation is waiting to settle,
+	// so even if there was headroom available while doing previous up allocation
+	// it may not have used up all available headroom,
+	// check before probing again as this could use available headroom and
+	// up allocate all tracks to their desired layers, that would avoid
+	// an unnecessary probe cluster
+	if s.state == streamAllocatorStateDeficient {
+		s.maybeBoostDeficientTracks()
+	}
+
 	// probe if necessary and timing is right
 	if s.state == streamAllocatorStateDeficient {
 		s.maybeProbe()


### PR DESCRIPTION
There are cases where the probe result has enough headroom to up allocate all deficient tracks. Mainly happens after a loss scenario where the estimate is actually still high.

After boosting once, there was a check for the track to hit the desired layer before boosting again. But, that is not really necessary. Can boost target and forwarder should resolve to the latest target. Removing that check in the forwarder.

Also, adding a gratuitous boost check in stream allocator periodic ping when deficient to look for opportunities to boost.