### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -14,6 +14,9 @@
 
 name: Release to Docker
 
+permissions:
+  contents: read
+
 # Controls when the action will run.
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/livekit/livekit/security/code-scanning/35](https://github.com/livekit/livekit/security/code-scanning/35)

In general, the fix is to declare an explicit `permissions:` block either at the workflow root or for the specific job, limiting `GITHUB_TOKEN` to the minimal scopes needed. For a build-and-push-to-Docker workflow like this, the only GitHub interaction is checking out the code, which needs `contents: read`. All DockerHub interactions use `secrets.DOCKERHUB_*` and do not require `GITHUB_TOKEN` write access.

The best minimal fix without changing functionality is to add a root-level `permissions:` block after the `name:` (or under `on:`) that sets `contents: read`. This will apply to all jobs (currently only `docker`) unless overridden. No steps need write access to repository contents, issues, or pull requests, and no extra scopes are required, so `contents: read` is sufficient. Concretely, in `.github/workflows/docker.yaml`, add:

```yaml
permissions:
  contents: read
```

at the top workflow level (e.g., between `name: Release to Docker` and `on:`). No imports or further definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
