### PR TITLE
Check for multiple layers for managed track.

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -1636,9 +1636,9 @@ func (t *PCTransport) AddTrackToStreamAllocator(subTrack types.SubscribedTrack) 
 	}
 
 	t.streamAllocator.AddTrack(subTrack.DownTrack(), streamallocator.AddTrackParams{
-		Source:      subTrack.MediaTrack().Source(),
-		IsSimulcast: subTrack.MediaTrack().IsSimulcast(),
-		PublisherID: subTrack.MediaTrack().PublisherID(),
+		Source:         subTrack.MediaTrack().Source(),
+		IsMultiLayered: len(subTrack.MediaTrack().ToProto().GetLayers()) > 1,
+		PublisherID:    subTrack.MediaTrack().PublisherID(),
 	})
 }
 

--- a/pkg/sfu/streamallocator/streamallocator.go
+++ b/pkg/sfu/streamallocator/streamallocator.go
@@ -273,10 +273,10 @@ func (s *StreamAllocator) SetSendSideBWEInterceptor(sendSideBWEInterceptor cc.Ba
 }
 
 type AddTrackParams struct {
-	Source      livekit.TrackSource
-	Priority    uint8
-	IsSimulcast bool
-	PublisherID livekit.ParticipantID
+	Source         livekit.TrackSource
+	Priority       uint8
+	IsMultiLayered bool
+	PublisherID    livekit.ParticipantID
 }
 
 func (s *StreamAllocator) AddTrack(downTrack *sfu.DownTrack, params AddTrackParams) {
@@ -284,7 +284,7 @@ func (s *StreamAllocator) AddTrack(downTrack *sfu.DownTrack, params AddTrackPara
 		return
 	}
 
-	track := NewTrack(downTrack, params.Source, params.IsSimulcast, params.PublisherID, s.params.Logger)
+	track := NewTrack(downTrack, params.Source, params.IsMultiLayered, params.PublisherID, s.params.Logger)
 	track.SetPriority(params.Priority)
 
 	trackID := livekit.TrackID(downTrack.ID())

--- a/pkg/sfu/streamallocator/track.go
+++ b/pkg/sfu/streamallocator/track.go
@@ -23,12 +23,12 @@ import (
 )
 
 type Track struct {
-	downTrack   *sfu.DownTrack
-	source      livekit.TrackSource
-	isSimulcast bool
-	priority    uint8
-	publisherID livekit.ParticipantID
-	logger      logger.Logger
+	downTrack      *sfu.DownTrack
+	source         livekit.TrackSource
+	isMultiLayered bool
+	priority       uint8
+	publisherID    livekit.ParticipantID
+	logger         logger.Logger
 
 	maxLayer buffer.VideoLayer
 
@@ -43,17 +43,17 @@ type Track struct {
 func NewTrack(
 	downTrack *sfu.DownTrack,
 	source livekit.TrackSource,
-	isSimulcast bool,
+	isMultiLayered bool,
 	publisherID livekit.ParticipantID,
 	logger logger.Logger,
 ) *Track {
 	t := &Track{
-		downTrack:   downTrack,
-		source:      source,
-		isSimulcast: isSimulcast,
-		publisherID: publisherID,
-		logger:      logger,
-		streamState: StreamStateInactive,
+		downTrack:      downTrack,
+		source:         source,
+		isMultiLayered: isMultiLayered,
+		publisherID:    publisherID,
+		logger:         logger,
+		streamState:    StreamStateInactive,
 	}
 	t.SetPriority(0)
 	t.SetMaxLayer(downTrack.MaxLayer())
@@ -110,7 +110,7 @@ func (t *Track) DownTrack() *sfu.DownTrack {
 }
 
 func (t *Track) IsManaged() bool {
-	return t.source != livekit.TrackSource_SCREEN_SHARE || t.isSimulcast
+	return t.source != livekit.TrackSource_SCREEN_SHARE || t.isMultiLayered
 }
 
 func (t *Track) ID() livekit.TrackID {


### PR DESCRIPTION
The previous check was checking only for simulcast and would have made a screen share track published with multiple layers using SVC as unmanaged.