### PR TITLE
add datapacket stream metrics

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1904,6 +1904,9 @@ func (p *ParticipantImpl) onDataMessage(kind livekit.DataPacket_Kind, data []byt
 		if payload.StreamHeader == nil {
 			return
 		}
+
+		prometheus.RecordDataPacketStream(payload.StreamHeader, len(dp.DestinationIdentities))
+
 		if p.IsAgent() && dp.ParticipantIdentity != "" && string(p.params.Identity) != dp.ParticipantIdentity {
 			switch contentHeader := payload.StreamHeader.ContentHeader.(type) {
 			case *livekit.DataStream_Header_TextHeader:

--- a/pkg/telemetry/prometheus/datapacket.go
+++ b/pkg/telemetry/prometheus/datapacket.go
@@ -1,0 +1,70 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/livekit/protocol/livekit"
+)
+
+var (
+	promDataPacketStreamDestCount *prometheus.HistogramVec
+	promDataPacketStreamSize      *prometheus.HistogramVec
+	promDataPacketStreamTotal     *prometheus.CounterVec
+)
+
+func initDataPacketStats(nodeID string, nodeType livekit.NodeType) {
+	promDataPacketStreamDestCount = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:   livekitNamespace,
+		Subsystem:   "datapacket_stream",
+		Name:        "dest_count",
+		ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
+		Buckets:     []float64{1, 2, 3, 4, 5, 10, 15, 25, 50},
+	}, []string{"type"})
+	promDataPacketStreamSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:   livekitNamespace,
+		Subsystem:   "datapacket_stream",
+		Name:        "bytes",
+		ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
+		Buckets:     []float64{128, 512, 2048, 8192, 32768, 131072, 524288, 2097152, 8388608, 33554432},
+	}, []string{"type"})
+	promDataPacketStreamTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace:   livekitNamespace,
+		Subsystem:   "datapacket_stream",
+		Name:        "total",
+		ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
+	}, []string{"type", "mime_type"})
+
+	prometheus.MustRegister(promDataPacketStreamDestCount)
+	prometheus.MustRegister(promDataPacketStreamSize)
+	prometheus.MustRegister(promDataPacketStreamTotal)
+}
+
+func RecordDataPacketStream(h *livekit.DataStream_Header, destCount int) {
+	typ := "unknown"
+	switch h.ContentHeader.(type) {
+	case *livekit.DataStream_Header_TextHeader:
+		typ = "text"
+	case *livekit.DataStream_Header_ByteHeader:
+		typ = "bytes"
+	}
+
+	promDataPacketStreamDestCount.WithLabelValues(typ).Observe(float64(destCount))
+	if h.TotalLength != nil {
+		promDataPacketStreamSize.WithLabelValues(typ).Observe(float64(*h.TotalLength))
+	}
+	promDataPacketStreamTotal.WithLabelValues(typ, h.MimeType).Inc()
+}

--- a/pkg/telemetry/prometheus/node.go
+++ b/pkg/telemetry/prometheus/node.go
@@ -127,6 +127,7 @@ func Init(nodeID string, nodeType livekit.NodeType) error {
 	initRoomStats(nodeID, nodeType)
 	rpc.InitPSRPCStats(prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()})
 	initQualityStats(nodeID, nodeType)
+	initDataPacketStats(nodeID, nodeType)
 
 	var err error
 	cpuStats, err = hwstats.NewCPUStats(nil)


### PR DESCRIPTION
these allow us to measure
* by type
  * total stream declared size
  * average/approximate ntile stream size
  * count of streams by size class (128B-33MB every other 2^n)
  * total recipients
  * average/approximate ntile recipient count
  * count of streams by recipient count class (1, 2, 3, 4, 5, 10, 15, 25, 50)
* by type/mime type
  * total streams
  
we can compute rates or render histograms/spectrograms...

how important is mime type? could we maybe trim the encoding and filter to a set of known values? eg. `image/png` -> `image`?