### PR TITLE
Feature: Add RoomMetadataUpdated webhook

### DIFF
--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -924,7 +924,9 @@ func (r *RoomManager) UpdateRoomMetadata(ctx context.Context, req *livekit.Updat
 	done := room.SetMetadata(req.Metadata)
 	// wait till the update is applied
 	<-done
-	return room.ToProto(), nil
+	roomInfo := room.ToProto()
+	r.telemetry.RoomMetadataUpdated(ctx, roomInfo)
+	return roomInfo, nil
 }
 
 func (r *RoomManager) ListDispatch(ctx context.Context, req *livekit.ListAgentDispatchRequest) (*livekit.ListAgentDispatchResponse, error) {

--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -73,6 +73,15 @@ func (t *telemetryService) RoomEnded(ctx context.Context, room *livekit.Room) {
 	})
 }
 
+func (t *telemetryService) RoomMetadataUpdated(ctx context.Context, room *livekit.Room) {
+	t.enqueue(func() {
+		t.NotifyEvent(ctx, &livekit.WebhookEvent{
+			Event: webhook.EventRoomMetadataChanged,
+			Room:  room,
+		})
+	})
+}
+
 func (t *telemetryService) ParticipantJoined(
 	ctx context.Context,
 	room *livekit.Room,

--- a/pkg/telemetry/telemetryfakes/fake_telemetry_service.go
+++ b/pkg/telemetry/telemetryfakes/fake_telemetry_service.go
@@ -134,6 +134,12 @@ type FakeTelemetryService struct {
 		arg1 context.Context
 		arg2 *livekit.Room
 	}
+	RoomMetadataUpdatedStub        func(context.Context, *livekit.Room)
+	roomMetadataUpdatedMutex       sync.RWMutex
+	roomMetadataUpdatedArgsForCall []struct {
+		arg1 context.Context
+		arg2 *livekit.Room
+	}
 	RoomProjectReporterStub        func(context.Context) roomobs.ProjectReporter
 	roomProjectReporterMutex       sync.RWMutex
 	roomProjectReporterArgsForCall []struct {
@@ -891,6 +897,39 @@ func (fake *FakeTelemetryService) RoomEndedArgsForCall(i int) (context.Context, 
 	fake.roomEndedMutex.RLock()
 	defer fake.roomEndedMutex.RUnlock()
 	argsForCall := fake.roomEndedArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeTelemetryService) RoomMetadataUpdated(arg1 context.Context, arg2 *livekit.Room) {
+	fake.roomMetadataUpdatedMutex.Lock()
+	fake.roomMetadataUpdatedArgsForCall = append(fake.roomMetadataUpdatedArgsForCall, struct {
+		arg1 context.Context
+		arg2 *livekit.Room
+	}{arg1, arg2})
+	stub := fake.RoomMetadataUpdatedStub
+	fake.recordInvocation("RoomMetadataUpdated", []interface{}{arg1, arg2})
+	fake.roomMetadataUpdatedMutex.Unlock()
+	if stub != nil {
+		fake.RoomMetadataUpdatedStub(arg1, arg2)
+	}
+}
+
+func (fake *FakeTelemetryService) RoomMetadataUpdatedCallCount() int {
+	fake.roomMetadataUpdatedMutex.RLock()
+	defer fake.roomMetadataUpdatedMutex.RUnlock()
+	return len(fake.roomMetadataUpdatedArgsForCall)
+}
+
+func (fake *FakeTelemetryService) RoomMetadataUpdatedCalls(stub func(context.Context, *livekit.Room)) {
+	fake.roomMetadataUpdatedMutex.Lock()
+	defer fake.roomMetadataUpdatedMutex.Unlock()
+	fake.RoomMetadataUpdatedStub = stub
+}
+
+func (fake *FakeTelemetryService) RoomMetadataUpdatedArgsForCall(i int) (context.Context, *livekit.Room) {
+	fake.roomMetadataUpdatedMutex.RLock()
+	defer fake.roomMetadataUpdatedMutex.RUnlock()
+	argsForCall := fake.roomMetadataUpdatedArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -36,6 +36,7 @@ type TelemetryService interface {
 	// events
 	RoomStarted(ctx context.Context, room *livekit.Room)
 	RoomEnded(ctx context.Context, room *livekit.Room)
+	RoomMetadataUpdated(ctx context.Context, room *livekit.Room)
 	// ParticipantJoined - a participant establishes signal connection to a room
 	ParticipantJoined(ctx context.Context, room *livekit.Room, participant *livekit.ParticipantInfo, clientInfo *livekit.ClientInfo, clientMeta *livekit.AnalyticsClientMeta, shouldSendEvent bool, guard *ReferenceGuard)
 	// ParticipantActive - a participant establishes media connection
@@ -95,9 +96,10 @@ type NullTelemetryService struct {
 	NullAnalyticService
 }
 
-func (n NullTelemetryService) TrackStats(key StatsKey, stat *livekit.AnalyticsStat) {}
-func (n NullTelemetryService) RoomStarted(ctx context.Context, room *livekit.Room)  {}
-func (n NullTelemetryService) RoomEnded(ctx context.Context, room *livekit.Room)    {}
+func (n NullTelemetryService) TrackStats(key StatsKey, stat *livekit.AnalyticsStat)        {}
+func (n NullTelemetryService) RoomStarted(ctx context.Context, room *livekit.Room)         {}
+func (n NullTelemetryService) RoomEnded(ctx context.Context, room *livekit.Room)           {}
+func (n NullTelemetryService) RoomMetadataUpdated(ctx context.Context, room *livekit.Room) {}
 func (n NullTelemetryService) ParticipantJoined(ctx context.Context, room *livekit.Room, participant *livekit.ParticipantInfo, clientInfo *livekit.ClientInfo, clientMeta *livekit.AnalyticsClientMeta, shouldSendEvent bool, guard *ReferenceGuard) {
 }
 func (n NullTelemetryService) ParticipantActive(ctx context.Context, room *livekit.Room, participant *livekit.ParticipantInfo, clientMeta *livekit.AnalyticsClientMeta, isMigration bool, guard *ReferenceGuard) {

--- a/test/webhook_test.go
+++ b/test/webhook_test.go
@@ -97,6 +97,23 @@ func TestWebhooks(t *testing.T) {
 			})
 			ts.ClearEvents()
 
+			// room metadata updated
+			_, err := server.RoomManager().UpdateRoomMetadata(context.Background(), &livekit.UpdateRoomMetadataRequest{
+				Room:     testRoom,
+				Metadata: "updated metadata",
+			})
+			require.NoError(t, err)
+			testutils.WithTimeout(t, func() string {
+				if ts.GetEvent(webhook.EventRoomMetadataChanged) == nil {
+					return "did not receive RoomMetadataChanged"
+				}
+				return ""
+			})
+			metadataChanged := ts.GetEvent(webhook.EventRoomMetadataChanged)
+			require.Equal(t, testRoom, metadataChanged.Room.Name)
+			require.Equal(t, "updated metadata", metadataChanged.Room.Metadata)
+			ts.ClearEvents()
+
 			// first participant leaves
 			c1.Stop()
 			testutils.WithTimeout(t, func() string {


### PR DESCRIPTION
Add webhook EventRoomMetadataChanged to livekit .
This webhook makes it easier to track state on an own server.