### PR TITLE
Stop deleting rooms older than 24 hours

### DIFF
--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -49,7 +49,6 @@ import (
 )
 
 const (
-	roomPurgeSeconds     = 24 * 60 * 60
 	tokenRefreshInterval = 5 * time.Minute
 	tokenDefaultTTL      = 10 * time.Minute
 )
@@ -190,26 +189,6 @@ func (r *RoomManager) deleteRoom(ctx context.Context, roomName livekit.RoomName)
 	}
 
 	return err
-}
-
-// CleanupRooms cleans up after old rooms that have been around for a while
-func (r *RoomManager) CleanupRooms() error {
-	// cleanup rooms that have been left for over a day
-	ctx := context.Background()
-	rooms, err := r.roomStore.ListRooms(ctx, nil)
-	if err != nil {
-		return err
-	}
-
-	now := time.Now().Unix()
-	for _, room := range rooms {
-		if (now - room.CreationTime) > roomPurgeSeconds {
-			if err := r.deleteRoom(ctx, livekit.RoomName(room.Name)); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 func (r *RoomManager) CloseIdleRooms() {

--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -160,10 +160,6 @@ func NewLivekitServer(conf *config.Config,
 		}
 	}
 
-	// clean up old rooms on startup
-	if err = roomManager.CleanupRooms(); err != nil {
-		return
-	}
 	if err = router.RemoveDeadNodes(); err != nil {
 		return
 	}


### PR DESCRIPTION
Removes a call to `CleanupRooms` which, on sever startup will prune any rooms from the backing store (Redis) older than 24 hours, which was a hardcoded value.

This causes issues described in https://github.com/livekit/livekit/issues/3317 see that thread for discussion