### PR TITLE
Fix the incorrect default value setting for departure.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.8.2] - 2025-01-07
+## [1.8.3] - 2025-01-07
 
 ### Added
 

--- a/version/version.go
+++ b/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const Version = "1.8.2"
+const Version = "1.8.3"


### PR DESCRIPTION
- Change the default departure value from DepartureTimeout in the request to DepartureTimeout in the configuration.
- Ensure that when clone.DepartureTimeout is 0, the default value set in the configuration file is used.