### PR TITLE
Forward transfer headers to internal request

### DIFF
--- a/pkg/service/sip.go
+++ b/pkg/service/sip.go
@@ -707,5 +707,6 @@ func (s *SIPService) transferSIPParticipantRequest(ctx context.Context, req *liv
 		SipCallId:    callID,
 		TransferTo:   req.TransferTo,
 		PlayDialtone: req.PlayDialtone,
+		Headers:      req.Headers,
 	}, nil
 }


### PR DESCRIPTION
This patch ensures that SIP headers provided in TransferSIPParticipantRequest requested by an agent are correctly forwarded to the internal SIP transfer request.

Previously, req.Headers was accepted but never passed along, causing headers from the initiating agent to be dropped.

This change adds a single line to include req.Headers in the internal request.