### PR TITLE
Add OnSubscirberReady callback on LocalParticipant.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -241,6 +241,7 @@ type ParticipantImpl struct {
 	onTrackUpdated       func(types.LocalParticipant, types.MediaTrack)
 	onTrackUnpublished   func(types.LocalParticipant, types.MediaTrack)
 	onStateChange        func(p types.LocalParticipant)
+	onSubscriberReady    func(p types.LocalParticipant)
 	onMigrateStateChange func(p types.LocalParticipant, migrateState types.MigrateState)
 	onParticipantUpdate  func(types.LocalParticipant)
 	onDataPacket         func(types.LocalParticipant, livekit.DataPacket_Kind, *livekit.DataPacket)
@@ -752,6 +753,18 @@ func (p *ParticipantImpl) getOnStateChange() func(p types.LocalParticipant) {
 	return p.onStateChange
 }
 
+func (p *ParticipantImpl) OnSubscriberReady(callback func(p types.LocalParticipant)) {
+	p.lock.Lock()
+	p.onSubscriberReady = callback
+	p.lock.Unlock()
+}
+
+func (p *ParticipantImpl) getOnSubscriberReady() func(p types.LocalParticipant) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.onSubscriberReady
+}
+
 func (p *ParticipantImpl) OnMigrateStateChange(callback func(p types.LocalParticipant, state types.MigrateState)) {
 	p.lock.Lock()
 	p.onMigrateStateChange = callback
@@ -905,7 +918,9 @@ func (p *ParticipantImpl) HandleOffer(offer webrtc.SessionDescription) error {
 	offer = p.setCodecPreferencesForPublisher(offer)
 	err := p.TransportManager.HandleOffer(offer, shouldPend)
 	if p.params.UseOneShotSignallingMode {
-		p.updateState(livekit.ParticipantInfo_ACTIVE)
+		if onSubscriberReady := p.getOnSubscriberReady(); onSubscriberReady != nil {
+			go onSubscriberReady(p)
+		}
 	}
 	return err
 }

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -481,6 +481,9 @@ func (r *Room) Join(participant types.LocalParticipant, requestSource routing.Me
 			go r.RemoveParticipant(p.Identity(), p.ID(), types.ParticipantCloseReasonNone)
 		}
 	})
+	participant.OnSubscriberReady(func(p types.LocalParticipant) {
+		r.subscribeToExistingTracks(p)
+	})
 	// it's important to set this before connection, we don't want to miss out on any published tracks
 	participant.OnTrackPublished(r.onTrackPublished)
 	participant.OnTrackUpdated(r.onTrackUpdated)
@@ -733,6 +736,7 @@ func (r *Room) RemoveParticipant(identity livekit.ParticipantIdentity, pID livek
 	p.OnTrackPublished(nil)
 	p.OnTrackUnpublished(nil)
 	p.OnStateChange(nil)
+	p.OnSubscriberReady(nil)
 	p.OnParticipantUpdate(nil)
 	p.OnDataPacket(nil)
 	p.OnDataMessage(nil)

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -418,6 +418,7 @@ type LocalParticipant interface {
 
 	// callbacks
 	OnStateChange(func(p LocalParticipant))
+	OnSubscriberReady(callback func(LocalParticipant))
 	OnMigrateStateChange(func(p LocalParticipant, migrateState MigrateState))
 	// OnTrackPublished - remote added a track
 	OnTrackPublished(func(LocalParticipant, MediaTrack))

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -772,6 +772,11 @@ type FakeLocalParticipant struct {
 	onSubscribeStatusChangedArgsForCall []struct {
 		arg1 func(publisherID livekit.ParticipantID, subscribed bool)
 	}
+	OnSubscriberReadyStub        func(func(types.LocalParticipant))
+	onSubscriberReadyMutex       sync.RWMutex
+	onSubscriberReadyArgsForCall []struct {
+		arg1 func(types.LocalParticipant)
+	}
 	OnTrackPublishedStub        func(func(types.LocalParticipant, types.MediaTrack))
 	onTrackPublishedMutex       sync.RWMutex
 	onTrackPublishedArgsForCall []struct {
@@ -5256,6 +5261,38 @@ func (fake *FakeLocalParticipant) OnSubscribeStatusChangedArgsForCall(i int) fun
 	return argsForCall.arg1
 }
 
+func (fake *FakeLocalParticipant) OnSubscriberReady(arg1 func(types.LocalParticipant)) {
+	fake.onSubscriberReadyMutex.Lock()
+	fake.onSubscriberReadyArgsForCall = append(fake.onSubscriberReadyArgsForCall, struct {
+		arg1 func(types.LocalParticipant)
+	}{arg1})
+	stub := fake.OnSubscriberReadyStub
+	fake.recordInvocation("OnSubscriberReady", []interface{}{arg1})
+	fake.onSubscriberReadyMutex.Unlock()
+	if stub != nil {
+		fake.OnSubscriberReadyStub(arg1)
+	}
+}
+
+func (fake *FakeLocalParticipant) OnSubscriberReadyCallCount() int {
+	fake.onSubscriberReadyMutex.RLock()
+	defer fake.onSubscriberReadyMutex.RUnlock()
+	return len(fake.onSubscriberReadyArgsForCall)
+}
+
+func (fake *FakeLocalParticipant) OnSubscriberReadyCalls(stub func(func(types.LocalParticipant))) {
+	fake.onSubscriberReadyMutex.Lock()
+	defer fake.onSubscriberReadyMutex.Unlock()
+	fake.OnSubscriberReadyStub = stub
+}
+
+func (fake *FakeLocalParticipant) OnSubscriberReadyArgsForCall(i int) func(types.LocalParticipant) {
+	fake.onSubscriberReadyMutex.RLock()
+	defer fake.onSubscriberReadyMutex.RUnlock()
+	argsForCall := fake.onSubscriberReadyArgsForCall[i]
+	return argsForCall.arg1
+}
+
 func (fake *FakeLocalParticipant) OnTrackPublished(arg1 func(types.LocalParticipant, types.MediaTrack)) {
 	fake.onTrackPublishedMutex.Lock()
 	fake.onTrackPublishedArgsForCall = append(fake.onTrackPublishedArgsForCall, struct {
@@ -8009,6 +8046,8 @@ func (fake *FakeLocalParticipant) Invocations() map[string][][]interface{} {
 	defer fake.onStateChangeMutex.RUnlock()
 	fake.onSubscribeStatusChangedMutex.RLock()
 	defer fake.onSubscribeStatusChangedMutex.RUnlock()
+	fake.onSubscriberReadyMutex.RLock()
+	defer fake.onSubscriberReadyMutex.RUnlock()
 	fake.onTrackPublishedMutex.RLock()
 	defer fake.onTrackPublishedMutex.RUnlock()
 	fake.onTrackUnpublishedMutex.RLock()


### PR DESCRIPTION
Was setting the state to ACTIVE prematurely to enable the subscription inter-lock in one shot signalling mode. But, that is incorrectly changing state.

Use a callback to indicate subscriber ready and let the participant ACTIVE happen when the connection actually establishes.