### PR TITLE
Disable dd parser for vp8 if extension is not found

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -868,7 +868,15 @@ func (b *Buffer) getExtPacket(rtpPacket *rtp.Packet, arrivalTime int64, flowStat
 	if b.ddParser != nil {
 		ddVal, videoLayer, err := b.ddParser.Parse(ep.Packet)
 		if err != nil {
-			return nil
+			if errors.Is(err, ErrDDExtentionNotFound) {
+				if b.mime == mime.MimeTypeVP8 {
+					b.logger.Infow("dd extension not found for vp8 packet, disable dd parser")
+					b.ddParser = nil
+					b.createFrameRateCalculator()
+				}
+			} else {
+				return nil
+			}
 		} else if ddVal != nil {
 			ep.DependencyDescriptor = ddVal
 			ep.VideoLayer = videoLayer

--- a/pkg/sfu/buffer/dependencydescriptorparser.go
+++ b/pkg/sfu/buffer/dependencydescriptorparser.go
@@ -30,6 +30,7 @@ import (
 var (
 	ErrFrameEarlierThanKeyFrame            = fmt.Errorf("frame is earlier than current keyframe")
 	ErrDDStructureAttachedToNonFirstPacket = fmt.Errorf("dependency descriptor structure is attached to non-first packet of a frame")
+	ErrDDExtentionNotFound                 = fmt.Errorf("dependency descriptor extension not found")
 )
 
 type DependencyDescriptorParser struct {
@@ -80,7 +81,7 @@ func (r *DependencyDescriptorParser) Parse(pkt *rtp.Packet) (*ExtDependencyDescr
 		if ddNotFoundCount%100 == 0 {
 			r.logger.Warnw("dependency descriptor extension is not present", nil, "seq", pkt.SequenceNumber, "count", ddNotFoundCount)
 		}
-		return nil, videoLayer, nil
+		return nil, videoLayer, ErrDDExtentionNotFound
 	}
 
 	var ddVal dd.DependencyDescriptor


### PR DESCRIPTION
Browser would not send dd extension for vp8 in some case even if it is negotiated.