### PR TITLE
Count request/response packets on both client and server side.

### DIFF
--- a/pkg/routing/interfaces.go
+++ b/pkg/routing/interfaces.go
@@ -95,7 +95,7 @@ type NullMessageSource struct {
 func NewNullMessageSource(connID livekit.ConnectionID) *NullMessageSource {
 	return &NullMessageSource{
 		connID:  connID,
-		msgChan: make(chan proto.Message, 0),
+		msgChan: make(chan proto.Message),
 	}
 }
 

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -595,7 +595,7 @@ func (r *Room) Join(
 
 	joinResponse := r.createJoinResponseLocked(participant, iceServers)
 	if err := participant.SendJoinResponse(joinResponse); err != nil {
-		prometheus.ServiceOperationCounter.WithLabelValues("participant_join", "error", "send_response").Add(1)
+		prometheus.RecordServiceOperationError("participant_join", "send_response")
 		return err
 	}
 
@@ -617,7 +617,7 @@ func (r *Room) Join(
 		}
 	}
 
-	prometheus.ServiceOperationCounter.WithLabelValues("participant_join", "success", "").Add(1)
+	prometheus.RecordServiceOperationSuccess("participant_join")
 
 	return nil
 }

--- a/pkg/service/localstore.go
+++ b/pkg/service/localstore.go
@@ -229,10 +229,8 @@ func (s *LocalStore) ListAgentDispatches(ctx context.Context, roomName livekit.R
 	agentJobs := s.agentJobs[roomName]
 
 	var js []*livekit.Job
-	if agentJobs != nil {
-		for _, j := range agentJobs {
-			js = append(js, utils.CloneProto(j))
-		}
+	for _, j := range agentJobs {
+		js = append(js, utils.CloneProto(j))
 	}
 	var ds []*livekit.AgentDispatch
 

--- a/pkg/service/signal.go
+++ b/pkg/service/signal.go
@@ -168,6 +168,8 @@ func (r *signalService) RelaySignal(stream psrpc.ServerStream[*rpc.RelaySignalRe
 			reqChan,
 			signalRequestMessageReader{},
 			r.config,
+			prometheus.RecordSignalResponseSuccess,
+			prometheus.RecordSignalResponseFailure,
 		)
 		l.Debugw("signal stream closed", "error", err)
 

--- a/pkg/service/twirp.go
+++ b/pkg/service/twirp.go
@@ -203,7 +203,7 @@ func statusReporterResponseSent(ctx context.Context) {
 		code = r.error.Code()
 	}
 
-	prometheus.TwirpRequestStatusCounter.WithLabelValues(r.service, r.method, statusFamily, string(code)).Add(1)
+	prometheus.RecordTwirpRequestStatus(r.service, r.method, statusFamily, code)
 }
 
 func statusReporterErrorReceived(ctx context.Context, e twirp.Error) context.Context {


### PR DESCRIPTION
Currently, the signal requests are counted on media side and signal responses are counted on controller side. This does not provide the granularity to check how many response messages each media node is sending.

Seeing some cases where track subscriptions are slow under load. This would be good to see if the media node is doing a lot of signal response messages.