### PR TITLE
Reduce chances of metadata cache overflow.

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -373,7 +373,7 @@ func NewDownTrack(params DowntrackParams) (*DownTrack, error) {
 		Logger: d.params.Logger.WithValues(
 			"stream", "primary",
 		),
-	}, 4096)
+	}, 32768)
 	d.deltaStatsSenderSnapshotId = d.rtpStats.NewSenderSnapshotId()
 
 	d.rtpStatsRTX = rtpstats.NewRTPStatsSender(rtpstats.RTPStatsParams{
@@ -381,7 +381,7 @@ func NewDownTrack(params DowntrackParams) (*DownTrack, error) {
 		Logger: d.params.Logger.WithValues(
 			"stream", "rtx",
 		),
-	}, 1024)
+	}, 4096)
 	d.deltaStatsRTXSenderSnapshotId = d.rtpStatsRTX.NewSenderSnapshotId()
 
 	d.forwarder = NewForwarder(

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -368,12 +368,18 @@ func NewDownTrack(params DowntrackParams) (*DownTrack, error) {
 		"subscriberID", d.SubscriberID(),
 	)
 
+	var mdCacheSize, mdCacheSizeRTX int
+	if d.kind == webrtc.RTPCodecTypeVideo {
+		mdCacheSize, mdCacheSizeRTX = 32768, 4096
+	} else {
+		mdCacheSize, mdCacheSizeRTX = 8192, 1024
+	}
 	d.rtpStats = rtpstats.NewRTPStatsSender(rtpstats.RTPStatsParams{
 		ClockRate: d.codec.ClockRate,
 		Logger: d.params.Logger.WithValues(
 			"stream", "primary",
 		),
-	}, 32768)
+	}, mdCacheSize)
 	d.deltaStatsSenderSnapshotId = d.rtpStats.NewSenderSnapshotId()
 
 	d.rtpStatsRTX = rtpstats.NewRTPStatsSender(rtpstats.RTPStatsParams{
@@ -381,7 +387,7 @@ func NewDownTrack(params DowntrackParams) (*DownTrack, error) {
 		Logger: d.params.Logger.WithValues(
 			"stream", "rtx",
 		),
-	}, 4096)
+	}, mdCacheSizeRTX)
 	d.deltaStatsRTXSenderSnapshotId = d.rtpStatsRTX.NewSenderSnapshotId()
 
 	d.forwarder = NewForwarder(

--- a/pkg/sfu/rtpstats/rtpstats_sender.go
+++ b/pkg/sfu/rtpstats/rtpstats_sender.go
@@ -603,7 +603,7 @@ func (r *RTPStatsSender) UpdateFromReceiverReport(rr rtcp.ReceptionReport) (rtt 
 	// there are cases where remote does not send RTCP Receiver Report for extended periods of time,
 	// some times several minutes, in that interval the sequence number rolls over,
 	// check for a gap higher than sequence number range and adjust
-	if r.extHighestSN > extReceivedRRSN && (r.extHighestSN-extReceivedRRSN) > 65536 {
+	for r.extHighestSN > extReceivedRRSN && (r.extHighestSN-extReceivedRRSN) > 65536 {
 		r.extHighestSNFromRR += 65536
 		r.logger.Infow(
 			"receiver report potentially received after a long time, adjusting",


### PR DESCRIPTION
Down track uses RTCP Receiver Report from remote to figure out losses, etc which is used both for
analytics reporting and connection quality.

There was a cache of 4K packets in RTPStatsSender
which is used when RTCP Receiver Report is received to reconcile data of bytes/packets/losses etc.
That cache overflows (or underflows depending on
how you look at it) because of a couple of reasons

1. Remote side (mainly Firefox) does not seem to wrap sequence numbers properly at times. So, it looks to the SFU that it is getting reports about old packets. But, once that happens once, it continues on. NOTE: This could actually be not a failure to wrap, but not receiving RTCP Receiver Report for a long time, some times for several minutes. It is unclear if this is due to some Firefox issue or Pion issue or LK issue.

2. High packet rate + congestion also causes this.

To alleviate this, doing two things
- increase packet cache sise, that will increase the memory needed by ~250 MB for 2K video down tracks. That should be fine on a server. Increasing the cache size by 16 KB per audio down track. So, if the server is handling a bunch of audio tracks, the increase in memory requirements should not be that much higher.
- Try to reset the reconciliation logic so that once a wrap around is missed, it does not continue on forever after that, i. e. one interval should see a large jump, but subsequent reports should get processed.