### PR TITLE
Update self-hosting deployment documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Sign up for [LiveKit Cloud](https://cloud.livekit.io/).
 
 ### Self-host
 
-Read our [deployment docs](https://docs.livekit.io/deploy/) for more information.
+Read our [deployment docs](https://docs.livekit.io/transport/self-hosting/) for more information.
 
 ## Building from source
 


### PR DESCRIPTION
Docs site seems to have changed since this was linked in the readme.  This updates the link to atleast point to self hosting docs and not the normal deployment docs.