### PR TITLE
Restart API on receiver.

### DIFF
--- a/pkg/rtc/wrappedreceiver.go
+++ b/pkg/rtc/wrappedreceiver.go
@@ -501,6 +501,12 @@ func (d *DummyReceiver) VideoSizes() []buffer.VideoSize {
 	return nil
 }
 
+func (d *DummyReceiver) Restart(reason string) {
+	if receiver := d.getReceiver(); receiver != nil {
+		receiver.Restart(reason)
+	}
+}
+
 func (d *DummyReceiver) getReceiver() sfu.TrackReceiver {
 	if receiver, ok := d.receiver.Load().(sfu.TrackReceiver); ok {
 		return receiver

--- a/pkg/sfu/receiver_base.go
+++ b/pkg/sfu/receiver_base.go
@@ -151,6 +151,10 @@ type TrackReceiver interface {
 
 	// VideoSizes returns the video size parsed from rtp packet for each spatial layer.
 	VideoSizes() []buffer.VideoSize
+
+	// closes all associated buffers and issues a resync to all attached downtracks so that
+	// they can resync and have proper sequncing without gaps in sequence numbers / timestamps
+	Restart(reason string)
 }
 
 // --------------------------------------
@@ -348,6 +352,13 @@ func (r *ReceiverBase) UpdateTrackInfo(ti *livekit.TrackInfo) {
 	r.bufferMu.Unlock()
 
 	r.streamTrackerManager.UpdateTrackInfo(ti)
+}
+
+func (r *ReceiverBase) Restart(reason string) {
+	r.bufferMu.Lock()
+	defer r.bufferMu.Unlock()
+
+	r.resyncLocked(reason)
 }
 
 func (r *ReceiverBase) resyncLocked(reason string) {


### PR DESCRIPTION
Can be used when track moves forward/backward.