### PR TITLE
Handle no codecs in track info.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2745,6 +2745,7 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 					"simulcast codec without mime type", nil,
 					"trackID", ti.Sid,
 					"track", logger.Proto(ti),
+					"addTrackRequest", logger.Proto(req),
 				)
 				continue
 			}

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2741,6 +2741,11 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 		seenCodecs := make(map[string]struct{})
 		for _, codec := range req.SimulcastCodecs {
 			if codec.Codec == "" {
+				p.pubLogger.Warnw(
+					"simulcast codec without mime type", nil,
+					"trackID", ti.Sid,
+					"track", logger.Proto(ti),
+				)
 				continue
 			}
 

--- a/pkg/rtc/participant_sdp.go
+++ b/pkg/rtc/participant_sdp.go
@@ -95,6 +95,17 @@ func (p *ParticipantImpl) populateSdpCid(parsedOffer *sdp.SessionDescription) ([
 				continue
 			}
 
+			if len(info.Codecs) == 0 {
+				p.pubLogger.Warnw(
+					"track without codecs", nil,
+					"trackID", info.Sid,
+					"pendingTrack", p.pendingTracks[signalCid],
+					"media", unmatch,
+					"parsedOffer", parsedOffer,
+				)
+				continue
+			}
+
 			found := false
 			updated := false
 			for _, sdpCodec := range sdpCodecs {
@@ -125,6 +136,12 @@ func (p *ParticipantImpl) populateSdpCid(parsedOffer *sdp.SessionDescription) ([
 
 			if updated {
 				p.pendingTracks[signalCid].trackInfos[0] = utils.CloneProto(info)
+				p.pubLogger.Debugw(
+					"pending track SDP cid updated",
+					"signalCid", signalCid,
+					"trackID", info.Sid,
+					"pendingTrack", p.pendingTracks[signalCid],
+				)
 			}
 			p.pendingTracksLock.Unlock()
 		}


### PR DESCRIPTION
Not sure how it happens, but seeing a panic caused by no codecs in track info. Avoiding that and logging information when it happens.