### PR TITLE
Correct reason for poor/lost score.

### DIFF
--- a/pkg/sfu/connectionquality/scorer.go
+++ b/pkg/sfu/connectionquality/scorer.go
@@ -408,10 +408,10 @@ func (q *qualityScorer) updateAtLocked(stat *windowStat, at time.Time) {
 	var score, packetScore, bitrateScore, layerScore float64
 	if stat.packets+stat.packetsPadding == 0 {
 		if !stat.lastRTCPAt.IsZero() && at.Sub(stat.lastRTCPAt) > stat.duration {
-			reason = "dry"
+			reason = "rtcp"
 			score = qualityTransitionScore[livekit.ConnectionQuality_LOST]
 		} else {
-			reason = "rtcp"
+			reason = "dry"
 			score = qualityTransitionScore[livekit.ConnectionQuality_POOR]
 		}
 	} else {

--- a/pkg/sfu/rtpstats/rtpstats_base.go
+++ b/pkg/sfu/rtpstats/rtpstats_base.go
@@ -468,6 +468,13 @@ func (r *rtpStatsBase) deltaInfo(
 			StartTime: time.Unix(0, startTime),
 			EndTime:   time.Unix(0, endTime),
 		}
+		loggingFields = []interface{}{
+			"snapshotID", snapshotID,
+			"snapshotNow", now,
+			"snapshotThen", then,
+			"duration", time.Duration(endTime - startTime),
+		}
+		err = errors.New("no packets in delta")
 		return
 	}
 


### PR DESCRIPTION
No functional change, just logging reason was confusing. Also, log no packets case. Seeing some instances in staging where there are periods of no packets received. Trying to understand better.