### PR TITLE
fix(roomservice): route participant reads through PSRPC instead of Redis

### DIFF
--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -774,6 +774,37 @@ func (r *RoomManager) roomAndParticipantForReq(ctx context.Context, req particip
 	return room, participant, nil
 }
 
+func (r *RoomManager) ListParticipants(ctx context.Context, req *livekit.ListParticipantsRequest) (*livekit.ListParticipantsResponse, error) {
+	room := r.GetRoom(ctx, livekit.RoomName(req.Room))
+	if room == nil {
+		return nil, ErrRoomNotFound
+	}
+
+	participants := room.GetParticipants()
+	items := make([]*livekit.ParticipantInfo, 0, len(participants))
+	for _, p := range participants {
+		items = append(items, p.ToProto())
+	}
+
+	return &livekit.ListParticipantsResponse{
+		Participants: items,
+	}, nil
+}
+
+func (r *RoomManager) GetParticipant(ctx context.Context, req *livekit.RoomParticipantIdentity) (*livekit.ParticipantInfo, error) {
+	room := r.GetRoom(ctx, livekit.RoomName(req.Room))
+	if room == nil {
+		return nil, ErrRoomNotFound
+	}
+
+	participant := room.GetParticipant(livekit.ParticipantIdentity(req.Identity))
+	if participant == nil {
+		return nil, ErrParticipantNotFound
+	}
+
+	return participant.ToProto(), nil
+}
+
 func (r *RoomManager) RemoveParticipant(ctx context.Context, req *livekit.RoomParticipantIdentity) (*livekit.RemoveParticipantResponse, error) {
 	room, participant, err := r.roomAndParticipantForReq(ctx, req)
 	if err != nil {

--- a/pkg/service/roomservice.go
+++ b/pkg/service/roomservice.go
@@ -161,14 +161,11 @@ func (s *RoomService) ListParticipants(ctx context.Context, req *livekit.ListPar
 		return nil, twirpAuthError(err)
 	}
 
-	participants, err := s.roomStore.ListParticipants(ctx, livekit.RoomName(req.Room))
+	res, err := s.roomClient.ListParticipants(ctx, s.topicFormatter.RoomTopic(ctx, livekit.RoomName(req.Room)), req)
 	if err != nil {
 		return nil, err
 	}
 
-	res := &livekit.ListParticipantsResponse{
-		Participants: participants,
-	}
 	RecordResponse(ctx, res)
 	return res, nil
 }
@@ -181,7 +178,7 @@ func (s *RoomService) GetParticipant(ctx context.Context, req *livekit.RoomParti
 		return nil, twirpAuthError(err)
 	}
 
-	participant, err := s.roomStore.LoadParticipant(ctx, livekit.RoomName(req.Room), livekit.ParticipantIdentity(req.Identity))
+	participant, err := s.roomClient.GetParticipant(ctx, s.topicFormatter.RoomTopic(ctx, livekit.RoomName(req.Room)), req)
 	if err != nil {
 		return nil, err
 	}
@@ -199,13 +196,12 @@ func (s *RoomService) RemoveParticipant(ctx context.Context, req *livekit.RoomPa
 		return nil, twirpAuthError(err)
 	}
 
-	if _, err := s.roomStore.LoadParticipant(ctx, livekit.RoomName(req.Room), livekit.ParticipantIdentity(req.Identity)); err == ErrParticipantNotFound {
-		return nil, twirp.NotFoundError("participant not found")
-	}
-
 	res, err := s.participantClient.RemoveParticipant(ctx, s.topicFormatter.ParticipantTopic(ctx, livekit.RoomName(req.Room), livekit.ParticipantIdentity(req.Identity)), req)
+	if err != nil {
+		return nil, err
+	}
 	RecordResponse(ctx, res)
-	return res, err
+	return res, nil
 }
 
 func (s *RoomService) MutePublishedTrack(ctx context.Context, req *livekit.MuteRoomTrackRequest) (*livekit.MuteRoomTrackResponse, error) {
@@ -240,15 +236,6 @@ func (s *RoomService) UpdateParticipant(ctx context.Context, req *livekit.Update
 
 	if err := EnsureAdminPermission(ctx, livekit.RoomName(req.Room)); err != nil {
 		return nil, twirpAuthError(err)
-	}
-
-	if os, ok := s.roomStore.(OSSServiceStore); ok {
-		found, err := os.HasParticipant(ctx, livekit.RoomName(req.Room), livekit.ParticipantIdentity(req.Identity))
-		if err != nil {
-			return nil, err
-		} else if !found {
-			return nil, ErrParticipantNotFound
-		}
 	}
 
 	res, err := s.participantClient.UpdateParticipant(ctx, s.topicFormatter.ParticipantTopic(ctx, livekit.RoomName(req.Room), livekit.ParticipantIdentity(req.Identity)), req)

--- a/pkg/service/roomservice_test.go
+++ b/pkg/service/roomservice_test.go
@@ -108,6 +108,8 @@ func newTestRoomService(limitConf config.LimitConfig) *TestRoomService {
 	router := &routingfakes.FakeRouter{}
 	allocator := &servicefakes.FakeRoomAllocator{}
 	store := &servicefakes.FakeServiceStore{}
+	roomClient := &rpcfakes.FakeTypedRoomClient{}
+	participantClient := &rpcfakes.FakeTypedParticipantClient{}
 	svc, err := service.NewRoomService(
 		limitConf,
 		config.APIConfig{ExecutionTimeout: 2},
@@ -116,23 +118,194 @@ func newTestRoomService(limitConf config.LimitConfig) *TestRoomService {
 		store,
 		nil,
 		rpc.NewTopicFormatter(),
-		&rpcfakes.FakeTypedRoomClient{},
-		&rpcfakes.FakeTypedParticipantClient{},
+		roomClient,
+		participantClient,
 	)
 	if err != nil {
 		panic(err)
 	}
 	return &TestRoomService{
-		RoomService: *svc,
-		router:      router,
-		allocator:   allocator,
-		store:       store,
+		RoomService:       *svc,
+		router:            router,
+		allocator:         allocator,
+		store:             store,
+		roomClient:        roomClient,
+		participantClient: participantClient,
 	}
 }
 
 type TestRoomService struct {
 	service.RoomService
-	router    *routingfakes.FakeRouter
-	allocator *servicefakes.FakeRoomAllocator
-	store     *servicefakes.FakeServiceStore
+	router            *routingfakes.FakeRouter
+	allocator         *servicefakes.FakeRoomAllocator
+	store             *servicefakes.FakeServiceStore
+	roomClient        *rpcfakes.FakeTypedRoomClient
+	participantClient *rpcfakes.FakeTypedParticipantClient
+}
+
+const testRoom = "mytestroom"
+
+func adminContext(roomName string) context.Context {
+	grant := &auth.ClaimGrants{
+		Video: &auth.VideoGrant{RoomAdmin: true, Room: roomName},
+	}
+	return service.WithGrants(context.Background(), grant, "")
+}
+
+// --- ListParticipants ---
+
+func TestListParticipants_RoutesViaPSRPC(t *testing.T) {
+	t.Run("calls roomClient instead of roomStore", func(t *testing.T) {
+		svc := newTestRoomService(config.LimitConfig{})
+
+		expectedParticipants := []*livekit.ParticipantInfo{
+			{Sid: "PA_123", Identity: "alice", State: livekit.ParticipantInfo_ACTIVE},
+			{Sid: "PA_456", Identity: "bob", State: livekit.ParticipantInfo_ACTIVE},
+		}
+
+		svc.roomClient.ListParticipantsReturns(&livekit.ListParticipantsResponse{
+			Participants: expectedParticipants,
+		}, nil)
+
+		ctx := adminContext(testRoom)
+		res, err := svc.ListParticipants(ctx, &livekit.ListParticipantsRequest{
+			Room: testRoom,
+		})
+		require.NoError(t, err)
+		require.Len(t, res.Participants, 2)
+		require.Equal(t, "alice", res.Participants[0].Identity)
+		require.Equal(t, "bob", res.Participants[1].Identity)
+
+		// Verify roomClient was called (PSRPC path)
+		require.Equal(t, 1, svc.roomClient.ListParticipantsCallCount())
+
+		// Verify roomStore was NOT called (Redis path)
+		require.Equal(t, 0, svc.store.ListParticipantsCallCount())
+	})
+
+	t.Run("missing permissions", func(t *testing.T) {
+		svc := newTestRoomService(config.LimitConfig{})
+		grant := &auth.ClaimGrants{
+			Video: &auth.VideoGrant{},
+		}
+		ctx := service.WithGrants(context.Background(), grant, "")
+		_, err := svc.ListParticipants(ctx, &livekit.ListParticipantsRequest{
+			Room: testRoom,
+		})
+		require.Error(t, err)
+
+		// roomClient should NOT have been called — auth failed first
+		require.Equal(t, 0, svc.roomClient.ListParticipantsCallCount())
+	})
+}
+
+// --- GetParticipant ---
+
+func TestGetParticipant_RoutesViaPSRPC(t *testing.T) {
+	t.Run("calls roomClient instead of roomStore", func(t *testing.T) {
+		svc := newTestRoomService(config.LimitConfig{})
+
+		expectedParticipant := &livekit.ParticipantInfo{
+			Sid:      "PA_789",
+			Identity: "sip-caller",
+			State:    livekit.ParticipantInfo_ACTIVE,
+		}
+
+		svc.roomClient.GetParticipantReturns(expectedParticipant, nil)
+
+		ctx := adminContext(testRoom)
+		res, err := svc.GetParticipant(ctx, &livekit.RoomParticipantIdentity{
+			Room:     testRoom,
+			Identity: "sip-caller",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "sip-caller", res.Identity)
+		require.Equal(t, "PA_789", res.Sid)
+
+		// Verify roomClient was called (PSRPC path)
+		require.Equal(t, 1, svc.roomClient.GetParticipantCallCount())
+
+		// Verify roomStore was NOT called (Redis path)
+		require.Equal(t, 0, svc.store.LoadParticipantCallCount())
+	})
+
+	t.Run("missing permissions", func(t *testing.T) {
+		svc := newTestRoomService(config.LimitConfig{})
+		grant := &auth.ClaimGrants{
+			Video: &auth.VideoGrant{},
+		}
+		ctx := service.WithGrants(context.Background(), grant, "")
+		_, err := svc.GetParticipant(ctx, &livekit.RoomParticipantIdentity{
+			Room:     testRoom,
+			Identity: "sip-caller",
+		})
+		require.Error(t, err)
+		require.Equal(t, 0, svc.roomClient.GetParticipantCallCount())
+	})
+}
+
+// --- RemoveParticipant: Redis guard removed ---
+
+func TestRemoveParticipant_NoRedisGuard(t *testing.T) {
+	t.Run("does not check roomStore before forwarding to PSRPC", func(t *testing.T) {
+		svc := newTestRoomService(config.LimitConfig{})
+
+		svc.participantClient.RemoveParticipantReturns(&livekit.RemoveParticipantResponse{}, nil)
+
+		ctx := adminContext(testRoom)
+		_, err := svc.RemoveParticipant(ctx, &livekit.RoomParticipantIdentity{
+			Room:     testRoom,
+			Identity: "sip-caller",
+		})
+		require.NoError(t, err)
+
+		// The PSRPC participant client should have been called
+		require.Equal(t, 1, svc.participantClient.RemoveParticipantCallCount())
+
+		// The store should NOT have been called as a guard.
+		require.Equal(t, 0, svc.store.LoadParticipantCallCount())
+	})
+}
+
+// --- UpdateParticipant: Redis guard removed ---
+
+func TestUpdateParticipant_NoRedisGuard(t *testing.T) {
+	t.Run("does not check roomStore before forwarding to PSRPC", func(t *testing.T) {
+		svc := newTestRoomService(config.LimitConfig{})
+
+		expectedParticipant := &livekit.ParticipantInfo{
+			Sid:      "PA_789",
+			Identity: "sip-caller",
+			Metadata: "new-metadata",
+		}
+		svc.participantClient.UpdateParticipantReturns(expectedParticipant, nil)
+
+		ctx := adminContext(testRoom)
+		res, err := svc.UpdateParticipant(ctx, &livekit.UpdateParticipantRequest{
+			Room:     testRoom,
+			Identity: "sip-caller",
+			Metadata: "new-metadata",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "new-metadata", res.Metadata)
+
+		// The PSRPC participant client should have been called
+		require.Equal(t, 1, svc.participantClient.UpdateParticipantCallCount())
+
+		// The store should NOT have been called as a guard.
+		require.Equal(t, 0, svc.store.LoadParticipantCallCount())
+	})
+
+	t.Run("still validates metadata limits before PSRPC", func(t *testing.T) {
+		svc := newTestRoomService(config.LimitConfig{MaxMetadataSize: 5})
+		ctx := adminContext(testRoom)
+		_, err := svc.UpdateParticipant(ctx, &livekit.UpdateParticipantRequest{
+			Room:     testRoom,
+			Identity: "sip-caller",
+			Metadata: "this-metadata-exceeds-the-5-byte-limit",
+		})
+		require.Error(t, err)
+		// Should fail at validation, never reaching PSRPC
+		require.Equal(t, 0, svc.participantClient.UpdateParticipantCallCount())
+	})
 }

--- a/test/docker_test.go
+++ b/test/docker_test.go
@@ -1,0 +1,94 @@
+// Copyright 2024 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"testing"
+
+	"go.uber.org/atomic"
+
+	"github.com/ory/dockertest/v3"
+)
+
+var dockerPool *dockertest.Pool
+
+func TestMain(m *testing.M) {
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		log.Printf("Warning: could not construct Docker pool: %s (multi-node tests will require local Redis)", err)
+	} else if err = pool.Client.Ping(); err != nil {
+		log.Printf("Warning: could not connect to Docker: %s (multi-node tests will require local Redis)", err)
+	} else {
+		dockerPool = pool
+	}
+
+	// Wire up the Redis address resolver for multi-node tests.
+	resolveRedisAddr = redisAddr
+
+	code := m.Run()
+	os.Exit(code)
+}
+
+func waitTCPPort(t testing.TB, addr string) {
+	if err := dockerPool.Retry(func() error {
+		conn, err := net.Dial("tcp", addr)
+		if err != nil {
+			return err
+		}
+		_ = conn.Close()
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+var redisLast atomic.Uint32
+
+func runRedis(t testing.TB) string {
+	if dockerPool == nil {
+		t.Fatal("Docker not available, cannot start Redis container")
+	}
+	c, err := dockerPool.RunWithOptions(&dockertest.RunOptions{
+		Name:       fmt.Sprintf("lktest-integ-redis-%d", redisLast.Inc()),
+		Repository: "redis", Tag: "latest",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = dockerPool.Purge(c)
+	})
+	addr := c.GetHostPort("6379/tcp")
+	waitTCPPort(t, addr)
+
+	t.Log("Redis running on", addr)
+	return addr
+}
+
+// redisAddr returns the address of a usable Redis instance.
+// It tries localhost:6379 first, and falls back to a Docker container.
+func redisAddr(t testing.TB) string {
+	conn, err := net.Dial("tcp", "localhost:6379")
+	if err == nil {
+		_ = conn.Close()
+		return "localhost:6379"
+	}
+	t.Log("local redis not available, starting Docker container")
+	return runRedis(t)
+}

--- a/test/integration_helpers.go
+++ b/test/integration_helpers.go
@@ -79,20 +79,33 @@ func setupSingleNodeTest(name string) (*service.LivekitServer, func()) {
 	}
 }
 
-func setupMultiNodeTest(name string) (*service.LivekitServer, *service.LivekitServer, func()) {
+// resolveRedisAddr is set by docker_test.go to provide Docker-based Redis fallback.
+// If nil, falls back to localhost:6379.
+var resolveRedisAddr func(t testing.TB) string
+
+func setupMultiNodeTest(name string, t ...testing.TB) (*service.LivekitServer, *service.LivekitServer, func()) {
 	logger.Infow("----------------STARTING TEST----------------", "test", name)
-	s1 := createMultiNodeServer(guid.New(nodeID1), defaultServerPort)
-	s2 := createMultiNodeServer(guid.New(nodeID2), secondServerPort)
+
+	var addr string
+	if len(t) > 0 && resolveRedisAddr != nil {
+		addr = resolveRedisAddr(t[0])
+	} else {
+		addr = "localhost:6379"
+	}
+
+	s1 := createMultiNodeServer(guid.New(nodeID1), defaultServerPort, addr)
+	s2 := createMultiNodeServer(guid.New(nodeID2), secondServerPort, addr)
 	go s1.Start()
 	go s2.Start()
 
 	waitForServerToStart(s1)
 	waitForServerToStart(s2)
 
+	rc := redisClient(addr)
 	return s1, s2, func() {
 		s1.Stop(true)
 		s2.Stop(true)
-		redisClient().FlushAll(context.Background())
+		rc.FlushAll(context.Background())
 		logger.Infow("----------------FINISHING TEST----------------", "test", name)
 	}
 }
@@ -174,7 +187,7 @@ func createSingleNodeServer(configUpdater func(*config.Config)) *service.Livekit
 	return s
 }
 
-func createMultiNodeServer(nodeID string, port uint32) *service.LivekitServer {
+func createMultiNodeServer(nodeID string, port uint32, redisAddress string) *service.LivekitServer {
 	var err error
 	conf, err := config.NewConfig("", true, nil, nil)
 	if err != nil {
@@ -183,7 +196,7 @@ func createMultiNodeServer(nodeID string, port uint32) *service.LivekitServer {
 	conf.Port = port
 	conf.RTC.UDPPort = rtcconfig.PortRange{Start: int(port) + 1}
 	conf.RTC.TCPPort = port + 2
-	conf.Redis.Address = "localhost:6379"
+	conf.Redis.Address = redisAddress
 	conf.Keys = map[string]string{testApiKey: testApiSecret}
 	conf.EnableDataTracks = true
 
@@ -283,9 +296,9 @@ func createRTCClientWithToken(token string, port int, testRTCServicePath testRTC
 	return c
 }
 
-func redisClient() *redis.Client {
+func redisClient(addr string) *redis.Client {
 	return redis.NewClient(&redis.Options{
-		Addr: "localhost:6379",
+		Addr: addr,
 	})
 }
 

--- a/test/participant_consistency_test.go
+++ b/test/participant_consistency_test.go
@@ -1,0 +1,484 @@
+// Copyright 2024 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// These integration tests verify that ListParticipants, GetParticipant,
+// RemoveParticipant, and UpdateParticipant return consistent data immediately
+// after a participant connects — without the eventual consistency gap that
+// occurred when these APIs read from Redis instead of the authoritative
+// in-memory room state.
+
+package test
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/livekit/protocol/auth"
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/logger"
+	"github.com/livekit/protocol/utils/guid"
+	"github.com/livekit/protocol/webhook"
+
+	"github.com/livekit/livekit-server/pkg/config"
+	"github.com/livekit/livekit-server/pkg/routing"
+	"github.com/livekit/livekit-server/pkg/service"
+	"github.com/livekit/livekit-server/pkg/testutils"
+)
+
+// =============================================================================
+// Single-node tests
+// =============================================================================
+
+// TestSingleNodeListParticipantsImmediateConsistency verifies that a participant
+// appears in ListParticipants immediately after connecting.
+func TestSingleNodeListParticipantsImmediateConsistency(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+		return
+	}
+
+	_, finish := setupSingleNodeTest("TestSingleNodeListParticipantsImmediateConsistency")
+	defer finish()
+
+	for _, testRTCServicePath := range testRTCServicePaths {
+		t.Run(fmt.Sprintf("testRTCServicePath=%s", testRTCServicePath.String()), func(t *testing.T) {
+			c1 := createRTCClient("list_consistency_p1", defaultServerPort, testRTCServicePath, nil)
+			defer c1.Stop()
+			waitUntilConnected(t, c1)
+
+			ctx := contextWithToken(adminRoomToken(testRoom))
+
+			testutils.WithTimeout(t, func() string {
+				res, err := roomClient.ListParticipants(ctx, &livekit.ListParticipantsRequest{
+					Room: testRoom,
+				})
+				if err != nil {
+					return fmt.Sprintf("ListParticipants error: %v", err)
+				}
+				for _, p := range res.Participants {
+					if p.Identity == "list_consistency_p1" {
+						return ""
+					}
+				}
+				return fmt.Sprintf("participant not found in list, got %d participants", len(res.Participants))
+			})
+		})
+	}
+}
+
+// TestSingleNodeGetParticipantImmediateConsistency verifies that GetParticipant
+// returns the participant immediately after connecting.
+func TestSingleNodeGetParticipantImmediateConsistency(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+		return
+	}
+
+	_, finish := setupSingleNodeTest("TestSingleNodeGetParticipantImmediateConsistency")
+	defer finish()
+
+	for _, testRTCServicePath := range testRTCServicePaths {
+		t.Run(fmt.Sprintf("testRTCServicePath=%s", testRTCServicePath.String()), func(t *testing.T) {
+			c1 := createRTCClient("get_consistency_p1", defaultServerPort, testRTCServicePath, nil)
+			defer c1.Stop()
+			waitUntilConnected(t, c1)
+
+			ctx := contextWithToken(adminRoomToken(testRoom))
+
+			testutils.WithTimeout(t, func() string {
+				p, err := roomClient.GetParticipant(ctx, &livekit.RoomParticipantIdentity{
+					Room:     testRoom,
+					Identity: "get_consistency_p1",
+				})
+				if err != nil {
+					return fmt.Sprintf("GetParticipant error: %v", err)
+				}
+				if p.Identity != "get_consistency_p1" {
+					return fmt.Sprintf("wrong identity: %s", p.Identity)
+				}
+				return ""
+			})
+		})
+	}
+}
+
+// TestSingleNodeMultipleParticipantsConsistency verifies that when multiple
+// participants join in quick succession, ListParticipants returns all of them.
+func TestSingleNodeMultipleParticipantsConsistency(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+		return
+	}
+
+	_, finish := setupSingleNodeTest("TestSingleNodeMultipleParticipantsConsistency")
+	defer finish()
+
+	for _, testRTCServicePath := range testRTCServicePaths {
+		t.Run(fmt.Sprintf("testRTCServicePath=%s", testRTCServicePath.String()), func(t *testing.T) {
+			c1 := createRTCClient("multi_p1", defaultServerPort, testRTCServicePath, nil)
+			c2 := createRTCClient("multi_p2", defaultServerPort, testRTCServicePath, nil)
+			c3 := createRTCClient("multi_p3", defaultServerPort, testRTCServicePath, nil)
+			defer stopClients(c1, c2, c3)
+			waitUntilConnected(t, c1, c2, c3)
+
+			ctx := contextWithToken(adminRoomToken(testRoom))
+
+			testutils.WithTimeout(t, func() string {
+				res, err := roomClient.ListParticipants(ctx, &livekit.ListParticipantsRequest{
+					Room: testRoom,
+				})
+				if err != nil {
+					return fmt.Sprintf("ListParticipants error: %v", err)
+				}
+				if len(res.Participants) != 3 {
+					return fmt.Sprintf("expected 3 participants, got %d", len(res.Participants))
+				}
+				return ""
+			})
+
+			for _, identity := range []string{"multi_p1", "multi_p2", "multi_p3"} {
+				p, err := roomClient.GetParticipant(ctx, &livekit.RoomParticipantIdentity{
+					Room:     testRoom,
+					Identity: identity,
+				})
+				require.NoError(t, err)
+				require.Equal(t, identity, p.Identity)
+			}
+		})
+	}
+}
+
+// TestSingleNodeUpdateParticipantImmediatelyAfterJoin verifies that
+// UpdateParticipant works immediately after a participant joins, without
+// being blocked by a stale Redis guard.
+func TestSingleNodeUpdateParticipantImmediatelyAfterJoin(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+		return
+	}
+
+	_, finish := setupSingleNodeTest("TestSingleNodeUpdateParticipantImmediatelyAfterJoin")
+	defer finish()
+
+	for _, testRTCServicePath := range testRTCServicePaths {
+		t.Run(fmt.Sprintf("testRTCServicePath=%s", testRTCServicePath.String()), func(t *testing.T) {
+			c1 := createRTCClient("update_imm_p1", defaultServerPort, testRTCServicePath, nil)
+			defer c1.Stop()
+			waitUntilConnected(t, c1)
+
+			ctx := contextWithToken(adminRoomToken(testRoom))
+
+			testutils.WithTimeout(t, func() string {
+				res, err := roomClient.UpdateParticipant(ctx, &livekit.UpdateParticipantRequest{
+					Room:     testRoom,
+					Identity: "update_imm_p1",
+					Metadata: "immediate-metadata",
+				})
+				if err != nil {
+					return fmt.Sprintf("UpdateParticipant error: %v", err)
+				}
+				if res.Metadata != "immediate-metadata" {
+					return fmt.Sprintf("metadata not updated: %s", res.Metadata)
+				}
+				return ""
+			})
+		})
+	}
+}
+
+// =============================================================================
+// Multi-node tests
+// =============================================================================
+
+// TestMultiNodeListParticipantsConsistency verifies that ListParticipants returns
+// accurate data in a multi-node setup where the API call may hit a different node
+// than the one hosting the room.
+func TestMultiNodeListParticipantsConsistency(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+		return
+	}
+
+	for _, testRTCServicePath := range testRTCServicePaths {
+		t.Run(fmt.Sprintf("testRTCServicePath=%s", testRTCServicePath.String()), func(t *testing.T) {
+			_, _, finish := setupMultiNodeTest("TestMultiNodeListParticipantsConsistency", t)
+			defer finish()
+
+			c1 := createRTCClient("mn_list_p1", defaultServerPort, testRTCServicePath, nil)
+			defer c1.Stop()
+			waitUntilConnected(t, c1)
+
+			ctx := contextWithToken(adminRoomToken(testRoom))
+
+			testutils.WithTimeout(t, func() string {
+				res, err := roomClient.ListParticipants(ctx, &livekit.ListParticipantsRequest{
+					Room: testRoom,
+				})
+				if err != nil {
+					return fmt.Sprintf("ListParticipants error: %v", err)
+				}
+				for _, p := range res.Participants {
+					if p.Identity == "mn_list_p1" {
+						return ""
+					}
+				}
+				return fmt.Sprintf("participant not found, got %d participants", len(res.Participants))
+			})
+		})
+	}
+}
+
+// TestMultiNodeGetParticipantConsistency verifies GetParticipant in multi-node.
+func TestMultiNodeGetParticipantConsistency(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+		return
+	}
+
+	for _, testRTCServicePath := range testRTCServicePaths {
+		t.Run(fmt.Sprintf("testRTCServicePath=%s", testRTCServicePath.String()), func(t *testing.T) {
+			_, _, finish := setupMultiNodeTest("TestMultiNodeGetParticipantConsistency", t)
+			defer finish()
+
+			c1 := createRTCClient("mn_get_p1", defaultServerPort, testRTCServicePath, nil)
+			defer c1.Stop()
+			waitUntilConnected(t, c1)
+
+			ctx := contextWithToken(adminRoomToken(testRoom))
+
+			testutils.WithTimeout(t, func() string {
+				p, err := roomClient.GetParticipant(ctx, &livekit.RoomParticipantIdentity{
+					Room:     testRoom,
+					Identity: "mn_get_p1",
+				})
+				if err != nil {
+					return fmt.Sprintf("GetParticipant error: %v", err)
+				}
+				if p.Identity != "mn_get_p1" {
+					return fmt.Sprintf("wrong identity: %s", p.Identity)
+				}
+				return ""
+			})
+		})
+	}
+}
+
+// TestMultiNodeUpdateParticipantConsistency verifies UpdateParticipant works
+// immediately in multi-node without the Redis guard blocking it.
+func TestMultiNodeUpdateParticipantConsistency(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+		return
+	}
+
+	for _, testRTCServicePath := range testRTCServicePaths {
+		t.Run(fmt.Sprintf("testRTCServicePath=%s", testRTCServicePath.String()), func(t *testing.T) {
+			_, _, finish := setupMultiNodeTest("TestMultiNodeUpdateParticipantConsistency", t)
+			defer finish()
+
+			c1 := createRTCClient("mn_update_p1", defaultServerPort, testRTCServicePath, nil)
+			defer c1.Stop()
+			waitUntilConnected(t, c1)
+
+			ctx := contextWithToken(adminRoomToken(testRoom))
+
+			testutils.WithTimeout(t, func() string {
+				res, err := roomClient.UpdateParticipant(ctx, &livekit.UpdateParticipantRequest{
+					Room:     testRoom,
+					Identity: "mn_update_p1",
+					Metadata: "updated-immediately",
+				})
+				if err != nil {
+					return fmt.Sprintf("UpdateParticipant error: %v", err)
+				}
+				if res.Metadata != "updated-immediately" {
+					return fmt.Sprintf("metadata not updated: %s", res.Metadata)
+				}
+				return ""
+			})
+		})
+	}
+}
+
+// =============================================================================
+// Webhook race condition reproduction test
+// =============================================================================
+
+// TestListParticipantsConsistentAfterWebhook reproduces the original bug:
+// participant_joined webhook fires, backend immediately calls ListParticipants,
+// participant is missing from the response.
+func TestListParticipantsConsistentAfterWebhook(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+		return
+	}
+
+	for _, testRTCServicePath := range testRTCServicePaths {
+		t.Run(fmt.Sprintf("testRTCServicePath=%s", testRTCServicePath.String()), func(t *testing.T) {
+			server, ts, finish, err := setupServerWithWebhookAndListCheck()
+			require.NoError(t, err)
+			defer finish()
+
+			_ = server
+
+			c1 := createRTCClient("webhook_race_p1", defaultServerPort, testRTCServicePath, nil)
+			defer c1.Stop()
+			waitUntilConnected(t, c1)
+
+			testutils.WithTimeout(t, func() string {
+				if ts.GetEvent(webhook.EventParticipantJoined) == nil {
+					return "did not receive ParticipantJoined webhook"
+				}
+				return ""
+			})
+
+			listErr := ts.GetListParticipantsError()
+			require.Empty(t, listErr, "ListParticipants called from webhook handler failed: %s", listErr)
+
+			joined := ts.GetEvent(webhook.EventParticipantJoined)
+			require.Equal(t, "webhook_race_p1", joined.Participant.Identity)
+		})
+	}
+}
+
+// --- Webhook test server that calls ListParticipants on participant_joined ---
+
+type webhookListCheckServer struct {
+	webhookTestServer
+	listCheckError string
+	listCheckMu    sync.Mutex
+}
+
+func newWebhookListCheckServer(addr string) *webhookListCheckServer {
+	s := &webhookListCheckServer{}
+	s.events = make(map[string]*livekit.WebhookEvent)
+	s.provider = auth.NewFileBasedKeyProviderFromMap(map[string]string{testApiKey: testApiSecret})
+	s.server = &http.Server{
+		Addr:    addr,
+		Handler: s,
+	}
+	return s
+}
+
+func (s *webhookListCheckServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	data, err := webhook.Receive(r, s.provider)
+	if err != nil {
+		logger.Errorw("could not receive webhook", err)
+		return
+	}
+
+	event := livekit.WebhookEvent{}
+	if err = protojson.Unmarshal(data, &event); err != nil {
+		logger.Errorw("could not unmarshal event", err)
+		return
+	}
+
+	s.lock.Lock()
+	s.events[event.Event] = &event
+	s.lock.Unlock()
+
+	if event.Event == webhook.EventParticipantJoined && event.Room != nil {
+		listClient := livekit.NewRoomServiceJSONClient(
+			fmt.Sprintf("http://localhost:%d", defaultServerPort),
+			&http.Client{},
+		)
+
+		ctx := contextWithToken(adminRoomToken(event.Room.Name))
+		res, err := listClient.ListParticipants(ctx, &livekit.ListParticipantsRequest{
+			Room: event.Room.Name,
+		})
+
+		s.listCheckMu.Lock()
+		defer s.listCheckMu.Unlock()
+
+		if err != nil {
+			s.listCheckError = fmt.Sprintf("ListParticipants error: %v", err)
+			return
+		}
+
+		found := false
+		for _, p := range res.Participants {
+			if p.Identity == event.Participant.Identity {
+				found = true
+				break
+			}
+		}
+		if !found {
+			identities := make([]string, 0, len(res.Participants))
+			for _, p := range res.Participants {
+				identities = append(identities, p.Identity)
+			}
+			s.listCheckError = fmt.Sprintf(
+				"participant %q from webhook not found in ListParticipants (got %v)",
+				event.Participant.Identity, identities,
+			)
+		}
+	}
+}
+
+func (s *webhookListCheckServer) GetListParticipantsError() string {
+	s.listCheckMu.Lock()
+	defer s.listCheckMu.Unlock()
+	return s.listCheckError
+}
+
+func setupServerWithWebhookAndListCheck() (server *service.LivekitServer, testServer *webhookListCheckServer, finishFunc func(), err error) {
+	conf, err := config.NewConfig("", true, nil, nil)
+	if err != nil {
+		panic(fmt.Sprintf("could not create config: %v", err))
+	}
+	conf.WebHook.URLs = []string{"http://localhost:7891"}
+	conf.WebHook.APIKey = testApiKey
+	conf.Keys = map[string]string{testApiKey: testApiSecret}
+
+	testServer = newWebhookListCheckServer(":7891")
+	if err = testServer.Start(); err != nil {
+		return
+	}
+
+	currentNode, err := routing.NewLocalNode(conf)
+	if err != nil {
+		return
+	}
+	currentNode.SetNodeID(livekit.NodeID(guid.New(nodeID1)))
+
+	server, err = service.InitializeServer(conf, currentNode)
+	if err != nil {
+		return
+	}
+
+	go func() {
+		if err := server.Start(); err != nil {
+			logger.Errorw("server returned error", err)
+		}
+	}()
+
+	waitForServerToStart(server)
+
+	roomClient = livekit.NewRoomServiceJSONClient(
+		fmt.Sprintf("http://localhost:%d", defaultServerPort),
+		&http.Client{},
+	)
+
+	finishFunc = func() {
+		server.Stop(true)
+		testServer.Stop()
+	}
+	return
+}


### PR DESCRIPTION
## Changes

`ListParticipants` and `GetParticipant` read from Redis, which is eventually consistent. When called right after a `participant_joined` webhook, they return stale data or "not found" roughly 5-15% of the time.

Same issue with `RemoveParticipant` and `UpdateParticipant`, both have Redis guard clauses that reject valid requests before the write propagates.

The fix routes participant reads through PSRPC to the RTC node that owns the room, reading from in-memory state (the actual source of truth) instead of Redis. Also removes the redundant Redis guards from Remove/Update since the PSRPC handler already returns "not found" when appropriate.

Redis still serves as the persistence layer for crash recovery and room-level queries, this just stops using it for real-time participant lookups where it was never the right choice.

:exclamation: I also automated the `redis` part for being able to run the multi-node integration tests locally.

## Related issues

Partially addresses #4227. Doesn't fix the `participant_connection_aborted` case (that's a media connectivity issue), but eliminates the "participant not found" failures users hit when calling APIs immediately after receiving events.

## Dependencies

This fix requires that we have the following `livekit/protocol` changes released:

- https://github.com/livekit/protocol/pull/1459

Once that is done, I'll update the `go.mod` file.