### PR TITLE
fire TrackSubscribed event only when subscriber is visible

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -434,6 +434,8 @@ func (t *MediaTrack) SetMuted(muted bool) {
 	t.MediaTrackReceiver.SetMuted(muted)
 }
 
+// OnTrackSubscribed is called when the track is subscribed by a non-hidden subscriber
+// this allows the publisher to know when they should start sending data
 func (t *MediaTrack) OnTrackSubscribed() {
 	if !t.everSubscribed.Swap(true) && t.params.OnTrackEverSubscribed != nil {
 		go t.params.OnTrackEverSubscribed(t.ID())

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -162,11 +162,13 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 		AdaptiveStream:    sub.GetAdaptiveStream(),
 	})
 
-	subTrack.AddOnBind(func(err error) {
-		if err == nil {
-			t.params.MediaTrack.OnTrackSubscribed()
-		}
-	})
+	if !sub.Hidden() {
+		subTrack.AddOnBind(func(err error) {
+			if err == nil {
+				t.params.MediaTrack.OnTrackSubscribed()
+			}
+		})
+	}
 
 	// Bind callback can happen from replaceTrack, so set it up early
 	var reusingTransceiver atomic.Bool


### PR DESCRIPTION
TrackSubscribed is meant to give publishers an indication when the subscriber is ready to receive its audio. When there are hidden recorders in the room, we do not want them to trigger this event.