### PR TITLE
Temporary change: use pre-defined rids

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -133,7 +133,7 @@ func NewMediaTrack(params MediaTrackParams, ti *livekit.TrackInfo) *MediaTrack {
 				t.dynacastManager.NotifySubscriberMaxQuality(
 					subscriberID,
 					mimeType,
-					buffer.GetVideoQualityForSpatialLayer(layer, t.MediaTrackReceiver.TrackInfo()),
+					buffer.SpatialLayerToVideoQuality(layer, t.MediaTrackReceiver.TrackInfo()),
 				)
 			},
 		)
@@ -165,7 +165,7 @@ func (t *MediaTrack) OnSubscribedMaxQualityChange(
 		for _, q := range maxSubscribedQualities {
 			receiver := t.Receiver(q.CodecMime)
 			if receiver != nil {
-				receiver.SetMaxExpectedSpatialLayer(buffer.GetSpatialLayerForVideoQuality(q.Quality, t.MediaTrackReceiver.TrackInfo()))
+				receiver.SetMaxExpectedSpatialLayer(buffer.VideoQualityToSpatialLayer(q.Quality, t.MediaTrackReceiver.TrackInfo()))
 			}
 		}
 	}
@@ -263,22 +263,15 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track sfu.TrackRe
 	t.lock.Lock()
 	var regressCodec bool
 	mimeType := mime.NormalizeMimeType(track.Codec().MimeType)
-	layer := buffer.GetSpatialLayerForRid(track.RID(), ti)
+	layer := buffer.RidToSpatialLayer(track.RID(), ti, buffer.DefaultVideoLayersRid)
 	t.params.Logger.Debugw(
 		"AddReceiver",
 		"rid", track.RID(),
 		"layer", layer,
 		"ssrc", track.SSRC(),
 		"codec", track.Codec(),
-	)
-	logger.Infow(
-		"AddReceiver",
-		"rid", track.RID(),
-		"layer", layer,
-		"ssrc", track.SSRC(),
-		"codec", track.Codec(),
 		"trackInfo", logger.Proto(ti),
-	) // REMOVE
+	)
 	wr := t.MediaTrackReceiver.Receiver(mimeType)
 	if wr == nil {
 		priority := -1

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -174,7 +174,7 @@ func NewMediaTrackReceiver(params MediaTrackReceiverParams, ti *livekit.TrackInf
 }
 
 func (t *MediaTrackReceiver) Restart() {
-	hq := buffer.GetSpatialLayerForVideoQuality(livekit.VideoQuality_HIGH, t.TrackInfo())
+	hq := buffer.VideoQualityToSpatialLayer(livekit.VideoQuality_HIGH, t.TrackInfo())
 
 	for _, receiver := range t.loadReceivers() {
 		receiver.SetMaxExpectedSpatialLayer(hq)
@@ -671,12 +671,12 @@ func (t *MediaTrackReceiver) updateTrackInfoOfReceivers() {
 func (t *MediaTrackReceiver) SetLayerSsrc(mimeType mime.MimeType, rid string, ssrc uint32) {
 	t.lock.Lock()
 	trackInfo := t.TrackInfoClone()
-	layer := buffer.GetSpatialLayerForRid(rid, trackInfo)
+	layer := buffer.RidToSpatialLayer(rid, trackInfo, buffer.DefaultVideoLayersRid)
 	if layer == buffer.InvalidLayerSpatial {
 		// non-simulcast case will not have `rid`
 		layer = 0
 	}
-	quality := buffer.GetVideoQualityForSpatialLayer(layer, trackInfo)
+	quality := buffer.SpatialLayerToVideoQuality(layer, trackInfo)
 	// set video layer ssrc info
 	for i, ci := range trackInfo.Codecs {
 		if mime.NormalizeMimeType(ci.MimeType) != mimeType {
@@ -846,7 +846,7 @@ func (t *MediaTrackReceiver) TrackInfoClone() *livekit.TrackInfo {
 
 func (t *MediaTrackReceiver) NotifyMaxLayerChange(maxLayer int32) {
 	trackInfo := t.TrackInfo()
-	quality := buffer.GetVideoQualityForSpatialLayer(maxLayer, trackInfo)
+	quality := buffer.SpatialLayerToVideoQuality(maxLayer, trackInfo)
 	ti := &livekit.TrackInfo{
 		Sid:    trackInfo.Sid,
 		Type:   trackInfo.Type,

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -181,7 +181,7 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 		if !wr.DetermineReceiver(codec) {
 			if t.onSubscriberMaxQualityChange != nil {
 				go func() {
-					spatial := buffer.GetSpatialLayerForVideoQuality(livekit.VideoQuality_HIGH, t.params.MediaTrack.ToProto())
+					spatial := buffer.VideoQualityToSpatialLayer(livekit.VideoQuality_HIGH, t.params.MediaTrack.ToProto())
 					t.onSubscriberMaxQualityChange(downTrack.SubscriberID(), mime.NormalizeMimeType(codec.MimeType), spatial)
 				}()
 			}

--- a/pkg/rtc/subscribedtrack.go
+++ b/pkg/rtc/subscribedtrack.go
@@ -257,7 +257,7 @@ func (t *SubscribedTrack) applySettings() {
 			quality = mt.GetQualityForDimension(t.settings.Width, t.settings.Height)
 		}
 
-		spatial = buffer.GetSpatialLayerForVideoQuality(quality, mt.ToProto())
+		spatial = buffer.VideoQualityToSpatialLayer(quality, mt.ToProto())
 		if t.settings.Fps > 0 {
 			temporal = mt.GetTemporalLayerForSpatialFps(spatial, t.settings.Fps, dt.Mime())
 		}

--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -383,7 +383,7 @@ func (w *WebRTCReceiver) AddUpTrack(track TrackRemote, buff *buffer.Buffer) erro
 
 	layer := int32(0)
 	if w.Kind() == webrtc.RTPCodecTypeVideo && !w.isSVC {
-		layer = buffer.GetSpatialLayerForRid(track.RID(), w.trackInfo.Load())
+		layer = buffer.RidToSpatialLayer(track.RID(), w.trackInfo.Load(), buffer.DefaultVideoLayersRid)
 	}
 	if layer < 0 {
 		w.logger.Warnw(
@@ -499,7 +499,8 @@ func (w *WebRTCReceiver) notifyMaxExpectedLayer(layer int32) {
 
 	expectedBitrate := int64(0)
 	for _, vl := range ti.Layers {
-		if vl.SpatialLayer <= layer {
+		l := buffer.VideoQualityToSpatialLayer(vl.Quality, ti)
+		if l <= layer {
 			expectedBitrate += int64(vl.Bitrate)
 		}
 	}

--- a/pkg/sfu/streamtrackermanager.go
+++ b/pkg/sfu/streamtrackermanager.go
@@ -597,7 +597,8 @@ func (s *StreamTrackerManager) maxExpectedLayerFromTrackInfoLocked() {
 	ti := s.trackInfo.Load()
 	if ti != nil {
 		for _, layer := range ti.Layers {
-			if layer.SpatialLayer > s.maxExpectedLayer {
+			spatialLayer := buffer.VideoQualityToSpatialLayer(layer.Quality, ti)
+			if spatialLayer > s.maxExpectedLayer {
 				s.maxExpectedLayer = layer.SpatialLayer
 			}
 		}


### PR DESCRIPTION
To address a compatibility issue across relay. Will revert this once the compatibility is addressed.