### PR TITLE
Split down stream snapshot into sender view and receiver view.

### DIFF
--- a/pkg/sfu/buffer/streamstats.go
+++ b/pkg/sfu/buffer/streamstats.go
@@ -19,4 +19,6 @@ import "github.com/livekit/livekit-server/pkg/sfu/rtpstats"
 type StreamStatsWithLayers struct {
 	RTPStats *rtpstats.RTPDeltaInfo
 	Layers   map[int32]*rtpstats.RTPDeltaInfo
+
+	RTPStatsRemoteView *rtpstats.RTPDeltaInfo
 }

--- a/pkg/sfu/playoutdelay.go
+++ b/pkg/sfu/playoutdelay.go
@@ -119,7 +119,7 @@ func (c *PlayoutDelayController) SeedState(pdcs PlayoutDelayControllerState) {
 
 func (c *PlayoutDelayController) SetJitter(jitter uint32) {
 	c.lock.Lock()
-	deltaInfoSender := c.rtpStats.DeltaInfoSender(c.senderSnapshotID)
+	deltaInfoSender, _ := c.rtpStats.DeltaInfoSender(c.senderSnapshotID)
 	var nackPercent uint32
 	if deltaInfoSender != nil && deltaInfoSender.Packets > 0 {
 		nackPercent = deltaInfoSender.Nacks * 100 / deltaInfoSender.Packets

--- a/pkg/sfu/rtpstats/rtpstats_base.go
+++ b/pkg/sfu/rtpstats/rtpstats_base.go
@@ -134,6 +134,18 @@ func (s *snapshot) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	return nil
 }
 
+func (s *snapshot) maybeUpdateMaxRTT(rtt uint32) {
+	if rtt > s.maxRtt {
+		s.maxRtt = rtt
+	}
+}
+
+func (s *snapshot) maybeUpdateMaxJitter(jitter float64) {
+	if jitter > s.maxJitter {
+		s.maxJitter = jitter
+	}
+}
+
 // ------------------------------------------------------------------
 
 type wrappedRTPDriftLogger struct {
@@ -646,10 +658,7 @@ func (r *rtpStatsBase) updateJitter(ets uint64, packetTime int64) float64 {
 			}
 
 			for i := uint32(0); i < r.nextSnapshotID-cFirstSnapshotID; i++ {
-				s := &r.snapshots[i]
-				if r.jitter > s.maxJitter {
-					s.maxJitter = r.jitter
-				}
+				r.snapshots[i].maybeUpdateMaxJitter(r.jitter)
 			}
 		}
 


### PR DESCRIPTION
Receiver view is used for connection quality.

Sender view is used for analytics. One thing that this introduces is that sender view uses the packet loss information from receiver view as true loss is available only in the RTCP Receiver Reports received from the remote side. So, the time alignment is off, i. e. receiver report happens periodically and it includes information till the time at which it was sent from remote side, but sender could have sent more packets after that time.

The split should ensure that analytics does not rely on remote side sending proper receiver repoerts albeit at slight misalignment of loss statistic for remotes that do send RTCP RR (which should be majority of the cases)