### PR TITLE
Mark last run of grow bucket outside goroutine.

### DIFF
--- a/pkg/sfu/buffer/buffer_base.go
+++ b/pkg/sfu/buffer/buffer_base.go
@@ -135,7 +135,7 @@ type BufferProvider interface {
 }
 
 const (
-	bucketCapCheckInterval = 1e9 / 2
+	bucketCapCheckInterval = 1e9
 )
 
 type BufferBaseParams struct {
@@ -1228,10 +1228,6 @@ func (b *BufferBase) maybeGrowBucket(now int64) {
 		oldCap := cap
 		if deltaInfo := b.rtpStats.DeltaInfo(b.ppsSnapshotId); deltaInfo != nil {
 			duration := deltaInfo.EndTime.Sub(deltaInfo.StartTime)
-			b.logger.Infow("DBG delta stats",
-				"duration", duration,
-				"deltaInfo", deltaInfo,
-			)
 			if duration < 500*time.Millisecond {
 				return
 			}
@@ -1250,8 +1246,6 @@ func (b *BufferBase) maybeGrowBucket(now int64) {
 					"rtpStats", b.rtpStats,
 				)
 			}
-		} else {
-			b.logger.Infow("DBG delta stats nil")
 		}
 	}()
 }

--- a/pkg/sfu/streamtracker/streamtracker_packet.go
+++ b/pkg/sfu/streamtracker/streamtracker_packet.go
@@ -78,13 +78,11 @@ type StreamTrackerPacket struct {
 	initialized bool
 
 	cycleCount uint32
-	lastCheck  time.Time
 }
 
 func NewStreamTrackerPacket(params StreamTrackerPacketParams) StreamTrackerImpl {
 	return &StreamTrackerPacket{
-		params:    params,
-		lastCheck: time.Now(),
+		params: params,
 	}
 }
 
@@ -119,19 +117,10 @@ func (s *StreamTrackerPacket) Observe(_hasMarker bool, _ts uint32) StreamStatusC
 
 func (s *StreamTrackerPacket) CheckStatus() StreamStatusChange {
 	if !s.initialized {
-		s.lastCheck = time.Now()
 		// should not be getting called when not initialized, but be safe
 		return StreamStatusChangeNone
 	}
 
-	s.params.Logger.Infow(
-		"DBG check status",
-		"countSinceLast", s.countSinceLast,
-		"cycleCount", s.cycleCount,
-		"samplesRequired", s.params.Config.SamplesRequired,
-		"timeSinceLast", time.Since(s.lastCheck),
-	)
-	s.lastCheck = time.Now()
 	if s.countSinceLast >= s.params.Config.SamplesRequired {
 		s.cycleCount++
 	} else {


### PR DESCRIPTION
Otherwise, multiple goroutines could fire. Not bad as internally short windows are not used, but it is wasteful.