### PR TITLE
feat: Add server-side ForceRelay configuration option

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -121,10 +121,11 @@ rtc:
   # # migrate an established-but-lossy UDP connection to ICE/TCP or TURN/TLS. requires tcp_fallback_rtt_threshold > 0, default false
   # allow_udp_unstable_fallback: false
   # # Force all clients to use relay (TURN) servers only, bypassing direct P2P connections
-  # # When set to true, clients will be forced to use TURN servers for media traffic
-  # # When set to false, clients will not be forced to use relay
-  # # When not set (default), force relay behavior is determined by ICE configuration
-  # force_relay: false
+  # # true: clients are told to use TURN servers for media traffic
+  # # false: clients are told not to force relay, they cannot opt into it on their own either.
+  # #   relay is still forced for a participant the server has fallen back to TURN/TLS for
+  # # not set (default): force relay is determined by the ICE configuration in use
+  # force_relay: true
   # # number of packets to buffer in the SFU for video, defaults to 500
   # packet_buffer_size_video: 500
   # # number of packets to buffer in the SFU for audio, defaults to 200

--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -120,6 +120,11 @@ rtc:
   # tcp_fallback_rtt_threshold: 0
   # # migrate an established-but-lossy UDP connection to ICE/TCP or TURN/TLS. requires tcp_fallback_rtt_threshold > 0, default false
   # allow_udp_unstable_fallback: false
+  # # Force all clients to use relay (TURN) servers only, bypassing direct P2P connections
+  # # When set to true, clients will be forced to use TURN servers for media traffic
+  # # When set to false, clients will not be forced to use relay
+  # # When not set (default), force relay behavior is determined by ICE configuration
+  # force_relay: false
   # # number of packets to buffer in the SFU for video, defaults to 500
   # packet_buffer_size_video: 500
   # # number of packets to buffer in the SFU for audio, defaults to 200

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -160,6 +160,9 @@ type RTCConfig struct {
 
 	// enable rtp stream restart detection for published tracks
 	EnableRTPStreamRestartDetection bool `yaml:"enable_rtp_stream_restart_detection,omitempty"`
+
+	// Force relay mode for all clients
+	ForceRelay *bool `yaml:"force_relay,omitempty"`
 }
 
 type TURNServer struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -62,6 +62,7 @@ func TestGeneratedFlags(t *testing.T) {
 	c.Set("rtc.allow_tcp_fallback", "true")
 	c.Set("rtc.reconnect_on_publication_error", "true")
 	c.Set("rtc.reconnect_on_subscription_error", "false")
+	c.Set("rtc.force_relay", "true")
 
 	conf, err := NewConfig("", true, c, nil)
 	require.NoError(t, err)
@@ -78,6 +79,49 @@ func TestGeneratedFlags(t *testing.T) {
 
 	require.NotNil(t, conf.RTC.ReconnectOnSubscriptionError)
 	require.False(t, *conf.RTC.ReconnectOnSubscriptionError)
+
+	require.NotNil(t, conf.RTC.ForceRelay)
+	require.True(t, *conf.RTC.ForceRelay)
+}
+
+func TestForceRelayConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		configContent  string
+		expectedValue  *bool
+	}{
+		{
+			name: "ForceRelay enabled",
+			configContent: `rtc:
+  force_relay: true`,
+			expectedValue: func() *bool { b := true; return &b }(),
+		},
+		{
+			name: "ForceRelay disabled",
+			configContent: `rtc:
+  force_relay: false`,
+			expectedValue: func() *bool { b := false; return &b }(),
+		},
+		{
+			name:          "ForceRelay not set",
+			configContent: `rtc: {}`,
+			expectedValue: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf, err := NewConfig(tt.configContent, true, nil, nil)
+			require.NoError(t, err)
+
+			if tt.expectedValue == nil {
+				require.Nil(t, conf.RTC.ForceRelay)
+			} else {
+				require.NotNil(t, conf.RTC.ForceRelay)
+				require.Equal(t, *tt.expectedValue, *conf.RTC.ForceRelay)
+			}
+		})
+	}
 }
 
 func TestYAMLTag(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -86,9 +86,9 @@ func TestGeneratedFlags(t *testing.T) {
 
 func TestForceRelayConfig(t *testing.T) {
 	tests := []struct {
-		name           string
-		configContent  string
-		expectedValue  *bool
+		name          string
+		configContent string
+		expectedValue *bool
 	}{
 		{
 			name: "ForceRelay enabled",

--- a/pkg/rtc/config.go
+++ b/pkg/rtc/config.go
@@ -37,6 +37,7 @@ type WebRTCConfig struct {
 	Receiver      ReceiverConfig
 	Publisher     DirectionConfig
 	Subscriber    DirectionConfig
+	ForceRelay    *bool
 }
 
 type ReceiverConfig struct {
@@ -88,6 +89,7 @@ func NewWebRTCConfig(conf *config.Config) (*WebRTCConfig, error) {
 		},
 		Publisher:  getPublisherConfig(false),
 		Subscriber: getSubscriberConfig(rtcConf.CongestionControl.UseSendSideBWEInterceptor || rtcConf.CongestionControl.UseSendSideBWE),
+		ForceRelay: rtcConf.ForceRelay,
 	}, nil
 }
 

--- a/pkg/rtc/config_test.go
+++ b/pkg/rtc/config_test.go
@@ -1,0 +1,67 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rtc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/livekit-server/pkg/config"
+)
+
+func TestWebRTCConfig_ForceRelay(t *testing.T) {
+	tests := []struct {
+		name          string
+		forceRelay    *bool
+		expectedValue *bool
+	}{
+		{
+			name:          "ForceRelay enabled",
+			forceRelay:    func() *bool { b := true; return &b }(),
+			expectedValue: func() *bool { b := true; return &b }(),
+		},
+		{
+			name:          "ForceRelay disabled",
+			forceRelay:    func() *bool { b := false; return &b }(),
+			expectedValue: func() *bool { b := false; return &b }(),
+		},
+		{
+			name:          "ForceRelay not set",
+			forceRelay:    nil,
+			expectedValue: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &config.Config{
+				RTC: config.RTCConfig{
+					ForceRelay: tt.forceRelay,
+				},
+			}
+
+			webRTCConfig, err := NewWebRTCConfig(conf)
+			require.NoError(t, err)
+
+			if tt.expectedValue == nil {
+				require.Nil(t, webRTCConfig.ForceRelay)
+			} else {
+				require.NotNil(t, webRTCConfig.ForceRelay)
+				require.Equal(t, *tt.expectedValue, *webRTCConfig.ForceRelay)
+			}
+		})
+	}
+}

--- a/pkg/rtc/config_test.go
+++ b/pkg/rtc/config_test.go
@@ -30,13 +30,13 @@ func TestWebRTCConfig_ForceRelay(t *testing.T) {
 	}{
 		{
 			name:          "ForceRelay enabled",
-			forceRelay:    func() *bool { b := true; return &b }(),
-			expectedValue: func() *bool { b := true; return &b }(),
+			forceRelay:    boolPtr(true),
+			expectedValue: boolPtr(true),
 		},
 		{
 			name:          "ForceRelay disabled",
-			forceRelay:    func() *bool { b := false; return &b }(),
-			expectedValue: func() *bool { b := false; return &b }(),
+			forceRelay:    boolPtr(false),
+			expectedValue: boolPtr(false),
 		},
 		{
 			name:          "ForceRelay not set",

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -411,6 +411,12 @@ func NewParticipant(params ParticipantParams) (*ParticipantImpl, error) {
 	p.SwapResponseSink(params.Sink, types.SignallingCloseReasonUnknown)
 	p.setupEnabledCodecs(params.PublishEnabledCodecs, params.SubscribeEnabledCodecs, params.ClientConf.GetDisabledCodecs())
 
+	// apply it up front so that it is part of the first join response, an ICE config change does
+	// not happen for a participant joining for the first time
+	p.lock.Lock()
+	p.setConfiguredForceRelayLocked()
+	p.lock.Unlock()
+
 	if p.supervisor != nil {
 		p.supervisor.OnPublicationError(p.onPublicationError)
 	}
@@ -625,6 +631,25 @@ func (p *ParticipantImpl) GetClientConfiguration() *livekit.ClientConfiguration 
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 	return utils.CloneProto(p.params.ClientConf)
+}
+
+// setConfiguredForceRelayLocked applies the server configured force relay setting, if any, to the
+// client configuration. It reports whether the setting was configured, i.e. whether the ICE config
+// based fallback should be skipped.
+func (p *ParticipantImpl) setConfiguredForceRelayLocked() bool {
+	if p.params.Config == nil || p.params.Config.ForceRelay == nil {
+		return false
+	}
+
+	if p.params.ClientConf == nil {
+		p.params.ClientConf = &livekit.ClientConfiguration{}
+	}
+	if *p.params.Config.ForceRelay {
+		p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_ENABLED
+	} else {
+		p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_DISABLED
+	}
+	return true
 }
 
 func (p *ParticipantImpl) GetBufferFactory() *buffer.Factory {
@@ -2087,19 +2112,11 @@ func (p *ParticipantImpl) setupTransportManager() error {
 		p.lock.Lock()
 		onICEConfigChanged := p.onICEConfigChanged
 
-		if p.params.ClientConf == nil {
-			p.params.ClientConf = &livekit.ClientConfiguration{}
-		}
-
-		// Check if ForceRelay is explicitly set in config first
-		if p.params.Config != nil && p.params.Config.ForceRelay != nil {
-			if *p.params.Config.ForceRelay {
-				p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_ENABLED
-			} else {
-				p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_DISABLED
+		// an explicit force relay config always wins over what the ICE config implies
+		if !p.setConfiguredForceRelayLocked() {
+			if p.params.ClientConf == nil {
+				p.params.ClientConf = &livekit.ClientConfiguration{}
 			}
-		} else {
-			// Fall back to ICE config based logic
 			if iceConfig.PreferenceSubscriber == livekit.ICECandidateType_ICT_TLS {
 				p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_ENABLED
 			} else {

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -638,23 +638,38 @@ func (p *ParticipantImpl) GetClientConfiguration() *livekit.ClientConfiguration 
 	return utils.CloneProto(p.params.ClientConf)
 }
 
-// setConfiguredForceRelayLocked applies the server configured force relay setting, if any, to the
-// client configuration. It reports whether the setting was configured, i.e. whether the ICE config
-// based fallback should be skipped.
-func (p *ParticipantImpl) setConfiguredForceRelayLocked() bool {
+// forceRelaySettingLocked resolves the force relay client configuration for the given ICE config.
+// A server configured force relay setting decides it, except when the server has already moved the
+// participant to TURN/TLS, in which case relay is the only thing that is going to work anyway.
+func (p *ParticipantImpl) forceRelaySettingLocked(iceConfig *livekit.ICEConfig) livekit.ClientConfigSetting {
+	if iceConfig.GetPreferenceSubscriber() == livekit.ICECandidateType_ICT_TLS {
+		return livekit.ClientConfigSetting_ENABLED
+	}
+
+	if p.params.Config != nil && p.params.Config.ForceRelay != nil {
+		if *p.params.Config.ForceRelay {
+			return livekit.ClientConfigSetting_ENABLED
+		}
+		return livekit.ClientConfigSetting_DISABLED
+	}
+
+	// UNSET indicates that clients could override RTCConfiguration to forceRelay
+	return livekit.ClientConfigSetting_UNSET
+}
+
+// setConfiguredForceRelayLocked applies a server configured force relay setting to the client
+// configuration. Nothing configured leaves the client configuration alone, so that nothing is sent
+// down where nothing was sent down before.
+func (p *ParticipantImpl) setConfiguredForceRelayLocked() {
 	if p.params.Config == nil || p.params.Config.ForceRelay == nil {
-		return false
+		return
 	}
 
 	if p.params.ClientConf == nil {
 		p.params.ClientConf = &livekit.ClientConfiguration{}
 	}
-	if *p.params.Config.ForceRelay {
-		p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_ENABLED
-	} else {
-		p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_DISABLED
-	}
-	return true
+	// there is no ICE config yet at this point, it is applied by the ICE config change handler
+	p.params.ClientConf.ForceRelay = p.forceRelaySettingLocked(nil)
 }
 
 func (p *ParticipantImpl) GetBufferFactory() *buffer.Factory {
@@ -2117,18 +2132,10 @@ func (p *ParticipantImpl) setupTransportManager() error {
 		p.lock.Lock()
 		onICEConfigChanged := p.onICEConfigChanged
 
-		// an explicit force relay config always wins over what the ICE config implies
-		if !p.setConfiguredForceRelayLocked() {
-			if p.params.ClientConf == nil {
-				p.params.ClientConf = &livekit.ClientConfiguration{}
-			}
-			if iceConfig.PreferenceSubscriber == livekit.ICECandidateType_ICT_TLS {
-				p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_ENABLED
-			} else {
-				// UNSET indicates that clients could override RTCConfiguration to forceRelay
-				p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_UNSET
-			}
+		if p.params.ClientConf == nil {
+			p.params.ClientConf = &livekit.ClientConfiguration{}
 		}
+		p.params.ClientConf.ForceRelay = p.forceRelaySettingLocked(iceConfig)
 		p.lock.Unlock()
 
 		if onICEConfigChanged != nil {

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2090,11 +2090,22 @@ func (p *ParticipantImpl) setupTransportManager() error {
 		if p.params.ClientConf == nil {
 			p.params.ClientConf = &livekit.ClientConfiguration{}
 		}
-		if iceConfig.PreferenceSubscriber == livekit.ICECandidateType_ICT_TLS {
-			p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_ENABLED
+
+		// Check if ForceRelay is explicitly set in config first
+		if p.params.Config != nil && p.params.Config.ForceRelay != nil {
+			if *p.params.Config.ForceRelay {
+				p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_ENABLED
+			} else {
+				p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_DISABLED
+			}
 		} else {
-			// UNSET indicates that clients could override RTCConfiguration to forceRelay
-			p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_UNSET
+			// Fall back to ICE config based logic
+			if iceConfig.PreferenceSubscriber == livekit.ICECandidateType_ICT_TLS {
+				p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_ENABLED
+			} else {
+				// UNSET indicates that clients could override RTCConfiguration to forceRelay
+				p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_UNSET
+			}
 		}
 		p.lock.Unlock()
 

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -411,9 +411,14 @@ func NewParticipant(params ParticipantParams) (*ParticipantImpl, error) {
 	p.SwapResponseSink(params.Sink, types.SignallingCloseReasonUnknown)
 	p.setupEnabledCodecs(params.PublishEnabledCodecs, params.SubscribeEnabledCodecs, params.ClientConf.GetDisabledCodecs())
 
+	p.lock.Lock()
+	// the client configuration manager hands out a shared instance for non merged rules, so take a
+	// copy before anything modifies it for this participant
+	if p.params.ClientConf != nil {
+		p.params.ClientConf = utils.CloneProto(p.params.ClientConf)
+	}
 	// apply it up front so that it is part of the first join response, an ICE config change does
 	// not happen for a participant joining for the first time
-	p.lock.Lock()
 	p.setConfiguredForceRelayLocked()
 	p.lock.Unlock()
 

--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -17,6 +17,7 @@ package rtc
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -876,6 +877,44 @@ func TestParticipant_ForceRelayConfigOnJoin(t *testing.T) {
 			require.NotNil(t, clientConf)
 			require.Equal(t, tc.expectedForceRelay, clientConf.ForceRelay)
 		})
+	}
+}
+
+// StaticClientConfigurationManager.GetConfiguration hands out the shared global
+// *livekit.ClientConfiguration for Merge:false rules, so participants matching the same rule
+// get the very same pointer. Applying force relay must not write into it.
+func TestParticipant_ForceRelayDoesNotMutateSharedClientConf(t *testing.T) {
+	shared := &livekit.ClientConfiguration{
+		DisabledCodecs: &livekit.DisabledCodecs{
+			Publish: []*livekit.Codec{{Mime: mime.MimeTypeH264.String()}},
+		},
+	}
+
+	const numParticipants = 8
+	var wg sync.WaitGroup
+	participants := make([]*ParticipantImpl, numParticipants)
+	for i := range participants {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			participants[i] = newParticipantForTestWithOpts(
+				livekit.ParticipantIdentity(fmt.Sprintf("test%d", i)),
+				&participantOpts{forceRelay: boolPtr(true), clientConf: shared},
+			)
+		}()
+	}
+	wg.Wait()
+
+	// the shared configuration has to be left exactly as it was
+	require.Equal(t, livekit.ClientConfigSetting_UNSET, shared.ForceRelay)
+	require.NotNil(t, shared.DisabledCodecs)
+
+	// while every participant still gets the setting plus what it inherited
+	for _, p := range participants {
+		clientConf := p.GetClientConfiguration()
+		require.NotNil(t, clientConf)
+		require.Equal(t, livekit.ClientConfigSetting_ENABLED, clientConf.ForceRelay)
+		require.Len(t, clientConf.GetDisabledCodecs().GetPublish(), 1)
 	}
 }
 

--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -932,10 +932,18 @@ func TestParticipant_ForceRelayOnICEConfigChange(t *testing.T) {
 			expectedForceRelay: livekit.ClientConfigSetting_ENABLED,
 		},
 		{
-			name:               "config disabled takes precedence over TLS preference",
+			name:               "config disabled keeps relay off",
+			forceRelay:         boolPtr(false),
+			icePreference:      livekit.ICECandidateType_ICT_TCP,
+			expectedForceRelay: livekit.ClientConfigSetting_DISABLED,
+		},
+		{
+			// the server has already moved the participant to TURN/TLS, telling the client not to
+			// force relay would take away the fallback it just got
+			name:               "TLS fallback wins over config disabled",
 			forceRelay:         boolPtr(false),
 			icePreference:      livekit.ICECandidateType_ICT_TLS,
-			expectedForceRelay: livekit.ClientConfigSetting_DISABLED,
+			expectedForceRelay: livekit.ClientConfigSetting_ENABLED,
 		},
 		{
 			name:               "not configured, TLS preference forces relay",

--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -762,6 +762,7 @@ type participantOpts struct {
 	publisher       bool
 	clientConf      *livekit.ClientConfiguration
 	clientInfo      *livekit.ClientInfo
+	forceRelay      *bool
 }
 
 func newParticipantForTestWithOpts(identity livekit.ParticipantIdentity, opts *participantOpts) *ParticipantImpl {
@@ -778,6 +779,7 @@ func newParticipantForTestWithOpts(identity livekit.ParticipantIdentity, opts *p
 	if err != nil {
 		panic(err)
 	}
+	rtcConf.ForceRelay = opts.forceRelay
 	ff := buffer.NewFactoryOfBufferFactory(500, 200)
 	rtcConf.SetBufferFactory(ff.CreateBufferFactory())
 	grants := &auth.ClaimGrants{
@@ -827,91 +829,101 @@ func newParticipantForTest(identity livekit.ParticipantIdentity) *ParticipantImp
 	return newParticipantForTestWithOpts(identity, nil)
 }
 
-func TestParticipant_ForceRelayLogic(t *testing.T) {
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+// ForceRelay set through server config has to be in the very first JoinResponse, i.e. it must
+// not depend on an ICE config change, which does not happen for a first time participant.
+func TestParticipant_ForceRelayConfigOnJoin(t *testing.T) {
 	tests := []struct {
-		name                 string
-		configForceRelay     *bool
-		icePreference        livekit.ICECandidateType
-		expectedForceRelay   livekit.ClientConfigSetting
+		name               string
+		forceRelay         *bool
+		expectedClientConf bool
+		expectedForceRelay livekit.ClientConfigSetting
 	}{
 		{
-			name:               "Explicit ForceRelay enabled",
-			configForceRelay:   func() *bool { b := true; return &b }(),
+			name:               "force relay enabled in config",
+			forceRelay:         boolPtr(true),
+			expectedClientConf: true,
+			expectedForceRelay: livekit.ClientConfigSetting_ENABLED,
+		},
+		{
+			name:               "force relay disabled in config",
+			forceRelay:         boolPtr(false),
+			expectedClientConf: true,
+			expectedForceRelay: livekit.ClientConfigSetting_DISABLED,
+		},
+		{
+			// not configured, so nothing should be sent down and clients keep deciding on their own
+			name:               "force relay not configured",
+			forceRelay:         nil,
+			expectedClientConf: false,
+			expectedForceRelay: livekit.ClientConfigSetting_UNSET,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newParticipantForTestWithOpts("test", &participantOpts{forceRelay: tc.forceRelay})
+
+			// no ICE config change, exactly what a first time participant sees
+			clientConf := p.GetClientConfiguration()
+			if !tc.expectedClientConf {
+				require.Nil(t, clientConf)
+				return
+			}
+			require.NotNil(t, clientConf)
+			require.Equal(t, tc.expectedForceRelay, clientConf.ForceRelay)
+		})
+	}
+}
+
+func TestParticipant_ForceRelayOnICEConfigChange(t *testing.T) {
+	tests := []struct {
+		name               string
+		forceRelay         *bool
+		icePreference      livekit.ICECandidateType
+		expectedForceRelay livekit.ClientConfigSetting
+	}{
+		{
+			name:               "config takes precedence over ICE preference",
+			forceRelay:         boolPtr(true),
 			icePreference:      livekit.ICECandidateType_ICT_TCP,
 			expectedForceRelay: livekit.ClientConfigSetting_ENABLED,
 		},
 		{
-			name:               "Explicit ForceRelay disabled",
-			configForceRelay:   func() *bool { b := false; return &b }(),
+			name:               "config disabled takes precedence over TLS preference",
+			forceRelay:         boolPtr(false),
 			icePreference:      livekit.ICECandidateType_ICT_TLS,
 			expectedForceRelay: livekit.ClientConfigSetting_DISABLED,
 		},
 		{
-			name:               "No explicit config, ICE TLS preference",
-			configForceRelay:   nil,
+			name:               "not configured, TLS preference forces relay",
+			forceRelay:         nil,
 			icePreference:      livekit.ICECandidateType_ICT_TLS,
 			expectedForceRelay: livekit.ClientConfigSetting_ENABLED,
 		},
 		{
-			name:               "No explicit config, ICE TCP preference",
-			configForceRelay:   nil,
+			name:               "not configured, TCP preference leaves it to the client",
+			forceRelay:         nil,
 			icePreference:      livekit.ICECandidateType_ICT_TCP,
 			expectedForceRelay: livekit.ClientConfigSetting_UNSET,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create WebRTC config with ForceRelay setting
-			webRTCConfig := &WebRTCConfig{
-				ForceRelay: tt.configForceRelay,
-			}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newParticipantForTestWithOpts("test", &participantOpts{forceRelay: tc.forceRelay})
 
-			// Create participant with the config
-			p := newParticipantForTestWithOpts("test", &participantOpts{
-				publisher: true,
+			p.SetICEConfig(&livekit.ICEConfig{
+				PreferenceSubscriber: tc.icePreference,
+				PreferencePublisher:  tc.icePreference,
 			})
-			p.params.Config = webRTCConfig
 
-			// Setup transport manager to trigger ICE config change
-			err := p.setupTransportManager()
-			require.NoError(t, err)
-
-			// Simulate ICE config change
-			iceConfig := &livekit.ICEConfig{
-				PreferenceSubscriber: tt.icePreference,
-				PreferencePublisher:  tt.icePreference,
-			}
-
-			// Trigger the ICE config change handler
-			if p.TransportManager != nil {
-				// Access the ICE config change handler through a test helper
-				// This simulates what happens when ICE config changes
-				p.lock.Lock()
-				if p.params.ClientConf == nil {
-					p.params.ClientConf = &livekit.ClientConfiguration{}
-				}
-
-				// Apply the same logic as in the actual ICE config change handler
-				if p.params.Config != nil && p.params.Config.ForceRelay != nil {
-					if *p.params.Config.ForceRelay {
-						p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_ENABLED
-					} else {
-						p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_DISABLED
-					}
-				} else {
-					// Fall back to ICE config based logic
-					if iceConfig.PreferenceSubscriber == livekit.ICECandidateType_ICT_TLS {
-						p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_ENABLED
-					} else {
-						p.params.ClientConf.ForceRelay = livekit.ClientConfigSetting_UNSET
-					}
-				}
-				p.lock.Unlock()
-
-				// Verify the result
-				require.Equal(t, tt.expectedForceRelay, p.params.ClientConf.ForceRelay)
-			}
+			clientConf := p.GetClientConfiguration()
+			require.NotNil(t, clientConf)
+			require.Equal(t, tc.expectedForceRelay, clientConf.ForceRelay)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
Adds ability to control ForceRelay setting from server configuration, enabling administrators to enforce TURN-only connections for all clients.

## Motivation
Currently, ForceRelay behavior is determined dynamically based on ICE configuration. This doesn't provide explicit control for organizations requiring all media traffic through controlled relay servers or environments where direct P2P connections are prohibited.

## Changes
- Added `ForceRelay *bool` field to `config.RTCConfig` and `rtc.WebRTCConfig`
- Applied the setting in `NewParticipant`, so it is carried by the first JoinResponse. An ICE config change does not happen for a participant joining for the first time, so applying it only from the `OnICEConfigChanged` handler would never reach a fresh join
- Resolved the setting together with the ICE config in use, so the TURN/TLS fallback still forces relay for a participant the server has migrated to it
- Copied the client configuration per participant, as the client configuration manager hands out a shared instance for non merged rules
- Added configuration example in `config-sample.yaml`
- Maintained full backward compatibility

## Usage

### YAML Configuration
```yaml
rtc:
  force_relay: true  # Force all clients to use TURN servers
```

### Environment Variable
```bash
export LIVEKIT_RTC_FORCE_RELAY=true
```

## Behavior
- `force_relay: true` → Clients forced to use TURN servers (`ClientConfigSetting_ENABLED`)
- `force_relay: false` → Clients told not to force relay (`ClientConfigSetting_DISABLED`), except for a participant the server has fallen back to TURN/TLS for, which still gets `ClientConfigSetting_ENABLED`
- Not set → Legacy ICE-based logic, backward compatible. The client configuration is left untouched, so nothing is sent down where nothing was sent down before

## Files Changed
- `pkg/config/config.go` - Added ForceRelay field to RTCConfig
- `pkg/rtc/config.go` - Added ForceRelay field to WebRTCConfig
- `pkg/rtc/participant.go` - ForceRelay decision logic, applied at join and on ICE config changes
- `pkg/config/config_test.go`, `pkg/rtc/config_test.go`, `pkg/rtc/participant_internal_test.go` - Tests
- `config-sample.yaml` - Added configuration example

## Testing
- [x] Backward compatibility maintained
- [x] Configuration precedence works correctly
- [x] Manual testing with different config values
- [x] Unit tests for config parsing
- [x] Unit tests for WebRTCConfig propagation
- [x] `TestParticipant_ForceRelayConfigOnJoin` - the setting reaches the first JoinResponse with no ICE config change
- [x] `TestParticipant_ForceRelayOnICEConfigChange` - config precedence and the TURN/TLS fallback
- [x] `TestParticipant_ForceRelayDoesNotMutateSharedClientConf` - concurrent joins sharing one client configuration, verified under `-race`

This enhancement addresses requests for better network security control and simplified deployment in restricted environments.
