### PR TITLE
security: remove TURN password from log output

### DIFF
--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -1003,7 +1003,7 @@ func (r *RoomManager) iceServersForParticipant(apiKey string, participant types.
 				participant.GetLogger().Warnw("could not create turn password", err)
 				hasSTUN = false
 			} else {
-				logger.Infow("created TURN password", "username", username, "password", password)
+				logger.Infow("created TURN password", "username", username)
 				iceServers = append(iceServers, &livekit.ICEServer{
 					Urls:       urls,
 					Username:   username,


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

## TURN Server Credentials Exposed in Logs

## Location
`pkg/service/roommanager.go:1006`

## Description
TURN authentication passwords are logged in plaintext. The log message directly includes the password value which may be stored, indexed, or backed up.

## Analysis Notes
This is a confirmed vulnerability. At line 1006, the code logs TURN credentials in plaintext: `logger.Infow("created TURN password", "username", username, "password", password)`. TURN credentials are security-sensitive as they allow relay of media traffic through the TURN server. Exposure risks include: (1) Log aggregation systems (ELK, Splunk, CloudWatch) storing credentials in searchable indexes, (2) Log files on disk accessible to operators or through backup systems, (3) Log shipping to third-party services, (4) Debug logs accidentally enabled in production. While TURN credentials are typically short-lived (generated per-participant), an attacker with log access could use them to relay arbitrary traffic through the TURN server, potentially for abuse or to intercept media if combined with other attacks.

## Fix Applied
Removed the `"password", password` key-value pair from the `logger.Infow` call at line 1006 of `pkg/service/roommanager.go`. The username is retained in the log statement for debugging purposes, consistent with the existing pattern in `pkg/service/turn.go:201` where TURN password errors are logged with only the username. The password value itself is never needed in logs since it can be regenerated deterministically from the API key and participant ID.

## Tests/Linters Ran
- `go vet ./pkg/service/...` — passed, no issues
- `go build ./pkg/service/...` — passed, compiles cleanly
- `go test -short ./pkg/service/... -count=1` — requires Docker (dockertest) which is unavailable in this environment; no test files cover the TURN credential logging code path

## Contribution Notes
No `CONTRIBUTING.md` or PR template was found in the repository. The commit follows conventional commit style consistent with recent project history. The change is a single-line modification removing the password field from a structured log statement.