### PR TITLE
Clean up published track on participant removal.

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -710,6 +710,7 @@ func (r *Room) RemoveParticipant(identity livekit.ParticipantIdentity, pID livek
 
 	// remove all published tracks
 	for _, t := range p.GetPublishedTracks() {
+		p.RemovePublishedTrack(t, false, true)
 		r.trackManager.RemoveTrack(t)
 	}
 


### PR DESCRIPTION
Clean up the tracks in the synchronous path and remove track from track manager. This is not strictly required in a single node case. But, multi-node needs this. So, doing this here for consistency.