### PR TITLE
Dependent participants should not trigger count towards FirstJoinedAt

### DIFF
--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -197,7 +197,10 @@ func (r *RoomManager) CloseIdleRooms() {
 	r.lock.RUnlock()
 
 	for _, room := range rooms {
-		room.CloseIfEmpty()
+		reason := room.CloseIfEmpty()
+		if reason != "" {
+			logger.Infow("closing idle room", "room", room.Name(), "reason", reason)
+		}
 	}
 }
 

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -199,7 +199,7 @@ func (r *RoomManager) CloseIdleRooms() {
 	for _, room := range rooms {
 		reason := room.CloseIfEmpty()
 		if reason != "" {
-			logger.Infow("closing idle room", "room", room.Name(), "reason", reason)
+			room.Logger.Infow("closing idle room", "reason", reason)
 		}
 	}
 }


### PR DESCRIPTION
According to the API, empty timeout should be honored as long as no independent participant joins the room. If we counted Agents and Egress as part of FirstJoinedAt, it would have the side effect of using departureTimeout instead of emptyTimeout for idle calculations.

also added logs to understand when idle rooms are closed