### PR TITLE
Call Broadcast in lock scope.

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -505,10 +505,10 @@ func (b *Buffer) Close() error {
 	b.closeOnce.Do(func() {
 		b.closed.Store(true)
 
-		b.Lock()
+		b.RLock()
 		rtpStats := b.rtpStats
 		b.readCond.Broadcast()
-		b.Unlock()
+		b.RUnlock()
 
 		if rtpStats != nil {
 			rtpStats.Stop()


### PR DESCRIPTION
Seems like there is a possible window where things can hang forever if a goroutine enters the Wait after the lock is released but before Broadcast gets called, it will never see that broadcast and will hang forever.