### PR TITLE
Send regressed codec upstream stats to analytics.

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -315,16 +315,22 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track sfu.TrackRe
 
 		// SIMULCAST-CODEC-TODO: these need to be receiver/mime aware, setting it up only for primary now
 		newWR.OnStatsUpdate(func(_ *sfu.WebRTCReceiver, stat *livekit.AnalyticsStat) {
-			if priority == 0 || t.regressionTargetCodecReceived {
-				// send for only one codec, either primary (priority == 0) OR regressed codec
+			// send for only one codec, either primary (priority == 0) OR regressed codec
+			t.lock.RLock()
+			regressionTargetCodecReceived := t.regressionTargetCodecReceived
+			t.lock.RUnlock()
+			if priority == 0 || regressionTargetCodecReceived {
 				key := telemetry.StatsKeyForTrack(livekit.StreamType_UPSTREAM, t.PublisherID(), t.ID(), ti.Source, ti.Type)
 				t.params.Telemetry.TrackStats(key, stat)
 			}
 		})
 
 		newWR.OnMaxLayerChange(func(maxLayer int32) {
-			if priority == 0 || t.regressionTargetCodecReceived {
-				// send for only one codec, either primary (priority == 0) OR regressed codec
+			// send for only one codec, either primary (priority == 0) OR regressed codec
+			t.lock.RLock()
+			regressionTargetCodecReceived := t.regressionTargetCodecReceived
+			t.lock.RUnlock()
+			if priority == 0 || regressionTargetCodecReceived {
 				t.MediaTrackReceiver.NotifyMaxLayerChange(maxLayer)
 			}
 		})

--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -312,15 +312,24 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track sfu.TrackRe
 				}
 			}
 		})
+
 		// SIMULCAST-CODEC-TODO: these need to be receiver/mime aware, setting it up only for primary now
-		if priority == 0 {
-			newWR.OnStatsUpdate(func(_ *sfu.WebRTCReceiver, stat *livekit.AnalyticsStat) {
+		newWR.OnStatsUpdate(func(_ *sfu.WebRTCReceiver, stat *livekit.AnalyticsStat) {
+			if priority == 0 || t.regressionTargetCodecReceived {
+				// send for only one codec, either primary (priority == 0) OR regressed codec
 				key := telemetry.StatsKeyForTrack(livekit.StreamType_UPSTREAM, t.PublisherID(), t.ID(), ti.Source, ti.Type)
 				t.params.Telemetry.TrackStats(key, stat)
-			})
+			}
+		})
 
-			newWR.OnMaxLayerChange(t.onMaxLayerChange)
-		}
+		newWR.OnMaxLayerChange(func(maxLayer int32) {
+			if priority == 0 || t.regressionTargetCodecReceived {
+				// send for only one codec, either primary (priority == 0) OR regressed codec
+				t.MediaTrackReceiver.NotifyMaxLayerChange(maxLayer)
+			}
+		})
+		// SIMULCAST-CODEC-TODO END: these need to be receiver/mime aware, setting it up only for primary now
+
 		if t.PrimaryReceiver() == nil {
 			// primary codec published, set potential codecs
 			potentialCodecs := make([]webrtc.RTPCodecParameters, 0, len(ti.Codecs))
@@ -445,10 +454,6 @@ func (t *MediaTrack) SetRTT(rtt uint32) {
 
 func (t *MediaTrack) HasPendingCodec() bool {
 	return t.MediaTrackReceiver.PrimaryReceiver() == nil
-}
-
-func (t *MediaTrack) onMaxLayerChange(maxLayer int32) {
-	t.MediaTrackReceiver.NotifyMaxLayerChange(maxLayer)
 }
 
 func (t *MediaTrack) Restart() {

--- a/pkg/telemetry/statsworker.go
+++ b/pkg/telemetry/statsworker.go
@@ -255,6 +255,7 @@ func coalesce(stats []*livekit.AnalyticsStat) *livekit.AnalyticsStat {
 		MinScore:    minScore,
 		MedianScore: utils.MedianFloat32(scores),
 		Streams:     []*livekit.AnalyticsStream{coalescedStream},
+		Mime:        stats[len(stats)-1].Mime, // use the latest Mime
 	}
 	numScores := len(scores)
 	if numScores > 0 {


### PR DESCRIPTION
There is more work to do for analytics for simulcast codec, i. e. when both codecs are published. Shorter term, ensure that analytics are sent for regressed codec if active.