### PR TITLE
fix: use_external_ip: false is ignored when turn_servers are configured

### DIFF
--- a/pkg/rtc/config.go
+++ b/pkg/rtc/config.go
@@ -67,6 +67,13 @@ func NewWebRTCConfig(conf *config.Config) (*WebRTCConfig, error) {
 		return nil, err
 	}
 
+	// When use_external_ip is false and turn_servers are configured,
+	// don't use STUN servers to respect the use_external_ip setting.
+	// TURN servers provide relay capability without needing STUN for external IP discovery.
+	if !rtcConf.UseExternalIP && len(rtcConf.TURNServers) > 0 {
+		webRTCConfig.Configuration.ICEServers = nil
+	}
+
 	// we don't want to use active TCP on a server, clients should be dialing
 	webRTCConfig.SettingEngine.DisableActiveTCP(true)
 


### PR DESCRIPTION
Fixes #4095

## Summary
- Clear ICEServers when `use_external_ip: false` and `turn_servers` are configured
- Prevents external IP discovery via STUN while maintaining connectivity through TURN relay

## Changes
- Added check in `pkg/rtc/config.go` to clear ICEServers from WebRTC configuration when both conditions are met:
  - `use_external_ip` is false (user doesn't want external IPs)
  - `turn_servers` are configured (relay capability available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)