### PR TITLE
Add packet to forwarding stats only if packet is forwarded.

### DIFF
--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -89,23 +89,23 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	}
 	rtcEgressLauncher := NewEgressLauncher(egressClient, ioInfoService, objectStore)
 	topicFormatter := rpc.NewTopicFormatter()
-	v, err := rpc.NewTypedRoomClient(clientParams)
+	roomClient, err := rpc.NewTypedRoomClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	v2, err := rpc.NewTypedParticipantClient(clientParams)
+	participantClient, err := rpc.NewTypedParticipantClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	roomService, err := NewRoomService(limitConfig, apiConfig, router, roomAllocator, objectStore, rtcEgressLauncher, topicFormatter, v, v2)
+	roomService, err := NewRoomService(limitConfig, apiConfig, router, roomAllocator, objectStore, rtcEgressLauncher, topicFormatter, roomClient, participantClient)
 	if err != nil {
 		return nil, err
 	}
-	v3, err := rpc.NewTypedAgentDispatchInternalClient(clientParams)
+	agentDispatchInternalClient, err := rpc.NewTypedAgentDispatchInternalClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	agentDispatchService := NewAgentDispatchService(v3, topicFormatter, roomAllocator, router)
+	agentDispatchService := NewAgentDispatchService(agentDispatchInternalClient, topicFormatter, roomAllocator, router)
 	egressService := NewEgressService(egressClient, rtcEgressLauncher, ioInfoService, roomService)
 	ingressConfig := getIngressConfig(conf)
 	ingressClient, err := rpc.NewIngressClient(clientParams)
@@ -120,11 +120,11 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	}
 	sipService := NewSIPService(sipConfig, nodeID, messageBus, sipClient, sipStore, roomService, telemetryService)
 	rtcService := NewRTCService(conf, roomAllocator, router, telemetryService)
-	v4, err := rpc.NewTypedWHIPParticipantClient(clientParams)
+	whipParticipantClient, err := rpc.NewTypedWHIPParticipantClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	serviceWHIPService, err := NewWHIPService(conf, router, roomAllocator, clientParams, topicFormatter, v4)
+	serviceWHIPService, err := NewWHIPService(conf, router, roomAllocator, clientParams, topicFormatter, whipParticipantClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sfu/downtrackspreader.go
+++ b/pkg/sfu/downtrackspreader.go
@@ -86,10 +86,10 @@ func (d *DownTrackSpreader) HasDownTrack(subscriberID livekit.ParticipantID) boo
 	return ok
 }
 
-func (d *DownTrackSpreader) Broadcast(writer func(TrackSender)) int {
+func (d *DownTrackSpreader) Broadcast(writer func(TrackSender)) {
 	downTracks := d.GetDownTracks()
 	if len(downTracks) == 0 {
-		return 0
+		return
 	}
 
 	threshold := uint64(d.params.Threshold)
@@ -101,7 +101,6 @@ func (d *DownTrackSpreader) Broadcast(writer func(TrackSender)) int {
 	// WriteRTP takes about 50µs on average, so we write to 2 down tracks per loop.
 	step := uint64(2)
 	utils.ParallelExec(downTracks, threshold, step, writer)
-	return len(downTracks)
 }
 
 func (d *DownTrackSpreader) DownTrackCount() int {

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1696,7 +1696,7 @@ func (f *Forwarder) GetTranslationParams(extPkt *buffer.ExtPacket, layer int32) 
 
 	return TranslationParams{
 		shouldDrop: true,
-	}, ErrUnknownKind
+	}, errUnknownKind
 }
 
 func (f *Forwarder) getRefLayerRTPTimestamp(ts uint32, refLayer, targetLayer int32) (uint32, error) {
@@ -2038,7 +2038,7 @@ func (f *Forwarder) getTranslationParamsCommon(extPkt *buffer.ExtPacket, layer i
 	tpRTP, err := f.rtpMunger.UpdateAndGetSnTs(extPkt, tp.marker)
 	if err != nil {
 		tp.shouldDrop = true
-		if err == ErrPaddingOnlyPacket || err == ErrDuplicatePacket || err == ErrOutOfOrderSequenceNumberCacheMiss {
+		if err == errPaddingOnlyPacket || err == errDuplicatePacket || err == errOutOfOrderSequenceNumberCacheMiss {
 			return nil
 		}
 		return err

--- a/pkg/sfu/redreceiver_test.go
+++ b/pkg/sfu/redreceiver_test.go
@@ -36,10 +36,10 @@ type dummyDowntrack struct {
 	receivedPkts    []*rtp.Packet
 }
 
-func (dt *dummyDowntrack) WriteRTP(p *buffer.ExtPacket, _ int32) error {
+func (dt *dummyDowntrack) WriteRTP(p *buffer.ExtPacket, _ int32) bool {
 	dt.lastReceivedPkt = p.Packet
 	dt.receivedPkts = append(dt.receivedPkts, p.Packet)
-	return nil
+	return true
 }
 
 func (dt *dummyDowntrack) TrackInfoAvailable() {}

--- a/pkg/sfu/rtpmunger.go
+++ b/pkg/sfu/rtpmunger.go
@@ -207,7 +207,7 @@ func (r *RTPMunger) UpdateAndGetSnTs(extPkt *buffer.ExtPacket, marker bool) (Tra
 		if err != nil {
 			return TranslationParamsRTP{
 				snOrdering: SequenceNumberOrderingOutOfOrder,
-			}, ErrOutOfOrderSequenceNumberCacheMiss
+			}, errOutOfOrderSequenceNumberCacheMiss
 		}
 
 		extSequenceNumber := extPkt.ExtSequenceNumber - snOffset
@@ -223,7 +223,7 @@ func (r *RTPMunger) UpdateAndGetSnTs(extPkt *buffer.ExtPacket, marker bool) (Tra
 			)
 			return TranslationParamsRTP{
 				snOrdering: SequenceNumberOrderingOutOfOrder,
-			}, ErrOutOfOrderSequenceNumberCacheMiss
+			}, errOutOfOrderSequenceNumberCacheMiss
 		}
 
 		return TranslationParamsRTP{
@@ -245,13 +245,13 @@ func (r *RTPMunger) UpdateAndGetSnTs(extPkt *buffer.ExtPacket, marker bool) (Tra
 
 		return TranslationParamsRTP{
 			snOrdering: SequenceNumberOrderingContiguous,
-		}, ErrPaddingOnlyPacket
+		}, errPaddingOnlyPacket
 	}
 
 	// can get duplicate packet due to FEC
 	return TranslationParamsRTP{
 		snOrdering: SequenceNumberOrderingDuplicate,
-	}, ErrDuplicatePacket
+	}, errDuplicatePacket
 }
 
 func (r *RTPMunger) FilterRTX(nacks []uint16) []uint16 {
@@ -284,7 +284,7 @@ func (r *RTPMunger) UpdateAndGetPaddingSnTs(
 	tsOffset := 0
 	if !r.lastMarker {
 		if !forceMarker {
-			return nil, ErrPaddingNotOnFrameBoundary
+			return nil, errPaddingNotOnFrameBoundary
 		}
 
 		// if forcing frame end, use timestamp of latest received frame for the first one

--- a/pkg/sfu/rtpmunger_test.go
+++ b/pkg/sfu/rtpmunger_test.go
@@ -228,7 +228,7 @@ func TestOutOfOrderSequenceNumber(t *testing.T) {
 	}
 
 	tp, err = r.UpdateAndGetSnTs(extPkt, extPkt.Packet.Marker)
-	require.Error(t, err, ErrOutOfOrderSequenceNumberCacheMiss)
+	require.Error(t, err, errOutOfOrderSequenceNumberCacheMiss)
 	require.Equal(t, tpExpected, tp)
 }
 
@@ -252,7 +252,7 @@ func TestDuplicateSequenceNumber(t *testing.T) {
 	}
 
 	tp, err := r.UpdateAndGetSnTs(extPkt, extPkt.Packet.Marker)
-	require.ErrorIs(t, err, ErrDuplicatePacket)
+	require.ErrorIs(t, err, errDuplicatePacket)
 	require.Equal(t, tpExpected, tp)
 }
 
@@ -274,7 +274,7 @@ func TestPaddingOnlyPacket(t *testing.T) {
 
 	tp, err := r.UpdateAndGetSnTs(extPkt, extPkt.Packet.Marker)
 	require.Error(t, err)
-	require.ErrorIs(t, err, ErrPaddingOnlyPacket)
+	require.ErrorIs(t, err, errPaddingOnlyPacket)
 	require.Equal(t, tpExpected, tp)
 	require.Equal(t, uint64(23333), r.extHighestIncomingSN)
 	require.Equal(t, uint64(23333), r.extLastSN)
@@ -366,7 +366,7 @@ func TestGapInSequenceNumber(t *testing.T) {
 	}
 
 	tp, err = r.UpdateAndGetSnTs(extPkt, extPkt.Packet.Marker)
-	require.ErrorIs(t, err, ErrPaddingOnlyPacket)
+	require.ErrorIs(t, err, errPaddingOnlyPacket)
 	require.Equal(t, tpExpected, tp)
 	require.Equal(t, uint64(65536+2), r.extHighestIncomingSN)
 	require.Equal(t, uint64(65536+1), r.extLastSN)
@@ -417,7 +417,7 @@ func TestGapInSequenceNumber(t *testing.T) {
 	}
 
 	tp, err = r.UpdateAndGetSnTs(extPkt, extPkt.Packet.Marker)
-	require.ErrorIs(t, err, ErrPaddingOnlyPacket)
+	require.ErrorIs(t, err, errPaddingOnlyPacket)
 	require.Equal(t, tpExpected, tp)
 	require.Equal(t, uint64(65536+5), r.extHighestIncomingSN)
 	require.Equal(t, uint64(65536+3), r.extLastSN)
@@ -521,7 +521,7 @@ func TestUpdateAndGetPaddingSnTs(t *testing.T) {
 	// getting padding without forcing marker should fail
 	_, err := r.UpdateAndGetPaddingSnTs(10, 10, 5, false, 0)
 	require.Error(t, err)
-	require.ErrorIs(t, err, ErrPaddingNotOnFrameBoundary)
+	require.ErrorIs(t, err, errPaddingNotOnFrameBoundary)
 
 	// forcing a marker should not error out.
 	// And timestamp on first padding should be the same as the last one.


### PR DESCRIPTION
Packets not being forwarded were getting included in forwarding stats calculation and skewing the measurement towards a smaller number.

The latency measurement does not include the batch IO of packets on send. With a 2ms batching, that will add an average latency of 1ms.