### PR TITLE
Include agent_name as a participant attribute

### DIFF
--- a/pkg/agent/testutils/server.go
+++ b/pkg/agent/testutils/server.go
@@ -33,6 +33,8 @@ type AgentService interface {
 
 type TestServer struct {
 	AgentService
+	TestAPIKey    string
+	TestAPISecret string
 }
 
 func NewTestServer(bus psrpc.MessageBus) *TestServer {
@@ -46,7 +48,7 @@ func NewTestServer(bus psrpc.MessageBus) *TestServer {
 }
 
 func NewTestServerWithService(s AgentService) *TestServer {
-	return &TestServer{s}
+	return &TestServer{s, "test", "verysecretsecret"}
 }
 
 type SimulatedWorkerOptions struct {

--- a/pkg/agent/worker.go
+++ b/pkg/agent/worker.go
@@ -43,6 +43,8 @@ var (
 	ErrDuplicateJobAssignment     = errors.New("duplicate job assignment")
 )
 
+const AgentNameAttributeKey = "lk.agent_name"
+
 type WorkerProtocolVersion int
 
 const CurrentProtocol = 1
@@ -365,6 +367,11 @@ func (w *Worker) AssignJob(ctx context.Context, job *livekit.Job) (*livekit.JobS
 		}
 
 		job.State.ParticipantIdentity = res.ParticipantIdentity
+		attributes := res.ParticipantAttributes
+		if attributes == nil {
+			attributes = make(map[string]string)
+		}
+		attributes[AgentNameAttributeKey] = w.AgentName
 
 		token, err := pagent.BuildAgentToken(
 			w.apiKey,
@@ -373,7 +380,7 @@ func (w *Worker) AssignJob(ctx context.Context, job *livekit.Job) (*livekit.JobS
 			res.ParticipantIdentity,
 			res.ParticipantName,
 			res.ParticipantMetadata,
-			res.ParticipantAttributes,
+			attributes,
 			w.Permissions,
 		)
 		if err != nil {

--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -89,23 +89,23 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	}
 	rtcEgressLauncher := NewEgressLauncher(egressClient, ioInfoService, objectStore)
 	topicFormatter := rpc.NewTopicFormatter()
-	v, err := rpc.NewTypedRoomClient(clientParams)
+	roomClient, err := rpc.NewTypedRoomClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	v2, err := rpc.NewTypedParticipantClient(clientParams)
+	participantClient, err := rpc.NewTypedParticipantClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	roomService, err := NewRoomService(limitConfig, apiConfig, router, roomAllocator, objectStore, rtcEgressLauncher, topicFormatter, v, v2)
+	roomService, err := NewRoomService(limitConfig, apiConfig, router, roomAllocator, objectStore, rtcEgressLauncher, topicFormatter, roomClient, participantClient)
 	if err != nil {
 		return nil, err
 	}
-	v3, err := rpc.NewTypedAgentDispatchInternalClient(clientParams)
+	agentDispatchInternalClient, err := rpc.NewTypedAgentDispatchInternalClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	agentDispatchService := NewAgentDispatchService(v3, topicFormatter, roomAllocator, router)
+	agentDispatchService := NewAgentDispatchService(agentDispatchInternalClient, topicFormatter, roomAllocator, router)
 	egressService := NewEgressService(egressClient, rtcEgressLauncher, ioInfoService, roomService)
 	ingressConfig := getIngressConfig(conf)
 	ingressClient, err := rpc.NewIngressClient(clientParams)
@@ -120,11 +120,11 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	}
 	sipService := NewSIPService(sipConfig, nodeID, messageBus, sipClient, sipStore, roomService, telemetryService)
 	rtcService := NewRTCService(conf, roomAllocator, router, telemetryService)
-	v4, err := rpc.NewTypedWHIPParticipantClient(clientParams)
+	whipParticipantClient, err := rpc.NewTypedWHIPParticipantClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	serviceWHIPService, err := NewWHIPService(conf, router, roomAllocator, clientParams, topicFormatter, v4)
+	serviceWHIPService, err := NewWHIPService(conf, router, roomAllocator, clientParams, topicFormatter, whipParticipantClient)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
client SDKs could more easily identify the agent that's in the room by inspecting `lk.agent_name` attribute