### PR TITLE
require participant broadcast when metadata/attributes are set in token

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -368,6 +368,7 @@ func NewParticipant(params ParticipantParams) (*ParticipantImpl, error) {
 		onClose:                       make(map[string]func(types.LocalParticipant)),
 		telemetryGuard:                &telemetry.ReferenceGuard{},
 		nextSubscribedDataTrackHandle: uint16(rand.Intn(256)),
+		requireBroadcast:              params.Grants.Metadata != "" || len(params.Grants.Attributes) != 0,
 	}
 	p.setupSignalling()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved participant broadcast behavior to automatically determine requirements based on authorization grants and metadata, ensuring proper streaming handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->