### PR TITLE
Do not instantiate 0 sized sequencer.

### DIFF
--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -113,6 +113,8 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 	case livekit.TrackType_VIDEO:
 		rtcpFeedback = t.params.SubscriberConfig.RTCPFeedback.Video
 		maxTrack = t.params.ReceiverConfig.PacketBufferSizeVideo
+	default:
+		t.params.Logger.Warnw("unexpected track type", nil, "kind", t.params.MediaTrack.Kind())
 	}
 	codecs := wr.Codecs()
 	for _, c := range codecs {

--- a/pkg/sfu/sequencer.go
+++ b/pkg/sfu/sequencer.go
@@ -119,6 +119,10 @@ type sequencer struct {
 }
 
 func newSequencer(size int, maybeSparse bool, logger logger.Logger) *sequencer {
+	if size == 0 {
+		return nil
+	}
+
 	s := &sequencer{
 		size:      size,
 		startTime: time.Now().UnixNano(),


### PR DESCRIPTION
This happens due to improper track type.

One possible option is to check the mime type of the track and calculate the size, but there are other places in the code which work off provided track type. So, just doing a defensive fix. Have to review code for all uses of type and how it affects things if client provides incorrect type.