### PR TITLE
Use ParticipantTelemetryListener of LocalParticipant.

### DIFF
--- a/pkg/rtc/mediatrackreceiver.go
+++ b/pkg/rtc/mediatrackreceiver.go
@@ -157,12 +157,11 @@ func NewMediaTrackReceiver(params MediaTrackReceiverParams, ti *livekit.TrackInf
 	t.trackInfo.Store(utils.CloneProto(ti))
 
 	t.MediaTrackSubscriptions = NewMediaTrackSubscriptions(MediaTrackSubscriptionsParams{
-		MediaTrack:        params.MediaTrack,
-		IsRelayed:         params.IsRelayed,
-		ReceiverConfig:    params.ReceiverConfig,
-		SubscriberConfig:  params.SubscriberConfig,
-		TelemetryListener: params.TelemetryListener,
-		Logger:            params.Logger,
+		MediaTrack:       params.MediaTrack,
+		IsRelayed:        params.IsRelayed,
+		ReceiverConfig:   params.ReceiverConfig,
+		SubscriberConfig: params.SubscriberConfig,
+		Logger:           params.Logger,
 	})
 	t.MediaTrackSubscriptions.OnDownTrackCreated(t.onDownTrackCreated)
 	return t

--- a/pkg/rtc/mediatracksubscriptions.go
+++ b/pkg/rtc/mediatracksubscriptions.go
@@ -53,8 +53,6 @@ type MediaTrackSubscriptionsParams struct {
 	ReceiverConfig   ReceiverConfig
 	SubscriberConfig DirectionConfig
 
-	TelemetryListener types.ParticipantTelemetryListener
-
 	Logger logger.Logger
 }
 
@@ -111,7 +109,7 @@ func (t *MediaTrackSubscriptions) AddSubscriber(sub types.LocalParticipant, wr *
 		Subscriber:         sub,
 		MediaTrack:         t.params.MediaTrack,
 		AdaptiveStream:     sub.GetAdaptiveStream(),
-		TelemetryListener:  t.params.TelemetryListener,
+		TelemetryListener:  sub.GetTelemetryListener(),
 		WrappedReceiver:    wr,
 		IsRelayed:          t.params.IsRelayed,
 		OnDownTrackCreated: t.onDownTrackCreated,

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -929,6 +929,14 @@ func (p *ParticipantImpl) TelemetryGuard() *telemetry.ReferenceGuard {
 	return p.telemetryGuard
 }
 
+func (p *ParticipantImpl) GetTelemetryListener() types.ParticipantTelemetryListener {
+	if p.params.TelemetryListener == nil {
+		return &types.NullParticipantTelemetryListener{}
+	}
+
+	return p.params.TelemetryListener
+}
+
 func (p *ParticipantImpl) AddOnClose(key string, callback func(types.LocalParticipant)) {
 	if p.isClosed.Load() {
 		go callback(p)

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -371,6 +371,7 @@ type LocalParticipant interface {
 	Participant
 
 	TelemetryGuard() *telemetry.ReferenceGuard
+	GetTelemetryListener() ParticipantTelemetryListener
 
 	// getters
 	GetCountry() string

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -541,6 +541,16 @@ type FakeLocalParticipant struct {
 	getSubscribedTracksReturnsOnCall map[int]struct {
 		result1 []types.SubscribedTrack
 	}
+	GetTelemetryListenerStub        func() types.ParticipantTelemetryListener
+	getTelemetryListenerMutex       sync.RWMutex
+	getTelemetryListenerArgsForCall []struct {
+	}
+	getTelemetryListenerReturns struct {
+		result1 types.ParticipantTelemetryListener
+	}
+	getTelemetryListenerReturnsOnCall map[int]struct {
+		result1 types.ParticipantTelemetryListener
+	}
 	GetTrailerStub        func() []byte
 	getTrailerMutex       sync.RWMutex
 	getTrailerArgsForCall []struct {
@@ -4193,6 +4203,59 @@ func (fake *FakeLocalParticipant) GetSubscribedTracksReturnsOnCall(i int, result
 	}
 	fake.getSubscribedTracksReturnsOnCall[i] = struct {
 		result1 []types.SubscribedTrack
+	}{result1}
+}
+
+func (fake *FakeLocalParticipant) GetTelemetryListener() types.ParticipantTelemetryListener {
+	fake.getTelemetryListenerMutex.Lock()
+	ret, specificReturn := fake.getTelemetryListenerReturnsOnCall[len(fake.getTelemetryListenerArgsForCall)]
+	fake.getTelemetryListenerArgsForCall = append(fake.getTelemetryListenerArgsForCall, struct {
+	}{})
+	stub := fake.GetTelemetryListenerStub
+	fakeReturns := fake.getTelemetryListenerReturns
+	fake.recordInvocation("GetTelemetryListener", []interface{}{})
+	fake.getTelemetryListenerMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLocalParticipant) GetTelemetryListenerCallCount() int {
+	fake.getTelemetryListenerMutex.RLock()
+	defer fake.getTelemetryListenerMutex.RUnlock()
+	return len(fake.getTelemetryListenerArgsForCall)
+}
+
+func (fake *FakeLocalParticipant) GetTelemetryListenerCalls(stub func() types.ParticipantTelemetryListener) {
+	fake.getTelemetryListenerMutex.Lock()
+	defer fake.getTelemetryListenerMutex.Unlock()
+	fake.GetTelemetryListenerStub = stub
+}
+
+func (fake *FakeLocalParticipant) GetTelemetryListenerReturns(result1 types.ParticipantTelemetryListener) {
+	fake.getTelemetryListenerMutex.Lock()
+	defer fake.getTelemetryListenerMutex.Unlock()
+	fake.GetTelemetryListenerStub = nil
+	fake.getTelemetryListenerReturns = struct {
+		result1 types.ParticipantTelemetryListener
+	}{result1}
+}
+
+func (fake *FakeLocalParticipant) GetTelemetryListenerReturnsOnCall(i int, result1 types.ParticipantTelemetryListener) {
+	fake.getTelemetryListenerMutex.Lock()
+	defer fake.getTelemetryListenerMutex.Unlock()
+	fake.GetTelemetryListenerStub = nil
+	if fake.getTelemetryListenerReturnsOnCall == nil {
+		fake.getTelemetryListenerReturnsOnCall = make(map[int]struct {
+			result1 types.ParticipantTelemetryListener
+		})
+	}
+	fake.getTelemetryListenerReturnsOnCall[i] = struct {
+		result1 types.ParticipantTelemetryListener
 	}{result1}
 }
 


### PR DESCRIPTION
Had made a change in remote participant case to not have telemetry listener as telemetry does not apply to remote participant. But, that listener ended up getting used for subscriber and became a null listener. Use the listener of the subscriber participant for subscribed tracks.