### PR TITLE
Normalize mime type and add utilities.

### DIFF
--- a/pkg/clientconfiguration/conf.go
+++ b/pkg/clientconfiguration/conf.go
@@ -15,6 +15,7 @@
 package clientconfiguration
 
 import (
+	"github.com/livekit/livekit-server/pkg/sfu/utils"
 	"github.com/livekit/protocol/livekit"
 )
 
@@ -28,7 +29,7 @@ var StaticConfigurations = []ConfigurationItem{
 	{
 		Match: &ScriptMatch{Expr: `c.browser == "safari"`},
 		Configuration: &livekit.ClientConfiguration{DisabledCodecs: &livekit.DisabledCodecs{Codecs: []*livekit.Codec{
-			{Mime: "video/av1"},
+			{Mime: utils.MimeTypeAV1},
 		}}},
 		Merge: false,
 	},
@@ -37,7 +38,7 @@ var StaticConfigurations = []ConfigurationItem{
 		  ((c.browser == "firefox" || c.browser == "firefox mobile") && (c.os == "linux" || c.os == "android"))`},
 		Configuration: &livekit.ClientConfiguration{
 			DisabledCodecs: &livekit.DisabledCodecs{
-				Publish: []*livekit.Codec{{Mime: "video/h264"}},
+				Publish: []*livekit.Codec{{Mime: utils.MimeTypeH264}},
 			},
 		},
 		Merge: false,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,7 @@ import (
 	"github.com/livekit/livekit-server/pkg/sfu/bwe/remotebwe"
 	"github.com/livekit/livekit-server/pkg/sfu/bwe/sendsidebwe"
 	"github.com/livekit/livekit-server/pkg/sfu/streamallocator"
+	"github.com/livekit/livekit-server/pkg/sfu/utils"
 	"github.com/livekit/mediatransportutil/pkg/rtcconfig"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
@@ -337,7 +338,7 @@ var DefaultConfig = Config{
 		AutoCreate: true,
 		EnabledCodecs: []CodecSpec{
 			{Mime: webrtc.MimeTypeOpus},
-			{Mime: sfu.MimeTypeAudioRed},
+			{Mime: utils.MimeTypeAudioRed},
 			{Mime: webrtc.MimeTypeVP8},
 			{Mime: webrtc.MimeTypeH264},
 			{Mime: webrtc.MimeTypeVP9},

--- a/pkg/rtc/dynacast/dynacastmanager.go
+++ b/pkg/rtc/dynacast/dynacastmanager.go
@@ -15,7 +15,6 @@
 package dynacast
 
 import (
-	"strings"
 	"sync"
 	"time"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/livekit/protocol/logger"
 
 	"github.com/livekit/livekit-server/pkg/rtc/types"
+	sfuutils "github.com/livekit/livekit-server/pkg/sfu/utils"
 	"github.com/livekit/livekit-server/pkg/utils"
 )
 
@@ -159,7 +159,7 @@ func (d *DynacastManager) getOrCreateDynacastQuality(mime string) *DynacastQuali
 		return nil
 	}
 
-	normalizedMime := strings.ToLower(mime)
+	normalizedMime := sfuutils.NormalizeMimeType(mime)
 	if dq := d.dynacastQuality[normalizedMime]; dq != nil {
 		return dq
 	}

--- a/pkg/rtc/dynacast/dynacastmanager_test.go
+++ b/pkg/rtc/dynacast/dynacastmanager_test.go
@@ -16,15 +16,14 @@ package dynacast
 
 import (
 	"sort"
-	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/pion/webrtc/v4"
 	"github.com/stretchr/testify/require"
 
 	"github.com/livekit/livekit-server/pkg/rtc/types"
+	"github.com/livekit/livekit-server/pkg/sfu/utils"
 	"github.com/livekit/protocol/livekit"
 )
 
@@ -47,15 +46,15 @@ func TestSubscribedMaxQuality(t *testing.T) {
 			lock.Unlock()
 		})
 
-		dm.NotifySubscriberMaxQuality("s1", webrtc.MimeTypeVP8, livekit.VideoQuality_HIGH)
-		dm.NotifySubscriberMaxQuality("s2", webrtc.MimeTypeAV1, livekit.VideoQuality_HIGH)
+		dm.NotifySubscriberMaxQuality("s1", utils.MimeTypeVP8, livekit.VideoQuality_HIGH)
+		dm.NotifySubscriberMaxQuality("s2", utils.MimeTypeAV1, livekit.VideoQuality_HIGH)
 
 		// mute all subscribers of vp8
-		dm.NotifySubscriberMaxQuality("s1", webrtc.MimeTypeVP8, livekit.VideoQuality_OFF)
+		dm.NotifySubscriberMaxQuality("s1", utils.MimeTypeVP8, livekit.VideoQuality_OFF)
 
 		expectedSubscribedQualities := []*livekit.SubscribedCodec{
 			{
-				Codec: strings.ToLower(webrtc.MimeTypeVP8),
+				Codec: utils.MimeTypeVP8,
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: false},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: false},
@@ -63,7 +62,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 				},
 			},
 			{
-				Codec: strings.ToLower(webrtc.MimeTypeAV1),
+				Codec: utils.MimeTypeAV1,
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: true},
@@ -95,16 +94,16 @@ func TestSubscribedMaxQuality(t *testing.T) {
 		})
 
 		dm.maxSubscribedQuality = map[string]livekit.VideoQuality{
-			strings.ToLower(webrtc.MimeTypeVP8): livekit.VideoQuality_LOW,
-			strings.ToLower(webrtc.MimeTypeAV1): livekit.VideoQuality_LOW,
+			utils.MimeTypeVP8: livekit.VideoQuality_LOW,
+			utils.MimeTypeAV1: livekit.VideoQuality_LOW,
 		}
-		dm.NotifySubscriberMaxQuality("s1", webrtc.MimeTypeVP8, livekit.VideoQuality_HIGH)
-		dm.NotifySubscriberMaxQuality("s2", webrtc.MimeTypeVP8, livekit.VideoQuality_MEDIUM)
-		dm.NotifySubscriberMaxQuality("s3", webrtc.MimeTypeAV1, livekit.VideoQuality_MEDIUM)
+		dm.NotifySubscriberMaxQuality("s1", utils.MimeTypeVP8, livekit.VideoQuality_HIGH)
+		dm.NotifySubscriberMaxQuality("s2", utils.MimeTypeVP8, livekit.VideoQuality_MEDIUM)
+		dm.NotifySubscriberMaxQuality("s3", utils.MimeTypeAV1, livekit.VideoQuality_MEDIUM)
 
 		expectedSubscribedQualities := []*livekit.SubscribedCodec{
 			{
-				Codec: strings.ToLower(webrtc.MimeTypeVP8),
+				Codec: utils.MimeTypeVP8,
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: true},
@@ -112,7 +111,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 				},
 			},
 			{
-				Codec: strings.ToLower(webrtc.MimeTypeAV1),
+				Codec: utils.MimeTypeAV1,
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: true},
@@ -128,11 +127,11 @@ func TestSubscribedMaxQuality(t *testing.T) {
 		}, 10*time.Second, 100*time.Millisecond)
 
 		// "s1" dropping to MEDIUM should disable HIGH layer
-		dm.NotifySubscriberMaxQuality("s1", webrtc.MimeTypeVP8, livekit.VideoQuality_MEDIUM)
+		dm.NotifySubscriberMaxQuality("s1", utils.MimeTypeVP8, livekit.VideoQuality_MEDIUM)
 
 		expectedSubscribedQualities = []*livekit.SubscribedCodec{
 			{
-				Codec: strings.ToLower(webrtc.MimeTypeVP8),
+				Codec: utils.MimeTypeVP8,
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: true},
@@ -140,7 +139,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 				},
 			},
 			{
-				Codec: strings.ToLower(webrtc.MimeTypeAV1),
+				Codec: utils.MimeTypeAV1,
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: true},
@@ -156,13 +155,13 @@ func TestSubscribedMaxQuality(t *testing.T) {
 		}, 10*time.Second, 100*time.Millisecond)
 
 		// "s1" , "s2" , "s3" dropping to LOW should disable HIGH & MEDIUM
-		dm.NotifySubscriberMaxQuality("s1", webrtc.MimeTypeVP8, livekit.VideoQuality_LOW)
-		dm.NotifySubscriberMaxQuality("s2", webrtc.MimeTypeVP8, livekit.VideoQuality_LOW)
-		dm.NotifySubscriberMaxQuality("s3", webrtc.MimeTypeAV1, livekit.VideoQuality_LOW)
+		dm.NotifySubscriberMaxQuality("s1", utils.MimeTypeVP8, livekit.VideoQuality_LOW)
+		dm.NotifySubscriberMaxQuality("s2", utils.MimeTypeVP8, livekit.VideoQuality_LOW)
+		dm.NotifySubscriberMaxQuality("s3", utils.MimeTypeAV1, livekit.VideoQuality_LOW)
 
 		expectedSubscribedQualities = []*livekit.SubscribedCodec{
 			{
-				Codec: strings.ToLower(webrtc.MimeTypeVP8),
+				Codec: utils.MimeTypeVP8,
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: false},
@@ -170,7 +169,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 				},
 			},
 			{
-				Codec: strings.ToLower(webrtc.MimeTypeAV1),
+				Codec: utils.MimeTypeAV1,
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: false},
@@ -186,7 +185,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 		}, 10*time.Second, 100*time.Millisecond)
 
 		// muting "s2" only should not disable all qualities of vp8, no change of expected qualities
-		dm.NotifySubscriberMaxQuality("s2", webrtc.MimeTypeVP8, livekit.VideoQuality_OFF)
+		dm.NotifySubscriberMaxQuality("s2", utils.MimeTypeVP8, livekit.VideoQuality_OFF)
 
 		time.Sleep(100 * time.Millisecond)
 		require.Eventually(t, func() bool {
@@ -197,12 +196,12 @@ func TestSubscribedMaxQuality(t *testing.T) {
 		}, 10*time.Second, 100*time.Millisecond)
 
 		// muting "s1" and s3 also should disable all qualities
-		dm.NotifySubscriberMaxQuality("s1", webrtc.MimeTypeVP8, livekit.VideoQuality_OFF)
-		dm.NotifySubscriberMaxQuality("s3", webrtc.MimeTypeAV1, livekit.VideoQuality_OFF)
+		dm.NotifySubscriberMaxQuality("s1", utils.MimeTypeVP8, livekit.VideoQuality_OFF)
+		dm.NotifySubscriberMaxQuality("s3", utils.MimeTypeAV1, livekit.VideoQuality_OFF)
 
 		expectedSubscribedQualities = []*livekit.SubscribedCodec{
 			{
-				Codec: strings.ToLower(webrtc.MimeTypeVP8),
+				Codec: utils.MimeTypeVP8,
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: false},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: false},
@@ -210,7 +209,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 				},
 			},
 			{
-				Codec: strings.ToLower(webrtc.MimeTypeAV1),
+				Codec: utils.MimeTypeAV1,
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: false},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: false},
@@ -226,11 +225,11 @@ func TestSubscribedMaxQuality(t *testing.T) {
 		}, 10*time.Second, 100*time.Millisecond)
 
 		// unmuting "s1" should enable vp8 previously set max quality
-		dm.NotifySubscriberMaxQuality("s1", webrtc.MimeTypeVP8, livekit.VideoQuality_LOW)
+		dm.NotifySubscriberMaxQuality("s1", utils.MimeTypeVP8, livekit.VideoQuality_LOW)
 
 		expectedSubscribedQualities = []*livekit.SubscribedCodec{
 			{
-				Codec: strings.ToLower(webrtc.MimeTypeVP8),
+				Codec: utils.MimeTypeVP8,
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: false},
@@ -238,7 +237,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 				},
 			},
 			{
-				Codec: strings.ToLower(webrtc.MimeTypeAV1),
+				Codec: utils.MimeTypeAV1,
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: false},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: false},
@@ -255,13 +254,13 @@ func TestSubscribedMaxQuality(t *testing.T) {
 
 		// a higher quality from a different node should trigger that quality
 		dm.NotifySubscriberNodeMaxQuality("n1", []types.SubscribedCodecQuality{
-			{CodecMime: webrtc.MimeTypeVP8, Quality: livekit.VideoQuality_HIGH},
-			{CodecMime: webrtc.MimeTypeAV1, Quality: livekit.VideoQuality_MEDIUM},
+			{CodecMime: utils.MimeTypeVP8, Quality: livekit.VideoQuality_HIGH},
+			{CodecMime: utils.MimeTypeAV1, Quality: livekit.VideoQuality_MEDIUM},
 		})
 
 		expectedSubscribedQualities = []*livekit.SubscribedCodec{
 			{
-				Codec: strings.ToLower(webrtc.MimeTypeVP8),
+				Codec: utils.MimeTypeVP8,
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: true},
@@ -269,7 +268,7 @@ func TestSubscribedMaxQuality(t *testing.T) {
 				},
 			},
 			{
-				Codec: strings.ToLower(webrtc.MimeTypeAV1),
+				Codec: utils.MimeTypeAV1,
 				Qualities: []*livekit.SubscribedQuality{
 					{Quality: livekit.VideoQuality_LOW, Enabled: true},
 					{Quality: livekit.VideoQuality_MEDIUM, Enabled: true},

--- a/pkg/rtc/mediaengine.go
+++ b/pkg/rtc/mediaengine.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/pion/webrtc/v4"
 
-	"github.com/livekit/livekit-server/pkg/sfu"
+	"github.com/livekit/livekit-server/pkg/sfu/utils"
 	"github.com/livekit/protocol/livekit"
 )
 
@@ -31,7 +31,7 @@ var OpusCodecCapability = webrtc.RTPCodecCapability{
 	SDPFmtpLine: "minptime=10;useinbandfec=1",
 }
 var RedCodecCapability = webrtc.RTPCodecCapability{
-	MimeType:    sfu.MimeTypeAudioRed,
+	MimeType:    utils.MimeTypeAudioRed,
 	ClockRate:   48000,
 	Channels:    2,
 	SDPFmtpLine: "111/111",
@@ -133,7 +133,7 @@ func registerCodecs(me *webrtc.MediaEngine, codecs []*livekit.Codec, rtcpFeedbac
 		if filterOutH264HighProfile && codec.RTPCodecCapability.SDPFmtpLine == h264HighProfileFmtp {
 			continue
 		}
-		if strings.EqualFold(codec.MimeType, webrtc.MimeTypeRTX) {
+		if utils.NormalizeMimeType(codec.MimeType) == utils.MimeTypeRTX {
 			continue
 		}
 		if IsCodecEnabled(codecs, codec.RTPCodecCapability) {
@@ -200,10 +200,10 @@ func IsCodecEnabled(codecs []*livekit.Codec, cap webrtc.RTPCodecCapability) bool
 
 func selectAlternativeVideoCodec(enabledCodecs []*livekit.Codec) string {
 	for _, c := range enabledCodecs {
-		if strings.HasPrefix(c.Mime, "video/") {
+		if utils.IsMimeTypeVideo(c.Mime) {
 			return c.Mime
 		}
 	}
 	// no viable codec in the list of enabled codecs, fall back to the most widely supported codec
-	return webrtc.MimeTypeVP8
+	return utils.MimeTypeVP8
 }

--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -34,6 +34,7 @@ import (
 	"github.com/livekit/livekit-server/pkg/sfu"
 	"github.com/livekit/livekit-server/pkg/sfu/buffer"
 	"github.com/livekit/livekit-server/pkg/sfu/connectionquality"
+	"github.com/livekit/livekit-server/pkg/sfu/utils"
 	"github.com/livekit/livekit-server/pkg/telemetry"
 	util "github.com/livekit/mediatransportutil"
 )
@@ -238,7 +239,7 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track sfu.TrackRe
 
 	ti := t.MediaTrackReceiver.TrackInfoClone()
 	t.lock.Lock()
-	mime := strings.ToLower(track.Codec().MimeType)
+	mime := utils.NormalizeMimeType(track.Codec().MimeType)
 	layer := buffer.RidToSpatialLayer(track.RID(), ti)
 	t.params.Logger.Debugw(
 		"AddReceiver",
@@ -311,7 +312,7 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track sfu.TrackRe
 			parameters := receiver.GetParameters()
 			for _, c := range ti.Codecs {
 				for _, nc := range parameters.Codecs {
-					if strings.EqualFold(nc.MimeType, c.MimeType) {
+					if utils.NormalizeMimeType(nc.MimeType) == c.MimeType {
 						potentialCodecs = append(potentialCodecs, nc)
 						break
 					}

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/livekit/livekit-server/pkg/sfu/buffer"
+	sfuutils "github.com/livekit/livekit-server/pkg/sfu/utils"
 	sutils "github.com/livekit/livekit-server/pkg/utils"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
@@ -279,7 +280,7 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 			Stereo: info.Stereo,
 			Red:    !info.DisableRed,
 		}
-		if addTrackParams.Red && (len(codecs) == 1 && strings.EqualFold(codecs[0].MimeType, webrtc.MimeTypeOpus)) {
+		if addTrackParams.Red && (len(codecs) == 1 && sfuutils.NormalizeMimeType(codecs[0].MimeType) == sfuutils.MimeTypeOpus) {
 			addTrackParams.Red = false
 		}
 

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2403,7 +2403,7 @@ func (p *ParticipantImpl) mediaTrackReceived(track sfu.TrackRemote, rtpReceiver 
 			var codecFound int
 			for _, c := range ti.Codecs {
 				for _, nc := range parameters.Codecs {
-					if strings.EqualFold(nc.MimeType, c.MimeType) {
+					if sfuutils.NormalizeMimeType(nc.MimeType) == c.MimeType {
 						codecFound++
 						break
 					}
@@ -2486,7 +2486,7 @@ func (p *ParticipantImpl) addMigratedTrack(cid string, ti *livekit.TrackInfo) *M
 	parameters := rtpReceiver.GetParameters()
 	for _, c := range ti.Codecs {
 		for _, nc := range parameters.Codecs {
-			if strings.EqualFold(nc.MimeType, c.MimeType) {
+			if sfuutils.NormalizeMimeType(nc.MimeType) == c.MimeType {
 				potentialCodecs = append(potentialCodecs, nc)
 				break
 			}
@@ -2495,10 +2495,10 @@ func (p *ParticipantImpl) addMigratedTrack(cid string, ti *livekit.TrackInfo) *M
 	// check for mime_type for tracks that do not have simulcast_codecs set
 	if ti.MimeType != "" {
 		for _, nc := range parameters.Codecs {
-			if strings.EqualFold(nc.MimeType, ti.MimeType) {
+			if sfuutils.NormalizeMimeType(nc.MimeType) == ti.MimeType {
 				alreadyAdded := false
 				for _, pc := range potentialCodecs {
-					if strings.EqualFold(pc.MimeType, ti.MimeType) {
+					if sfuutils.NormalizeMimeType(pc.MimeType) == ti.MimeType {
 						alreadyAdded = true
 						break
 					}
@@ -2980,7 +2980,7 @@ func (p *ParticipantImpl) setupEnabledCodecs(publishEnabledCodecs []*livekit.Cod
 	shouldDisable := func(c *livekit.Codec, disabled []*livekit.Codec) bool {
 		for _, disableCodec := range disabled {
 			// disable codec's fmtp is empty means disable this codec entirely
-			if strings.EqualFold(c.Mime, disableCodec.Mime) {
+			if sfuutils.NormalizeMimeType(c.Mime) == sfuutils.NormalizeMimeType(disableCodec.Mime) {
 				return true
 			}
 		}
@@ -2994,13 +2994,14 @@ func (p *ParticipantImpl) setupEnabledCodecs(publishEnabledCodecs []*livekit.Cod
 		}
 
 		// sort by compatibility, since we will look for backups in these.
-		if strings.EqualFold(c.Mime, webrtc.MimeTypeVP8) {
+		normalizedMimeType := sfuutils.NormalizeMimeType(c.Mime)
+		if normalizedMimeType == sfuutils.MimeTypeVP8 {
 			if len(p.enabledPublishCodecs) > 0 {
 				p.enabledPublishCodecs = slices.Insert(p.enabledPublishCodecs, 0, c)
 			} else {
 				p.enabledPublishCodecs = append(p.enabledPublishCodecs, c)
 			}
-		} else if strings.EqualFold(c.Mime, webrtc.MimeTypeH264) {
+		} else if normalizedMimeType == sfuutils.MimeTypeH264 {
 			p.enabledPublishCodecs = append(p.enabledPublishCodecs, c)
 		} else {
 			publishCodecs = append(publishCodecs, c)
@@ -3021,7 +3022,7 @@ func (p *ParticipantImpl) setupEnabledCodecs(publishEnabledCodecs []*livekit.Cod
 func (p *ParticipantImpl) GetEnabledPublishCodecs() []*livekit.Codec {
 	codecs := make([]*livekit.Codec, 0, len(p.enabledPublishCodecs))
 	for _, c := range p.enabledPublishCodecs {
-		if strings.EqualFold(c.Mime, webrtc.MimeTypeRTX) {
+		if sfuutils.NormalizeMimeType(c.Mime) == sfuutils.MimeTypeRTX {
 			continue
 		}
 		codecs = append(codecs, c)

--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -432,7 +432,7 @@ func TestDisablePublishCodec(t *testing.T) {
 		Cid:  "cid1",
 		Type: livekit.TrackType_VIDEO,
 		SimulcastCodecs: []*livekit.SimulcastCodec{{
-			Codec: "h264",
+			Codec: "video/h264",
 			Cid:   "cid1",
 		}},
 	})
@@ -455,7 +455,7 @@ func TestDisablePublishCodec(t *testing.T) {
 		Cid:  "cid2",
 		Type: livekit.TrackType_VIDEO,
 		SimulcastCodecs: []*livekit.SimulcastCodec{{
-			Codec: "vp8",
+			Codec: "video/vp8",
 			Cid:   "cid2",
 		}},
 	})
@@ -483,7 +483,7 @@ func TestPreferVideoCodecForPublisher(t *testing.T) {
 			Source: livekit.TrackSource_CAMERA,
 			SimulcastCodecs: []*livekit.SimulcastCodec{
 				{
-					Codec: "h264",
+					Codec: "video/h264",
 					Cid:   trackCid,
 				},
 			},

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -2089,7 +2089,7 @@ func configureAudioTransceiver(tr *webrtc.RTPTransceiver, stereo bool, nack bool
 	codecs := sender.GetParameters().Codecs
 	configCodecs := make([]webrtc.RTPCodecParameters, 0, len(codecs))
 	for _, c := range codecs {
-		if strings.EqualFold(c.MimeType, webrtc.MimeTypeOpus) {
+		if sfuutils.NormalizeMimeType(c.MimeType) == sfuutils.MimeTypeOpus {
 			c.SDPFmtpLine = strings.ReplaceAll(c.SDPFmtpLine, ";sprop-stereo=1", "")
 			if stereo {
 				c.SDPFmtpLine += ";sprop-stereo=1"

--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -16,7 +16,6 @@ package rtc
 
 import (
 	"errors"
-	"strings"
 	"sync"
 
 	"github.com/pion/webrtc/v4"
@@ -27,6 +26,7 @@ import (
 	"github.com/livekit/protocol/logger"
 
 	"github.com/livekit/livekit-server/pkg/sfu"
+	"github.com/livekit/livekit-server/pkg/sfu/utils"
 )
 
 // wrapper around WebRTC receiver, overriding its ID
@@ -59,13 +59,14 @@ func NewWrappedReceiver(params WrappedReceiverParams) *WrappedReceiver {
 
 	codecs := params.UpstreamCodecs
 	if len(codecs) == 1 {
-		if strings.EqualFold(codecs[0].MimeType, sfu.MimeTypeAudioRed) {
+		normalizedMimeType := utils.NormalizeMimeType(codecs[0].MimeType)
+		if normalizedMimeType == utils.MimeTypeAudioRed {
 			// if upstream is opus/red, then add opus to match clients that don't support red
 			codecs = append(codecs, webrtc.RTPCodecParameters{
 				RTPCodecCapability: OpusCodecCapability,
 				PayloadType:        111,
 			})
-		} else if !params.DisableRed && strings.EqualFold(codecs[0].MimeType, webrtc.MimeTypeOpus) {
+		} else if !params.DisableRed && normalizedMimeType == utils.MimeTypeOpus {
 			// if upstream is opus only and red enabled, add red to match clients that support red
 			codecs = append(codecs, webrtc.RTPCodecParameters{
 				RTPCodecCapability: RedCodecCapability,
@@ -96,16 +97,18 @@ func (r *WrappedReceiver) DetermineReceiver(codec webrtc.RTPCodecCapability) boo
 	r.lock.Lock()
 	r.determinedCodec = codec
 
+	codecMimeType := utils.NormalizeMimeType(codec.MimeType)
 	var trackReceiver sfu.TrackReceiver
 	for _, receiver := range r.receivers {
-		if c := receiver.Codec(); strings.EqualFold(c.MimeType, codec.MimeType) {
+		receiverMimeType := utils.NormalizeMimeType(receiver.Codec().MimeType)
+		if receiverMimeType == codecMimeType {
 			trackReceiver = receiver
 			break
-		} else if strings.EqualFold(c.MimeType, sfu.MimeTypeAudioRed) && strings.EqualFold(codec.MimeType, webrtc.MimeTypeOpus) {
+		} else if (receiverMimeType == utils.MimeTypeAudioRed) && (codecMimeType == utils.MimeTypeOpus) {
 			// audio opus/red can match opus only
 			trackReceiver = receiver.GetPrimaryReceiverForRed()
 			break
-		} else if strings.EqualFold(c.MimeType, webrtc.MimeTypeOpus) && strings.EqualFold(codec.MimeType, sfu.MimeTypeAudioRed) {
+		} else if (receiverMimeType == utils.MimeTypeOpus) && (codecMimeType == utils.MimeTypeAudioRed) {
 			trackReceiver = receiver.GetRedReceiver()
 			break
 		}

--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -104,11 +104,11 @@ func (r *WrappedReceiver) DetermineReceiver(codec webrtc.RTPCodecCapability) boo
 		if receiverMimeType == codecMimeType {
 			trackReceiver = receiver
 			break
-		} else if (receiverMimeType == utils.MimeTypeAudioRed) && (codecMimeType == utils.MimeTypeOpus) {
+		} else if receiverMimeType == utils.MimeTypeAudioRed && codecMimeType == utils.MimeTypeOpus {
 			// audio opus/red can match opus only
 			trackReceiver = receiver.GetPrimaryReceiverForRed()
 			break
-		} else if (receiverMimeType == utils.MimeTypeOpus) && (codecMimeType == utils.MimeTypeAudioRed) {
+		} else if receiverMimeType == utils.MimeTypeOpus && codecMimeType == utils.MimeTypeAudioRed {
 			trackReceiver = receiver.GetRedReceiver()
 			break
 		}

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -36,6 +36,7 @@ import (
 	dd "github.com/livekit/livekit-server/pkg/sfu/rtpextension/dependencydescriptor"
 	"github.com/livekit/livekit-server/pkg/sfu/rtpstats"
 	"github.com/livekit/livekit-server/pkg/sfu/streamtracker"
+	sfuutils "github.com/livekit/livekit-server/pkg/sfu/utils"
 )
 
 var (
@@ -235,8 +236,8 @@ func NewWebRTCReceiver(
 		codec:    track.Codec(),
 		kind:     track.Kind(),
 		onRTCP:   onRTCP,
-		isSVC:    buffer.IsSvcCodec(track.Codec().MimeType),
-		isRED:    buffer.IsRedCodec(track.Codec().MimeType),
+		isSVC:    sfuutils.IsSvcCodec(track.Codec().MimeType),
+		isRED:    sfuutils.IsRedCodec(track.Codec().MimeType),
 	}
 
 	for _, opt := range opts {
@@ -259,9 +260,9 @@ func NewWebRTCReceiver(
 		}
 	})
 	w.connectionStats.Start(
-		w.codec.MimeType,
+		sfuutils.NormalizeMimeType(w.codec.MimeType),
 		// TODO: technically not correct to declare FEC on when RED. Need the primary codec's fmtp line to check.
-		strings.EqualFold(w.codec.MimeType, MimeTypeAudioRed) || strings.Contains(strings.ToLower(w.codec.SDPFmtpLine), "useinbandfec=1"),
+		(sfuutils.NormalizeMimeType(w.codec.MimeType) == sfuutils.MimeTypeAudioRed) || strings.Contains(strings.ToLower(w.codec.SDPFmtpLine), "useinbandfec=1"),
 	)
 
 	w.streamTrackerManager = NewStreamTrackerManager(logger, trackInfo, w.isSVC, w.codec.ClockRate, streamTrackerManagerConfig)

--- a/pkg/sfu/redprimaryreceiver.go
+++ b/pkg/sfu/redprimaryreceiver.go
@@ -27,10 +27,6 @@ import (
 	"github.com/livekit/protocol/logger"
 )
 
-const (
-	MimeTypeAudioRed = "audio/red"
-)
-
 var (
 	ErrIncompleteRedHeader = errors.New("incomplete red block header")
 	ErrIncompleteRedBlock  = errors.New("incomplete red block payload")

--- a/pkg/sfu/utils/mimetype.go
+++ b/pkg/sfu/utils/mimetype.go
@@ -14,17 +14,22 @@
 
 package utils
 
-type MimeType int
-
-const (
-	MimeTypeUnknown MimeType = iota
-	MimeTypeVP8
-	MimeTypeVP9
-	MimeTypeH264
-	MimeTypeAV1
+import (
+	"fmt"
+	"strings"
 )
 
-func MatchMimeType(mimeType string) MimeType {
+type MimeTypeNumber int
+
+const (
+	MimeTypeNumberUnknown MimeTypeNumber = iota
+	MimeTypeNumberVP8
+	MimeTypeNumberVP9
+	MimeTypeNumberH264
+	MimeTypeNumberAV1
+)
+
+func MatchMimeType(mimeType string) MimeTypeNumber {
 	switch len(mimeType) {
 	case 9:
 		switch mimeType[0] {
@@ -45,9 +50,9 @@ func MatchMimeType(mimeType string) MimeType {
 									case 'p', 'P':
 										switch mimeType[8] {
 										case '8':
-											return MimeTypeVP8
+											return MimeTypeNumberVP8
 										case '9':
-											return MimeTypeVP9
+											return MimeTypeNumberVP9
 										}
 									}
 								case 'a', 'A':
@@ -55,7 +60,7 @@ func MatchMimeType(mimeType string) MimeType {
 									case 'v', 'V':
 										switch mimeType[8] {
 										case '1':
-											return MimeTypeAV1
+											return MimeTypeNumberAV1
 										}
 									}
 								}
@@ -86,7 +91,7 @@ func MatchMimeType(mimeType string) MimeType {
 										case '6':
 											switch mimeType[9] {
 											case '4':
-												return MimeTypeH264
+												return MimeTypeNumberH264
 											}
 										}
 									}
@@ -98,5 +103,80 @@ func MatchMimeType(mimeType string) MimeType {
 			}
 		}
 	}
-	return MimeTypeUnknown
+	return MimeTypeNumberUnknown
+}
+
+const (
+	MimeTypePrefixAudio = "audio/"
+	MimeTypePrefixVideo = "video/"
+	MimeTypeSuffixRTX   = "rtx"
+
+	MimeTypeH264     = MimeTypePrefixVideo + "H264"
+	MimeTypeH265     = MimeTypePrefixVideo + "H265"
+	MimeTypeOpus     = MimeTypePrefixAudio + "opus"
+	MimeTypeAudioRed = MimeTypePrefixAudio + "red"
+	MimeTypeVP8      = MimeTypePrefixVideo + "VP8"
+	MimeTypeVP9      = MimeTypePrefixVideo + "VP9"
+	MimeTypeAV1      = MimeTypePrefixVideo + "AV1"
+	MimeTypeG722     = MimeTypePrefixAudio + "G722"
+	MimeTypePCMU     = MimeTypePrefixAudio + "PCMU"
+	MimeTypePCMA     = MimeTypePrefixAudio + "PCMA"
+	MimeTypeRTX      = MimeTypePrefixVideo + "rtx"
+	MimeTypeFlexFEC  = MimeTypePrefixVideo + "flexfec"
+)
+
+func IsMimeTypeAudio(mime string) bool {
+	return strings.HasPrefix(NormalizeMimeType(mime), MimeTypePrefixAudio)
+}
+
+func IsMimeTypeVideo(mime string) bool {
+	return strings.HasPrefix(NormalizeMimeType(mime), MimeTypePrefixVideo)
+}
+
+func NormalizeMimeType(mime string) string {
+	switch {
+	case strings.EqualFold(mime, MimeTypeH264):
+		return MimeTypeH264
+	case strings.EqualFold(mime, MimeTypeH265):
+		return MimeTypeH265
+	case strings.EqualFold(mime, MimeTypeOpus):
+		return MimeTypeOpus
+	case strings.EqualFold(mime, MimeTypeAudioRed):
+		return MimeTypeAudioRed
+	case strings.EqualFold(mime, MimeTypeVP8):
+		return MimeTypeVP8
+	case strings.EqualFold(mime, MimeTypeVP9):
+		return MimeTypeVP9
+	case strings.EqualFold(mime, MimeTypeAV1):
+		return MimeTypeAV1
+	case strings.EqualFold(mime, MimeTypeG722):
+		return MimeTypeG722
+	case strings.EqualFold(mime, MimeTypePCMU):
+		return MimeTypePCMU
+	case strings.EqualFold(mime, MimeTypePCMA):
+		return MimeTypePCMA
+	case strings.EqualFold(mime, MimeTypeRTX):
+		return MimeTypeRTX
+	case strings.EqualFold(mime, MimeTypeFlexFEC):
+		return MimeTypeFlexFEC
+	}
+
+	panic(fmt.Sprintf("unknown mime type: %s", mime))
+	return ""
+}
+
+// SVC-TODO: Have to use more conditions to differentiate between
+// SVC-TODO: SVC and non-SVC (could be single layer or simulcast).
+// SVC-TODO: May only need to differentiate between simulcast and non-simulcast
+// SVC-TODO: i. e. may be possible to treat single layer as SVC to get proper/intended functionality.
+func IsSvcCodec(mime string) bool {
+	switch MatchMimeType(mime) {
+	case MimeTypeNumberAV1, MimeTypeNumberVP9:
+		return true
+	}
+	return false
+}
+
+func IsRedCodec(mime string) bool {
+	return NormalizeMimeType(mime) == MimeTypeAudioRed
 }

--- a/pkg/sfu/utils/mimetype.go
+++ b/pkg/sfu/utils/mimetype.go
@@ -15,7 +15,6 @@
 package utils
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -161,8 +160,7 @@ func NormalizeMimeType(mime string) string {
 		return MimeTypeFlexFEC
 	}
 
-	panic(fmt.Sprintf("unknown mime type: %s", mime))
-	return ""
+	return strings.ToLower(mime)
 }
 
 // SVC-TODO: Have to use more conditions to differentiate between

--- a/pkg/sfu/utils/mimetype_test.go
+++ b/pkg/sfu/utils/mimetype_test.go
@@ -21,26 +21,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func toLowerSwitch(mimeType string) MimeType {
+func toLowerSwitch(mimeType string) MimeTypeNumber {
 	switch strings.ToLower(mimeType) {
 	case "video/vp8":
-		return MimeTypeVP8
+		return MimeTypeNumberVP8
 	case "video/vp9":
-		return MimeTypeVP9
+		return MimeTypeNumberVP9
 	case "video/h264":
-		return MimeTypeH264
+		return MimeTypeNumberH264
 	case "video/av1":
-		return MimeTypeAV1
+		return MimeTypeNumberAV1
 	default:
-		return MimeTypeUnknown
+		return MimeTypeNumberUnknown
 	}
 }
 
 func TestMimeTypeMatch(t *testing.T) {
-	require.Equal(t, MimeTypeVP8, MatchMimeType("VIDEO/VP8"), "VIDEO/VP8")
-	require.Equal(t, MimeTypeVP9, MatchMimeType("VIDEO/VP9"), "VIDEO/VP9")
-	require.Equal(t, MimeTypeH264, MatchMimeType("VIDEO/H264"), "VIDEO/H264")
-	require.Equal(t, MimeTypeAV1, MatchMimeType("VIDEO/AV1"), "VIDEO/AV1")
+	require.Equal(t, MimeTypeNumberVP8, MatchMimeType("VIDEO/VP8"), "VIDEO/VP8")
+	require.Equal(t, MimeTypeNumberVP9, MatchMimeType("VIDEO/VP9"), "VIDEO/VP9")
+	require.Equal(t, MimeTypeNumberH264, MatchMimeType("VIDEO/H264"), "VIDEO/H264")
+	require.Equal(t, MimeTypeNumberAV1, MatchMimeType("VIDEO/AV1"), "VIDEO/AV1")
 }
 
 func BenchmarkMimeTypeMatch(b *testing.B) {

--- a/test/singlenode_test.go
+++ b/test/singlenode_test.go
@@ -156,7 +156,7 @@ func TestSinglePublisher(t *testing.T) {
 	waitUntilConnected(t, c1, c2)
 
 	// publish a track and ensure clients receive it ok
-	t1, err := c1.AddStaticTrack("audio/opus", "audio", "webcamaudio")
+	t1, err := c1.AddStaticTrack("audio/OPUS", "audio", "webcamaudio")
 	require.NoError(t, err)
 	defer t1.Stop()
 	t2, err := c1.AddStaticTrack("video/vp8", "video", "webcamvideo")


### PR DESCRIPTION
An attempt to normalize mime type and avoid string compares remembering to do case insensitive search.

Not the best solution. Open to ideas. But, define our own mime types (just in case Pion changes things and Pion also does not have red mime type defined which should be easy to add though) and tried to use it everywhere. But, as we get a bunch of callbacks and info from Pion, needed conversion in more places than I anticipated. And also makes it necessary to carry that cognitive load of what comes from Pion and needing to process it properly.

The type being `string` makes this a hard one to rein in. Maybe, all internal usage should use a type name? And then convert ones coming from proto and webrtc (which are both strings) to internal type as necessary and do the checks?

Still there are a bunch of places in code using `webrtc.MimeTypeX` from pion including in config.go. And use of raw strings in tests as well. Maybe, should convert all of them to our mime type. If we use a type name for our type, can do the `String()` method to convert to `string` as necessary.

Making a draft PR and requesting feedback.