### PR TITLE
Resort to full search for requested quality is not available.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -3574,7 +3574,7 @@ func (p *ParticipantImpl) getPendingTrackPrimaryBySdpCid(sdpCid string) *pending
 func (p *ParticipantImpl) setTrackID(cid string, info *livekit.TrackInfo) {
 	var trackID string
 	// if already pending, use the same SID
-	// should not happen as this means multiple `AddTrack` requests have been called, but check anyway
+	// it is possible to have multiple AddTrackRequests for the same track
 	if pti := p.pendingTracks[cid]; pti != nil {
 		trackID = pti.trackInfos[0].Sid
 	}
@@ -3582,11 +3582,13 @@ func (p *ParticipantImpl) setTrackID(cid string, info *livekit.TrackInfo) {
 	// otherwise generate
 	if trackID == "" {
 		trackPrefix := utils.TrackPrefix
-		if info.Type == livekit.TrackType_VIDEO {
+		switch info.Type {
+		case livekit.TrackType_VIDEO:
 			trackPrefix += "V"
-		} else if info.Type == livekit.TrackType_AUDIO {
+		case livekit.TrackType_AUDIO:
 			trackPrefix += "A"
 		}
+
 		switch info.Source {
 		case livekit.TrackSource_CAMERA:
 			trackPrefix += "C"

--- a/pkg/sfu/buffer/videolayerutils.go
+++ b/pkg/sfu/buffer/videolayerutils.go
@@ -439,6 +439,7 @@ func GetSpatialLayerForRid(mimeType mime.MimeType, rid string, ti *livekit.Track
 		"invalid layer for rid, returning default",
 		"trackID", ti.Sid,
 		"rid", rid,
+		"mimeType", mimeType,
 		"trackInfo", logger.Proto(ti),
 	)
 	return 0
@@ -462,7 +463,7 @@ func GetSpatialLayerForVideoQuality(mimeType mime.MimeType, quality livekit.Vide
 	}
 
 	// requested quality is higher than available layers, return the highest available layer
-	return layers[len(layers)-1].SpatialLayer
+	return VideoQualityToSpatialLayer(mimeType, quality, ti)
 }
 
 func GetVideoQualityForSpatialLayer(mimeType mime.MimeType, spatialLayer int32, ti *livekit.TrackInfo) livekit.VideoQuality {


### PR DESCRIPTION
When doing code changes for dynamic rid, inadventently relied on ordering of quality in track info layers to pick the highest layer if the requested quality is higher than available qualities. @cnderrauber addressed it in
https://github.com/livekit/livekit/pull/3998. Just adding some more robustness behind that by doing a full search when requested quality is not available.

Tested using JS SDK demo app and picking different qualities from subscriber side with adaptive streaming turned off.