### PR TITLE
Better naming/logging for send side bwe

### DIFF
--- a/pkg/sfu/bwe/bwe.go
+++ b/pkg/sfu/bwe/bwe.go
@@ -85,6 +85,8 @@ type BWE interface {
 
 	UpdateRTT(rtt float64)
 
+	CongestionState() CongestionState
+
 	CanProbe() bool
 	ProbeDuration() time.Duration
 	ProbeClusterStarting(pci ccutils.ProbeClusterInfo)
@@ -96,7 +98,7 @@ type BWE interface {
 // ------------------------------------------------
 
 type BWEListener interface {
-	OnCongestionStateChange(congestionState CongestionState, estimatedAvailableChannelCapacity int64)
+	OnCongestionStateChange(fromState CongestionState, toState CongestionState, estimatedAvailableChannelCapacity int64)
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/bwe/null_bwe.go
+++ b/pkg/sfu/bwe/null_bwe.go
@@ -50,6 +50,10 @@ func (n *NullBWE) HandleTWCCFeedback(_report *rtcp.TransportLayerCC) {}
 
 func (n *NullBWE) UpdateRTT(rtt float64) {}
 
+func (n *NullBWE) CongestionState() CongestionState {
+	return CongestionStateNone
+}
+
 func (n *NullBWE) CanProbe() bool {
 	return false
 }

--- a/pkg/sfu/bwe/remotebwe/remote_bwe.go
+++ b/pkg/sfu/bwe/remotebwe/remote_bwe.go
@@ -137,12 +137,12 @@ func (r *RemoteBWE) HandleREMB(
 	r.channelObserver.AddEstimate(r.lastReceivedEstimate)
 	r.channelObserver.AddNack(sentPackets, repeatedNacks)
 
-	shouldNotify, state, committedChannelCapacity := r.congestionDetectionStateMachine()
+	shouldNotify, fromState, toState, committedChannelCapacity := r.congestionDetectionStateMachine()
 	r.lock.Unlock()
 
 	if shouldNotify {
 		if bweListener := r.getBWEListener(); bweListener != nil {
-			bweListener.OnCongestionStateChange(state, committedChannelCapacity)
+			bweListener.OnCongestionStateChange(fromState, toState, committedChannelCapacity)
 		}
 	}
 }
@@ -154,18 +154,19 @@ func (r *RemoteBWE) UpdateRTT(rtt float64) {
 	r.probeController.UpdateRTT(rtt)
 }
 
-func (r *RemoteBWE) congestionDetectionStateMachine() (bool, bwe.CongestionState, int64) {
-	newState := r.congestionState
+func (r *RemoteBWE) congestionDetectionStateMachine() (bool, bwe.CongestionState, bwe.CongestionState, int64) {
+	fromState := r.congestionState
+	toState := r.congestionState
 	update := false
 	trend, reason := r.channelObserver.GetTrend()
 
-	switch r.congestionState {
+	switch fromState {
 	case bwe.CongestionStateNone:
 		if trend == channelTrendCongesting {
 			if r.probeController.IsInProbe() || r.estimateAvailableChannelCapacity(reason) {
 				// when in probe, if congested, stays there till probe is done,
 				// the estimate stays at pre-probe level
-				newState = bwe.CongestionStateCongested
+				toState = bwe.CongestionStateCongested
 			}
 		}
 
@@ -176,26 +177,26 @@ func (r *RemoteBWE) congestionDetectionStateMachine() (bool, bwe.CongestionState
 				update = true
 			}
 		} else {
-			newState = bwe.CongestionStateCongestedHangover
+			toState = bwe.CongestionStateCongestedHangover
 		}
 
 	case bwe.CongestionStateCongestedHangover:
 		if trend == channelTrendCongesting {
 			if r.estimateAvailableChannelCapacity(reason) {
-				newState = bwe.CongestionStateCongested
+				toState = bwe.CongestionStateCongested
 			}
 		} else if time.Since(r.congestionStateSwitchedAt) >= r.params.Config.CongestedHangoverDuration {
-			newState = bwe.CongestionStateNone
+			toState = bwe.CongestionStateNone
 		}
 	}
 
 	shouldNotify := false
-	if newState != r.congestionState || update {
-		r.updateCongestionState(newState, reason)
+	if toState != fromState || update {
+		r.updateCongestionState(toState, reason)
 		shouldNotify = true
 	}
 
-	return shouldNotify, r.congestionState, r.committedChannelCapacity
+	return shouldNotify, fromState, r.congestionState, r.committedChannelCapacity
 }
 
 func (r *RemoteBWE) estimateAvailableChannelCapacity(reason channelCongestionReason) bool {
@@ -240,6 +241,13 @@ func (r *RemoteBWE) updateCongestionState(state bwe.CongestionState, reason chan
 
 	r.congestionState = state
 	r.congestionStateSwitchedAt = mono.Now()
+}
+
+func (r *RemoteBWE) CongestionState() bwe.CongestionState {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.congestionState
 }
 
 func (r *RemoteBWE) CanProbe() bool {

--- a/pkg/sfu/bwe/remotebwe/remote_bwe.go
+++ b/pkg/sfu/bwe/remotebwe/remote_bwe.go
@@ -192,11 +192,11 @@ func (r *RemoteBWE) congestionDetectionStateMachine() (bool, bwe.CongestionState
 
 	shouldNotify := false
 	if toState != fromState || update {
-		r.updateCongestionState(toState, reason)
+		fromState, toState = r.updateCongestionState(toState, reason)
 		shouldNotify = true
 	}
 
-	return shouldNotify, fromState, r.congestionState, r.committedChannelCapacity
+	return shouldNotify, fromState, toState, r.committedChannelCapacity
 }
 
 func (r *RemoteBWE) estimateAvailableChannelCapacity(reason channelCongestionReason) bool {
@@ -230,7 +230,7 @@ func (r *RemoteBWE) estimateAvailableChannelCapacity(reason channelCongestionRea
 	return true
 }
 
-func (r *RemoteBWE) updateCongestionState(state bwe.CongestionState, reason channelCongestionReason) {
+func (r *RemoteBWE) updateCongestionState(state bwe.CongestionState, reason channelCongestionReason) (bwe.CongestionState, bwe.CongestionState) {
 	r.params.Logger.Infow(
 		"remote bwe: congestion state change",
 		"from", r.congestionState,
@@ -239,8 +239,10 @@ func (r *RemoteBWE) updateCongestionState(state bwe.CongestionState, reason chan
 		"committedChannelCapacity", r.committedChannelCapacity,
 	)
 
+	fromState := r.congestionState
 	r.congestionState = state
 	r.congestionStateSwitchedAt = mono.Now()
+	return fromState, r.congestionState
 }
 
 func (r *RemoteBWE) CongestionState() bwe.CongestionState {

--- a/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
@@ -40,23 +40,23 @@ func (c CongestionSignalConfig) IsTriggered(numGroups int, duration int64) bool 
 
 var (
 	defaultQueuingDelayEarlyWarningCongestionSignalConfig = CongestionSignalConfig{
-		MinNumberOfGroups: 1,
-		MinDuration:       100 * time.Millisecond,
+		MinNumberOfGroups: 2,
+		MinDuration:       200 * time.Millisecond,
 	}
 
 	defaultLossEarlyWarningCongestionSignalConfig = CongestionSignalConfig{
-		MinNumberOfGroups: 2,
-		MinDuration:       300 * time.Millisecond,
-	}
-
-	defaultQueuingDelayCongestedCongestionSignalConfig = CongestionSignalConfig{
 		MinNumberOfGroups: 3,
 		MinDuration:       300 * time.Millisecond,
 	}
 
+	defaultQueuingDelayCongestedCongestionSignalConfig = CongestionSignalConfig{
+		MinNumberOfGroups: 4,
+		MinDuration:       400 * time.Millisecond,
+	}
+
 	defaultLossCongestedCongestionSignalConfig = CongestionSignalConfig{
 		MinNumberOfGroups: 6,
-		MinDuration:       900 * time.Millisecond,
+		MinDuration:       600 * time.Millisecond,
 	}
 )
 

--- a/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
@@ -954,16 +954,18 @@ func (c *congestionDetector) estimateAvailableChannelCapacity(oldestContributing
 }
 
 func (c *congestionDetector) updateCongestionState(state bwe.CongestionState, reason string, oldestContributingGroup int) (bwe.CongestionState, bwe.CongestionState) {
-	c.params.Logger.Infow(
-		"send side bwe: congestion state change",
+	loggingFields := []any{
 		"from", c.congestionState,
 		"to", state,
 		"reason", reason,
 		"numPacketGroups", len(c.packetGroups),
-		"numContributingGroups", len(c.packetGroups[oldestContributingGroup:]),
-		"contributingGroups", logger.ObjectSlice(c.packetGroups[oldestContributingGroup:]),
+		"oldestContributingGroup", oldestContributingGroup,
 		"estimatedAvailableChannelCapacity", c.estimatedAvailableChannelCapacity,
-	)
+	}
+	if state == bwe.CongestionStateEarlyWarning || state == bwe.CongestionStateCongested {
+		loggingFields = append(loggingFields, "contributingGroups", logger.ObjectSlice(c.packetGroups[oldestContributingGroup:]))
+	}
+	c.params.Logger.Infow("send side bwe: congestion state change", loggingFields...)
 
 	if state != c.congestionState {
 		c.congestionStateSwitchedAt = mono.Now()

--- a/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
@@ -808,7 +808,7 @@ func (c *congestionDetector) congestionDetectionStateMachine() (bool, bwe.Conges
 		if qr == queuingRegionJQR {
 			toState = bwe.CongestionStateCongested
 		} else {
-			qr, _, _ := c.getEarlyWarningSignal()
+			qr, reason, oldestContributingGroup = c.getEarlyWarningSignal()
 			if qr == queuingRegionDQR {
 				toState = bwe.CongestionStateEarlyWarningHangover
 			}
@@ -823,7 +823,7 @@ func (c *congestionDetector) congestionDetectionStateMachine() (bool, bwe.Conges
 		}
 
 	case bwe.CongestionStateCongested:
-		qr, _, _ = c.getCongestedSignal()
+		qr, reason, oldestContributingGroup = c.getCongestedSignal()
 		if qr == queuingRegionDQR {
 			toState = bwe.CongestionStateCongestedHangover
 		}

--- a/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
@@ -847,18 +847,19 @@ func (c *congestionDetector) congestionDetectionStateMachine() (bool, bwe.Conges
 	}
 
 	if c.congestedCTRTrend != nil && c.congestedCTRTrend.GetDirection() == ccutils.TrendDirectionDownward {
-		shouldNotify = true
-
 		congestedAckedBitrate := c.congestedTrafficStats.AcknowledgedBitrate()
 		if congestedAckedBitrate < c.estimatedAvailableChannelCapacity {
 			c.estimatedAvailableChannelCapacity = congestedAckedBitrate
+
+			c.params.Logger.Infow(
+				"send side bwe: captured traffic ratio is trending downward",
+				"channel", c.congestedCTRTrend,
+				"trafficStats", c.congestedTrafficStats,
+				"estimatedAvailableChannelCapacity", c.estimatedAvailableChannelCapacity,
+			)
+
+			shouldNotify = true
 		}
-		c.params.Logger.Infow(
-			"send side bwe: captured traffic ratio is trending downward",
-			"channel", c.congestedCTRTrend,
-			"trafficStats", c.congestedTrafficStats,
-			"estimatedAvailableChannelCapacity", c.estimatedAvailableChannelCapacity,
-		)
 
 		// reset to get new set of samples for next trend
 		c.resetCTRTrend()

--- a/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
@@ -334,7 +334,7 @@ var (
 	defaultTrendDetectorConfigCongestedCTR = ccutils.TrendDetectorConfig{
 		RequiredSamples:        4,
 		RequiredSamplesMin:     2,
-		DownwardTrendThreshold: -0.5,
+		DownwardTrendThreshold: -0.7,
 		DownwardTrendMaxWait:   2 * time.Second,
 		CollapseThreshold:      500 * time.Millisecond,
 		ValidityWindow:         10 * time.Second,

--- a/pkg/sfu/bwe/sendsidebwe/packet_group.go
+++ b/pkg/sfu/bwe/sendsidebwe/packet_group.go
@@ -39,7 +39,7 @@ type PacketGroupConfig struct {
 
 var (
 	defaultPacketGroupConfig = PacketGroupConfig{
-		MinPackets:        20,
+		MinPackets:        30,
 		MaxWindowDuration: 500 * time.Millisecond,
 	}
 )

--- a/pkg/sfu/bwe/sendsidebwe/send_side_bwe.go
+++ b/pkg/sfu/bwe/sendsidebwe/send_side_bwe.go
@@ -114,6 +114,10 @@ func (s *SendSideBWE) UpdateRTT(rtt float64) {
 	s.congestionDetector.UpdateRTT(rtt)
 }
 
+func (s *SendSideBWE) CongestionState() bwe.CongestionState {
+	return s.congestionDetector.CongestionState()
+}
+
 func (s *SendSideBWE) CanProbe() bool {
 	return s.congestionDetector.CanProbe()
 }

--- a/pkg/sfu/bwe/sendsidebwe/traffic_stats.go
+++ b/pkg/sfu/bwe/sendsidebwe/traffic_stats.go
@@ -32,8 +32,8 @@ type WeightedLossConfig struct {
 
 var (
 	defaultWeightedLossConfig = WeightedLossConfig{
-		MinDurationForLossValidity: 200 * time.Millisecond,
-		MinPPSForLossValidity:      20,
+		MinDurationForLossValidity: 250 * time.Millisecond,
+		MinPPSForLossValidity:      30,
 		LossPenaltyFactor:          0.25,
 	}
 )


### PR DESCRIPTION
Started off as no-functional change PR, but added another commit after realising a window where optimal allocation was done in congested state.

It is arguable if optimal should be done in those cases, but for now checking BWE state also. Comments on the relevant commit
```
Check BWE congestion state before doing optimal allocation.
It is possible that BWE declares congestion, but the estimated bandwidth
may still be enough to accommodate all tracks. So, stream allocator
would still not in DEFICIENT state. On a new track allocation, it will
get optimal allocation although BWE is in congested state.

Take BWE congestion state into consideration before doing any track
allocation.
```