### PR TITLE
security: remove credential values from error messages

### DIFF
--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -86,13 +86,13 @@ func (m *APIKeyAuthMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request,
 
 		secret := m.provider.GetSecret(v.APIKey())
 		if secret == "" {
-			HandleError(w, r, http.StatusUnauthorized, errors.New("invalid API key: "+v.APIKey()))
+			HandleError(w, r, http.StatusUnauthorized, ErrInvalidAPIKey)
 			return
 		}
 
 		_, grants, err := v.Verify(secret)
 		if err != nil {
-			HandleError(w, r, http.StatusUnauthorized, errors.New("invalid token: "+authToken+", error: "+err.Error()))
+			HandleError(w, r, http.StatusUnauthorized, ErrInvalidAuthorizationToken)
 			return
 		}
 


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

## Authorization Token Leak in Error Messages

## Location
`pkg/service/auth.go:89,95`

## Description
Full authorization tokens and API keys were concatenated directly into error messages that are written to HTTP response bodies. The `HandleError` function in `utils.go:55` writes `err.Error()` directly via `w.Write([]byte(err.Error()))`, exposing sensitive credentials to clients.

At line 89, the API key was included verbatim:
```go
errors.New("invalid API key: "+v.APIKey())
```

At line 95, the full bearer token and verification error were included:
```go
errors.New("invalid token: "+authToken+", error: "+err.Error())
```

## Analysis Notes
This is a confirmed vulnerability. Sensitive credentials are returned to clients in HTTP responses and may be captured by error monitoring/logging systems, browser developer tools, proxy logs, or shared error reporting. The API key exposure is particularly concerning as API keys are long-lived credentials.

## Fix Applied
Replaced the inline `errors.New(...)` calls that included credential values with the existing sentinel errors `ErrInvalidAPIKey` and `ErrInvalidAuthorizationToken` already defined in the same file. This eliminates credential leakage while maintaining the same HTTP status codes and error semantics. The sentinel errors were already defined but not used at these specific error paths.

## Tests/Linters Ran
- `gofmt -d pkg/service/auth.go` — no formatting changes needed (clean)
- `go vet ./pkg/service/...` — passed with no issues
- `go build ./pkg/service/` — compiled successfully with no errors
- `go test ./pkg/service/ -run TestAuthMiddleware` — could not run; the package's `TestMain` requires Docker (Redis integration), which is unavailable in this environment. The test itself (`auth_test.go`) validates the happy path and invalid token path, neither of which is affected by this change since only error message content changed, not control flow.

## Contribution Notes
No `CONTRIBUTING.md` or PR template was found in the repository. The change follows the project's existing patterns: it uses the same sentinel error variables already defined in the file and maintains the same code style (gofmt-clean, consistent with surrounding code).