### PR TITLE
Disable SCTP zero checksum for old go client

### DIFF
--- a/pkg/rtc/clientinfo.go
+++ b/pkg/rtc/clientinfo.go
@@ -102,7 +102,7 @@ func (c ClientInfo) SupportErrorResponse() bool {
 }
 
 func (c ClientInfo) SupportSctpZeroChecksum() bool {
-	return !(c.isGo() && c.compareVersion("2.1.3") <= 0)
+	return !(c.isGo() && c.compareVersion("2.4.0") < 0)
 }
 
 // compareVersion compares a semver against the current client SDK version

--- a/pkg/rtc/config.go
+++ b/pkg/rtc/config.go
@@ -69,8 +69,6 @@ func NewWebRTCConfig(conf *config.Config) (*WebRTCConfig, error) {
 	// we don't want to use active TCP on a server, clients should be dialing
 	webRTCConfig.SettingEngine.DisableActiveTCP(true)
 
-	webRTCConfig.SettingEngine.EnableSCTPZeroChecksum(true)
-
 	if rtcConf.PacketBufferSize == 0 {
 		rtcConf.PacketBufferSize = 500
 	}

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -306,6 +306,10 @@ func newPeerConnection(params TransportParams, onBandwidthEstimator func(estimat
 		se.SetFireOnTrackBeforeFirstRTP(true)
 	}
 
+	if params.ClientInfo.SupportSctpZeroChecksum() {
+		se.EnableSCTPZeroChecksum(true)
+	}
+
 	//
 	// Disable SRTP replay protection (https://datatracker.ietf.org/doc/html/rfc3711#page-15).
 	// Needed due to lack of RTX stream support in Pion.


### PR DESCRIPTION
Old go-sdks with old pion/sctp version can't
process unknown parameters.