### PR TITLE
Rename log field pID to participantID

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -473,7 +473,7 @@ func (r *Room) Join(
 
 	r.logger.Debugw(
 		"new participant joined",
-		"pID", participant.ID(),
+		"participantID", participant.ID(),
 		"participant", participant.Identity(),
 		"clientInfo", logger.Proto(participant.GetClientInfo()),
 		"options", opts,

--- a/pkg/rtc/utils.go
+++ b/pkg/rtc/utils.go
@@ -122,7 +122,7 @@ func LoggerWithParticipant(l logger.Logger, identity livekit.ParticipantIdentity
 		values = append(values, "participant", identity)
 	}
 	if sid != "" {
-		values = append(values, "pID", sid)
+		values = append(values, "participantID", sid)
 	}
 	values = append(values, "remote", isRemote)
 	// enable sampling per participant

--- a/pkg/service/rtcservice.go
+++ b/pkg/service/rtcservice.go
@@ -308,7 +308,7 @@ func (s *RTCService) serve(w http.ResponseWriter, r *http.Request, needsJoinRequ
 			"room", roomName,
 			"roomID", roomID,
 			"participant", participantIdentity,
-			"pID", pID,
+			"participantID", pID,
 		}
 	}
 

--- a/pkg/service/whipservice.go
+++ b/pkg/service/whipservice.go
@@ -358,7 +358,7 @@ func (s *WHIPService) iceTrickle(
 		"method", "ice-trickle",
 		"room", roomName,
 		"participant", participantIdentity,
-		"pID", pID,
+		"participantID", pID,
 		"sdpFragment", sdpFragment,
 		"status", http.StatusNoContent,
 	)
@@ -410,7 +410,7 @@ func (s *WHIPService) iceRestart(
 		"method", "ice-restart",
 		"room", roomName,
 		"participant", participantIdentity,
-		"pID", pID,
+		"participantID", pID,
 		"sdpFragment", sdpFragment,
 		"status", http.StatusNoContent,
 		"res", logger.Proto(res),
@@ -514,7 +514,7 @@ func (s *WHIPService) handleParticipantDelete(w http.ResponseWriter, r *http.Req
 	sutils.GetLogger(r.Context()).Infow(
 		"API WHIP.Delete",
 		"participant", claims.Identity,
-		"pID", r.PathValue("participant_id"),
+		"participantID", r.PathValue("participant_id"),
 		"room", roomName,
 		"status", http.StatusOK,
 	)

--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -198,7 +198,7 @@ func (t *telemetryService) ParticipantLeft(ctx context.Context,
 					"room", room.Name,
 					"roomID", room.Sid,
 					"participant", participant.Identity,
-					"pID", participant.Sid,
+					"participantID", participant.Sid,
 					"worker", worker,
 				)
 			}

--- a/pkg/telemetry/statsworker.go
+++ b/pkg/telemetry/statsworker.go
@@ -207,7 +207,7 @@ func (s *StatsWorker) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	e.AddString("room", string(s.roomName))
 	e.AddString("roomID", string(s.roomID))
 	e.AddString("participant", string(s.participantIdentity))
-	e.AddString("pID", string(s.participantID))
+	e.AddString("participantID", string(s.participantID))
 	e.AddBool("isConnected", s.isConnected)
 	e.AddTime("closedAt", s.closedAt)
 	e.AddObject("refCount", s.refCount)

--- a/test/client/client.go
+++ b/test/client/client.go
@@ -334,7 +334,7 @@ func NewRTCClient(conn *websocket.Conn, useSinglePeerConnection bool, opts *Opti
 	})
 	publisherHandler.OnOfferCalls(c.onOffer)
 	publisherHandler.OnFullyEstablishedCalls(func() {
-		logger.Debugw("publisher fully established", "participant", c.localParticipant.Identity, "pID", c.localParticipant.Sid)
+		logger.Debugw("publisher fully established", "participant", c.localParticipant.Identity, "participantID", c.localParticipant.Sid)
 		c.publisherFullyEstablished.Store(true)
 	})
 
@@ -426,7 +426,7 @@ func NewRTCClient(conn *websocket.Conn, useSinglePeerConnection bool, opts *Opti
 			}
 		})
 		subscriberHandler.OnFullyEstablishedCalls(func() {
-			logger.Debugw("subscriber fully established", "participant", c.localParticipant.Identity, "pID", c.localParticipant.Sid)
+			logger.Debugw("subscriber fully established", "participant", c.localParticipant.Identity, "participantID", c.localParticipant.Sid)
 			c.subscriberFullyEstablished.Store(true)
 		})
 		subscriberHandler.OnAnswerCalls(func(answer webrtc.SessionDescription, answerId uint32, _midToTrackID map[string]string) error {
@@ -632,7 +632,7 @@ func (c *RTCClient) handleSignalResponse(res *livekit.SignalResponse) error {
 					livekit.ParticipantID(publishedDataTrack.PublisherSid),
 					uint16(handle),
 					livekit.TrackID(publishedDataTrack.TrackSid),
-					logger.GetLogger().WithValues("participant", c.localParticipant.Identity, "pID", c.localParticipant.Sid),
+					logger.GetLogger().WithValues("participant", c.localParticipant.Identity, "participantID", c.localParticipant.Sid),
 				)
 			}
 		}
@@ -860,7 +860,7 @@ func (c *RTCClient) AddTrack(track *webrtc.TrackLocalStaticSample, path string, 
 		logger.Errorw(
 			"add track failed", err,
 			"participant", c.localParticipant.Identity,
-			"pID", c.localParticipant.Sid,
+			"participantID", c.localParticipant.Sid,
 			"trackID", track.ID(),
 		)
 		return
@@ -1209,7 +1209,7 @@ func (c *RTCClient) processRemoteTrack(track *webrtc.TrackRemote) {
 		logger.Infow(
 			"client caching track",
 			"participant", c.localParticipant.Identity,
-			"pID", c.ID(),
+			"participantID", c.ID(),
 			"codec", track.Codec(),
 			"ssrc", track.SSRC(),
 		)
@@ -1230,7 +1230,7 @@ func (c *RTCClient) processRemoteTrack(track *webrtc.TrackRemote) {
 	logger.Infow(
 		"client added track",
 		"participant", c.localParticipant.Identity,
-		"pID", c.ID(),
+		"participantID", c.ID(),
 		"publisherID", publisherID,
 		"trackID", trackID,
 		"codec", track.Codec(),
@@ -1253,7 +1253,7 @@ func (c *RTCClient) processRemoteTrack(track *webrtc.TrackRemote) {
 			logger.Infow(
 				"client track removed",
 				"participant", c.localParticipant.Identity,
-				"pID", c.ID(),
+				"participantID", c.ID(),
 				"publisherID", publisherID,
 				"trackID", trackID,
 				"codec", track.Codec(),
@@ -1274,7 +1274,7 @@ func (c *RTCClient) processRemoteTrack(track *webrtc.TrackRemote) {
 			logger.Infow(
 				"consumed from participant",
 				"participant", c.localParticipant.Identity,
-				"pID", c.ID(),
+				"participantID", c.ID(),
 				"publisherID", publisherID,
 				"trackID", trackID,
 				"size", numBytes,


### PR DESCRIPTION
## Summary
- Rename all occurrences of the `"pID"` log field to `"participantID"` for consistency across repos

## Test plan
- [ ] Verify logs emit `participantID` instead of `pID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)