### PR TITLE
Prepare release v1.9.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.4] - 2025-11-15
+
+### Added
+- Log reason for subscriber not being able to determine codec. (#4071)
+- Kind details for connector (#4072)
+
+### Fixed
+- Prevent invalid track access while peer connection is shutting down. (#4054)
+
+### Changed
+- Update PsRPC to get redis pipeliner implementation (#4055)
+- Forwarding latency measurement. (#4056. #4057, #4059, #4061, #4062, #4067, #4080)
+- Update pion/transport to v3.1.1 (to get batch I/O ping-pong buffer) (#4070)
+- Use sync.Pool for objects in packet path. (#4066)
+- Bump protocol to pull sip validation changes and error mapping (#4081)
+
 ## [1.9.3] - 2025-11-02
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -150,5 +150,3 @@ require (
 	google.golang.org/grpc v1.76.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace golang.org/x/tools => golang.org/x/tools v0.37.0 // counterfeiter is broken

--- a/version/version.go
+++ b/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const Version = "1.9.3"
+const Version = "1.9.4"


### PR DESCRIPTION
- Removing x/tools replace for release script to work. Will add it after the release.