### PR TITLE
Use logger from request context.

### DIFF
--- a/pkg/routing/signal.go
+++ b/pkg/routing/signal.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/livekit/livekit-server/pkg/config"
 	"github.com/livekit/livekit-server/pkg/telemetry/prometheus"
+	"github.com/livekit/livekit-server/pkg/utils"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/rpc"
@@ -88,7 +89,7 @@ func (r *signalClient) StartParticipantSignal(
 		return
 	}
 
-	l := logger.GetLogger().WithValues(
+	l := utils.GetLogger(ctx).WithValues(
 		"room", roomName,
 		"reqNodeID", nodeID,
 		"participant", pi.Identity,

--- a/pkg/service/signal.go
+++ b/pkg/service/signal.go
@@ -23,6 +23,7 @@ import (
 	"github.com/livekit/livekit-server/pkg/config"
 	"github.com/livekit/livekit-server/pkg/routing"
 	"github.com/livekit/livekit-server/pkg/telemetry/prometheus"
+	"github.com/livekit/livekit-server/pkg/utils"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/rpc"
@@ -86,7 +87,7 @@ type defaultSessionHandler struct {
 }
 
 func (s *defaultSessionHandler) Logger(ctx context.Context) logger.Logger {
-	return logger.GetLogger()
+	return utils.GetLogger(ctx)
 }
 
 func (s *defaultSessionHandler) HandleSession(

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -22,8 +22,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/livekit/livekit-server/pkg/utils"
 	"github.com/livekit/protocol/livekit"
-	"github.com/livekit/protocol/logger"
 )
 
 func handleError(w http.ResponseWriter, r *http.Request, status int, err error, keysAndValues ...interface{}) {
@@ -32,7 +32,7 @@ func handleError(w http.ResponseWriter, r *http.Request, status int, err error, 
 		keysAndValues = append(keysAndValues, "method", r.Method, "path", r.URL.Path)
 	}
 	if !errors.Is(err, context.Canceled) && !errors.Is(r.Context().Err(), context.Canceled) {
-		logger.GetLogger().WithCallDepth(1).Warnw("error handling request", err, keysAndValues...)
+		utils.GetLogger(r.Context()).WithCallDepth(1).Warnw("error handling request", err, keysAndValues...)
 	}
 	w.WriteHeader(status)
 	_, _ = w.Write([]byte(err.Error()))


### PR DESCRIPTION
That will have projectID and can potentially be used for project level logging if we are able to pass around the project logger more.