### PR TITLE
Request key frame on subscription change.

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -1244,6 +1244,7 @@ func (d *DownTrack) SetMaxSpatialLayer(spatialLayer int32) {
 	}
 
 	d.postMaxLayerNotifierEvent("max-subscribed")
+	d.postKeyFrameRequestEvent()
 
 	if sal := d.getStreamAllocatorListener(); sal != nil {
 		sal.OnSubscribedLayerChanged(d, maxLayer)


### PR DESCRIPTION
To assist the path where the requested layer is higher than current seen maximum and there is no congestion.