### PR TITLE
TWCC tweaks

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -323,7 +323,7 @@ var DefaultConfig = Config{
 			StreamAllocator:           streamallocator.DefaultStreamAllocatorConfig,
 			RemoteBWE:                 remotebwe.DefaultRemoteBWEConfig,
 			UseSendSideBWEInterceptor: false,
-			UseSendSideBWE:            true,
+			UseSendSideBWE:            false,
 			SendSideBWE:               sendsidebwe.DefaultSendSideBWEConfig,
 		},
 		DatachannelSlowThreshold: 1000000,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -323,7 +323,7 @@ var DefaultConfig = Config{
 			StreamAllocator:           streamallocator.DefaultStreamAllocatorConfig,
 			RemoteBWE:                 remotebwe.DefaultRemoteBWEConfig,
 			UseSendSideBWEInterceptor: false,
-			UseSendSideBWE:            false,
+			UseSendSideBWE:            true,
 			SendSideBWE:               sendsidebwe.DefaultSendSideBWEConfig,
 		},
 		DatachannelSlowThreshold: 1000000,

--- a/pkg/sfu/bwe/bwe.go
+++ b/pkg/sfu/bwe/bwe.go
@@ -36,9 +36,7 @@ type CongestionState int
 const (
 	CongestionStateNone CongestionState = iota
 	CongestionStateEarlyWarning
-	CongestionStateEarlyWarningHangover
 	CongestionStateCongested
-	CongestionStateCongestedHangover
 )
 
 func (c CongestionState) String() string {
@@ -47,12 +45,8 @@ func (c CongestionState) String() string {
 		return "NONE"
 	case CongestionStateEarlyWarning:
 		return "EARLY_WARNING"
-	case CongestionStateEarlyWarningHangover:
-		return "EARLY_WARNING_HANGOVER"
 	case CongestionStateCongested:
 		return "CONGESTED"
-	case CongestionStateCongestedHangover:
-		return "CONGESTED_HANGOVER"
 	default:
 		return fmt.Sprintf("%d", int(c))
 	}

--- a/pkg/sfu/bwe/remotebwe/remote_bwe.go
+++ b/pkg/sfu/bwe/remotebwe/remote_bwe.go
@@ -27,22 +27,20 @@ import (
 // ---------------------------------------------------------------------------
 
 type RemoteBWEConfig struct {
-	NackRatioAttenuator       float64               `yaml:"nack_ratio_attenuator,omitempty"`
-	ExpectedUsageThreshold    float64               `yaml:"expected_usage_threshold,omitempty"`
-	ChannelObserverProbe      ChannelObserverConfig `yaml:"channel_observer_probe,omitempty"`
-	ChannelObserverNonProbe   ChannelObserverConfig `yaml:"channel_observer_non_probe,omitempty"`
-	CongestedHangoverDuration time.Duration         `yaml:"congested_hangover_duration,omitempty"`
-	ProbeController           ProbeControllerConfig `yaml:"probe_controller,omitempty"`
+	NackRatioAttenuator     float64               `yaml:"nack_ratio_attenuator,omitempty"`
+	ExpectedUsageThreshold  float64               `yaml:"expected_usage_threshold,omitempty"`
+	ChannelObserverProbe    ChannelObserverConfig `yaml:"channel_observer_probe,omitempty"`
+	ChannelObserverNonProbe ChannelObserverConfig `yaml:"channel_observer_non_probe,omitempty"`
+	ProbeController         ProbeControllerConfig `yaml:"probe_controller,omitempty"`
 }
 
 var (
 	DefaultRemoteBWEConfig = RemoteBWEConfig{
-		NackRatioAttenuator:       0.4,
-		ExpectedUsageThreshold:    0.95,
-		ChannelObserverProbe:      defaultChannelObserverConfigProbe,
-		ChannelObserverNonProbe:   defaultChannelObserverConfigNonProbe,
-		CongestedHangoverDuration: 3 * time.Second,
-		ProbeController:           DefaultProbeControllerConfig,
+		NackRatioAttenuator:     0.4,
+		ExpectedUsageThreshold:  0.95,
+		ChannelObserverProbe:    defaultChannelObserverConfigProbe,
+		ChannelObserverNonProbe: defaultChannelObserverConfigNonProbe,
+		ProbeController:         DefaultProbeControllerConfig,
 	}
 )
 
@@ -177,15 +175,6 @@ func (r *RemoteBWE) congestionDetectionStateMachine() (bool, bwe.CongestionState
 				update = true
 			}
 		} else {
-			toState = bwe.CongestionStateCongestedHangover
-		}
-
-	case bwe.CongestionStateCongestedHangover:
-		if trend == channelTrendCongesting {
-			if r.estimateAvailableChannelCapacity(reason) {
-				toState = bwe.CongestionStateCongested
-			}
-		} else if time.Since(r.congestionStateSwitchedAt) >= r.params.Config.CongestedHangoverDuration {
 			toState = bwe.CongestionStateNone
 		}
 	}

--- a/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
@@ -963,7 +963,7 @@ func (c *congestionDetector) congestionDetectionStateMachine() (bool, bwe.Conges
 			"queuingRegion", c.queuingRegion,
 			"qdMeasurement", c.qdMeasurement,
 			"lossMeasurement", c.lossMeasurement,
-		)	// REMOVE
+		) // REMOVE
 		if c.queuingRegion == queuingRegionDQR {
 			// RAJA-TODO toState = bwe.CongestionStateCongestedHangover
 			toState = bwe.CongestionStateNone

--- a/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
@@ -944,13 +944,6 @@ func (c *congestionDetector) congestionDetectionStateMachine() (bool, bwe.Conges
 
 	case bwe.CongestionStateCongested:
 		c.updateCongestedSignal()
-		c.params.Logger.Infow(
-			"RAJA congested state",
-			"congestionReason", c.congestionReason,
-			"queuingRegion", c.queuingRegion,
-			"qdMeasurement", c.qdMeasurement,
-			"lossMeasurement", c.lossMeasurement,
-		) // REMOVE
 		if c.queuingRegion == queuingRegionDQR {
 			toState = bwe.CongestionStateNone
 		}

--- a/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
@@ -45,8 +45,8 @@ var (
 	}
 
 	defaultQueuingDelayEarlyWarningDQRConfig = CongestionSignalConfig{
-		MinNumberOfGroups: 4,
-		MinDuration:       400 * time.Millisecond,
+		MinNumberOfGroups: 3,
+		MinDuration:       300 * time.Millisecond,
 	}
 
 	defaultLossEarlyWarningJQRConfig = CongestionSignalConfig{
@@ -55,8 +55,8 @@ var (
 	}
 
 	defaultLossEarlyWarningDQRConfig = CongestionSignalConfig{
-		MinNumberOfGroups: 6,
-		MinDuration:       600 * time.Millisecond,
+		MinNumberOfGroups: 4,
+		MinDuration:       400 * time.Millisecond,
 	}
 
 	defaultQueuingDelayCongestedJQRConfig = CongestionSignalConfig{
@@ -65,8 +65,8 @@ var (
 	}
 
 	defaultQueuingDelayCongestedDQRConfig = CongestionSignalConfig{
-		MinNumberOfGroups: 8,
-		MinDuration:       800 * time.Millisecond,
+		MinNumberOfGroups: 5,
+		MinDuration:       500 * time.Millisecond,
 	}
 
 	defaultLossCongestedJQRConfig = CongestionSignalConfig{
@@ -75,8 +75,8 @@ var (
 	}
 
 	defaultLossCongestedDQRConfig = CongestionSignalConfig{
-		MinNumberOfGroups: 12,
-		MinDuration:       1200 * time.Millisecond,
+		MinNumberOfGroups: 6,
+		MinDuration:       600 * time.Millisecond,
 	}
 )
 

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -727,6 +727,7 @@ func (s *StreamAllocator) handleSignalPeriodicPing(Event) {
 		}
 	}
 
+	/* RAJA-TODO
 	// try up allocations in case there is available headroom,
 	// it is possible that a previous up allocation is waiting to settle,
 	// so even if there was headroom available while doing previous up allocation
@@ -737,6 +738,7 @@ func (s *StreamAllocator) handleSignalPeriodicPing(Event) {
 	if s.state == streamAllocatorStateDeficient {
 		s.maybeBoostDeficientTracks()
 	}
+	*/
 
 	// probe if necessary and timing is right
 	if s.state == streamAllocatorStateDeficient {

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -1441,11 +1441,11 @@ func updateStreamStateChange(track *Track, allocation sfu.VideoAllocation, updat
 }
 
 func isHoldableCongestionState(bweCongestionState bwe.CongestionState) bool {
-	return bweCongestionState == bwe.CongestionStateEarlyWarning || bweCongestionState == bwe.CongestionStateEarlyWarningHangover
+	return bweCongestionState == bwe.CongestionStateEarlyWarning
 }
 
 func isDeficientCongestionState(bweCongestionState bwe.CongestionState) bool {
-	return bweCongestionState == bwe.CongestionStateCongested || bweCongestionState == bwe.CongestionStateCongestedHangover
+	return bweCongestionState == bwe.CongestionStateCongested
 }
 
 // ------------------------------------------------

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -727,19 +727,6 @@ func (s *StreamAllocator) handleSignalPeriodicPing(Event) {
 		}
 	}
 
-	/* RAJA-TODO
-	// try up allocations in case there is available headroom,
-	// it is possible that a previous up allocation is waiting to settle,
-	// so even if there was headroom available while doing previous up allocation
-	// it may not have used up all available headroom,
-	// check before probing again as this could use available headroom and
-	// up allocate all tracks to their desired layers, that would avoid
-	// an unnecessary probe cluster
-	if s.state == streamAllocatorStateDeficient {
-		s.maybeBoostDeficientTracks()
-	}
-	*/
-
 	// probe if necessary and timing is right
 	if s.state == streamAllocatorStateDeficient {
 		s.maybeProbe()


### PR DESCRIPTION
- Remove hangover states. Replace with a string of packet groups satisfying the dis-joint queuing region criteria to declare moving away from congestion state.
- Tweak pps condition for loss validity to take duration into consideration. Longer duration gives better pps measurement, so a lower value is acceptable.

Still the SVC case is choppy, but this makes congestion relief signal more reliable.