### PR TITLE
feat: make INSTALL_PATH overridable in install script

### DIFF
--- a/install-livekit.sh
+++ b/install-livekit.sh
@@ -21,7 +21,7 @@ set -o errexit
 set -o pipefail
 
 REPO="livekit"
-INSTALL_PATH="/usr/local/bin"
+INSTALL_PATH="${INSTALL_PATH:-/usr/local/bin}"
 
 log()  { printf "%b\n" "$*"; }
 abort() {


### PR DESCRIPTION
Allow users to override the installation path by setting the`INSTALL_PATH ` environment variable before running the script. 

This can be useful in CI environments such as CircleCI where the default `/usr/local/bin` path requires sudo privileges that may not be available or desired.

Usage:
- default: `curl -sSL https://get.livekit.io/cli | bash`
- custom: `INSTALL_PATH="$HOME/.local/bin" curl -sSL https://get.livekit.io/cli | bash`