### PR TITLE
Feat/cloudflare turn

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,6 +88,8 @@ type RTCConfig struct {
 
 	TURNServers []TURNServer `yaml:"turn_servers,omitempty"`
 
+	CloudflareTURN `yaml:"cloudflare_turn,omitempty"`
+
 	// Deprecated
 	StrictACKs bool `yaml:"strict_acks,omitempty"`
 
@@ -131,6 +133,11 @@ type TURNServer struct {
 	Protocol   string `yaml:"protocol,omitempty"`
 	Username   string `yaml:"username,omitempty"`
 	Credential string `yaml:"credential,omitempty"`
+}
+
+type CloudflareTURN struct {
+	KeyID    string `yaml:"key_id,omitempty"`
+	APIToken string `yaml:"api_token,omitempty"`
 }
 
 type CongestionControlConfig struct {

--- a/pkg/utils/cloudflareturn.go
+++ b/pkg/utils/cloudflareturn.go
@@ -1,0 +1,61 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+var rtcBaseURL = "https://rtc.live.cloudflare.com"
+var client = &http.Client{
+	Timeout: 10 * time.Second,
+}
+
+type CloudFlareIceConfig struct {
+	IceServers []CloudFlareIceServer `json:"iceServers"`
+}
+
+type CloudFlareIceServer struct {
+	URLs       []string `json:"urls"`
+	Username   string   `json:"username"`
+	Credential string   `json:"credential"`
+}
+
+func FetchCloudflareTurnIceConfig(ctx context.Context, keyID, apiToken string) (*CloudFlareIceConfig, error) {
+	url := fmt.Sprintf("%s/v1/turn/keys/%s/credentials/generate-ice-servers", rtcBaseURL, keyID)
+	payload := struct {
+		TTL int `json:"ttl"`
+	}{TTL: int(iceConfigTTLMin.Seconds())}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+apiToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status: %s, body: %v, err:%v,", resp.Status, resp, err)
+	}
+
+	var cfg CloudFlareIceConfig
+	if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}

--- a/pkg/utils/cloudflareturn_test.go
+++ b/pkg/utils/cloudflareturn_test.go
@@ -1,0 +1,86 @@
+package utils
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestFetchCloudflareIceConfig(t *testing.T) {
+	const jsonResp = `{
+	  "iceServers": [{
+	    "urls": [
+	      "stun:stun.cloudflare.com:3478",
+	      "stun:stun.cloudflare.com:53",
+	      "turn:turn.cloudflare.com:3478?transport=udp",
+	      "turn:turn.cloudflare.com:53?transport=udp",
+	      "turn:turn.cloudflare.com:3478?transport=tcp",
+	      "turn:turn.cloudflare.com:80?transport=tcp",
+	      "turns:turn.cloudflare.com:5349?transport=tcp",
+	      "turns:turn.cloudflare.com:443?transport=tcp"
+	    ],
+	    "username":   "bc91…e3e",
+	    "credential": "ebd7…4a0"
+	  }]
+	}`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("bad Authorization header: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(jsonResp))
+	}))
+	defer ts.Close()
+
+	// Override base URL *just for this test*
+	oldBase := rtcBaseURL
+	rtcBaseURL = ts.URL
+	defer func() { rtcBaseURL = oldBase }()
+
+	got, err := FetchCloudflareTurnIceConfig(context.Background(), "test-key", "test-token")
+	if err != nil {
+		t.Fatalf("FetchCloudflareTurnIceConfig returned error: %v", err)
+	}
+
+	want := &CloudFlareIceConfig{
+		IceServers: []CloudFlareIceServer{{
+			URLs: []string{
+				"stun:stun.cloudflare.com:3478",
+				"stun:stun.cloudflare.com:53",
+				"turn:turn.cloudflare.com:3478?transport=udp",
+				"turn:turn.cloudflare.com:53?transport=udp",
+				"turn:turn.cloudflare.com:3478?transport=tcp",
+				"turn:turn.cloudflare.com:80?transport=tcp",
+				"turns:turn.cloudflare.com:5349?transport=tcp",
+				"turns:turn.cloudflare.com:443?transport=tcp",
+			},
+			Username:   "bc91…e3e",
+			Credential: "ebd7…4a0",
+		}},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mismatch:\n got  %+v\n want %+v", got, want)
+	}
+}
+
+func TestFetchCloudflareIceConfig_Non200(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	oldBase := rtcBaseURL
+	rtcBaseURL = ts.URL
+	defer func() { rtcBaseURL = oldBase }()
+
+	if _, err := FetchCloudflareTurnIceConfig(context.Background(), "x", "y"); err == nil {
+		t.Fatal("expected error for 500 response, got nil")
+	}
+}


### PR DESCRIPTION
Hello,

I'm working on a project that uses Cloudflare TURN, but I noticed that when using an external TURN server, LiveKit currently doesn't support short-term TURN credentials. Unfortunately, that's the only credential method Cloudflare provides.

To support this, I've added a CloudflareTURN config option and implemented TURN credential generation during iceServersForParticipant.

Please take a look. I would appreciate your feedback.


https://developers.cloudflare.com/realtime/turn/