### PR TITLE
Generate config flags

### DIFF
--- a/cmd/server/commands.go
+++ b/cmd/server/commands.go
@@ -92,7 +92,11 @@ func helpVerbose(_ context.Context, c *cli.Command) error {
 		return err
 	}
 
-	c.Flags = append(baseFlags, generatedFlags...)
+	flags := append([]cli.Flag{}, baseFlags...)
+	flags = append(flags, generatedFlags...)
+	root := c.Root()
+	root.Flags = flags
+	c.Flags = flags
 	return cli.ShowAppHelp(c)
 }
 


### PR DESCRIPTION
Fix #4262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI flags now display their default values in help text for all configuration options.

* **Bug Fixes**
  * Fixed flag propagation logic in command help display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->