### PR TITLE
Do not call receiver methods under settings lock.

### DIFF
--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -246,7 +246,6 @@ func (d *DummyReceiver) Upgrade(receiver sfu.TrackReceiver) {
 		receiver.SetUpTrackPaused(d.paused)
 	}
 
-	// RAJA-TODO
 	d.settingsLock.Lock()
 	if d.primaryReceiver != nil {
 		d.primaryReceiver.upgrade(receiver)


### PR DESCRIPTION
CI flagged a potential lock order reversal in https://github.com/livekit/livekit/actions/runs/18531658065/job/52815807499