### PR TITLE
chore(logs): log VLS type for VP9/AV1

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -344,6 +344,7 @@ func (f *Forwarder) DetermineCodec(codec webrtc.RTPCodecCapability, extensions [
 
 	case mime.MimeTypeVP9:
 		if f.isReceiverSimulcast {
+			f.logger.Debugw("selecting simulcast video layer selector for VP9")
 			if f.vls != nil {
 				f.vls = videolayerselector.NewSimulcastFromOther(f.vls)
 			} else {
@@ -353,12 +354,14 @@ func (f *Forwarder) DetermineCodec(codec webrtc.RTPCodecCapability, extensions [
 		} else {
 			isDDAvailable := ddAvailable(extensions)
 			if isDDAvailable {
+				f.logger.Debugw("selecting dependency descriptor video layer selector for VP9")
 				if f.vls != nil {
 					f.vls = videolayerselector.NewDependencyDescriptorFromOther(f.vls)
 				} else {
 					f.vls = videolayerselector.NewDependencyDescriptor(f.logger)
 				}
 			} else {
+				f.logger.Debugw("selecting VP9 SVC video layer selector")
 				if f.vls != nil {
 					f.vls = videolayerselector.NewVP9FromOther(f.vls)
 				} else {
@@ -371,12 +374,14 @@ func (f *Forwarder) DetermineCodec(codec webrtc.RTPCodecCapability, extensions [
 		isDDAvailable := ddAvailable(extensions)
 		if f.isReceiverSimulcast || !isDDAvailable {
 			// AV1-SIMULCAST-TODO: Add temporal layer selector for AV1
+			f.logger.Debugw("selecting simulcast video layer selector for AV1")
 			if f.vls != nil {
 				f.vls = videolayerselector.NewSimulcastFromOther(f.vls)
 			} else {
 				f.vls = videolayerselector.NewSimulcast(f.logger)
 			}
 		} else {
+			f.logger.Debugw("selecting dependency descriptor video layer selector for AV1")
 			if f.vls != nil {
 				f.vls = videolayerselector.NewDependencyDescriptorFromOther(f.vls)
 			} else {


### PR DESCRIPTION
SubscriberId is already part of params coming from downtrack.go, do we need anything else? https://github.com/livekit/livekit/blob/master/pkg/sfu/downtrack.go#L377-L379