### PR TITLE
Do not send leave if nil (to older clients)

### DIFF
--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -290,7 +290,11 @@ func (p *ParticipantImpl) sendLeaveRequest(
 			}
 		}
 	}
-	return p.signaller.WriteMessage(p.signalling.SignalLeaveRequest(leave))
+	if leave != nil {
+		return p.signaller.WriteMessage(p.signalling.SignalLeaveRequest(leave))
+	}
+
+	return nil
 }
 
 func (p *ParticipantImpl) sendSdpAnswer(answer webrtc.SessionDescription, answerId uint32) error {


### PR DESCRIPTION
this should fix e2e migration tests for client v1