### PR TITLE
Reduce memory allocation in WritePaddingRTP / WriteProbePackets

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -1034,6 +1034,7 @@ func (d *DownTrack) WritePaddingRTP(bytesToSend int, paddingOnMute bool, forceMa
 	}
 
 	bytesSent := 0
+	payloads := make([]byte, RTPPaddingMaxPayloadSize*len(snts))
 	for i := 0; i < len(snts); i++ {
 		hdr := &rtp.Header{
 			Version:        2,
@@ -1046,7 +1047,7 @@ func (d *DownTrack) WritePaddingRTP(bytesToSend int, paddingOnMute bool, forceMa
 		}
 		d.addDummyExtensions(hdr)
 
-		payload := make([]byte, RTPPaddingMaxPayloadSize)
+		payload := payloads[i*RTPPaddingMaxPayloadSize : (i+1)*RTPPaddingMaxPayloadSize : (i+1)*RTPPaddingMaxPayloadSize]
 		// last byte of padding has padding size including that byte
 		payload[RTPPaddingMaxPayloadSize-1] = byte(RTPPaddingMaxPayloadSize)
 

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -2106,6 +2106,7 @@ func (d *DownTrack) WriteProbePackets(bytesToSend int, usePadding bool) int {
 		}
 
 		rtxExtSequenceNumber := d.rtxSequenceNumber.Inc()
+		payloads := make([]byte, RTPPaddingMaxPayloadSize*num)
 		for i := 0; i < num; i++ {
 			hdr := &rtp.Header{
 				Version:        2,
@@ -2118,7 +2119,7 @@ func (d *DownTrack) WriteProbePackets(bytesToSend int, usePadding bool) int {
 			}
 			d.addDummyExtensions(hdr)
 
-			payload := make([]byte, RTPPaddingMaxPayloadSize)
+			payload := payloads[i*RTPPaddingMaxPayloadSize : (i+1)*RTPPaddingMaxPayloadSize : (i+1)*RTPPaddingMaxPayloadSize]
 			// last byte of padding has padding size including that byte
 			payload[RTPPaddingMaxPayloadSize-1] = byte(RTPPaddingMaxPayloadSize)
 


### PR DESCRIPTION
Tiny optimisation to reduce memory allocations within for cycle