### PR TITLE
Limit taking rids from SDP only in WHIP path.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -993,6 +993,10 @@ func (p *ParticipantImpl) synthesizeAddTrackRequests(offer webrtc.SessionDescrip
 }
 
 func (p *ParticipantImpl) updateRidsFromSDP(offer *webrtc.SessionDescription) {
+	if !p.params.UseOneShotSignallingMode {
+		return
+	}
+
 	if offer == nil {
 		return
 	}


### PR DESCRIPTION
Some clients are not sending q;h;f; ordering which affects layer/quality mapping.