### PR TITLE
feat: broadcast SIP call state updates to room participants

### DIFF
--- a/pkg/service/wire.go
+++ b/pkg/service/wire.go
@@ -62,6 +62,7 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 		telemetry.NewAnalyticsService,
 		telemetry.NewTelemetryService,
 		getMessageBus,
+
 		NewIOInfoService,
 		wire.Bind(new(IOClient), new(*IOInfoService)),
 		rpc.NewEgressClient,

--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -8,6 +8,8 @@ package service
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/livekit/livekit-server/pkg/agent"
 	"github.com/livekit/livekit-server/pkg/config"
 	"github.com/livekit/livekit-server/pkg/routing"
@@ -26,10 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/redis/go-redis/v9"
 	"gopkg.in/yaml.v3"
-	"os"
-)
 
-import (
 	_ "net/http/pprof"
 )
 

--- a/pkg/telemetry/telemetryfakes/fake_telemetry_service.go
+++ b/pkg/telemetry/telemetryfakes/fake_telemetry_service.go
@@ -169,6 +169,12 @@ type FakeTelemetryService struct {
 		arg1 context.Context
 		arg2 []*livekit.AnalyticsStat
 	}
+	SIPCallStateUpdateStub        func(context.Context, *livekit.SIPCallInfo)
+	sIPCallStateUpdateMutex       sync.RWMutex
+	sIPCallStateUpdateArgsForCall []struct {
+		arg1 context.Context
+		arg2 *livekit.SIPCallInfo
+	}
 	TrackMaxSubscribedVideoQualityStub        func(context.Context, livekit.ParticipantID, *livekit.TrackInfo, mime.MimeType, livekit.VideoQuality)
 	trackMaxSubscribedVideoQualityMutex       sync.RWMutex
 	trackMaxSubscribedVideoQualityArgsForCall []struct {
@@ -1089,6 +1095,39 @@ func (fake *FakeTelemetryService) SendStatsArgsForCall(i int) (context.Context, 
 	fake.sendStatsMutex.RLock()
 	defer fake.sendStatsMutex.RUnlock()
 	argsForCall := fake.sendStatsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeTelemetryService) SIPCallStateUpdate(arg1 context.Context, arg2 *livekit.SIPCallInfo) {
+	fake.sIPCallStateUpdateMutex.Lock()
+	fake.sIPCallStateUpdateArgsForCall = append(fake.sIPCallStateUpdateArgsForCall, struct {
+		arg1 context.Context
+		arg2 *livekit.SIPCallInfo
+	}{arg1, arg2})
+	stub := fake.SIPCallStateUpdateStub
+	fake.recordInvocation("SIPCallStateUpdate", []interface{}{arg1, arg2})
+	fake.sIPCallStateUpdateMutex.Unlock()
+	if stub != nil {
+		fake.SIPCallStateUpdateStub(arg1, arg2)
+	}
+}
+
+func (fake *FakeTelemetryService) SIPCallStateUpdateCallCount() int {
+	fake.sIPCallStateUpdateMutex.RLock()
+	defer fake.sIPCallStateUpdateMutex.RUnlock()
+	return len(fake.sIPCallStateUpdateArgsForCall)
+}
+
+func (fake *FakeTelemetryService) SIPCallStateUpdateCalls(stub func(context.Context, *livekit.SIPCallInfo)) {
+	fake.sIPCallStateUpdateMutex.Lock()
+	defer fake.sIPCallStateUpdateMutex.Unlock()
+	fake.SIPCallStateUpdateStub = stub
+}
+
+func (fake *FakeTelemetryService) SIPCallStateUpdateArgsForCall(i int) (context.Context, *livekit.SIPCallInfo) {
+	fake.sIPCallStateUpdateMutex.RLock()
+	defer fake.sIPCallStateUpdateMutex.RUnlock()
+	argsForCall := fake.sIPCallStateUpdateArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -80,6 +80,7 @@ type TelemetryService interface {
 	Report(ctx context.Context, reportInfo *livekit.ReportInfo)
 	APICall(ctx context.Context, apiCallInfo *livekit.APICallInfo)
 	Webhook(ctx context.Context, webhookInfo *livekit.WebhookInfo)
+	SIPCallStateUpdate(ctx context.Context, info *livekit.SIPCallInfo)
 
 	// helpers
 	AnalyticsService
@@ -146,7 +147,8 @@ func (n NullTelemetryService) APICall(ctx context.Context, apiCallInfo *livekit.
 func (n NullTelemetryService) Webhook(ctx context.Context, webhookInfo *livekit.WebhookInfo)        {}
 func (n NullTelemetryService) NotifyEgressEvent(ctx context.Context, event string, info *livekit.EgressInfo) {
 }
-func (n NullTelemetryService) FlushStats() {}
+func (n NullTelemetryService) SIPCallStateUpdate(ctx context.Context, info *livekit.SIPCallInfo) {}
+func (n NullTelemetryService) FlushStats()                                                       {}
 
 // -----------------------------
 


### PR DESCRIPTION
## What this PR does / why we need it
This PR implements broadcasting of SIP call state events (e.g., `486 Busy Here`, `603 Decline`, `200 OK`) directly to all participants within the associated LiveKit room as **Data Packets**.
Currently, clients connected to a room have no visibility into the state of an outbound SIP call initiated from that room. They don't know if the recipient picked up, rejected the call, or if the line was busy. This change bridges that gap by forwarding these events from [IOInfoService](cci:2://file:///Users/shreyansh/Documents/Development/livekit-source/livekit/pkg/service/ioservice.go:31:0-41:1) to the room's participants.
## Key Changes
1.  **[IOInfoService](cci:2://file:///Users/shreyansh/Documents/Development/livekit-source/livekit/pkg/service/ioservice.go:31:0-41:1) Update**:
    *   Injected [RoomManager](cci:2://file:///Users/shreyansh/Documents/Development/livekit-source/livekit/pkg/service/roommanager.go:66:0-102:1) into [IOInfoService](cci:2://file:///Users/shreyansh/Documents/Development/livekit-source/livekit/pkg/service/ioservice.go:31:0-41:1).
    *   Updated [UpdateSIPCallState](cci:1://file:///Users/shreyansh/Documents/Development/livekit-source/sip/pkg/sip/analytics.go:32:1-32:129) to locate the relevant room and broadcast a [DataPacket](cci:1://file:///Users/shreyansh/Documents/Development/livekit-source/livekit/pkg/rtc/room.go:825:0-827:1) with the topic `sip.call.update` containing the SIP event details.
2.  **Wiring**:
    *   Updated [pkg/service/server.go](cci:7://file:///Users/shreyansh/Documents/Development/livekit-source/livekit/pkg/service/server.go:0:0-0:0) to inject [RoomManager](cci:2://file:///Users/shreyansh/Documents/Development/livekit-source/livekit/pkg/service/roommanager.go:66:0-102:1) into [IOInfoService](cci:2://file:///Users/shreyansh/Documents/Development/livekit-source/livekit/pkg/service/ioservice.go:31:0-41:1) via a setter ([SetRoomManager](cci:1://file:///Users/shreyansh/Documents/Development/livekit-source/livekit/pkg/service/ioservice.go:71:0-73:1)) to handle circular dependencies properly during initialization.
3.  **Telemetry**:
    *   Updated `FakeTelemetryService` to include the [SIPCallStateUpdate](cci:1://file:///Users/shreyansh/Documents/Development/livekit-source/livekit/pkg/telemetry/telemetryservice.go:82:1-82:67) method stub to ensure tests pass.
## Verification
Validated manually using a LiveKit client and a SIP softphone:
1.  Connected a client to a room and listened for `sip.call.update` data packets.
2.  Initiated a SIP call from the room.
3.  Performed various actions on the SIP side (Answer, Reject, Hang up).
4.  Confirmed the client received the corresponding JSON payload in real-time.
**Example Payload:**
{
  "call_id": "<sip-call-id>",
  "room_name": "room-1",
  "sip_call_id": "<sip-id>",
  "sip_status_code": "486",
  "sip_status_text": "Busy Here"
}