### PR TITLE
Add StopEgress function to the EgressLauncher interface

### DIFF
--- a/pkg/rtc/egress.go
+++ b/pkg/rtc/egress.go
@@ -29,6 +29,7 @@ import (
 
 type EgressLauncher interface {
 	StartEgress(context.Context, *rpc.StartEgressRequest) (*livekit.EgressInfo, error)
+	StopEgress(context.Context, *livekit.StopEgressRequest) (*livekit.EgressInfo, error)
 }
 
 func StartParticipantEgress(

--- a/pkg/service/egress.go
+++ b/pkg/service/egress.go
@@ -254,6 +254,13 @@ func (s *egressLauncher) StartEgress(ctx context.Context, req *rpc.StartEgressRe
 	return info, nil
 }
 
+func (s *egressLauncher) StopEgress(ctx context.Context, req *livekit.StopEgressRequest) (*livekit.EgressInfo, error) {
+	if s.client == nil {
+		return nil, ErrEgressNotConnected
+	}
+	return s.client.StopEgress(ctx, req.EgressId, req)
+}
+
 type LayoutMetadata struct {
 	Layout string `json:"layout"`
 }
@@ -344,11 +351,7 @@ func (s *EgressService) StopEgress(ctx context.Context, req *livekit.StopEgressR
 		return nil, twirpAuthError(err)
 	}
 
-	if s.client == nil {
-		return nil, ErrEgressNotConnected
-	}
-
-	info, err = s.client.StopEgress(ctx, req.EgressId, req)
+	info, err = s.launcher.StopEgress(ctx, req)
 	if err != nil {
 		var loadErr error
 		info, loadErr = s.io.GetEgress(ctx, &rpc.GetEgressRequest{EgressId: req.EgressId})


### PR DESCRIPTION
This allows for abstracting away how the stop is implemented - default implementation stays the same - the existing OSS egress launcher just calls the existing Stop method on the client.