### PR TITLE
Audio uses signal SignalCid and SdpCid.

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -60,6 +60,8 @@ type MediaTrack struct {
 }
 
 type MediaTrackParams struct {
+	SignalCid             string
+	SdpCid                string
 	ParticipantID         livekit.ParticipantID
 	ParticipantIdentity   livekit.ParticipantIdentity
 	ParticipantVersion    uint32
@@ -175,6 +177,10 @@ func (t *MediaTrack) NotifySubscriberNodeMaxQuality(nodeID livekit.NodeID, quali
 }
 
 func (t *MediaTrack) HasSignalCid(cid string) bool {
+	if t.params.SignalCid == cid {
+		return true
+	}
+
 	for _, c := range t.MediaTrackReceiver.TrackInfo().Codecs {
 		if c.SignalCid == cid {
 			return true
@@ -194,6 +200,10 @@ func (t *MediaTrack) SdpCids() []string {
 }
 
 func (t *MediaTrack) HasSdpCid(cid string) bool {
+	if t.params.SdpCid == cid {
+		return true
+	}
+
 	for _, c := range t.MediaTrackReceiver.TrackInfo().Codecs {
 		if c.SdpCid == cid {
 			return true

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2607,6 +2607,8 @@ func (p *ParticipantImpl) addMigratedTrack(cid string, ti *livekit.TrackInfo) *M
 
 func (p *ParticipantImpl) addMediaTrack(signalCid string, sdpCid string, ti *livekit.TrackInfo) *MediaTrack {
 	mt := NewMediaTrack(MediaTrackParams{
+		SignalCid:             signalCid,
+		SdpCid:                sdpCid,
 		ParticipantID:         p.params.SID,
 		ParticipantIdentity:   p.params.Identity,
 		ParticipantVersion:    p.version.Load(),


### PR DESCRIPTION
This is a bit annoying and painful. Audio does not have the information in the track info (because it does not use Codecs, it should probably at some point to make it consistent).

Reverting some bits from previous PR for IsSimulcast per receiver.