### PR TITLE
Log probes.

### DIFF
--- a/pkg/sfu/bwe/remotebwe/remote_bwe.go
+++ b/pkg/sfu/bwe/remotebwe/remote_bwe.go
@@ -220,7 +220,7 @@ func (r *RemoteBWE) estimateAvailableChannelCapacity(reason channelCongestionRea
 }
 
 func (r *RemoteBWE) updateCongestionState(state bwe.CongestionState, reason channelCongestionReason) (bwe.CongestionState, bwe.CongestionState) {
-	r.params.Logger.Infow(
+	r.params.Logger.Debugw(
 		"remote bwe: congestion state change",
 		"from", r.congestionState,
 		"to", state,
@@ -309,7 +309,7 @@ func (r *RemoteBWE) ProbeClusterFinalize() (ccutils.ProbeSignal, int64, bool) {
 	r.congestionState = bwe.CongestionStateNone
 	r.newChannelObserver()
 
-	r.params.Logger.Debugw(
+	r.params.Logger.Infow(
 		"remote bwe: probe finalized",
 		"lastReceived", r.lastReceivedEstimate,
 		"expectedBandwidthUsage", r.lastExpectedBandwidthUsage,

--- a/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
+++ b/pkg/sfu/bwe/sendsidebwe/congestion_detector.go
@@ -797,7 +797,7 @@ func (c *congestionDetector) ProbeClusterFinalize() (ccutils.ProbeSignal, int64,
 	}
 
 	isSignalValid := c.params.Config.ProbeSignal.IsValid(pci)
-	c.params.Logger.Debugw(
+	c.params.Logger.Infow(
 		"send side bwe: probe finalized",
 		"isSignalValid", isSignalValid,
 		"probeClusterInfo", pci,

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -1953,8 +1953,9 @@ func (d *DownTrack) retransmitPacket(epm *extPacketMeta, sourcePkt []byte, isPro
 		SSRC:           d.ssrc,
 	}
 	rtxOffset := 0
-	rtxExtSequenceNumber := d.rtxSequenceNumber.Inc()
+	var rtxExtSequenceNumber uint64
 	if d.payloadTypeRTX != 0 && d.ssrcRTX != 0 {
+		rtxExtSequenceNumber = d.rtxSequenceNumber.Inc()
 		rtxOffset = 2
 
 		hdr.PayloadType = d.payloadTypeRTX
@@ -2115,9 +2116,9 @@ func (d *DownTrack) WriteProbePackets(bytesToSend int, usePadding bool) int {
 			return 0
 		}
 
-		rtxExtSequenceNumber := d.rtxSequenceNumber.Inc()
 		payloads := make([]byte, RTPPaddingMaxPayloadSize*num)
 		for i := 0; i < num; i++ {
+			rtxExtSequenceNumber := d.rtxSequenceNumber.Inc()
 			hdr := &rtp.Header{
 				Version:        2,
 				Padding:        true,


### PR DESCRIPTION
- Seeing some logs which indicates probes might be over-eager, so logging probe results at Infow
- Changing another log to Debugw to offset the above :-)
- RTX sequence number was not getting incremented for every padding packet when using padding mode.