### PR TITLE
Adjust for hold time when fowarding RTCP report.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -3457,7 +3457,6 @@ func (p *ParticipantImpl) handleTrackPublished(track types.MediaTrack, isMigrate
 			p.Identity(),
 			track.ToProto(),
 		)
-
 	}
 
 	p.pendingTracksLock.Lock()

--- a/pkg/sfu/rtpstats/rtpstats_base.go
+++ b/pkg/sfu/rtpstats/rtpstats_base.go
@@ -417,7 +417,7 @@ func (r *rtpStatsBase) maybeAdjustFirstPacketTime(
 			"nowTime", time.Unix(0, now),
 			"before", time.Unix(0, r.firstTime),
 			"after", time.Unix(0, firstTime),
-			"adjustment", adjustment,
+			"adjustment", time.Duration(adjustment),
 			"extNowTS", extNowTS,
 			"extStartTS", extStartTS,
 			"srData", WrappedRTCPSenderReportStateLogger{srData},

--- a/pkg/sfu/rtpstats/rtpstats_receiver.go
+++ b/pkg/sfu/rtpstats/rtpstats_receiver.go
@@ -542,9 +542,11 @@ func (r *RTPStatsReceiver) SetRtcpSenderReportData(srData *livekit.RTCPSenderRep
 	r.updatePropagationDelayAndRecordSenderReport(srDataExt)
 	r.checkRTPClockSkewAgainstMediaPathForSenderReport(srDataExt)
 
-	if err, loggingFields := r.maybeAdjustFirstPacketTime(r.srNewest, 0, r.timestamp.GetExtendedStart()); err != nil {
+	adjustment, err, loggingFields := r.maybeAdjustFirstPacketTime(r.srNewest, 0, r.timestamp.GetExtendedStart())
+	if err != nil {
 		r.logger.Infow(err.Error(), append(loggingFields, "rtpStats", lockedRTPStatsReceiverLogEncoder{r})...)
 	}
+	r.propagationDelayEstimator.InitialAdjustment(adjustment)
 	return true
 }
 

--- a/pkg/sfu/utils/owd_estimator.go
+++ b/pkg/sfu/utils/owd_estimator.go
@@ -34,7 +34,7 @@ type OWDEstimatorParams struct {
 }
 
 var OWDEstimatorParamsDefault = OWDEstimatorParams{
-	// OWD (One-Way-Delay) Estimator is used to estimate propagation delay between sender and receicer.
+	// OWD (One-Way-Delay) Estimator is used to estimate propagation delay between sender and receiver.
 	// As they operate on different clock domains, it is not possible to get exact propagation delay easily.
 	// So, this module is an estimator using a simple approach explained below. It should not be used for
 	// things that require high accuracy.
@@ -72,6 +72,7 @@ type OWDEstimator struct {
 	params OWDEstimatorParams
 
 	initialized                        bool
+	initialAdjustmentDone              bool
 	lastSenderClockTimeNs              int64
 	lastPropagationDelayNs             int64
 	lastDeltaPropagationDelayNs        int64
@@ -172,6 +173,22 @@ func (o *OWDEstimator) Update(senderClockTimeNs int64, receiverClockTimeNs int64
 	}
 	o.lastSenderClockTimeNs = senderClockTimeNs
 	return o.estimatedPropagationDelayNs, stepChange
+}
+
+func (o *OWDEstimator) InitialAdjustment(owd int64) int64 {
+	if o.initialAdjustmentDone {
+		return o.estimatedPropagationDelayNs
+	}
+
+	o.initialAdjustmentDone = true
+	// one time adjustment at init
+	// example: when this is used to measure one-way-delay of RTCP sender reports,
+	// it is possible that the first sender report is delayed and experiences more
+	// than existing propagation delay. This allows adjustment of initial estimate.
+	if owd < 0 && -owd < o.estimatedPropagationDelayNs {
+		o.estimatedPropagationDelayNs += owd
+	}
+	return o.estimatedPropagationDelayNs
 }
 
 func (o *OWDEstimator) EstimatedPropagationDelay() int64 {

--- a/pkg/sfu/utils/owd_estimator.go
+++ b/pkg/sfu/utils/owd_estimator.go
@@ -175,7 +175,7 @@ func (o *OWDEstimator) Update(senderClockTimeNs int64, receiverClockTimeNs int64
 	return o.estimatedPropagationDelayNs, stepChange
 }
 
-func (o *OWDEstimator) InitialAdjustment(owd int64) int64 {
+func (o *OWDEstimator) InitialAdjustment(adjustmentNs int64) int64 {
 	if o.initialAdjustmentDone {
 		return o.estimatedPropagationDelayNs
 	}
@@ -185,8 +185,8 @@ func (o *OWDEstimator) InitialAdjustment(owd int64) int64 {
 	// example: when this is used to measure one-way-delay of RTCP sender reports,
 	// it is possible that the first sender report is delayed and experiences more
 	// than existing propagation delay. This allows adjustment of initial estimate.
-	if owd < 0 && -owd < o.estimatedPropagationDelayNs {
-		o.estimatedPropagationDelayNs += owd
+	if adjustmentNs < 0 && -adjustmentNs < o.estimatedPropagationDelayNs {
+		o.estimatedPropagationDelayNs += adjustmentNs
 	}
 	return o.estimatedPropagationDelayNs
 }


### PR DESCRIPTION
When passing through RTCP sender report, holding it for some time before sending means the remote receiver could see varying amount of propagation delay if the remote uses something like local_clock - ntp_sender_report_time and adapting to it.

Ideally, SFU should just forward RTCP Sender Report, but the current pull model to group RTCP sender reports makes it a bigger change. So, adjust it by hold time.

Also add a initial condition for one-way-delay estimator which can init with a smaller value of latency if the first sample to measure one-way-delay itself experienced higher delay than the prevailing conditions.