### PR TITLE
Revert unintentional change to not handle transport fallback on

### DIFF
--- a/pkg/rtc/transportmanager.go
+++ b/pkg/rtc/transportmanager.go
@@ -150,7 +150,7 @@ func NewTransportManager(params TransportManagerParams) (*TransportManager, erro
 		IsSendSide:                   params.UseOneShotSignallingMode || params.UseSinglePeerConnection,
 		AllowPlayoutDelay:            params.AllowPlayoutDelay,
 		Transport:                    livekit.SignalTarget_PUBLISHER,
-		Handler:                      params.PublisherHandler,
+		Handler:                      TransportManagerTransportHandler{params.PublisherHandler, t, lgr},
 		UseOneShotSignallingMode:     params.UseOneShotSignallingMode,
 		DataChannelMaxBufferedAmount: params.DataChannelMaxBufferedAmount,
 		DatachannelSlowThreshold:     params.DatachannelSlowThreshold,

--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -89,23 +89,23 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	}
 	rtcEgressLauncher := NewEgressLauncher(egressClient, ioInfoService, objectStore)
 	topicFormatter := rpc.NewTopicFormatter()
-	v, err := rpc.NewTypedRoomClient(clientParams)
+	roomClient, err := rpc.NewTypedRoomClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	v2, err := rpc.NewTypedParticipantClient(clientParams)
+	participantClient, err := rpc.NewTypedParticipantClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	roomService, err := NewRoomService(limitConfig, apiConfig, router, roomAllocator, objectStore, rtcEgressLauncher, topicFormatter, v, v2)
+	roomService, err := NewRoomService(limitConfig, apiConfig, router, roomAllocator, objectStore, rtcEgressLauncher, topicFormatter, roomClient, participantClient)
 	if err != nil {
 		return nil, err
 	}
-	v3, err := rpc.NewTypedAgentDispatchInternalClient(clientParams)
+	agentDispatchInternalClient, err := rpc.NewTypedAgentDispatchInternalClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	agentDispatchService := NewAgentDispatchService(v3, topicFormatter, roomAllocator, router)
+	agentDispatchService := NewAgentDispatchService(agentDispatchInternalClient, topicFormatter, roomAllocator, router)
 	egressService := NewEgressService(egressClient, rtcEgressLauncher, ioInfoService, roomService)
 	ingressConfig := getIngressConfig(conf)
 	ingressClient, err := rpc.NewIngressClient(clientParams)
@@ -120,11 +120,11 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	}
 	sipService := NewSIPService(sipConfig, nodeID, messageBus, sipClient, sipStore, roomService, telemetryService)
 	rtcService := NewRTCService(conf, roomAllocator, router, telemetryService)
-	v4, err := rpc.NewTypedWHIPParticipantClient(clientParams)
+	whipParticipantClient, err := rpc.NewTypedWHIPParticipantClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	serviceWHIPService, err := NewWHIPService(conf, router, roomAllocator, clientParams, topicFormatter, v4)
+	serviceWHIPService, err := NewWHIPService(conf, router, roomAllocator, clientParams, topicFormatter, whipParticipantClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sfu/rtpstats/rtpstats_base.go
+++ b/pkg/sfu/rtpstats/rtpstats_base.go
@@ -435,8 +435,8 @@ func (r *rtpStatsBase) maybeAdjustFirstPacketTime(
 			err = errors.New("adjusting first packet time, too big, ignoring")
 			loggingFields = getFields()
 		} else {
-			r.logger.Debugw("adjusting first packet time", getFields()...)
 			r.firstTimeAdjustment += time.Duration(adjustment)
+			r.logger.Debugw("adjusting first packet time", getFields()...)
 			r.firstTime = firstTime
 		}
 	}


### PR DESCRIPTION
publisher peer connection.

While cleaning up during single peer connection changes, unintentionally removed handler.

Also, another small change to log first packet time adjustment after increment.