### PR TITLE
Do not hold lock when creating buffer

### DIFF
--- a/pkg/sfu/receiver_base.go
+++ b/pkg/sfu/receiver_base.go
@@ -709,6 +709,12 @@ func (r *ReceiverBase) GetOrCreateBuffer(layer int32) buffer.BufferProvider {
 	buff, err := r.params.OnNewBufferNeeded(layer, ti)
 	if err != nil {
 		r.params.Logger.Errorw("could not create buffer", err)
+
+		r.bufferMu.Lock()
+		r.bufferPromises[layer] = nil
+		r.bufferMu.Unlock()
+
+		close(bp.ready)
 		return nil
 	}
 


### PR DESCRIPTION
As it can do some initialisations and have a longish call stack and don't want code changes in that path cause deadlock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved buffer creation coordination to reliably handle concurrent requests without conflicts.
  * Enhanced synchronization during buffer initialization to ensure consistent state across parallel operations.
  * Prevented race conditions in buffer lifecycle management.

* **Performance**
  * Optimized buffer retrieval logic for improved handling in high-concurrency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->