### PR TITLE
Mark RTCP buffer Write as noinline.

### DIFF
--- a/pkg/sfu/buffer/rtcpreader.go
+++ b/pkg/sfu/buffer/rtcpreader.go
@@ -31,6 +31,7 @@ func NewRTCPReader(ssrc uint32) *RTCPReader {
 	return &RTCPReader{ssrc: ssrc}
 }
 
+//go:noinline
 func (r *RTCPReader) Write(p []byte) (n int, err error) {
 	if r.closed.Load() {
 		err = io.EOF


### PR DESCRIPTION
Seeing a bunch of objects in ReadStreamSRTP.write which does not make a lot of sense as the function does not allocate anything (https://github.com/pion/srtp/blob/8fe528a0c4ebb5c46d40a9fd5b77e5b6655fa919/stream_srtp.go#L68-L77)

RTP buffer was marked noinline in an easrlier PR.
Marking RTCP buffer write also as noinline to check if heap reporting changes.