### PR TITLE
Log stream headers

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1918,6 +1918,7 @@ func (p *ParticipantImpl) onDataMessage(kind livekit.DataPacket_Kind, data []byt
 			"stream_id", payload.StreamHeader.StreamId,
 			"mime_type", payload.StreamHeader.MimeType,
 			"total_length", payload.StreamHeader.TotalLength,
+			"dest_count", len(dp.DestinationIdentities),
 			"type", func() string {
 				switch payload.StreamHeader.ContentHeader.(type) {
 				case *livekit.DataStream_Header_TextHeader:

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1913,6 +1913,22 @@ func (p *ParticipantImpl) onDataMessage(kind livekit.DataPacket_Kind, data []byt
 				overrideSenderIdentity = true
 			}
 		}
+		p.pubLogger.Infow("received stream header data packet",
+			"topic", payload.StreamHeader.Topic,
+			"stream_id", payload.StreamHeader.StreamId,
+			"mime_type", payload.StreamHeader.MimeType,
+			"total_length", payload.StreamHeader.TotalLength,
+			"type", func() string {
+				switch payload.StreamHeader.ContentHeader.(type) {
+				case *livekit.DataStream_Header_TextHeader:
+					return "text"
+				case *livekit.DataStream_Header_ByteHeader:
+					return "bytes"
+				default:
+					return "unknown"
+				}
+			}(),
+		)
 	case *livekit.DataPacket_StreamChunk:
 		if payload.StreamChunk == nil {
 			return


### PR DESCRIPTION
Similar to RPC, this will allow basic adoption monitoring during initial feature rollout.

we're logging just basic info, the only thing remotely user-entered is the "topic", similar to how we currently log RPC "method"

here's a sample log from a local server while using the send text feature of the js demo app

```
2025-02-19T00:05:31.384-0800    INFO    livekit.pub     rtc/participant.go:1916 received stream header data packet      {"room": "data-test", "roomID": "RM_sbeEuQCgiZuT", "participant": "a", "pID": "PA_5256tZoMhpFq", "remote": false, "topic": "lk.chat", "stream_id": "459e8819-fb36-487f-a6e7-2b2e43dd86ab", "mime_type": "text/plain", "total_length": null, "dest_count": 1, "type": "text"}
```

and for send file

```
2025-02-19T00:05:39.482-0800    INFO    livekit.pub     rtc/participant.go:1916 received stream header data packet      {"room": "data-test", "roomID": "RM_sbeEuQCgiZuT", "participant": "b", "pID": "PA_xyuNULhdKH2x", "remote": false, "topic": "files", "stream_id": "dc91e8bd-47bc-4f3f-bee5-eaa8beb4bd1b", "mime_type": "image/png", "total_length": 89205, "dest_count": 0, "type": "bytes"}
```