### PR TITLE
Prevent bind lock deadlock on muted.

### DIFF
--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -183,6 +183,8 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 				}()
 			}
 		}
+
+		subTrack.SetPublisherMuted(t.params.MediaTrack.IsMuted())
 	})
 	downTrack.OnBinding(func(err error) {
 		if err != nil {
@@ -203,8 +205,6 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 		}
 
 		go subTrack.Bound(nil)
-
-		subTrack.SetPublisherMuted(t.params.MediaTrack.IsMuted())
 	})
 
 	downTrack.OnStatsUpdate(func(_ *sfu.DownTrack, stat *livekit.AnalyticsStat) {

--- a/pkg/sfu/streamtrackermanager.go
+++ b/pkg/sfu/streamtrackermanager.go
@@ -481,7 +481,7 @@ func (s *StreamTrackerManager) getLayeredBitrateLocked() ([]int32, Bitrates) {
 	for i, tracker := range s.trackers {
 		if tracker != nil {
 			tls := make([]int64, buffer.DefaultMaxLayerTemporal+1)
-			if slices.Contains(s.availableLayers ,int32(i)) {
+			if slices.Contains(s.availableLayers, int32(i)) {
 				tls = tracker.BitrateTemporalCumulative()
 			}
 


### PR DESCRIPTION
Need to re-visit the bind lock scope and maybe make the codec/mime atomic and access them without bind lock. But, doing whack-a-mole a bit first to move things forward. Will look at making them atomics.