### PR TITLE
Defer setting clock rate in RTPStats module till codec is bound.

### DIFF
--- a/pkg/sfu/buffer/buffer_base.go
+++ b/pkg/sfu/buffer/buffer_base.go
@@ -444,10 +444,9 @@ func (b *BufferBase) SetStreamRestartDetection(enable bool) {
 }
 
 func (b *BufferBase) setupRTPStats(clockRate uint32) {
-	b.rtpStats = rtpstats.NewRTPStatsReceiver(rtpstats.RTPStatsParams{
-		ClockRate: clockRate,
-		Logger:    b.logger,
-	})
+	b.rtpStats = rtpstats.NewRTPStatsReceiver(rtpstats.RTPStatsParams{})
+	b.rtpStats.SetClockRate(clockRate)
+
 	b.ppsSnapshotId = b.rtpStats.NewSnapshotId()
 	if b.params.IsReportingEnabled {
 		b.rrSnapshotId = b.rtpStats.NewSnapshotId()
@@ -455,10 +454,9 @@ func (b *BufferBase) setupRTPStats(clockRate uint32) {
 	}
 
 	if b.params.IsOOBSequenceNumber {
-		b.rtpStatsLite = rtpstats.NewRTPStatsReceiverLite(rtpstats.RTPStatsParams{
-			ClockRate: clockRate,
-			Logger:    b.logger,
-		})
+		b.rtpStatsLite = rtpstats.NewRTPStatsReceiverLite(rtpstats.RTPStatsParams{})
+		b.rtpStatsLite.SetClockRate(clockRate)
+
 		b.liteStatsSnapshotId = b.rtpStatsLite.NewSnapshotLiteId()
 	}
 }

--- a/pkg/sfu/playoutdelay_test.go
+++ b/pkg/sfu/playoutdelay_test.go
@@ -26,7 +26,9 @@ import (
 )
 
 func TestPlayoutDelay(t *testing.T) {
-	stats := rtpstats.NewRTPStatsSender(rtpstats.RTPStatsParams{ClockRate: 900000, Logger: logger.GetLogger()}, 128)
+	stats := rtpstats.NewRTPStatsSender(rtpstats.RTPStatsParams{}, 128)
+	stats.SetClockRate(90000)
+
 	c, err := NewPlayoutDelayController(100, 120, logger.GetLogger(), stats)
 	require.NoError(t, err)
 

--- a/pkg/sfu/rtpstats/rtpstats_test.go
+++ b/pkg/sfu/rtpstats/rtpstats_test.go
@@ -21,8 +21,6 @@ import (
 
 	"github.com/pion/rtp"
 	"github.com/stretchr/testify/require"
-
-	"github.com/livekit/protocol/logger"
 )
 
 func getPacket(sn uint16, ts uint32, payloadSize int) *rtp.Packet {
@@ -37,10 +35,8 @@ func getPacket(sn uint16, ts uint32, payloadSize int) *rtp.Packet {
 
 func Test_RTPStatsReceiver_Update(t *testing.T) {
 	clockRate := uint32(90000)
-	r := NewRTPStatsReceiver(RTPStatsParams{
-		ClockRate: clockRate,
-		Logger:    logger.GetLogger(),
-	})
+	r := NewRTPStatsReceiver(RTPStatsParams{})
+	r.SetClockRate(clockRate)
 
 	sequenceNumber := uint16(rand.Float64() * float64(1<<16))
 	timestamp := uint32(rand.Float64() * float64(1<<32))
@@ -229,10 +225,8 @@ func Test_RTPStatsReceiver_Update(t *testing.T) {
 
 func Test_RTPStatsReceiver_Restart(t *testing.T) {
 	clockRate := uint32(90000)
-	r := NewRTPStatsReceiver(RTPStatsParams{
-		ClockRate: clockRate,
-		Logger:    logger.GetLogger(),
-	})
+	r := NewRTPStatsReceiver(RTPStatsParams{})
+	r.SetClockRate(clockRate)
 
 	// should not restart till there are at least threshold packets
 	require.False(t, r.maybeRestart(10, 20, 1000))


### PR DESCRIPTION
With audio simulcast codecs, it is possible that the clock rate of the primary codec is different from the secondary codec. If a subscriber binds to the secondary codec, the clock rate should be set correctly. Do it at bind time.