### PR TITLE
Use difference in key frame counter to stop seeder.

### DIFF
--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -1343,6 +1343,14 @@ func (b *Buffer) seedKeyFrame(keyFrameSeederGeneration int32) {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
+	initialCount := uint32(0)
+	b.RLock()
+	rtpStats := b.rtpStats
+	b.RUnlock()
+	if rtpStats != nil {
+		initialCount, _ = rtpStats.KeyFrame()
+	}
+
 	for {
 		if b.closed.Load() || b.keyFrameSeederGeneration.Load() != keyFrameSeederGeneration {
 			return
@@ -1354,15 +1362,12 @@ func (b *Buffer) seedKeyFrame(keyFrameSeederGeneration int32) {
 			return
 
 		case <-ticker.C:
-			b.RLock()
-			rtpStats := b.rtpStats
-			b.RUnlock()
-
 			if rtpStats != nil {
 				cnt, last := rtpStats.KeyFrame()
-				if cnt > 0 {
+				if cnt > initialCount {
 					b.logger.Debugw(
 						"stopping key frame seeder: received key frame",
+						"keyFrameCountInitial", initialCount,
 						"keyFrameCount", cnt,
 						"lastKeyFrame", last,
 					)


### PR DESCRIPTION
The key frame seeder could be started multiple times. Use difference to detect stop condition.