### PR TITLE
feat: auto create rooms for tokens with the RoomCreate grant

### DIFF
--- a/pkg/service/roomallocator.go
+++ b/pkg/service/roomallocator.go
@@ -174,7 +174,7 @@ func (r *StandardRoomAllocator) SelectRoomNode(ctx context.Context, roomName liv
 
 func (r *StandardRoomAllocator) ValidateCreateRoom(ctx context.Context, roomName livekit.RoomName) error {
 	// when auto create is disabled, we'll check to ensure it's already created
-	if !r.config.Room.AutoCreate {
+	if !r.config.Room.AutoCreate && EnsureCreatePermission(ctx) != nil {
 		_, _, err := r.roomStore.LoadRoom(ctx, roomName, false)
 		if err != nil {
 			return err


### PR DESCRIPTION
This pull request updates the check for auto creating rooms to also consider the RoomCreate grant per token instead of just the global config option.

With this patch, applications can decide on their own whether users or which users can auto create rooms. This allows applications that rely on auto creation (saving an API call) to co-exist with those who might want to mint tokens for subscribe-only users.

Specifically LaSuite Meet relies on the auto create behavior, however enabling the global config option would make a MatrixRTC deployment vulnerable to abuse, as users on remote homeservers get tokens in order to subscribe.