### PR TITLE
Revert to using answer for migration case.

### DIFF
--- a/pkg/rtc/transportmanager.go
+++ b/pkg/rtc/transportmanager.go
@@ -816,7 +816,7 @@ func (t *TransportManager) SetMigrateInfo(
 	}
 
 	if t.params.UseSinglePeerConnection {
-		t.publisher.SetPreviousSdp(previousAnswer, previousOffer)
+		t.publisher.SetPreviousSdp(previousOffer, previousAnswer)
 	} else {
 		t.subscriber.SetPreviousSdp(previousOffer, previousAnswer)
 	}


### PR DESCRIPTION
Was breaking migration in cases where there was inactive transceivers because of direction check.

This change will break single peer connection case, but can look at that one later.