### PR TITLE
Support Opus mixed with RED when encrypted.

### DIFF
--- a/pkg/rtc/subscribedtrack.go
+++ b/pkg/rtc/subscribedtrack.go
@@ -124,12 +124,14 @@ func NewSubscribedTrack(params SubscribedTrackParams) (*SubscribedTrack, error) 
 		streamID = PackSyncStreamID(params.MediaTrack.PublisherID(), params.MediaTrack.Stream())
 	}
 
+	isEncrypted := params.MediaTrack.IsEncrypted()
 	var trailer []byte
-	if params.MediaTrack.IsEncrypted() {
+	if isEncrypted {
 		trailer = params.Subscriber.GetTrailer()
 	}
 	downTrack, err := sfu.NewDownTrack(sfu.DownTrackParams{
 		Codecs:            codecs,
+		IsEncrypted:       isEncrypted,
 		Source:            params.MediaTrack.Source(),
 		Receiver:          params.WrappedReceiver,
 		BufferFactory:     params.Subscriber.GetBufferFactory(),

--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -60,7 +60,7 @@ func NewWrappedReceiver(params WrappedReceiverParams) *WrappedReceiver {
 	}
 
 	codecs := params.UpstreamCodecs
-	if len(codecs) == 1 && !params.IsEncrypted {
+	if len(codecs) == 1 {
 		normalizedMimeType := mime.NormalizeMimeType(codecs[0].MimeType)
 		if normalizedMimeType == mime.MimeTypeRED {
 			// if upstream is opus/red, then add opus to match clients that don't support red


### PR DESCRIPTION
Even when encrypted, can set up opus as the second codec to support the case of RED interspersed with Opus packets when the RED packet is too big to fit in one packet.

The change here is to not go through all up stream codecs when trying to find a match in DownTrack.Bind when source is encrypted. When encrypted, the down track codec should match the primary upstream codec, i. e. the codec at index 0.