### PR TITLE
Disable av1 for safari

### DIFF
--- a/pkg/clientconfiguration/conf.go
+++ b/pkg/clientconfiguration/conf.go
@@ -25,13 +25,13 @@ var StaticConfigurations = []ConfigurationItem{
 	// 	Configuration: &livekit.ClientConfiguration{ResumeConnection: livekit.ClientConfigSetting_DISABLED},
 	// 	Merge:         false,
 	// },
-	// {
-	// 	Match: &ScriptMatch{Expr: `c.browser == "safari" && c.os == "ios"`},
-	// 	Configuration: &livekit.ClientConfiguration{DisabledCodecs: &livekit.DisabledCodecs{Codecs: []*livekit.Codec{
-	// 		{Mime: "video/vp9"},
-	// 	}}},
-	// 	Merge: false,
-	// },
+	{
+		Match: &ScriptMatch{Expr: `c.browser == "safari"`},
+		Configuration: &livekit.ClientConfiguration{DisabledCodecs: &livekit.DisabledCodecs{Codecs: []*livekit.Codec{
+			{Mime: "video/av1"},
+		}}},
+		Merge: false,
+	},
 	{
 		Match: &ScriptMatch{Expr: `(c.device_model == "xiaomi 2201117ti" && c.os == "android") ||
 		  ((c.browser == "firefox" || c.browser == "firefox mobile") && (c.os == "linux" || c.os == "android"))`},


### PR DESCRIPTION
M3 chip/iphone15 pro has av1 enabled for safari but its hardware decoder can't decode av1 svc encoding.