### PR TITLE
Limit check to red + opus when looking for primary codec match.

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -464,9 +464,19 @@ func (d *DownTrack) Bind(t webrtc.TrackLocalContext) (webrtc.RTPCodecParameters,
 			matchedUpstreamCodec = c
 			break
 		} else {
-			// for encrypyted tracks, should match on primary codec, i. e. codec at index 0
+			// for encrypyted tracks, should match on primary codec,
+			// i. e. codec at index 0 if the combination of upstream codecs is opus and RED
 			if d.params.IsEncrypted {
-				break
+				isRedAndOpus := true
+				for _, u := range d.upstreamCodecs {
+					if !mime.IsMimeTypeStringOpus(u.MimeType) || !mime.IsMimeTypeStringRED(u.MimeType) {
+						isRedAndOpus = false
+						break
+					}
+				}
+				if isRedAndOpus {
+					break
+				}
 			}
 		}
 	}


### PR DESCRIPTION
For codec regression, even if track is encrypted, should be able to fall back to a backup codec and trigger a regression.