### PR TITLE
Send self participant update immediately.

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -1337,19 +1337,32 @@ func (r *Room) subscribeToExistingTracks(p types.LocalParticipant) {
 func (r *Room) broadcastParticipantState(p types.LocalParticipant, opts broadcastOptions) {
 	pi := p.ToProto()
 
-	if p.Hidden() {
-		if !opts.skipSource {
-			// send update only to hidden participant
+	// send it to the same participant immediately
+	selfSent := false
+	if !opts.skipSource {
+		defer func() {
+			if selfSent {
+				return
+			}
+
 			err := p.SendParticipantUpdate([]*livekit.ParticipantInfo{pi})
 			if err != nil {
 				p.GetLogger().Errorw("could not send update to participant", err)
 			}
-		}
+		}()
+	}
+
+	if p.Hidden() {
+		// hidden participant updates are sent only to the hidden participant itself,
+		// these could things like metadata update
 		return
 	}
 
 	updates := r.pushAndDequeueUpdates(pi, p.CloseReason(), opts.immediate)
-	r.sendParticipantUpdates(updates)
+	if len(updates) != 0 {
+		selfSent = true
+		r.sendParticipantUpdates(updates)
+	}
 }
 
 func (r *Room) sendParticipantUpdates(updates []*participantUpdate) {

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -1354,7 +1354,7 @@ func (r *Room) broadcastParticipantState(p types.LocalParticipant, opts broadcas
 
 	if p.Hidden() {
 		// hidden participant updates are sent only to the hidden participant itself,
-		// these could things like metadata update
+		// these could be things like metadata update
 		return
 	}
 


### PR DESCRIPTION
Match with cloud. Send immediately for non-hidden participants also