### PR TITLE
Use simulcast codec as default policy for audio track

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2909,7 +2909,10 @@ func (p *ParticipantImpl) addPendingTrackLocked(req *livekit.AddTrackRequest) *l
 	}
 
 	backupCodecPolicy := req.BackupCodecPolicy
-	if backupCodecPolicy != livekit.BackupCodecPolicy_SIMULCAST && p.params.DisableCodecRegression {
+
+	// enable simulcast codec for audio by default
+	if (backupCodecPolicy != livekit.BackupCodecPolicy_REGRESSION && req.Type == livekit.TrackType_AUDIO) ||
+		(backupCodecPolicy != livekit.BackupCodecPolicy_SIMULCAST && p.params.DisableCodecRegression) {
 		backupCodecPolicy = livekit.BackupCodecPolicy_SIMULCAST
 	}
 


### PR DESCRIPTION
Cost of simulcast codecs for audio is small and can avoid codec changing for existing subscribers in the middle 