### PR TITLE
Do not advertise NACK for RED.

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -955,10 +955,10 @@ func (t *PCTransport) AddTrack(
 		return
 	}
 
+	configureTransceiverCodecs(transceiver, enabledCodecs, rtcpFeedbackConfig, !t.params.IsOfferer)
 	if trackLocal.Kind() == webrtc.RTPCodecTypeAudio {
 		configureAudioTransceiver(transceiver, params.Stereo, !params.Red || !t.params.ClientInfo.SupportsAudioRED())
 	}
-	configureTransceiverCodecs(transceiver, enabledCodecs, rtcpFeedbackConfig, !t.params.IsOfferer)
 	t.adjustNumOutstandingMedia(transceiver)
 	return
 }
@@ -980,10 +980,10 @@ func (t *PCTransport) AddTransceiverFromTrack(
 		return
 	}
 
+	configureTransceiverCodecs(transceiver, enabledCodecs, rtcpFeedbackConfig, !t.params.IsOfferer)
 	if trackLocal.Kind() == webrtc.RTPCodecTypeAudio {
 		configureAudioTransceiver(transceiver, params.Stereo, !params.Red || !t.params.ClientInfo.SupportsAudioRED())
 	}
-	configureTransceiverCodecs(transceiver, enabledCodecs, rtcpFeedbackConfig, !t.params.IsOfferer)
 	t.adjustNumOutstandingMedia(transceiver)
 	return
 }


### PR DESCRIPTION
Set the transceiver codecs first in single peer connection mode and then do audio specific config so that NACK is removed for RED.