### PR TITLE
Do not seed if stream is already writable.

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -1281,9 +1281,6 @@ func (d *DownTrack) GetState() DownTrackState {
 }
 
 func (d *DownTrack) SeedState(state DownTrackState) {
-	d.bindLock.Lock()
-	defer d.bindLock.Unlock()
-
 	if d.writable.Load() {
 		return
 	}


### PR DESCRIPTION
It is possible that in migration case, when the forwarder state is
fetched from migrating out node and used to seed downtrack, it has
already started due to the time it takes to get the state. Seeding in
that state will reset things and cause large sequence number gaps
potentially.

It is okay to not seed (actually seeding in this path is a late introduction, although RFCs says that receivers should reset on ICE restart, code inspection has not shown it, so this was added to handle the case better).