### PR TITLE
Revert unbound transceiver stop.

### DIFF
--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -453,16 +453,8 @@ func (t *MediaTrackSubscriptions) downTrackClosed(
 	// delete the subscribed track only after caching.
 	if isExpectedToResume {
 		dt := subTrack.DownTrack()
-		tr, wasBound := dt.GetTransceiver()
-		if tr != nil {
-			if wasBound {
-				sub.CacheDownTrack(subTrack.ID(), tr, dt.GetState())
-			} else {
-				// unbound transceivers cannot be re-used as pion will not fire Bind() in
-				// ReplaceTrack().
-				t.params.Logger.Infow("stopping unbound transceiver")
-				tr.Stop()
-			}
+		if tr := dt.GetTransceiver(); tr != nil {
+			sub.CacheDownTrack(subTrack.ID(), tr, dt.GetState())
 		}
 	}
 

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -291,7 +291,6 @@ type DownTrack struct {
 
 	bindLock            sync.Mutex
 	bindState           atomic.Value
-	wasEverBound        atomic.Bool
 	onBinding           func(error)
 	bindOnReceiverReady func()
 	onBindAndConnected  func()
@@ -585,7 +584,6 @@ func (d *DownTrack) Bind(t webrtc.TrackLocalContext) (webrtc.RTPCodecParameters,
 			d.onBinding(nil)
 		}
 		d.setBindStateLocked(bindStateBound)
-		d.wasEverBound.Store(true)
 		d.bindLock.Unlock()
 
 		d.forwarder.DetermineCodec(codec.RTPCodecCapability, d.Receiver().HeaderExtensions())
@@ -854,8 +852,8 @@ func (d *DownTrack) SetTransceiver(transceiver *webrtc.RTPTransceiver) {
 	d.transceiver.Store(transceiver)
 }
 
-func (d *DownTrack) GetTransceiver() (*webrtc.RTPTransceiver, bool) {
-	return d.transceiver.Load(), d.wasEverBound.Load()
+func (d *DownTrack) GetTransceiver() *webrtc.RTPTransceiver {
+	return d.transceiver.Load()
 }
 
 func (d *DownTrack) postKeyFrameRequestEvent() {


### PR DESCRIPTION
This is causing duplicate a=msid in testing. Will chase condition that caused the addition of code to stop transceiver later.