### PR TITLE
Avoid matching on empty track id.

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -232,30 +232,36 @@ func (t *MediaTrack) ClearSubscriberNodes() {
 }
 
 func (t *MediaTrack) HasSignalCid(cid string) bool {
-	ti := t.MediaTrackReceiver.TrackInfoClone()
-	for _, c := range ti.Codecs {
-		if c.Cid == cid {
-			return true
+	if cid != "" {
+		ti := t.MediaTrackReceiver.TrackInfoClone()
+		for _, c := range ti.Codecs {
+			if c.Cid == cid {
+				return true
+			}
 		}
 	}
 	return false
 }
 
 func (t *MediaTrack) HasSdpCid(cid string) bool {
-	ti := t.MediaTrackReceiver.TrackInfoClone()
-	for _, c := range ti.Codecs {
-		if c.Cid == cid || c.SdpCid == cid {
-			return true
+	if cid != "" {
+		ti := t.MediaTrackReceiver.TrackInfoClone()
+		for _, c := range ti.Codecs {
+			if c.Cid == cid || c.SdpCid == cid {
+				return true
+			}
 		}
 	}
 	return false
 }
 
 func (t *MediaTrack) GetMimeTypeForSdpCid(cid string) mime.MimeType {
-	ti := t.MediaTrackReceiver.TrackInfoClone()
-	for _, c := range ti.Codecs {
-		if c.Cid == cid || c.SdpCid == cid {
-			return mime.NormalizeMimeType(c.MimeType)
+	if cid != "" {
+		ti := t.MediaTrackReceiver.TrackInfoClone()
+		for _, c := range ti.Codecs {
+			if c.Cid == cid || c.SdpCid == cid {
+				return mime.NormalizeMimeType(c.MimeType)
+			}
 		}
 	}
 	return mime.MimeTypeUnknown


### PR DESCRIPTION
Due to SDP ordering, Pion did not provide track ID on a receiver.

~Pion needs a=msid line to be before a=ssrc line -> need to check if this is a spec requirement~ - pion relies on msid on same line for non-simulcast sources.

Because of the above, it had empty id for the receiver in onTrack. That matched a published track because we do not duplicate SdpCid in TrackInfo if the SDP cid matches the signal cid. But, the search checks both and it matched on empty SDP cid.

Do not accept empty ids in searches to prevent this from happening.