### PR TITLE
Split signal segmenter and reassembler.

### DIFF
--- a/pkg/rtc/signalling/interfaces.go
+++ b/pkg/rtc/signalling/interfaces.go
@@ -25,6 +25,7 @@ import (
 
 type ParticipantSignalHandler interface {
 	HandleRequest(msg proto.Message) error
+	PruneStaleReassemblies()
 }
 
 type ParticipantSignaller interface {

--- a/pkg/rtc/signalling/signalhandlerunimplemented.go
+++ b/pkg/rtc/signalling/signalhandlerunimplemented.go
@@ -25,3 +25,5 @@ type signalhandlerUnimplemented struct{}
 func (u *signalhandlerUnimplemented) HandleRequest(msg proto.Message) error {
 	return nil
 }
+
+func (u *signalhandlerUnimplemented) PruneStaleReassemblies() {}

--- a/pkg/rtc/signalling/signallerv2async.go
+++ b/pkg/rtc/signalling/signallerv2async.go
@@ -40,14 +40,14 @@ type signallerv2Async struct {
 
 	*signallerAsyncBase
 
-	signalFragment *SignalFragment
+	signalSegmenter *SignalSegmenter
 }
 
 func NewSignallerv2Async(params Signallerv2AsyncParams) ParticipantSignaller {
 	return &signallerv2Async{
 		params:             params,
 		signallerAsyncBase: newSignallerAsyncBase(signallerAsyncBaseParams{Logger: params.Logger}),
-		signalFragment: NewSignalFragment(SignalFragmentParams{
+		signalSegmenter: NewSignalSegmenter(SignalSegmenterParams{
 			Logger: params.Logger,
 		}),
 	}
@@ -100,7 +100,7 @@ func (s *signallerv2Async) WriteMessage(msg proto.Message) error {
 			)
 		}
 	} else {
-		fragments = s.signalFragment.Segment(marshaled)
+		fragments = s.signalSegmenter.Segment(marshaled)
 	}
 
 	sendMsg := func(m proto.Message) error {

--- a/pkg/rtc/signalling/signallingv2.go
+++ b/pkg/rtc/signalling/signallingv2.go
@@ -31,17 +31,13 @@ type signallingv2 struct {
 
 	params Signallingv2Params
 
-	signalCache    *SignalCache
-	signalFragment *SignalFragment
+	signalCache *SignalCache
 }
 
 func NewSignallingv2(params Signallingv2Params) ParticipantSignalling {
 	return &signallingv2{
 		params: params,
 		signalCache: NewSignalCache(SignalCacheParams{
-			Logger: params.Logger,
-		}),
-		signalFragment: NewSignalFragment(SignalFragmentParams{
 			Logger: params.Logger,
 		}),
 	}

--- a/pkg/rtc/signalling/signalreassembler.go
+++ b/pkg/rtc/signalling/signalreassembler.go
@@ -138,7 +138,7 @@ func (s *SignalReassembler) Reassemble(fragment *livekit.Fragment) []byte {
 	for _, fr := range re.fragments {
 		data = append(data, fr.Data...)
 	}
-	delete(s.reassemblies, fragment.PacketId) // fully re-assembled, can be deleted from cache
+	delete(s.reassemblies, re.packetId) // fully re-assembled, can be deleted from cache
 	return data
 }
 

--- a/pkg/rtc/signalling/signalsegmenter.go
+++ b/pkg/rtc/signalling/signalsegmenter.go
@@ -61,10 +61,11 @@ func (s *SignalSegmenter) Segment(data []byte) []*livekit.Fragment {
 	numFragments := uint32((len(data) + s.params.MaxFragmentSize - 1) / s.params.MaxFragmentSize)
 	fragmentNumber := uint32(1)
 	consumed := 0
+	packetId := s.packetId.Inc()
 	for len(data[consumed:]) != 0 {
 		fragmentSize := min(len(data[consumed:]), s.params.MaxFragmentSize)
 		fragment := &livekit.Fragment{
-			PacketId:       s.packetId.Inc(),
+			PacketId:       packetId,
 			FragmentNumber: fragmentNumber,
 			NumFragments:   numFragments,
 			FragmentSize:   uint32(fragmentSize),

--- a/pkg/rtc/signalling/signalsegmenter.go
+++ b/pkg/rtc/signalling/signalsegmenter.go
@@ -1,0 +1,80 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signalling
+
+import (
+	"math/rand"
+
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/logger"
+	"go.uber.org/atomic"
+)
+
+const (
+	defaultMaxFragmentSize = 8192
+)
+
+type SignalSegmenterParams struct {
+	Logger          logger.Logger
+	MaxFragmentSize int
+	FirstPacketId   uint32 // should be used for testing only
+}
+
+type SignalSegmenter struct {
+	params SignalSegmenterParams
+
+	packetId atomic.Uint32
+}
+
+func NewSignalSegmenter(params SignalSegmenterParams) *SignalSegmenter {
+	s := &SignalSegmenter{
+		params: params,
+	}
+	if s.params.MaxFragmentSize == 0 {
+		s.params.MaxFragmentSize = defaultMaxFragmentSize
+	}
+	s.packetId.Store(params.FirstPacketId)
+	if s.packetId.Load() == 0 {
+		s.packetId.Store(uint32(rand.Intn(1<<8) + 1))
+	}
+	return s
+}
+
+func (s *SignalSegmenter) Segment(data []byte) []*livekit.Fragment {
+	if len(data) <= s.params.MaxFragmentSize {
+		return nil
+	}
+
+	var fragments []*livekit.Fragment
+	numFragments := uint32((len(data) + s.params.MaxFragmentSize - 1) / s.params.MaxFragmentSize)
+	fragmentNumber := uint32(1)
+	consumed := 0
+	for len(data[consumed:]) != 0 {
+		fragmentSize := min(len(data[consumed:]), s.params.MaxFragmentSize)
+		fragment := &livekit.Fragment{
+			PacketId:       s.packetId.Inc(),
+			FragmentNumber: fragmentNumber,
+			NumFragments:   numFragments,
+			FragmentSize:   uint32(fragmentSize),
+			TotalSize:      uint32(len(data)),
+			Data:           data[consumed : consumed+fragmentSize],
+		}
+		fragments = append(fragments, fragment)
+		fragmentNumber++
+		consumed += fragmentSize
+	}
+
+	return fragments
+}


### PR DESCRIPTION
As reassembler may need to run a goroutine for pruning, splitting it up so that we do not have unnecessary goroutines. Keeping the UT unified though.

Also, for now, trying to see if `Prune` can be called from external place to avoid creating a goroutine and have extra state/functions to close the reassembler and clean up goroutine etc. May still have to do goroutine, but have not created one for now.