### PR TITLE
Set rids for all codecs.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1016,6 +1016,8 @@ func (p *ParticipantImpl) updateRidsFromSDP(offer *webrtc.SessionDescription) {
 			continue
 		}
 
+		// SIMULCAST-CODEC-TODO - have to update published track's TrackInfo when backup codec starts publishing
+
 		p.pendingTracksLock.Lock()
 		pti := p.pendingTracks[mst]
 		if pti != nil {
@@ -2849,10 +2851,6 @@ func (p *ParticipantImpl) mediaTrackReceived(track sfu.TrackRemote, rtpReceiver 
 		}
 
 		for _, codec := range ti.Codecs {
-			if !mime.IsMimeTypeStringEqual(codec.MimeType, track.Codec().MimeType) {
-				continue
-			}
-
 			for _, layer := range codec.Layers {
 				layer.SpatialLayer = buffer.VideoQualityToSpatialLayer(layer.Quality, ti)
 				layer.Rid = buffer.VideoQualityToRid(layer.Quality, ti, sdpRids)


### PR DESCRIPTION
Back up codecs will not have pending track. The update needs to happen on published track.

Have added a note about updating in published track. Can happen when we have separate layers for primary and backup.