### PR TITLE
Simulcast audio fixes

### DIFF
--- a/pkg/rtc/mediaengine.go
+++ b/pkg/rtc/mediaengine.go
@@ -45,7 +45,7 @@ var (
 		PayloadType: 63,
 	}
 
-	pcmuCodecParameters = webrtc.RTPCodecParameters{
+	PCMUCodecParameters = webrtc.RTPCodecParameters{
 		RTPCodecCapability: webrtc.RTPCodecCapability{
 			MimeType:  mime.MimeTypePCMU.String(),
 			ClockRate: 8000,
@@ -53,7 +53,7 @@ var (
 		PayloadType: 0,
 	}
 
-	pcmaCodecParameters = webrtc.RTPCodecParameters{
+	PCMACodecParameters = webrtc.RTPCodecParameters{
 		RTPCodecCapability: webrtc.RTPCodecCapability{
 			MimeType:  mime.MimeTypePCMA.String(),
 			ClockRate: 8000,
@@ -166,7 +166,7 @@ func registerCodecs(me *webrtc.MediaEngine, codecs []*livekit.Codec, rtcpFeedbac
 		}
 	}
 
-	for _, codec := range []webrtc.RTPCodecParameters{pcmuCodecParameters, pcmaCodecParameters} {
+	for _, codec := range []webrtc.RTPCodecParameters{PCMUCodecParameters, PCMACodecParameters} {
 		if !IsCodecEnabled(codecs, codec.RTPCodecCapability) {
 			continue
 		}

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -566,7 +566,6 @@ func (t *MediaTrackReceiver) AddSubscriber(sub types.LocalParticipant) (types.Su
 			potentialCodecs = append(potentialCodecs, codec)
 		}
 	}
-	t.params.Logger.Infow("potential codecs", "codecs", potentialCodecs) // REMOVE
 
 	streamId := string(t.PublisherID())
 	if sub.ProtocolVersion().SupportsPackedStreamId() {

--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -566,6 +566,7 @@ func (t *MediaTrackReceiver) AddSubscriber(sub types.LocalParticipant) (types.Su
 			potentialCodecs = append(potentialCodecs, codec)
 		}
 	}
+	t.params.Logger.Infow("potential codecs", "codecs", potentialCodecs) // REMOVE
 
 	streamId := string(t.PublisherID())
 	if sub.ProtocolVersion().SupportsPackedStreamId() {
@@ -581,7 +582,7 @@ func (t *MediaTrackReceiver) AddSubscriber(sub types.LocalParticipant) (types.Su
 		StreamId:       streamId,
 		UpstreamCodecs: potentialCodecs,
 		Logger:         tLogger,
-		DisableRed:     t.TrackInfo().GetDisableRed() || !t.params.AudioConfig.ActiveREDEncoding,
+		DisableRed:     !IsRedEnabled(t.TrackInfo()) || !t.params.AudioConfig.ActiveREDEncoding,
 		IsEncrypted:    t.IsEncrypted(),
 	})
 	subID := sub.ID()
@@ -598,7 +599,11 @@ func (t *MediaTrackReceiver) AddSubscriber(sub types.LocalParticipant) (types.Su
 	t.lock.RUnlock()
 
 	if remove {
-		t.params.Logger.Debugw("removing subscriber on a not-open track", "subscriberID", subID, "isExpectedToResume", isExpectedToResume)
+		t.params.Logger.Debugw(
+			"removing subscriber on a not-open track",
+			"subscriberID", subID,
+			"isExpectedToResume", isExpectedToResume,
+		)
 		_ = t.MediaTrackSubscriptions.RemoveSubscriber(subID, isExpectedToResume)
 		return nil, ErrNotOpen
 	}

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -207,7 +207,7 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 		info := t.params.MediaTrack.ToProto()
 		addTrackParams := types.AddTrackParams{
 			Stereo: slices.Contains(info.AudioFeatures, livekit.AudioTrackFeature_TF_STEREO),
-			Red:    !info.DisableRed,
+			Red:    IsRedEnabled(info),
 		}
 		codecs := wr.Codecs()
 		if addTrackParams.Red && (len(codecs) == 1 && mime.IsMimeTypeStringOpus(codecs[0].MimeType)) {

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2930,7 +2930,7 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 					mimeType = altCodec
 				}
 				if videoLayerMode == livekit.VideoLayer_MODE_UNUSED {
-					if mime.IsMimeTypeStringSVC(mimeType) {
+					if mime.IsMimeTypeStringSVCCapable(mimeType) {
 						videoLayerMode = livekit.VideoLayer_MULTIPLE_SPATIAL_LAYERS_PER_STREAM
 					} else {
 						if p.params.ClientInfo.isOBS() {

--- a/pkg/rtc/participant_sdp.go
+++ b/pkg/rtc/participant_sdp.go
@@ -303,10 +303,11 @@ func (p *ParticipantImpl) setCodecPreferencesOpusRedForPublisher(
 			continue
 		}
 
-		// if RED is disabled for this track, don't prefer RED codec in offer
+		preferRED := IsRedEnabled(ti)
+		// if RED is enabled for this track, prefer RED codec in offer
 		for _, codec := range codecs {
 			// codec contain opus/red
-			if !ti.DisableRed &&
+			if preferRED &&
 				mime.IsMimeTypeCodecStringRED(codec.Name) &&
 				strings.Contains(codec.Fmtp, strconv.FormatInt(int64(opusPayload), 10)) {
 				configureReceiverCodecs(transceiver, "audio/red", true)

--- a/pkg/rtc/subscribedtrack.go
+++ b/pkg/rtc/subscribedtrack.go
@@ -433,9 +433,7 @@ func (t *SubscribedTrack) OnRttUpdate(rtt uint32) {
 }
 
 func (t *SubscribedTrack) OnCodecNegotiated(codec webrtc.RTPCodecCapability) {
-	t.logger.Infow("RAJA, got codec negotiated", "codec", codec) // REMOVE
 	if !t.params.WrappedReceiver.DetermineReceiver(codec) {
-		t.logger.Infow("RAJA, got codec negotiated could not determine receiver", "codec", codec) // REMOVE
 		return
 	}
 
@@ -454,9 +452,7 @@ func (t *SubscribedTrack) OnCodecNegotiated(codec webrtc.RTPCodecCapability) {
 				}
 
 			case livekit.TrackType_AUDIO:
-				t.logger.Infow("RAJA, got codec negotiated notifying trying", "codec", codec) // REMOVE
 				if t.params.OnSubscriberAudioCodecChange != nil {
-					t.logger.Infow("RAJA, got codec negotiated notifying", "codec", codec) // REMOVE
 					t.params.OnSubscriberAudioCodecChange(t.downTrack.SubscriberID(), mimeType, true)
 				}
 			}

--- a/pkg/rtc/subscribedtrack.go
+++ b/pkg/rtc/subscribedtrack.go
@@ -433,7 +433,9 @@ func (t *SubscribedTrack) OnRttUpdate(rtt uint32) {
 }
 
 func (t *SubscribedTrack) OnCodecNegotiated(codec webrtc.RTPCodecCapability) {
-	if t.params.WrappedReceiver.DetermineReceiver(codec) {
+	t.logger.Infow("RAJA, got codec negotiated", "codec", codec) // REMOVE
+	if !t.params.WrappedReceiver.DetermineReceiver(codec) {
+		t.logger.Infow("RAJA, got codec negotiated could not determine receiver", "codec", codec) // REMOVE
 		return
 	}
 
@@ -447,10 +449,16 @@ func (t *SubscribedTrack) OnCodecNegotiated(codec webrtc.RTPCodecCapability) {
 					livekit.VideoQuality_HIGH,
 					t.params.MediaTrack.ToProto(),
 				)
-				t.params.OnSubscriberMaxQualityChange(t.downTrack.SubscriberID(), mimeType, spatial)
+				if t.params.OnSubscriberMaxQualityChange != nil {
+					t.params.OnSubscriberMaxQualityChange(t.downTrack.SubscriberID(), mimeType, spatial)
+				}
 
 			case livekit.TrackType_AUDIO:
-				t.params.OnSubscriberAudioCodecChange(t.downTrack.SubscriberID(), mimeType, true)
+				t.logger.Infow("RAJA, got codec negotiated notifying trying", "codec", codec) // REMOVE
+				if t.params.OnSubscriberAudioCodecChange != nil {
+					t.logger.Infow("RAJA, got codec negotiated notifying", "codec", codec) // REMOVE
+					t.params.OnSubscriberAudioCodecChange(t.downTrack.SubscriberID(), mimeType, true)
+				}
 			}
 		}()
 	}

--- a/pkg/rtc/utils.go
+++ b/pkg/rtc/utils.go
@@ -192,3 +192,11 @@ func ChunkProtoBatch[T proto.Message](batch []T, target int) [][]T {
 	}
 	return chunks
 }
+
+func IsRedEnabled(ti *livekit.TrackInfo) bool {
+	if len(ti.Codecs) != 0 && ti.Codecs[0].MimeType != "" {
+		return mime.IsMimeTypeStringRED(ti.Codecs[0].MimeType)
+	}
+
+	return !ti.GetDisableRed()
+}

--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -60,7 +60,6 @@ func NewWrappedReceiver(params WrappedReceiverParams) *WrappedReceiver {
 	}
 
 	codecs := params.UpstreamCodecs
-	/* RAJA-TODO
 	if len(codecs) == 1 && !params.IsEncrypted {
 		normalizedMimeType := mime.NormalizeMimeType(codecs[0].MimeType)
 		if normalizedMimeType == mime.MimeTypeRED {
@@ -73,7 +72,6 @@ func NewWrappedReceiver(params WrappedReceiverParams) *WrappedReceiver {
 			codecs[0], codecs[1] = codecs[1], codecs[0]
 		}
 	}
-	*/
 
 	return &WrappedReceiver{
 		params:    params,
@@ -96,15 +94,13 @@ func (r *WrappedReceiver) DetermineReceiver(codec webrtc.RTPCodecCapability) boo
 
 	codecMimeType := mime.NormalizeMimeType(codec.MimeType)
 	var trackReceiver sfu.TrackReceiver
-	for idx, receiver := range r.receivers {
+	for _, receiver := range r.receivers {
 		receiverMimeType := receiver.Mime()
-		r.params.Logger.Infow("RAJA receiver mime", "mime", receiverMimeType, "idx", idx) // REMOVE
 		if receiverMimeType == codecMimeType {
 			trackReceiver = receiver
 			break
 		}
 
-		/* RAJA-TODO
 		if !r.params.IsEncrypted {
 			if receiverMimeType == mime.MimeTypeRED && codecMimeType == mime.MimeTypeOpus {
 				// audio opus/red can match opus only
@@ -115,15 +111,10 @@ func (r *WrappedReceiver) DetermineReceiver(codec webrtc.RTPCodecCapability) boo
 				break
 			}
 		}
-		*/
 	}
 	if trackReceiver == nil {
-		r.params.Logger.Errorw("can't determine receiver for codec", nil, "codec", codec.MimeType)
-		/* RAJA-REMOVE
-		if len(r.receivers) > 0 {
-			trackReceiver = r.receivers[0]
-		}
-		*/
+		r.lock.Unlock()
+		r.params.Logger.Warnw("can't determine receiver for codec", nil, "codec", codec.MimeType)
 		return false
 	}
 	r.TrackReceiver = trackReceiver
@@ -136,13 +127,6 @@ func (r *WrappedReceiver) DetermineReceiver(codec webrtc.RTPCodecCapability) boo
 		trackReceiver.AddOnReady(f)
 	}
 
-	/* RAJA-REMOVE
-	if s, ok := trackReceiver.(*simulcastReceiver); ok {
-		if d, ok := s.TrackReceiver.(*DummyReceiver); ok {
-			return d.IsReady()
-		}
-	}
-	*/
 	return true
 }
 
@@ -454,12 +438,6 @@ func (d *DummyReceiver) AddOnReady(f func()) {
 		receiver.AddOnReady(f)
 	}
 }
-
-/* RAJA-REMOVE
-func (d *DummyReceiver) IsReady() bool {
-	return d.receiver.Load() != nil
-}
-*/
 
 func (d *DummyReceiver) AddOnCodecStateChange(f func(codec webrtc.RTPCodecParameters, state sfu.ReceiverCodecState)) {
 	var receiver sfu.TrackReceiver

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -331,7 +331,7 @@ func (b *Buffer) OnCodecChange(fn func(webrtc.RTPCodecParameters)) {
 }
 
 func (b *Buffer) createDDParserAndFrameRateCalculator() {
-	if mime.IsMimeTypeSVC(b.mime) || b.mime == mime.MimeTypeVP8 {
+	if mime.IsMimeTypeSVCCapable(b.mime) || b.mime == mime.MimeTypeVP8 {
 		frc := NewFrameRateCalculatorDD(b.clockRate, b.logger)
 		for i := range b.frameRateCalculator {
 			b.frameRateCalculator[i] = frc.GetFrameRateCalculatorForSpatial(int32(i))

--- a/pkg/sfu/mime/mimetype.go
+++ b/pkg/sfu/mime/mimetype.go
@@ -320,11 +320,7 @@ func IsMimeTypeVideo(mimeType MimeType) bool {
 	return strings.HasPrefix(mimeType.String(), MimeTypePrefixVideo)
 }
 
-// SVC-TODO: Have to use more conditions to differentiate between
-// SVC-TODO: SVC and non-SVC (could be single layer or simulcast).
-// SVC-TODO: May only need to differentiate between simulcast and non-simulcast
-// SVC-TODO: i. e. may be possible to treat single layer as SVC to get proper/intended functionality.
-func IsMimeTypeSVC(mimeType MimeType) bool {
+func IsMimeTypeSVCCapable(mimeType MimeType) bool {
 	switch mimeType {
 	case MimeTypeAV1, MimeTypeVP9:
 		return true
@@ -332,8 +328,8 @@ func IsMimeTypeSVC(mimeType MimeType) bool {
 	return false
 }
 
-func IsMimeTypeStringSVC(mime string) bool {
-	return IsMimeTypeSVC(NormalizeMimeType(mime))
+func IsMimeTypeStringSVCCapable(mime string) bool {
+	return IsMimeTypeSVCCapable(NormalizeMimeType(mime))
 }
 
 func IsMimeTypeStringRED(mime string) bool {


### PR DESCRIPTION
- Utility to determine if RED is enabled based on simulcast audio codec or `DisableRED` flag. Simulcast codec will take precedence
- Add test for RED based on simulcast codec
- Do not check for ready status in `DetermineReceiver`. More notes on this inline.