### PR TITLE
Increment RTP timestamp on padding when using dummy start.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -2153,7 +2153,7 @@ func (f *Forwarder) maybeStart() {
 	)
 }
 
-func (f *Forwarder) GetSnTsForPadding(num int, forceMarker bool) ([]SnTs, error) {
+func (f *Forwarder) GetSnTsForPadding(num int, frameRate uint32, forceMarker bool) ([]SnTs, error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -2167,7 +2167,13 @@ func (f *Forwarder) GetSnTsForPadding(num int, forceMarker bool) ([]SnTs, error)
 	if !f.vls.GetTarget().IsValid() {
 		forceMarker = true
 	}
-	return f.rtpMunger.UpdateAndGetPaddingSnTs(num, 0, 0, forceMarker, 0)
+	return f.rtpMunger.UpdateAndGetPaddingSnTs(
+		num,
+		f.clockRate,
+		frameRate,
+		forceMarker,
+		f.rtpMunger.GetState().ExtLastTimestamp,
+	)
 }
 
 func (f *Forwarder) GetSnTsForBlankFrames(frameRate uint32, numPackets int) ([]SnTs, bool, error) {
@@ -2192,7 +2198,13 @@ func (f *Forwarder) GetSnTsForBlankFrames(frameRate uint32, numPackets int) ([]S
 	if int64(extExpectedTS-extLastTS) <= 0 {
 		extExpectedTS = extLastTS + 1
 	}
-	snts, err := f.rtpMunger.UpdateAndGetPaddingSnTs(numPackets, f.clockRate, frameRate, frameEndNeeded, extExpectedTS)
+	snts, err := f.rtpMunger.UpdateAndGetPaddingSnTs(
+		numPackets,
+		f.clockRate,
+		frameRate,
+		frameEndNeeded,
+		extExpectedTS,
+	)
 	return snts, frameEndNeeded, err
 }
 

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -1943,7 +1943,7 @@ func TestForwarderGetSnTsForPadding(t *testing.T) {
 	disable(f)
 
 	// should get back frame end needed as the last packet did not have RTP marker set
-	snts, err := f.GetSnTsForPadding(5, false)
+	snts, err := f.GetSnTsForPadding(5, 0, false)
 	require.NoError(t, err)
 
 	numPadding := 5
@@ -1959,7 +1959,7 @@ func TestForwarderGetSnTsForPadding(t *testing.T) {
 	require.Equal(t, sntsExpected, snts)
 
 	// now that there is a marker, timestamp should jump on first padding when asked again
-	snts, err = f.GetSnTsForPadding(numPadding, false)
+	snts, err = f.GetSnTsForPadding(numPadding, 0, false)
 	require.NoError(t, err)
 
 	for i := 0; i < numPadding; i++ {

--- a/pkg/sfu/rtpmunger.go
+++ b/pkg/sfu/rtpmunger.go
@@ -269,7 +269,13 @@ func (r *RTPMunger) FilterRTX(nacks []uint16) []uint16 {
 	return filtered
 }
 
-func (r *RTPMunger) UpdateAndGetPaddingSnTs(num int, clockRate uint32, frameRate uint32, forceMarker bool, extRtpTimestamp uint64) ([]SnTs, error) {
+func (r *RTPMunger) UpdateAndGetPaddingSnTs(
+	num int,
+	clockRate uint32,
+	frameRate uint32,
+	forceMarker bool,
+	extRtpTimestamp uint64,
+) ([]SnTs, error) {
 	if num == 0 {
 		return nil, nil
 	}


### PR DESCRIPTION
This allows things like egress to have proper sequence to start the pipeline.