### PR TITLE
feat: add token revocation list

### DIFF
--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -48,12 +48,14 @@ var (
 
 // authentication middleware
 type APIKeyAuthMiddleware struct {
-	provider auth.KeyProvider
+	provider             auth.KeyProvider
+	tokenRevocationStore TokenRevocationStore
 }
 
-func NewAPIKeyAuthMiddleware(provider auth.KeyProvider) *APIKeyAuthMiddleware {
+func NewAPIKeyAuthMiddleware(provider auth.KeyProvider, tokenRevocationStore TokenRevocationStore) *APIKeyAuthMiddleware {
 	return &APIKeyAuthMiddleware{
-		provider: provider,
+		provider:             provider,
+		tokenRevocationStore: tokenRevocationStore,
 	}
 }
 
@@ -90,14 +92,22 @@ func (m *APIKeyAuthMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request,
 			return
 		}
 
-		_, grants, err := v.Verify(secret)
+		claims, grants, err := v.Verify(secret)
 		if err != nil {
 			HandleError(w, r, http.StatusUnauthorized, errors.New("invalid token: "+authToken+", error: "+err.Error()))
 			return
 		}
 
-		// set grants in context
 		ctx := r.Context()
+		if r.URL != nil && len(grants.Identity) > 0 && grants.Video != nil && len(grants.Video.Room) > 0 {
+			revoked, nbf, _ := m.tokenRevocationStore.IsRoomParticipantRevoked(ctx, livekit.ParticipantIdentity(grants.Identity), livekit.RoomName(grants.Video.Room))
+			if revoked && claims.NotBefore != nil && claims.NotBefore.Time().Unix() < nbf.Unix() {
+				HandleError(w, r, http.StatusUnauthorized, errors.New("invalid token"))
+				return
+			}
+		}
+
+		// set grants in context
 		r = r.WithContext(context.WithValue(ctx, grantsKey{}, &grantsValue{
 			claims: grants,
 			apiKey: v.APIKey(),

--- a/pkg/service/auth_test.go
+++ b/pkg/service/auth_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/livekit/protocol/auth/authfakes"
 
 	"github.com/livekit/livekit-server/pkg/service"
+	"github.com/livekit/livekit-server/pkg/service/servicefakes"
 )
 
 func TestAuthMiddleware(t *testing.T) {
@@ -32,8 +33,9 @@ func TestAuthMiddleware(t *testing.T) {
 	secret := "somesecretencodedinbase62extendto32bytes"
 	provider := &authfakes.FakeKeyProvider{}
 	provider.GetSecretReturns(secret)
+	store := &servicefakes.FakeServiceStore{}
 
-	m := service.NewAPIKeyAuthMiddleware(provider)
+	m := service.NewAPIKeyAuthMiddleware(provider, store)
 	var grants *auth.ClaimGrants
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		grants = service.GetGrants(r.Context())

--- a/pkg/service/interfaces.go
+++ b/pkg/service/interfaces.go
@@ -113,3 +113,11 @@ type AgentStore interface {
 	StoreAgentJob(ctx context.Context, job *livekit.Job) error
 	DeleteAgentJob(ctx context.Context, job *livekit.Job) error
 }
+
+var PARTICIPANT_REVOCATION_PREFIX = "token_revocation"
+
+type TokenRevocationStore interface {
+	RevokeRoomParticipant(ctx context.Context, identity *livekit.RoomParticipantIdentity) error
+	IsRoomParticipantRevoked(ctx context.Context, identity livekit.ParticipantIdentity, room livekit.RoomName) (bool, *time.Time, error)
+	CleanupForRoom(ctx context.Context, room livekit.RoomName)
+}

--- a/pkg/service/localstore.go
+++ b/pkg/service/localstore.go
@@ -16,6 +16,9 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -26,6 +29,11 @@ import (
 )
 
 var _ OSSServiceStore = (*LocalStore)(nil)
+
+type roomParticipantRevocationMapEntry struct {
+	ttl            time.Time
+	revocationTime time.Time
+}
 
 // encapsulates CRUD operations for room settings
 type LocalStore struct {
@@ -38,18 +46,22 @@ type LocalStore struct {
 	agentDispatches map[livekit.RoomName]map[string]*livekit.AgentDispatch
 	agentJobs       map[livekit.RoomName]map[string]*livekit.Job
 
+	roomParticipantRevocationMap map[string]roomParticipantRevocationMapEntry
+
 	lock       sync.RWMutex
 	globalLock sync.Mutex
 }
 
 func NewLocalStore() *LocalStore {
 	return &LocalStore{
-		rooms:           make(map[livekit.RoomName]*livekit.Room),
-		roomInternal:    make(map[livekit.RoomName]*livekit.RoomInternal),
-		participants:    make(map[livekit.RoomName]map[livekit.ParticipantIdentity]*livekit.ParticipantInfo),
-		agentDispatches: make(map[livekit.RoomName]map[string]*livekit.AgentDispatch),
-		agentJobs:       make(map[livekit.RoomName]map[string]*livekit.Job),
-		lock:            sync.RWMutex{},
+		rooms:                        make(map[livekit.RoomName]*livekit.Room),
+		roomInternal:                 make(map[livekit.RoomName]*livekit.RoomInternal),
+		participants:                 make(map[livekit.RoomName]map[livekit.ParticipantIdentity]*livekit.ParticipantInfo),
+		agentDispatches:              make(map[livekit.RoomName]map[string]*livekit.AgentDispatch),
+		agentJobs:                    make(map[livekit.RoomName]map[string]*livekit.Job),
+		roomParticipantRevocationMap: make(map[string]roomParticipantRevocationMapEntry),
+
+		lock: sync.RWMutex{},
 	}
 }
 
@@ -295,4 +307,47 @@ func (s *LocalStore) DeleteAgentJob(ctx context.Context, job *livekit.Job) error
 	}
 
 	return nil
+}
+
+func (s *LocalStore) RevokeRoomParticipant(ctx context.Context, identity *livekit.RoomParticipantIdentity) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	revocationTime := time.Unix(identity.RevokeTokenTs, 0)
+	s.roomParticipantRevocationMap[GenRoomParticipantRevocationIdentifier(livekit.ParticipantIdentity(identity.Identity), livekit.RoomName(identity.Room))] = roomParticipantRevocationMapEntry{
+		ttl:            revocationTime.Add(time.Minute * 11),
+		revocationTime: revocationTime,
+	}
+
+	return nil
+}
+
+func (s *LocalStore) IsRoomParticipantRevoked(ctx context.Context, identity livekit.ParticipantIdentity, room livekit.RoomName) (bool, *time.Time, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	identifier := GenRoomParticipantRevocationIdentifier(livekit.ParticipantIdentity(identity), livekit.RoomName(room))
+	revocationEntry, exists := s.roomParticipantRevocationMap[identifier]
+	if revocationEntry.ttl.Unix() < time.Now().Unix() {
+		delete(s.roomParticipantRevocationMap, identifier)
+		return false, nil, nil
+	}
+	return exists, &revocationEntry.revocationTime, nil
+}
+
+func (s *LocalStore) CleanupForRoom(ctx context.Context, room livekit.RoomName) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	entries := []string{}
+	for identifier := range s.roomParticipantRevocationMap {
+		if s.roomParticipantRevocationMap[identifier].ttl.Unix() < time.Now().Unix() ||
+			strings.HasPrefix(identifier, fmt.Sprintf("%s:room:%s", PARTICIPANT_REVOCATION_PREFIX, url.QueryEscape(room.String()))) {
+			entries = append(entries, identifier)
+		}
+	}
+
+	for i := range entries {
+		delete(s.roomParticipantRevocationMap, entries[i])
+	}
 }

--- a/pkg/service/redisstore.go
+++ b/pkg/service/redisstore.go
@@ -65,6 +65,9 @@ const (
 	AgentDispatchPrefix = "agent_dispatch:"
 	AgentJobPrefix      = "agent_job:"
 
+	// TokenRevocation
+	RoomParticipantRevocationsKey = "room_participents_revocations"
+
 	maxRetries = 5
 )
 
@@ -941,6 +944,32 @@ func (s *RedisStore) DeleteAgentJob(_ context.Context, job *livekit.Job) error {
 
 	key := AgentJobPrefix + string(job.Room.Name)
 	return s.rc.HDel(s.ctx, key, job.Id).Err()
+}
+
+func (s *RedisStore) RevokeRoomParticipant(ctx context.Context, identity *livekit.RoomParticipantIdentity) error {
+	revocationTime := time.Unix(identity.RevokeTokenTs, 0)
+	ttlDuration := 11 * time.Minute
+	err := s.rc.SetEx(s.ctx, GenRoomParticipantRevocationIdentifier(livekit.ParticipantIdentity(identity.Identity), livekit.RoomName(identity.Room)), revocationTime.Unix(), ttlDuration).Err()
+	if err != nil && err != redis.Nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *RedisStore) IsRoomParticipantRevoked(ctx context.Context, identity livekit.ParticipantIdentity, room livekit.RoomName) (bool, *time.Time, error) {
+	res := s.rc.Get(s.ctx, GenRoomParticipantRevocationIdentifier(livekit.ParticipantIdentity(identity), livekit.RoomName(room)))
+	revocationTimeInt, err := res.Int64()
+	if err != nil && err != redis.Nil {
+		return false, nil, nil
+	}
+
+	revocationTime := time.Unix(revocationTimeInt, 0)
+	return true, &revocationTime, nil
+}
+
+func (s *RedisStore) CleanupForRoom(ctx context.Context, room livekit.RoomName) {
+	// Not needed in the redis implementation
 }
 
 func redisStoreOne(ctx context.Context, s *RedisStore, key, id string, p proto.Message) error {

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -73,23 +73,24 @@ type iceConfigCacheKey struct {
 type RoomManager struct {
 	lock sync.RWMutex
 
-	config            *config.Config
-	rtcConfig         *rtc.WebRTCConfig
-	serverInfo        *livekit.ServerInfo
-	currentNode       routing.LocalNode
-	router            routing.Router
-	roomAllocator     RoomAllocator
-	roomManagerServer rpc.TypedRoomManagerServer
-	whipServer        rpc.WHIPServer[livekit.NodeID]
-	roomStore         ObjectStore
-	telemetry         telemetry.TelemetryService
-	clientConfManager clientconfiguration.ClientConfigurationManager
-	agentClient       agent.Client
-	agentStore        AgentStore
-	egressLauncher    rtc.EgressLauncher
-	versionGenerator  utils.TimedVersionGenerator
-	turnAuthHandler   *TURNAuthHandler
-	bus               psrpc.MessageBus
+	config               *config.Config
+	rtcConfig            *rtc.WebRTCConfig
+	serverInfo           *livekit.ServerInfo
+	currentNode          routing.LocalNode
+	router               routing.Router
+	roomAllocator        RoomAllocator
+	roomManagerServer    rpc.TypedRoomManagerServer
+	whipServer           rpc.WHIPServer[livekit.NodeID]
+	roomStore            ObjectStore
+	telemetry            telemetry.TelemetryService
+	tokenRevocationStore TokenRevocationStore
+	clientConfManager    clientconfiguration.ClientConfigurationManager
+	agentClient          agent.Client
+	agentStore           AgentStore
+	egressLauncher       rtc.EgressLauncher
+	versionGenerator     utils.TimedVersionGenerator
+	turnAuthHandler      *TURNAuthHandler
+	bus                  psrpc.MessageBus
 
 	rooms map[livekit.RoomName]*rtc.Room
 
@@ -115,6 +116,7 @@ func NewLocalRoomManager(
 	router routing.Router,
 	roomAllocator RoomAllocator,
 	telemetry telemetry.TelemetryService,
+	tokenRevocationStore TokenRevocationStore,
 	agentClient agent.Client,
 	agentStore AgentStore,
 	egressLauncher rtc.EgressLauncher,
@@ -129,21 +131,22 @@ func NewLocalRoomManager(
 	}
 
 	r := &RoomManager{
-		config:            conf,
-		rtcConfig:         rtcConf,
-		currentNode:       currentNode,
-		router:            router,
-		roomAllocator:     roomAllocator,
-		roomStore:         roomStore,
-		telemetry:         telemetry,
-		clientConfManager: clientconfiguration.NewStaticClientConfigurationManager(clientconfiguration.StaticConfigurations),
-		egressLauncher:    egressLauncher,
-		agentClient:       agentClient,
-		agentStore:        agentStore,
-		versionGenerator:  versionGenerator,
-		turnAuthHandler:   turnAuthHandler,
-		bus:               bus,
-		forwardStats:      forwardStats,
+		config:               conf,
+		rtcConfig:            rtcConf,
+		currentNode:          currentNode,
+		router:               router,
+		roomAllocator:        roomAllocator,
+		roomStore:            roomStore,
+		telemetry:            telemetry,
+		clientConfManager:    clientconfiguration.NewStaticClientConfigurationManager(clientconfiguration.StaticConfigurations),
+		egressLauncher:       egressLauncher,
+		agentClient:          agentClient,
+		agentStore:           agentStore,
+		versionGenerator:     versionGenerator,
+		turnAuthHandler:      turnAuthHandler,
+		bus:                  bus,
+		forwardStats:         forwardStats,
+		tokenRevocationStore: tokenRevocationStore,
 
 		rooms: make(map[livekit.RoomName]*rtc.Room),
 
@@ -823,6 +826,10 @@ func (r *RoomManager) RemoveParticipant(ctx context.Context, req *livekit.RoomPa
 	if err != nil {
 		return nil, err
 	}
+
+	// revoke access tokens
+	req.RevokeTokenTs = time.Now().Unix()
+	r.tokenRevocationStore.RevokeRoomParticipant(ctx, req)
 
 	participant.GetLogger().Infow("removing participant")
 	room.RemoveParticipant(livekit.ParticipantIdentity(req.Identity), "", types.ParticipantCloseReasonServiceRequestRemoveParticipant)

--- a/pkg/service/roomservice.go
+++ b/pkg/service/roomservice.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/twitchtv/twirp"
 
@@ -31,15 +32,16 @@ import (
 )
 
 type RoomService struct {
-	limitConf         config.LimitConfig
-	apiConf           config.APIConfig
-	router            routing.MessageRouter
-	roomAllocator     RoomAllocator
-	roomStore         ServiceStore
-	egressLauncher    rtc.EgressLauncher
-	topicFormatter    rpc.TopicFormatter
-	roomClient        rpc.TypedRoomClient
-	participantClient rpc.TypedParticipantClient
+	limitConf            config.LimitConfig
+	apiConf              config.APIConfig
+	router               routing.MessageRouter
+	roomAllocator        RoomAllocator
+	roomStore            ServiceStore
+	egressLauncher       rtc.EgressLauncher
+	topicFormatter       rpc.TopicFormatter
+	tokenRevocationStore TokenRevocationStore
+	roomClient           rpc.TypedRoomClient
+	participantClient    rpc.TypedParticipantClient
 
 	rpc.UnimplementedRoomServer
 	rpc.UnimplementedParticipantServer
@@ -55,17 +57,19 @@ func NewRoomService(
 	topicFormatter rpc.TopicFormatter,
 	roomClient rpc.TypedRoomClient,
 	participantClient rpc.TypedParticipantClient,
+	tokenRevocationStore TokenRevocationStore,
 ) (svc *RoomService, err error) {
 	svc = &RoomService{
-		limitConf:         limitConf,
-		apiConf:           apiConf,
-		router:            router,
-		roomAllocator:     roomAllocator,
-		roomStore:         serviceStore,
-		egressLauncher:    egressLauncher,
-		topicFormatter:    topicFormatter,
-		roomClient:        roomClient,
-		participantClient: participantClient,
+		limitConf:            limitConf,
+		apiConf:              apiConf,
+		router:               router,
+		roomAllocator:        roomAllocator,
+		roomStore:            serviceStore,
+		egressLauncher:       egressLauncher,
+		topicFormatter:       topicFormatter,
+		tokenRevocationStore: tokenRevocationStore,
+		roomClient:           roomClient,
+		participantClient:    participantClient,
 	}
 	return
 }
@@ -149,6 +153,8 @@ func (s *RoomService) DeleteRoom(ctx context.Context, req *livekit.DeleteRoomReq
 	if os, ok := s.roomStore.(OSSServiceStore); ok {
 		err = os.DeleteRoom(ctx, livekit.RoomName(req.Room))
 	}
+
+	s.tokenRevocationStore.CleanupForRoom(ctx, livekit.RoomName(req.Room))
 	res := &livekit.DeleteRoomResponse{}
 	RecordResponse(ctx, room)
 	return res, err
@@ -217,6 +223,9 @@ func (s *RoomService) RemoveParticipant(ctx context.Context, req *livekit.RoomPa
 		return nil, twirpAuthError(err)
 	}
 
+	// revoke access tokens
+	req.RevokeTokenTs = time.Now().Unix()
+	s.tokenRevocationStore.RevokeRoomParticipant(ctx, req)
 	if os, ok := s.roomStore.(OSSServiceStore); ok {
 		found, err := os.HasParticipant(ctx, livekit.RoomName(req.Room), livekit.ParticipantIdentity(req.Identity))
 		if err != nil {

--- a/pkg/service/roomservice_test.go
+++ b/pkg/service/roomservice_test.go
@@ -118,6 +118,7 @@ func newTestRoomService(limitConf config.LimitConfig) *TestRoomService {
 		rpc.NewTopicFormatter(),
 		&rpcfakes.FakeTypedRoomClient{},
 		&rpcfakes.FakeTypedParticipantClient{},
+		store,
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/service/rtcservice.go
+++ b/pkg/service/rtcservice.go
@@ -45,16 +45,16 @@ import (
 )
 
 type RTCService struct {
-	router        routing.MessageRouter
-	roomAllocator RoomAllocator
-	upgrader      websocket.Upgrader
-	config        *config.Config
-	isDev         bool
-	limits        config.LimitConfig
-	telemetry     telemetry.TelemetryService
-
-	mu          sync.Mutex
-	connections map[*websocket.Conn]struct{}
+	router               routing.MessageRouter
+	roomAllocator        RoomAllocator
+	upgrader             websocket.Upgrader
+	config               *config.Config
+	isDev                bool
+	limits               config.LimitConfig
+	telemetry            telemetry.TelemetryService
+	tokenRevocationStore TokenRevocationStore
+	mu                   sync.Mutex
+	connections          map[*websocket.Conn]struct{}
 }
 
 func NewRTCService(
@@ -62,15 +62,17 @@ func NewRTCService(
 	ra RoomAllocator,
 	router routing.MessageRouter,
 	telemetry telemetry.TelemetryService,
+	tokenRevocationStore TokenRevocationStore,
 ) *RTCService {
 	s := &RTCService{
-		router:        router,
-		roomAllocator: ra,
-		config:        conf,
-		isDev:         conf.Development,
-		limits:        conf.Limit,
-		telemetry:     telemetry,
-		connections:   map[*websocket.Conn]struct{}{},
+		router:               router,
+		roomAllocator:        ra,
+		config:               conf,
+		isDev:                conf.Development,
+		limits:               conf.Limit,
+		telemetry:            telemetry,
+		tokenRevocationStore: tokenRevocationStore,
+		connections:          map[*websocket.Conn]struct{}{},
 	}
 
 	s.upgrader = websocket.Upgrader{

--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -78,6 +78,7 @@ func NewLivekitServer(conf *config.Config,
 	roomManager *RoomManager,
 	signalServer *SignalServer,
 	turnServer *turn.Server,
+	tokenRevocationStore TokenRevocationStore,
 	currentNode routing.LocalNode,
 ) (s *LivekitServer, err error) {
 	s = &LivekitServer{
@@ -112,7 +113,7 @@ func NewLivekitServer(conf *config.Config,
 		negroni.HandlerFunc(RemoveDoubleSlashes),
 	}
 	if keyProvider != nil {
-		middlewares = append(middlewares, NewAPIKeyAuthMiddleware(keyProvider))
+		middlewares = append(middlewares, NewAPIKeyAuthMiddleware(keyProvider, tokenRevocationStore))
 	}
 
 	serverOptions := []any{

--- a/pkg/service/servicefakes/fake_service_store.go
+++ b/pkg/service/servicefakes/fake_service_store.go
@@ -3,7 +3,9 @@ package servicefakes
 
 import (
 	"context"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/livekit/livekit-server/pkg/service"
 	"github.com/livekit/protocol/livekit"
@@ -55,8 +57,10 @@ type FakeServiceStore struct {
 		result1 bool
 		result2 error
 	}
-	invocations      map[string][][]interface{}
-	invocationsMutex sync.RWMutex
+	roomParticipentRevocationMap map[string]time.Time
+	revocationMutex              sync.RWMutex
+	invocations                  map[string][][]interface{}
+	invocationsMutex             sync.RWMutex
 }
 
 func (fake *FakeServiceStore) ListRooms(arg1 context.Context, arg2 []livekit.RoomName) ([]*livekit.Room, error) {
@@ -271,6 +275,42 @@ func (fake *FakeServiceStore) Invocations() map[string][][]interface{} {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
+}
+
+func (s *FakeServiceStore) RevokeRoomParticipant(ctx context.Context, identity *livekit.RoomParticipantIdentity) error {
+	s.revocationMutex.Lock()
+	defer s.revocationMutex.Unlock()
+
+	revocationTime := time.Unix(identity.RevokeTokenTs, 0)
+	s.roomParticipentRevocationMap["r:"+identity.Room+":"+identity.Identity] = revocationTime
+
+	return nil
+}
+
+func (s *FakeServiceStore) IsRoomParticipantRevoked(ctx context.Context, identity livekit.ParticipantIdentity, room livekit.RoomName) (bool, *time.Time, error) {
+	s.revocationMutex.Lock()
+	defer s.revocationMutex.Unlock()
+
+	revocationTime, exists := s.roomParticipentRevocationMap["r:"+room.String()+":"+identity.String()]
+
+	return exists, &revocationTime, nil
+}
+
+func (s *FakeServiceStore) CleanupForRoom(ctx context.Context, room livekit.RoomName) {
+	s.revocationMutex.Lock()
+	defer s.revocationMutex.Unlock()
+
+	entries := []string{}
+	for identifier := range s.roomParticipentRevocationMap {
+
+		if strings.HasPrefix(identifier, "r:"+room.String()+":") {
+			entries = append(entries, identifier)
+		}
+	}
+
+	for i := range entries {
+		delete(s.roomParticipentRevocationMap, entries[i])
+	}
 }
 
 func (fake *FakeServiceStore) recordInvocation(key string, args []interface{}) {

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -419,4 +420,8 @@ func IsAgentWorkerPath(path string) bool {
 
 func IsAgentPath(path string) bool {
 	return strings.HasPrefix(path, "/agent")
+}
+
+func GenRoomParticipantRevocationIdentifier(identity livekit.ParticipantIdentity, room livekit.RoomName) string {
+	return fmt.Sprintf("%s:room:%s:participant:%s", PARTICIPANT_REVOCATION_PREFIX, url.QueryEscape(room.String()), url.QueryEscape(identity.String()))
 }

--- a/pkg/service/wire.go
+++ b/pkg/service/wire.go
@@ -54,6 +54,7 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 		createWebhookNotifier,
 		createForwardStats,
 		getNodeStatsConfig,
+		getTokenRevocationStore,
 		routing.CreateRouter,
 		getLimitConf,
 		getAPIConf,
@@ -219,6 +220,17 @@ func getIngressStore(s ObjectStore) IngressStore {
 }
 
 func getAgentStore(s ObjectStore) AgentStore {
+	switch store := s.(type) {
+	case *RedisStore:
+		return store
+	case *LocalStore:
+		return store
+	default:
+		return nil
+	}
+}
+
+func getTokenRevocationStore(s ObjectStore) TokenRevocationStore {
 	switch store := s.(type) {
 	case *RedisStore:
 		return store

--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -98,7 +98,8 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	if err != nil {
 		return nil, err
 	}
-	roomService, err := NewRoomService(limitConfig, apiConfig, router, roomAllocator, objectStore, rtcEgressLauncher, topicFormatter, roomClient, participantClient)
+	tokenRevocationStore := getTokenRevocationStore(objectStore)
+	roomService, err := NewRoomService(limitConfig, apiConfig, router, roomAllocator, objectStore, rtcEgressLauncher, topicFormatter, roomClient, participantClient, tokenRevocationStore)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +121,7 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 		return nil, err
 	}
 	sipService := NewSIPService(sipConfig, nodeID, messageBus, sipClient, sipStore, roomService, telemetryService)
-	rtcService := NewRTCService(conf, roomAllocator, router, telemetryService)
+	rtcService := NewRTCService(conf, roomAllocator, router, telemetryService, tokenRevocationStore)
 	whipParticipantClient, err := rpc.NewTypedWHIPParticipantClient(clientParams)
 	if err != nil {
 		return nil, err
@@ -142,7 +143,7 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	timedVersionGenerator := utils.NewDefaultTimedVersionGenerator()
 	turnAuthHandler := NewTURNAuthHandler(keyProvider)
 	forwardStats := createForwardStats(conf)
-	roomManager, err := NewLocalRoomManager(conf, objectStore, currentNode, router, roomAllocator, telemetryService, client, agentStore, rtcEgressLauncher, timedVersionGenerator, turnAuthHandler, messageBus, forwardStats)
+	roomManager, err := NewLocalRoomManager(conf, objectStore, currentNode, router, roomAllocator, telemetryService, tokenRevocationStore, client, agentStore, rtcEgressLauncher, timedVersionGenerator, turnAuthHandler, messageBus, forwardStats)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +156,7 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	if err != nil {
 		return nil, err
 	}
-	livekitServer, err := NewLivekitServer(conf, roomService, agentDispatchService, egressService, ingressService, sipService, ioInfoService, rtcService, serviceWHIPService, agentService, keyProvider, router, roomManager, signalServer, server, currentNode)
+	livekitServer, err := NewLivekitServer(conf, roomService, agentDispatchService, egressService, ingressService, sipService, ioInfoService, rtcService, serviceWHIPService, agentService, keyProvider, router, roomManager, signalServer, server, tokenRevocationStore, currentNode)
 	if err != nil {
 		return nil, err
 	}
@@ -284,6 +285,17 @@ func getIngressStore(s ObjectStore) IngressStore {
 }
 
 func getAgentStore(s ObjectStore) AgentStore {
+	switch store := s.(type) {
+	case *RedisStore:
+		return store
+	case *LocalStore:
+		return store
+	default:
+		return nil
+	}
+}
+
+func getTokenRevocationStore(s ObjectStore) TokenRevocationStore {
 	switch store := s.(type) {
 	case *RedisStore:
 		return store

--- a/test/multinode_roomservice_test.go
+++ b/test/multinode_roomservice_test.go
@@ -93,19 +93,19 @@ func TestMultiNodeRemoveParticipant(t *testing.T) {
 		return
 	}
 
-	for _, testRTCServicePath := range testRTCServicePaths {
+	for i, testRTCServicePath := range testRTCServicePaths {
 		t.Run(fmt.Sprintf("testRTCServicePath=%s", testRTCServicePath.String()), func(t *testing.T) {
 			_, _, finish := setupMultiNodeTest("TestMultiNodeRemoveParticipant")
 			defer finish()
 
-			c1 := createRTCClient("mn_remove_participant", defaultServerPort, testRTCServicePath, nil)
+			c1 := createRTCClient(fmt.Sprintf("mn_remove_participant_%d", i), defaultServerPort, testRTCServicePath, nil)
 			defer c1.Stop()
 			waitUntilConnected(t, c1)
 
 			ctx := contextWithToken(adminRoomToken(testRoom))
 			_, err := roomClient.RemoveParticipant(ctx, &livekit.RoomParticipantIdentity{
 				Room:     testRoom,
-				Identity: "mn_remove_participant",
+				Identity: fmt.Sprintf("mn_remove_participant_%d", i),
 			})
 			require.NoError(t, err)
 


### PR DESCRIPTION
The PR adds a basic token block list that serves to block the access token after calling the "RemoveParticipant" function in a room.

This makes it possible to permanently remove participants from the active room. Without this change, participants can rejoin at any time reusing there tokens.