### PR TITLE
Tweaks tresholds for logging high forwarding latency/jitter.

### DIFF
--- a/pkg/sfu/forwardstats.go
+++ b/pkg/sfu/forwardstats.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	highForwardingLatency = 20 * time.Millisecond
-	skewFactor            = 20
+	skewFactor            = 10
 )
 
 type ForwardStats struct {


### PR DESCRIPTION
Previous attempt showed skewed jitter (i. e. more than 10x latency), But, no large latency.

So, reducing the latency treshold to declare high latency. And also keeping track of lowest/highest per reporting window and logging those along with short term and long term measurements.

NOTE: previously short term and long term were separate calls with locks acquired. Now, it is all in one lock. So, it does increase the lock duration a bit, but hopefully not by too much as the welford merge for short term would go over 20 samples (at 50 ms sampling interval and 1 s reporting window).