### PR TITLE
Document node_ip Option in RTC Config Sample for NAT/Proxy Environments

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -65,6 +65,9 @@ rtc:
   # this is useful for cloud environments such as AWS & Google where hosts have an internal IP
   # that maps to an external one
   use_external_ip: true
+  # # when set, LiveKit will use the provided IP as the public IP advertised to clients
+  # # this is useful when the server is behind NAT or has a public IP that cannot be discovered via STUN
+  # node_ip: 203.0.113.0
   # # when set, LiveKit will attempt to use a UDP mux so all UDP traffic goes through
   # # listed port(s). To maximize system performance, we recommend using a range of ports
   # # greater or equal to the number of vCPUs on the machine.


### PR DESCRIPTION
While setting up LiveKit behind a proxy, I encountered repeated STUN discovery failures and couldn't find a documented way to manually specify the public IP address. After reviewing the codebase, I found that LiveKit does support a `node_ip` configuration option. However, it was not included in the sample configuration file or mentioned in the documentation.

This pull request addresses that gap by improving the sample configuration.

This pull request adds a new configuration option to the RTC section of the sample config file, making it easier to specify a public IP address for servers behind NAT or with undiscoverable public IPs.

RTC configuration improvements:

* Added the commented-out `node_ip` option to `config-sample.yaml`, allowing admins to explicitly set the public IP advertised to clientswhen automatic discovery is not possible.