### PR TITLE
Fix dynacast subscriber node clearing on move participant.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -4047,10 +4047,12 @@ func (p *ParticipantImpl) MoveToRoom(params types.MoveToRoomParams) {
 	for _, track := range p.GetPublishedTracks() {
 		for _, sub := range track.GetAllSubscribers() {
 			track.RemoveSubscriber(sub, false)
-			// clear the subscriber node max quality/audio codecs as the remote quality notify
-			// from source room would not reach the moving out participant.
-			track.(types.LocalMediaTrack).ClearSubscriberNodes()
 		}
+
+		// clear the subscriber node max quality/audio codecs as the remote quality notify
+		// from source room would not reach the moving out participant.
+		track.(types.LocalMediaTrack).ClearSubscriberNodes()
+
 		trackInfo := track.ToProto()
 		p.params.Telemetry.TrackUnpublished(
 			context.Background(),


### PR DESCRIPTION
Accidentally, it was left inside a for loop and it did not run if there were no subscribers.