### PR TITLE
Give more cache for RTX.

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -377,7 +377,7 @@ func NewDownTrack(params DowntrackParams) (*DownTrack, error) {
 
 	var mdCacheSize, mdCacheSizeRTX int
 	if d.kind == webrtc.RTPCodecTypeVideo {
-		mdCacheSize, mdCacheSizeRTX = 32768, 4096
+		mdCacheSize, mdCacheSizeRTX = 8192, 8192
 	} else {
 		mdCacheSize, mdCacheSizeRTX = 8192, 1024
 	}

--- a/pkg/sfu/rtpstats/rtpstats_sender.go
+++ b/pkg/sfu/rtpstats/rtpstats_sender.go
@@ -636,7 +636,7 @@ func (r *RTPStatsSender) UpdateFromReceiverReport(rr rtcp.ReceptionReport) (rtt 
 	}
 
 	extReceivedRRSN := extHighestSNFromRR + (r.extStartSN & 0xFFFF_FFFF_FFFF_0000)
-	if r.extHighestSNFromRR != extHighestSNFromRR && int64(r.extHighestSN-extReceivedRRSN) > (1<<16) {
+	if r.extHighestSNFromRR != extHighestSNFromRR && int64(r.extHighestSN-extReceivedRRSN) >= (1<<16) {
 		// there are cases where remote does not send RTCP Receiver Report for extended periods of time,
 		// some times several minutes, in that interval the sequence number rolls over,
 		//


### PR DESCRIPTION
- With probing the packet rate can get high suddenly and remote may not have sent receiver report as it might be sending for the non-spikey rate. That causes metadata cache overflows. So, give RTX more cahe.
- Don't need a large cache for primary as either reports come in regularly (or they are missing for a long time and having a biger cache is not the solution for that, so reduce primary cache size)
- Check for receiver report falling exactly back by (1 << 16). Had done that change in the inside for loop, but missed the top level check :-(