### PR TITLE
Use departure timeout from room preset.

### DIFF
--- a/pkg/service/roomallocator.go
+++ b/pkg/service/roomallocator.go
@@ -213,12 +213,11 @@ func (r *StandardRoomAllocator) applyNamedRoomConfiguration(req *livekit.CreateR
 
 	clone := utils.CloneProto(req)
 
-	// Request overwrites conf
 	if clone.EmptyTimeout == 0 {
 		clone.EmptyTimeout = conf.EmptyTimeout
 	}
 	if clone.DepartureTimeout == 0 {
-		clone.DepartureTimeout = req.DepartureTimeout
+		clone.DepartureTimeout = conf.DepartureTimeout
 	}
 	if clone.MaxParticipants == 0 {
 		clone.MaxParticipants = conf.MaxParticipants


### PR DESCRIPTION
Not sure why only that was applying from req which is effectively a no-op as the clone is a replica of the req. Guess, it was a typo/miss. Change it to use room preset config value.