### PR TITLE
Read client protocol from query param

### DIFF
--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -114,10 +114,10 @@ func SetRoomConfiguration(createRequest *livekit.CreateRoomRequest, conf *liveki
 func ParseClientInfo(r *http.Request) *livekit.ClientInfo {
 	values := r.Form
 	ci := &livekit.ClientInfo{}
-	if pv, err := strconv.Atoi(values.Get("protocol")); err == nil {
+	if pv, err := strconv.ParseInt(values.Get("protocol"), 10, 32); err == nil {
 		ci.Protocol = int32(pv)
 	}
-	if cp, err := strconv.Atoi(values.Get("client_protocol")); err == nil {
+	if cp, err := strconv.ParseInt(values.Get("client_protocol"), 10, 32); err == nil {
 		ci.ClientProtocol = int32(cp)
 	}
 	sdkString := values.Get("sdk")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new client protocol parameter so clients can specify protocol information in requests.  
* **Bug Fixes / Improvements**
  * Improved protocol value handling while remaining fully compatible with existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->