### PR TITLE
Update config.go to properly process bool env vars

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -578,9 +578,10 @@ func GenerateCLIFlags(existingFlags []cli.Flag, hidden bool) ([]cli.Flag, error)
 		switch kind {
 		case reflect.Bool:
 			flag = &cli.BoolFlag{
-				Name:   name,
-				Usage:  generatedCLIFlagUsage,
-				Hidden: hidden,
+				Name:    name,
+				EnvVars: []string{envVar},
+				Usage:   generatedCLIFlagUsage,
+				Hidden:  hidden,
 			}
 		case reflect.String:
 			flag = &cli.StringFlag{


### PR DESCRIPTION
Fixes issue https://github.com/livekit/livekit/issues/3381

**Quick summary:** when processing the `existingFlags` slice in method `config.go#GenerateCLIFlags`, if the flag is of kind Bool then its value is not being stored in the `cli.Flag` variable (no value is assigned to `EnvVars` property). This is only done for Bool flags. Every other kind of flag is having a value properly set.

This results in all boolean flags being later processed as "not set", ending always with their default value.