### PR TITLE
Ignore unknown mime in dynacast manager.

### DIFF
--- a/pkg/rtc/dynacast/dynacastmanager.go
+++ b/pkg/rtc/dynacast/dynacastmanager.go
@@ -187,7 +187,7 @@ func (d *DynacastManager) getOrCreateDynacastQuality(mimeType mime.MimeType) *Dy
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
-	if d.isClosed {
+	if d.isClosed || mimeType == mime.MimeTypeUnknown {
 		return nil
 	}
 

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -364,6 +364,7 @@ func NewDownTrack(params DowntrackParams) (*DownTrack, error) {
 		upstreamCodecs:      codecs,
 		kind:                kind,
 		codec:               codecs[0].RTPCodecCapability,
+		mime:                mime.NormalizeMimeType(codecs[0].MimeType),
 		clockRate:           codecs[0].ClockRate,
 		pacer:               params.Pacer,
 		maxLayerNotifierCh:  make(chan string, 1),

--- a/pkg/sfu/mime/mimetype.go
+++ b/pkg/sfu/mime/mimetype.go
@@ -41,6 +41,7 @@ const (
 	MimeTypeCodecPCMA
 	MimeTypeCodecRTX
 	MimeTypeCodecFlexFEC
+	MimeTypeCodecULPFEC
 )
 
 func (m MimeTypeCodec) String() string {
@@ -71,6 +72,8 @@ func (m MimeTypeCodec) String() string {
 		return "rtx"
 	case MimeTypeCodecFlexFEC:
 		return "flexfec"
+	case MimeTypeCodecULPFEC:
+		return "ulpfec"
 	}
 
 	return "MimeTypeCodecUnknown"
@@ -102,6 +105,8 @@ func NormalizeMimeTypeCodec(codec string) MimeTypeCodec {
 		return MimeTypeCodecRTX
 	case strings.EqualFold(codec, "flexfec"):
 		return MimeTypeCodecFlexFEC
+	case strings.EqualFold(codec, "ulpfec"):
+		return MimeTypeCodecULPFEC
 	}
 
 	return MimeTypeCodecUnknown
@@ -144,6 +149,7 @@ const (
 	MimeTypePCMA
 	MimeTypeRTX
 	MimeTypeFlexFEC
+	MimeTypeULPFEC
 )
 
 func (m MimeType) String() string {
@@ -174,6 +180,8 @@ func (m MimeType) String() string {
 		return webrtc.MimeTypeRTX
 	case MimeTypeFlexFEC:
 		return webrtc.MimeTypeFlexFEC
+	case MimeTypeULPFEC:
+		return "video/ulpfec"
 	}
 
 	return "MimeTypeUnknown"
@@ -205,6 +213,8 @@ func NormalizeMimeType(mime string) MimeType {
 		return MimeTypeRTX
 	case strings.EqualFold(mime, webrtc.MimeTypeFlexFEC):
 		return MimeTypeFlexFEC
+	case strings.EqualFold(mime, "video/ulpfec"):
+		return MimeTypeULPFEC
 	}
 
 	return MimeTypeUnknown


### PR DESCRIPTION
Actually, was caused by down track not initialising mime, but it is good to ignore unknown mime.

Also, added ulpfec sa SDP has that and there was a conversion which was returning unknown. Also, note that the mime types use audio for RED and video for flexfec and ulpfec although they are not media type dependent. Maybe, at point need to introduce `MimeTypeAudioRED` and `MimeTypeVideoRED`.