### PR TITLE
Support preserving external supplied time.

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -27,6 +27,7 @@ import (
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/observability/roomobs"
+	"github.com/livekit/protocol/utils/mono"
 
 	"github.com/livekit/livekit-server/pkg/config"
 	"github.com/livekit/livekit-server/pkg/rtc/dynacast"
@@ -313,6 +314,7 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track sfu.TrackRe
 						NtpTimestamp: pkt.NTPTime,
 						Packets:      pkt.PacketCount,
 						Octets:       uint64(pkt.OctetCount),
+						At:           mono.UnixNano(),
 					})
 				}
 			case *rtcp.ExtendedReport:

--- a/pkg/sfu/buffer/buffer_base.go
+++ b/pkg/sfu/buffer/buffer_base.go
@@ -1261,7 +1261,6 @@ func (b *BufferBase) doFpsCalc(ep *ExtPacket) {
 }
 
 func (b *BufferBase) SetSenderReportData(srData *livekit.RTCPSenderReportState) {
-	srData.At = mono.UnixNano()
 	b.RLock()
 	didSet := false
 	if b.rtpStats != nil {

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -71,6 +71,7 @@ type TrackSender interface {
 	Resync()
 	SetReceiver(TrackReceiver)
 	ReceiverRestart()
+	EnableForwardPacketArrivalTime(enable bool)
 }
 
 // -------------------------------------------------------------------
@@ -1645,6 +1646,9 @@ func (d *DownTrack) ReceiverRestart() {
 	receiver := d.Receiver()
 	d.forwarder.Restart()
 	d.forwarder.DetermineCodec(codec, receiver.HeaderExtensions(), receiver.VideoLayerMode())
+}
+
+func (d *DownTrack) EnableForwardPacketArrivalTime(_enable bool) {
 }
 
 func (d *DownTrack) CreateSourceDescriptionChunks() []rtcp.SourceDescriptionChunk {

--- a/pkg/sfu/receiver_base.go
+++ b/pkg/sfu/receiver_base.go
@@ -173,16 +173,17 @@ type REDTransformer interface {
 // --------------------------------------
 
 type ReceiverBaseParams struct {
-	TrackID                      livekit.TrackID
-	StreamID                     string
-	Kind                         webrtc.RTPCodecType
-	Codec                        webrtc.RTPCodecParameters
-	HeaderExtensions             []webrtc.RTPHeaderExtensionParameter
-	Logger                       logger.Logger
-	StreamTrackerManagerConfig   StreamTrackerManagerConfig
-	StreamTrackerManagerListener StreamTrackerManagerListener
-	IsSelfClosing                bool
-	OnClosed                     func()
+	TrackID                           livekit.TrackID
+	StreamID                          string
+	Kind                              webrtc.RTPCodecType
+	Codec                             webrtc.RTPCodecParameters
+	HeaderExtensions                  []webrtc.RTPHeaderExtensionParameter
+	Logger                            logger.Logger
+	StreamTrackerManagerConfig        StreamTrackerManagerConfig
+	StreamTrackerManagerListener      StreamTrackerManagerListener
+	IsSelfClosing                     bool
+	IsForwardPacketArrivalTimeEnabled bool
+	OnClosed                          func()
 }
 
 type ReceiverBase struct {
@@ -521,6 +522,7 @@ func (r *ReceiverBase) AddDownTrack(track TrackSender) error {
 
 	track.UpTrackMaxPublishedLayerChange(r.streamTrackerManager.GetMaxPublishedLayer())
 	track.UpTrackMaxTemporalLayerSeenChange(r.streamTrackerManager.GetMaxTemporalLayerSeen())
+	track.EnableForwardPacketArrivalTime(r.params.IsForwardPacketArrivalTimeEnabled)
 
 	r.downTrackSpreader.Store(track)
 	r.params.Logger.Debugw("downtrack added", "subscriberID", track.SubscriberID())


### PR DESCRIPTION
In some paths, it is better to preserve pre-recorded time. So, make the base implementations preserve the RTCP Sender Report receive time.

Also, add a method to enable forwarding packet arrival time. Could be used across relay.