### PR TITLE
Resolve FromAsCasing warning in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23-alpine as builder
+FROM golang:1.23-alpine AS builder
 
 ARG TARGETPLATFORM
 ARG TARGETARCH


### PR DESCRIPTION
Resolves annotation on 'Release to Docker' workflow executions e.g. https://github.com/livekit/livekit/actions/runs/12893620790

> The 'as' keyword should match the case of the 'from' keyword: Dockerfile#L15
> FromAsCasing: 'as' and 'FROM' keywords' casing do not match More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/
