### PR TITLE
Use isEnding to indicate if down track could be resumed.

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -1399,7 +1399,7 @@ func (d *DownTrack) CloseWithFlush(flush bool, isEnding bool) {
 	close(d.keyFrameRequesterCh)
 	d.keyFrameRequesterChMu.Unlock()
 
-	d.params.Listener.OnDownTrackClose(!flush)
+	d.params.Listener.OnDownTrackClose(!isEnding)
 }
 
 func (d *DownTrack) SetMaxSpatialLayer(spatialLayer int32) {


### PR DESCRIPTION
There is no need to cache down track if participant is going away.