### PR TITLE
Revert clearing RIDs.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1025,10 +1025,6 @@ func (p *ParticipantImpl) updateRidsFromSDP(offer *webrtc.SessionDescription) {
 					"trackID", pti.trackInfos[0].Sid,
 					"pendingTrack", pti,
 				)
-			} else {
-				for i := 0; i < len(pti.sdpRids); i++ {
-					pti.sdpRids[i] = ""
-				}
 			}
 		}
 		p.pendingTracksLock.Unlock()


### PR DESCRIPTION
With backup codec, there is no way to update RIDs currently. So, let the default be set for primary also. It is okay as it does not affect functionality. When we do per codec setting update to protocol, can set it properly for back up only.