### PR TITLE
Disable vp9 for safari 18.4

### DIFF
--- a/pkg/clientconfiguration/conf.go
+++ b/pkg/clientconfiguration/conf.go
@@ -35,7 +35,18 @@ var StaticConfigurations = []ConfigurationItem{
 				},
 			},
 		},
-		Merge: false,
+		Merge: true,
+	},
+	{
+		Match: &ScriptMatch{Expr: `c.browser == "safari" && c.browser_version > "18.3"`},
+		Configuration: &livekit.ClientConfiguration{
+			DisabledCodecs: &livekit.DisabledCodecs{
+				Publish: []*livekit.Codec{
+					{Mime: mime.MimeTypeVP9.String()},
+				},
+			},
+		},
+		Merge: true,
 	},
 	{
 		Match: &ScriptMatch{Expr: `(c.device_model == "xiaomi 2201117ti" && c.os == "android") ||

--- a/pkg/clientconfiguration/match.go
+++ b/pkg/clientconfiguration/match.go
@@ -88,7 +88,7 @@ func (c *clientObject) IndexGet(index tengo.Object) (res tengo.Object, err error
 	case "browser":
 		return &tengo.String{Value: strings.ToLower(c.info.Browser)}, nil
 	case "browser_version":
-		return &tengo.String{Value: c.info.BrowserVersion}, nil
+		return &ruleSdkVersion{sdkVersion: c.info.BrowserVersion}, nil
 	case "address":
 		return &tengo.String{Value: c.info.Address}, nil
 	}

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -3183,6 +3183,7 @@ func (p *ParticipantImpl) setupEnabledCodecs(publishEnabledCodecs []*livekit.Cod
 		subscribeCodecs = append(subscribeCodecs, c)
 	}
 	p.enabledSubscribeCodecs = subscribeCodecs
+	p.params.Logger.Debugw("setup enabled codecs", "publish", p.enabledPublishCodecs, "subscribe", p.enabledSubscribeCodecs, "disabled", disabledCodecs)
 }
 
 func (p *ParticipantImpl) GetEnabledPublishCodecs() []*livekit.Codec {

--- a/pkg/sfu/datachannel/datachannel_writer_test.go
+++ b/pkg/sfu/datachannel/datachannel_writer_test.go
@@ -23,7 +23,7 @@ func TestDataChannelWriter(t *testing.T) {
 	require.Equal(t, 2000, n)
 
 	t1 := time.Now()
-	mockDC.SetNextWriteCompleteAt(t0.Add(time.Second))
+	mockDC.SetNextWriteCompleteAt(t0.Add(time.Second * 3 / 2))
 	n, err = w.Write(buf[:10])
 	require.NoError(t, err)
 	require.Equal(t, 10, n)


### PR DESCRIPTION
safari 18.4's svc encoding is broken