### PR TITLE
Reduce seeder duration to 30s and also do not force send PLI.

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -1248,7 +1248,7 @@ func (b *Buffer) seedKeyFrame() {
 	// send gratuitous PLIs for some time or until a key frame is seen to
 	// get the engine rolling
 	b.logger.Debugw("starting key frame seeder")
-	timer := time.NewTimer(time.Minute)
+	timer := time.NewTimer(30 * time.Second)
 	defer timer.Stop()
 
 	ticker := time.NewTicker(time.Second)
@@ -1280,7 +1280,7 @@ func (b *Buffer) seedKeyFrame() {
 					return
 				}
 
-				b.SendPLI(true)
+				b.SendPLI(false)
 			}
 		}
 	}


### PR DESCRIPTION
Can use the normal PLI throttle cadence.