### PR TITLE
Revert participant state ACTIVE change.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -903,7 +903,11 @@ func (p *ParticipantImpl) HandleOffer(offer webrtc.SessionDescription) error {
 	}
 
 	offer = p.setCodecPreferencesForPublisher(offer)
-	return p.TransportManager.HandleOffer(offer, shouldPend)
+	err := p.TransportManager.HandleOffer(offer, shouldPend)
+	if p.params.UseOneShotSignallingMode {
+		p.updateState(livekit.ParticipantInfo_ACTIVE)
+	}
+	return err
 }
 
 func (p *ParticipantImpl) onPublisherAnswer(answer webrtc.SessionDescription) error {


### PR DESCRIPTION
Had made the change to align `participant active` to after the ICE connection is done and that log could list all candidates.

But, with one shot signalling, the state change has to be early to wait on (auto) subscriptions of track of other participant. So, state has to be changed early.