### PR TITLE
Fix dynacast quality for moving out tracks

### DIFF
--- a/pkg/rtc/dynacast/dynacastmanager.go
+++ b/pkg/rtc/dynacast/dynacastmanager.go
@@ -183,6 +183,15 @@ func (d *DynacastManager) NotifySubscriberNodeMaxQuality(nodeID livekit.NodeID, 
 	}
 }
 
+func (d *DynacastManager) ClearSubscriberNodesMaxQuality() {
+	d.lock.Lock()
+	dqs := d.getDynacastQualitiesLocked()
+	d.lock.Unlock()
+	for _, dq := range dqs {
+		dq.ClearSubscriberNodesMaxQuality()
+	}
+}
+
 func (d *DynacastManager) getOrCreateDynacastQuality(mimeType mime.MimeType) *DynacastQuality {
 	d.lock.Lock()
 	defer d.lock.Unlock()

--- a/pkg/rtc/dynacast/dynacastquality.go
+++ b/pkg/rtc/dynacast/dynacastquality.go
@@ -99,6 +99,13 @@ func (d *DynacastQuality) NotifySubscriberMaxQuality(subscriberID livekit.Partic
 	d.updateQualityChange(false)
 }
 
+func (d *DynacastQuality) ClearSubscriberNodesMaxQuality() {
+	d.lock.Lock()
+	d.maxSubscriberNodeQuality = make(map[livekit.NodeID]livekit.VideoQuality)
+	d.lock.Unlock()
+	d.updateQualityChange(false)
+}
+
 func (d *DynacastQuality) NotifySubscriberNodeMaxQuality(nodeID livekit.NodeID, quality livekit.VideoQuality) {
 	d.params.Logger.Debugw(
 		"setting subscriber node max quality",

--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -177,6 +177,12 @@ func (t *MediaTrack) NotifySubscriberNodeMaxQuality(nodeID livekit.NodeID, quali
 	}
 }
 
+func (t *MediaTrack) ClearSubscriberNodesMaxQuality() {
+	if t.dynacastManager != nil {
+		t.dynacastManager.ClearSubscriberNodesMaxQuality()
+	}
+}
+
 func (t *MediaTrack) SignalCid() string {
 	return t.params.SignalCid
 }

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -3328,6 +3328,9 @@ func (p *ParticipantImpl) MoveToRoom(params types.MoveToRoomParams) {
 	for _, track := range p.GetPublishedTracks() {
 		for _, sub := range track.GetAllSubscribers() {
 			track.RemoveSubscriber(sub, false)
+			// clear the subscriber node max quality as the remote quality notify
+			// from source room would not reach the moving out participant.
+			track.(types.LocalMediaTrack).ClearSubscriberNodesMaxQuality()
 		}
 		trackInfo := track.ToProto()
 		p.params.Telemetry.TrackUnpublished(

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -3326,6 +3326,9 @@ func (p *ParticipantImpl) MoveToRoom(params types.MoveToRoomParams) {
 	}
 
 	for _, track := range p.GetPublishedTracks() {
+		for _, sub := range track.GetAllSubscribers() {
+			track.RemoveSubscriber(sub, false)
+		}
 		trackInfo := track.ToProto()
 		p.params.Telemetry.TrackUnpublished(
 			context.Background(),

--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -1110,15 +1110,6 @@ func (s *trackSubscription) getNumAttempts() int32 {
 func (s *trackSubscription) handleSourceTrackRemoved() {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	startedAt := s.subStartedAt.Load()
-	if startedAt == nil || time.Since(*startedAt) < trackRemoveGracePeriod {
-		// to prevent race conditions, if we've recently been asked to subscribe to a track
-		// ignore when source was removed. reconciler will take care of it eventually
-		// this would address the case when a track was unpublished and republished immediately
-		// it's possible for another caller to call setDesired(true) for the republished track before
-		// handleSourceTrackRemoved is called on the previously unpublished track
-		return
-	}
 
 	// source track removed, we would unsubscribe
 	s.logger.Debugw("unsubscribing from track since source track was removed")

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -581,6 +581,7 @@ type LocalMediaTrack interface {
 	SetRTT(rtt uint32)
 
 	NotifySubscriberNodeMaxQuality(nodeID livekit.NodeID, qualities []SubscribedCodecQuality)
+	ClearSubscriberNodesMaxQuality()
 	NotifySubscriberNodeMediaLoss(nodeID livekit.NodeID, fractionalLoss uint8)
 }
 

--- a/pkg/rtc/types/typesfakes/fake_local_media_track.go
+++ b/pkg/rtc/types/typesfakes/fake_local_media_track.go
@@ -35,6 +35,10 @@ type FakeLocalMediaTrack struct {
 	clearAllReceiversArgsForCall []struct {
 		arg1 bool
 	}
+	ClearSubscriberNodesMaxQualityStub        func()
+	clearSubscriberNodesMaxQualityMutex       sync.RWMutex
+	clearSubscriberNodesMaxQualityArgsForCall []struct {
+	}
 	CloseStub        func(bool)
 	closeMutex       sync.RWMutex
 	closeArgsForCall []struct {
@@ -493,6 +497,30 @@ func (fake *FakeLocalMediaTrack) ClearAllReceiversArgsForCall(i int) bool {
 	defer fake.clearAllReceiversMutex.RUnlock()
 	argsForCall := fake.clearAllReceiversArgsForCall[i]
 	return argsForCall.arg1
+}
+
+func (fake *FakeLocalMediaTrack) ClearSubscriberNodesMaxQuality() {
+	fake.clearSubscriberNodesMaxQualityMutex.Lock()
+	fake.clearSubscriberNodesMaxQualityArgsForCall = append(fake.clearSubscriberNodesMaxQualityArgsForCall, struct {
+	}{})
+	stub := fake.ClearSubscriberNodesMaxQualityStub
+	fake.recordInvocation("ClearSubscriberNodesMaxQuality", []interface{}{})
+	fake.clearSubscriberNodesMaxQualityMutex.Unlock()
+	if stub != nil {
+		fake.ClearSubscriberNodesMaxQualityStub()
+	}
+}
+
+func (fake *FakeLocalMediaTrack) ClearSubscriberNodesMaxQualityCallCount() int {
+	fake.clearSubscriberNodesMaxQualityMutex.RLock()
+	defer fake.clearSubscriberNodesMaxQualityMutex.RUnlock()
+	return len(fake.clearSubscriberNodesMaxQualityArgsForCall)
+}
+
+func (fake *FakeLocalMediaTrack) ClearSubscriberNodesMaxQualityCalls(stub func()) {
+	fake.clearSubscriberNodesMaxQualityMutex.Lock()
+	defer fake.clearSubscriberNodesMaxQualityMutex.Unlock()
+	fake.ClearSubscriberNodesMaxQualityStub = stub
 }
 
 func (fake *FakeLocalMediaTrack) Close(arg1 bool) {
@@ -2280,6 +2308,8 @@ func (fake *FakeLocalMediaTrack) Invocations() map[string][][]interface{} {
 	defer fake.addSubscriberMutex.RUnlock()
 	fake.clearAllReceiversMutex.RLock()
 	defer fake.clearAllReceiversMutex.RUnlock()
+	fake.clearSubscriberNodesMaxQualityMutex.RLock()
+	defer fake.clearSubscriberNodesMaxQualityMutex.RUnlock()
 	fake.closeMutex.RLock()
 	defer fake.closeMutex.RUnlock()
 	fake.getAllSubscribersMutex.RLock()


### PR DESCRIPTION
* Remove start time checking in subscription manager
as We always use new track ID for republished track at https://github.com/livekit/livekit/pull/3020
so there is no race condition now.

* Also RemoveSubscriber for moving out tracks for safety,
the subscription manager will handle the removed event but
RemoveSubscriber again will not be bad.

* Clear subscriber node max quality for moving out tracks