### PR TITLE
Use contiguous groups to determine queuing region.

### DIFF
--- a/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
@@ -228,34 +228,24 @@ func (q *qdMeasurement) ProcessPacketGroup(pg *packetGroup, groupIdx int) {
 	}
 	q.maxSendTime = max(q.maxSendTime, maxSendTime)
 
-	if pqd < q.dqrMax {
+	switch {
+	case pqd < q.dqrMax:
 		q.numDQRGroups++
-		if q.numJQRGroups > 0 {
-			// JQR continuity is broken
-			q.isSealed = true
-			return
-		}
-
 		if q.dqrConfig.IsTriggered(q.numDQRGroups, q.maxSendTime-q.minSendTime) {
 			q.isSealed = true
 			q.queuingRegion = queuingRegionDQR
-			return
 		}
-	}
 
-	if pqd > q.jqrMin {
+	case pqd > q.jqrMin:
 		q.numJQRGroups++
-		if q.numDQRGroups > 0 {
-			// DQR continuity is broken
-			q.isSealed = true
-			return
-		}
-
 		if q.jqrConfig.IsTriggered(q.numJQRGroups, q.maxSendTime-q.minSendTime) {
 			q.isSealed = true
 			q.queuingRegion = queuingRegionJQR
-			return
 		}
+
+	default:
+		// broken continuity, seal
+		q.isSealed = true
 	}
 }
 
@@ -351,17 +341,19 @@ func (l *lossMeasurement) ProcessPacketGroup(pg *packetGroup, groupIdx int) {
 		if weightedLoss > l.jqrMinLoss {
 			l.weightedLoss = weightedLoss
 			l.queuingRegion = queuingRegionJQR
-			l.isDQRSealed = true // seal DQR also as JQR is already hit
+			l.isDQRSealed = true // seal DQR also as queuing region has been determined
 			return
 		}
 	}
 
-	if l.dqrConfig.IsTriggered(l.numGroups, l.ts.Duration()) {
+	if !l.isDQRSealed && l.dqrConfig.IsTriggered(l.numGroups, l.ts.Duration()) {
 		l.isDQRSealed = true
 
-		l.weightedLoss = l.ts.WeightedLoss()
-		if l.weightedLoss < l.dqrMaxLoss {
+		weightedLoss := l.ts.WeightedLoss()
+		if weightedLoss < l.dqrMaxLoss {
+			l.weightedLoss = weightedLoss
 			l.queuingRegion = queuingRegionDQR
+			l.isJQRSealed = true // seal JQR also as queuing region has been determined
 			return
 		}
 	}
@@ -855,7 +847,6 @@ func (c *congestionDetector) prunePacketGroups() {
 }
 
 func (c *congestionDetector) updateCongestionSignal(
-	stage string,
 	qdJQRConfig CongestionSignalConfig,
 	qdDQRConfig CongestionSignalConfig,
 	lossJQRConfig CongestionSignalConfig,
@@ -902,7 +893,6 @@ func (c *congestionDetector) updateCongestionSignal(
 
 func (c *congestionDetector) updateEarlyWarningSignal() {
 	c.updateCongestionSignal(
-		"early-warning",
 		c.params.Config.QueuingDelayEarlyWarningJQR,
 		c.params.Config.QueuingDelayEarlyWarningDQR,
 		c.params.Config.LossEarlyWarningJQR,
@@ -912,7 +902,6 @@ func (c *congestionDetector) updateEarlyWarningSignal() {
 
 func (c *congestionDetector) updateCongestedSignal() {
 	c.updateCongestionSignal(
-		"congested",
 		c.params.Config.QueuingDelayCongestedJQR,
 		c.params.Config.QueuingDelayCongestedDQR,
 		c.params.Config.LossCongestedJQR,

--- a/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
@@ -231,14 +231,20 @@ func (q *qdMeasurement) ProcessPacketGroup(pg *packetGroup, groupIdx int) {
 	switch {
 	case pqd < q.dqrMax:
 		q.numDQRGroups++
-		if q.dqrConfig.IsTriggered(q.numDQRGroups, q.maxSendTime-q.minSendTime) {
+		if q.numJQRGroups > 0 {
+			// broken continuity, seal
+			q.isSealed = true
+		} else if q.dqrConfig.IsTriggered(q.numDQRGroups, q.maxSendTime-q.minSendTime) {
 			q.isSealed = true
 			q.queuingRegion = queuingRegionDQR
 		}
 
 	case pqd > q.jqrMin:
 		q.numJQRGroups++
-		if q.jqrConfig.IsTriggered(q.numJQRGroups, q.maxSendTime-q.minSendTime) {
+		if q.numDQRGroups > 0 {
+			// broken continuity, seal
+			q.isSealed = true
+		} else if q.jqrConfig.IsTriggered(q.numJQRGroups, q.maxSendTime-q.minSendTime) {
 			q.isSealed = true
 			q.queuingRegion = queuingRegionJQR
 		}

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -1065,6 +1065,12 @@ func (s *StreamAllocator) maybeStopProbe() {
 func (s *StreamAllocator) maybeBoostDeficientTracks() {
 	availableChannelCapacity := s.getAvailableHeadroom(false)
 	if availableChannelCapacity <= 0 {
+		s.params.Logger.Infow(
+			"stream allocator: no available headroom to boost deficient tracks",
+			"committedChannelCapacity", s.committedChannelCapacity,
+			"availableChannelCapacity", availableChannelCapacity,
+			"expectedBandwidthUsage", s.getExpectedBandwidthUsage(),
+		)
 		return
 	}
 


### PR DESCRIPTION
Treating the neither DQR nor JQR group as continuing the current group chain causes congestion state to flip between NONE and EARLY_WARNING a bunch. That's because push and pull happening in the groups, i. e. one group pushes the queuing delay into JQR, the next group relieves the congestion some and puts it into neither JQR nor DQR region and next group has higher queueing delay again. And that causes EARLY_WARNING declaration. Then a couple of groups relieve congestion and it goes back to NONE. Changing it so that it has to be contiguous groups in the same region to switch states. That should reduce oscillations, but have to test more to ensure that it does not miss congestion detection.