### PR TITLE
Do not remove participant from cache on disconnect.

### DIFF
--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -118,10 +118,6 @@ func (p *ParticipantImpl) SendParticipantUpdate(participantsToUpdate []*livekit.
 			})
 			validUpdates = append(validUpdates, pi)
 		}
-
-		if pi.State == livekit.ParticipantInfo_DISCONNECTED {
-			p.updateCache.Remove(pID)
-		}
 	}
 	p.updateLock.Unlock()
 


### PR DESCRIPTION
Resuming participants need to know about participants disconnected during resume.

Reverts https://github.com/livekit/livekit/pull/4234