### PR TITLE
Do not warn about track not bound if participant is not ready.

### DIFF
--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -548,7 +548,7 @@ func (m *SubscriptionManager) reconcileSubscription(s *mediaTrackSubscription) {
 		// check bound status, notify error callback if it's not bound
 		// if a publisher leaves or closes the source track, SubscribedTrack will be closed as well and it will go
 		// back to needsSubscribe state
-		if s.durationSinceStart() > subscriptionTimeout {
+		if m.params.Participant.IsReady() && s.durationSinceStart() > subscriptionTimeout {
 			s.logger.Warnw("track not bound after timeout", nil)
 			s.maybeRecordError(m.params.Telemetry, s.subscriberID, ErrTrackNotBound, false)
 			m.params.OnSubscriptionError(s.trackID, true, ErrTrackNotBound)

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -691,7 +691,11 @@ func (f *Forwarder) SetRefSenderReport(layer int32, srData *livekit.RTCPSenderRe
 
 	if layer >= 0 && int(layer) < len(f.refInfos) {
 		if layer == f.referenceLayerSpatial && f.refInfos[layer].senderReport == nil {
-			f.logger.Debugw("received RTCP sender report for reference layer spatial", "layer", layer)
+			f.logger.Debugw(
+				"received RTCP sender report for reference layer spatial",
+				"layer", layer,
+				"srData", rtpstats.WrappedRTCPSenderReportStateLogger{RTCPSenderReportState: srData},
+			)
 		}
 		f.refInfos[layer] = refInfo{srData, 0, false}
 

--- a/pkg/sfu/receiver_base.go
+++ b/pkg/sfu/receiver_base.go
@@ -902,6 +902,8 @@ func (r *ReceiverBase) forwardRTP(
 			"layer", layer,
 			"numPacketsForwarded", numPacketsForwarded,
 			"numPacketsDropped", numPacketsDropped,
+			"forwarderGeneration", forwarderGeneration,
+			"forwardersGeneration", r.forwardersGeneration.Load(),
 		)
 		wg.Done()
 	}()

--- a/pkg/sfu/rtpstats/rtpstats_base.go
+++ b/pkg/sfu/rtpstats/rtpstats_base.go
@@ -193,6 +193,8 @@ func (w WrappedRTCPSenderReportStateLogger) MarshalLogObject(e zapcore.ObjectEnc
 	return nil
 }
 
+// ------------------------------------------------------------------
+
 func RTCPSenderReportPropagationDelay(rsrs *livekit.RTCPSenderReportState, passThrough bool) time.Duration {
 	if passThrough {
 		return 0


### PR DESCRIPTION
Analysed half a dozen cases and all of them were due to participant is not active yet.

Also, some misc logging changes.