### PR TITLE
Use microseconds for forwarding stats.

### DIFF
--- a/pkg/sfu/receiver.go
+++ b/pkg/sfu/receiver.go
@@ -29,6 +29,7 @@ import (
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/utils"
+	"github.com/livekit/protocol/utils/mono"
 
 	"github.com/livekit/livekit-server/pkg/sfu/audio"
 	"github.com/livekit/livekit-server/pkg/sfu/buffer"
@@ -826,7 +827,7 @@ func (w *WebRTCReceiver) forwardRTP(layer int32, buff *buffer.Buffer) {
 
 		// track delay/jitter
 		if writeCount > 0 && w.forwardStats != nil {
-			w.forwardStats.Update(pkt.Arrival, time.Now().UnixNano())
+			w.forwardStats.Update(pkt.Arrival, mono.UnixNano())
 		}
 
 		// track video layers


### PR DESCRIPTION
Latency is always 0, but jitter is high.
Not sure how that happens as latency is the welford mean and jitter is welford standard deviation. Feels like some mis-labeling.

Anyhow, switching to microseconds units to get better resolution.