### PR TITLE
fix: create SIP client without retry middleware to fix outbound call timeouts

### DIFF
--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -115,7 +115,11 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	}
 	ingressService := NewIngressService(ingressConfig, nodeID, messageBus, ingressClient, ingressStore, ioInfoService, telemetryService)
 	sipConfig := getSIPConfig(conf)
-	sipClient, err := rpc.NewSIPClientWithParams(clientParams)
+	sipClientParams := clientParams
+	sipClientParams.MaxAttempts = 0
+	sipClientParams.Timeout = 0
+	sipClientParams.Backoff = 0
+	sipClient, err := rpc.NewSIPClientWithParams(sipClientParams)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Outbound SIP calls with `wait_until_answered=True` break in v1.9.11 (works in v1.9.10) because PR #4222 changed the SIP client from `NewSIPClient(messageBus)` to `NewSIPClientWithParams(clientParams)`, which includes retry middleware with a 3s per-attempt timeout that overrides the caller-specified 80s `WithRequestTimeout`
- Copies `clientParams` and zeroes out `MaxAttempts`, `Timeout`, and `Backoff` before creating the SIP client, so the retry middleware is not added while preserving metrics + OpenTelemetry tracing from #4222
- This restores the pre-#4222 behavior for the two affected RPCs (`CreateSIPParticipant` and `TransferSIPParticipant`), which never had retry middleware — `NewSIPClient(messageBus)` created `ClientParams` with zero-value `PSRPCConfig`, so the retry guard (`MaxAttempts != 0 || Timeout != 0 || Backoff != 0`) was never triggered

Fixes #4269

## Test plan

- [x] `go build ./cmd/server/` succeeds
- [x] `go test ./pkg/service/...` passes (pre-existing `TestEgressStore` flake due to Redis state, unrelated)
- [x] Deploy and make an outbound SIP call with `wait_until_answered=True`
- [x] Confirm the call rings for the full ringing timeout (~30s) instead of hanging up at 3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)