### PR TITLE
Remove duplicate SSRC get.

### DIFF
--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -400,8 +400,6 @@ func (s *StreamAllocator) OnREMB(downTrack *sfu.DownTrack, remb *rtcp.ReceiverEs
 		}
 
 		// try to lock to track which is sending this update
-		downTrackSSRC := track.DownTrack().SSRC()
-		downTrackSSRCRTX := track.DownTrack().SSRCRTX()
 		for _, ssrc := range remb.SSRCs {
 			if ssrc == 0 {
 				continue


### PR DESCRIPTION
The duplicate was not checking for `nil`. The SSRC is already loaded with proper nil check before.