### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -14,6 +14,9 @@
 
 name: Test
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/livekit/livekit/security/code-scanning/36](https://github.com/livekit/livekit/security/code-scanning/36)

In general, this issue is fixed by adding an explicit `permissions:` block to the workflow (or to each job) so that the `GITHUB_TOKEN` is granted only the scopes it actually needs. For a simple CI job that checks out code, installs dependencies, runs tests, and uploads artifacts, `contents: read` is typically sufficient, and all other categories can be left at their implicit `none`.

The single best fix here, without changing existing functionality, is to add a workflow-level `permissions` block just after the `name:` (or anywhere at the root level) to set `contents: read`. None of the steps in `jobs.test` require write permissions or special scopes like `pull-requests` or `issues`. `actions/checkout` and `actions/upload-artifact` both work with `contents: read`. This change will apply to all jobs (currently just `test`) and clearly documents the intended minimum access.

Concretely:
- Edit `.github/workflows/buildtest.yaml`.
- Add:

  ```yaml
  permissions:
    contents: read
  ```

  between the existing `name: Test` and `on:` blocks (lines 15–17).  
No additional methods, imports, or definitions are needed because this is purely a workflow configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
