### PR TITLE
Include room metadata in webhook events.

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -1997,55 +1997,55 @@ type participantTelemetryListener struct {
 }
 
 func (l participantTelemetryListener) OnTrackPublishRequested(pID livekit.ParticipantID, identity livekit.ParticipantIdentity, ti *livekit.TrackInfo) {
-	l.room.telemetry.TrackPublishRequested(context.Background(), l.room.ID(), l.room.Name(), pID, identity, ti)
+	l.room.telemetry.TrackPublishRequested(context.Background(), l.room.ToProto(), pID, identity, ti)
 }
 
 func (l participantTelemetryListener) OnTrackPublished(pID livekit.ParticipantID, identity livekit.ParticipantIdentity, ti *livekit.TrackInfo, shouldSendEvent bool) {
-	l.room.telemetry.TrackPublished(context.Background(), l.room.ID(), l.room.Name(), pID, identity, ti, shouldSendEvent)
+	l.room.telemetry.TrackPublished(context.Background(), l.room.ToProto(), pID, identity, ti, shouldSendEvent)
 }
 
 func (l participantTelemetryListener) OnTrackUnpublished(pID livekit.ParticipantID, identity livekit.ParticipantIdentity, ti *livekit.TrackInfo, shouldSendEvent bool) {
-	l.room.telemetry.TrackUnpublished(context.Background(), l.room.ID(), l.room.Name(), pID, identity, ti, shouldSendEvent)
+	l.room.telemetry.TrackUnpublished(context.Background(), l.room.ToProto(), pID, identity, ti, shouldSendEvent)
 }
 
 func (l participantTelemetryListener) OnTrackSubscribeRequested(pID livekit.ParticipantID, ti *livekit.TrackInfo) {
-	l.room.telemetry.TrackSubscribeRequested(context.Background(), l.room.ID(), l.room.Name(), pID, ti)
+	l.room.telemetry.TrackSubscribeRequested(context.Background(), l.room.ToProto(), pID, ti)
 }
 
 func (l participantTelemetryListener) OnTrackSubscribed(pID livekit.ParticipantID, ti *livekit.TrackInfo, publisherInfo *livekit.ParticipantInfo, shouldSendEvent bool) {
-	l.room.telemetry.TrackSubscribed(context.Background(), l.room.ID(), l.room.Name(), pID, ti, publisherInfo, shouldSendEvent)
+	l.room.telemetry.TrackSubscribed(context.Background(), l.room.ToProto(), pID, ti, publisherInfo, shouldSendEvent)
 }
 
 func (l participantTelemetryListener) OnTrackUnsubscribed(pID livekit.ParticipantID, ti *livekit.TrackInfo, shouldSendEvent bool) {
-	l.room.telemetry.TrackUnsubscribed(context.Background(), l.room.ID(), l.room.Name(), pID, ti, shouldSendEvent)
+	l.room.telemetry.TrackUnsubscribed(context.Background(), l.room.ToProto(), pID, ti, shouldSendEvent)
 }
 
 func (l participantTelemetryListener) OnTrackSubscribeFailed(pID livekit.ParticipantID, ti livekit.TrackID, err error, isUserError bool) {
-	l.room.telemetry.TrackSubscribeFailed(context.Background(), l.room.ID(), l.room.Name(), pID, ti, err, isUserError)
+	l.room.telemetry.TrackSubscribeFailed(context.Background(), l.room.ToProto(), pID, ti, err, isUserError)
 }
 
 func (l participantTelemetryListener) OnTrackMuted(pID livekit.ParticipantID, ti *livekit.TrackInfo) {
-	l.room.telemetry.TrackMuted(context.Background(), l.room.ID(), l.room.Name(), pID, ti)
+	l.room.telemetry.TrackMuted(context.Background(), l.room.ToProto(), pID, ti)
 }
 
 func (l participantTelemetryListener) OnTrackUnmuted(pID livekit.ParticipantID, ti *livekit.TrackInfo) {
-	l.room.telemetry.TrackUnmuted(context.Background(), l.room.ID(), l.room.Name(), pID, ti)
+	l.room.telemetry.TrackUnmuted(context.Background(), l.room.ToProto(), pID, ti)
 }
 
 func (l participantTelemetryListener) OnTrackPublishedUpdate(pID livekit.ParticipantID, ti *livekit.TrackInfo) {
-	l.room.telemetry.TrackPublishedUpdate(context.Background(), l.room.ID(), l.room.Name(), pID, ti)
+	l.room.telemetry.TrackPublishedUpdate(context.Background(), l.room.ToProto(), pID, ti)
 }
 
 func (l participantTelemetryListener) OnTrackMaxSubscribedVideoQuality(pID livekit.ParticipantID, ti *livekit.TrackInfo, mime mime.MimeType, maxQuality livekit.VideoQuality) {
-	l.room.telemetry.TrackMaxSubscribedVideoQuality(context.Background(), l.room.ID(), l.room.Name(), pID, ti, mime, maxQuality)
+	l.room.telemetry.TrackMaxSubscribedVideoQuality(context.Background(), l.room.ToProto(), pID, ti, mime, maxQuality)
 }
 
 func (l participantTelemetryListener) OnTrackPublishRTPStats(pID livekit.ParticipantID, trackID livekit.TrackID, mimeType mime.MimeType, layer int, stats *livekit.RTPStats) {
-	l.room.telemetry.TrackPublishRTPStats(context.Background(), l.room.ID(), l.room.Name(), pID, trackID, mimeType, layer, stats)
+	l.room.telemetry.TrackPublishRTPStats(context.Background(), l.room.ToProto(), pID, trackID, mimeType, layer, stats)
 }
 
 func (l participantTelemetryListener) OnTrackSubscribeRTPStats(pID livekit.ParticipantID, trackID livekit.TrackID, mimeType mime.MimeType, stats *livekit.RTPStats) {
-	l.room.telemetry.TrackSubscribeRTPStats(context.Background(), l.room.ID(), l.room.Name(), pID, trackID, mimeType, stats)
+	l.room.telemetry.TrackSubscribeRTPStats(context.Background(), l.room.ToProto(), pID, trackID, mimeType, stats)
 }
 
 func (l participantTelemetryListener) OnTrackStats(key telemetry.StatsKey, stat *livekit.AnalyticsStat) {

--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -224,15 +224,13 @@ func (t *telemetryService) ParticipantLeft(ctx context.Context,
 
 func (t *telemetryService) TrackPublishRequested(
 	ctx context.Context,
-	roomID livekit.RoomID,
-	roomName livekit.RoomName,
+	room *livekit.Room,
 	participantID livekit.ParticipantID,
 	identity livekit.ParticipantIdentity,
 	track *livekit.TrackInfo,
 ) {
 	t.enqueue(func() {
 		prometheus.RecordTrackPublishAttempt(track.Type.String())
-		room := toMinimalRoomProto(roomID, roomName)
 		ev := newTrackEvent(livekit.AnalyticsEventType_TRACK_PUBLISH_REQUESTED, room, participantID, track)
 		if ev.Participant != nil {
 			ev.Participant.Identity = string(identity)
@@ -243,8 +241,7 @@ func (t *telemetryService) TrackPublishRequested(
 
 func (t *telemetryService) TrackPublished(
 	ctx context.Context,
-	roomID livekit.RoomID,
-	roomName livekit.RoomName,
+	room *livekit.Room,
 	participantID livekit.ParticipantID,
 	identity livekit.ParticipantIdentity,
 	track *livekit.TrackInfo,
@@ -257,7 +254,6 @@ func (t *telemetryService) TrackPublished(
 			return
 		}
 
-		room := toMinimalRoomProto(roomID, roomName)
 		participant := &livekit.ParticipantInfo{
 			Sid:      string(participantID),
 			Identity: string(identity),
@@ -277,28 +273,24 @@ func (t *telemetryService) TrackPublished(
 
 func (t *telemetryService) TrackPublishedUpdate(
 	ctx context.Context,
-	roomID livekit.RoomID,
-	roomName livekit.RoomName,
+	room *livekit.Room,
 	participantID livekit.ParticipantID,
 	track *livekit.TrackInfo,
 ) {
 	t.enqueue(func() {
-		room := toMinimalRoomProto(roomID, roomName)
 		t.SendEvent(ctx, newTrackEvent(livekit.AnalyticsEventType_TRACK_PUBLISHED_UPDATE, room, participantID, track))
 	})
 }
 
 func (t *telemetryService) TrackMaxSubscribedVideoQuality(
 	ctx context.Context,
-	roomID livekit.RoomID,
-	roomName livekit.RoomName,
+	room *livekit.Room,
 	participantID livekit.ParticipantID,
 	track *livekit.TrackInfo,
 	mime mime.MimeType,
 	maxQuality livekit.VideoQuality,
 ) {
 	t.enqueue(func() {
-		room := toMinimalRoomProto(roomID, roomName)
 		ev := newTrackEvent(livekit.AnalyticsEventType_TRACK_MAX_SUBSCRIBED_VIDEO_QUALITY, room, participantID, track)
 		ev.MaxSubscribedVideoQuality = maxQuality
 		ev.Mime = mime.String()
@@ -308,15 +300,13 @@ func (t *telemetryService) TrackMaxSubscribedVideoQuality(
 
 func (t *telemetryService) TrackSubscribeRequested(
 	ctx context.Context,
-	roomID livekit.RoomID,
-	roomName livekit.RoomName,
+	room *livekit.Room,
 	participantID livekit.ParticipantID,
 	track *livekit.TrackInfo,
 ) {
 	t.enqueue(func() {
 		prometheus.RecordTrackSubscribeAttempt()
 
-		room := toMinimalRoomProto(roomID, roomName)
 		ev := newTrackEvent(livekit.AnalyticsEventType_TRACK_SUBSCRIBE_REQUESTED, room, participantID, track)
 		t.SendEvent(ctx, ev)
 	})
@@ -324,8 +314,7 @@ func (t *telemetryService) TrackSubscribeRequested(
 
 func (t *telemetryService) TrackSubscribed(
 	ctx context.Context,
-	roomID livekit.RoomID,
-	roomName livekit.RoomName,
+	room *livekit.Room,
 	participantID livekit.ParticipantID,
 	track *livekit.TrackInfo,
 	publisher *livekit.ParticipantInfo,
@@ -338,7 +327,6 @@ func (t *telemetryService) TrackSubscribed(
 			return
 		}
 
-		room := toMinimalRoomProto(roomID, roomName)
 		ev := newTrackEvent(livekit.AnalyticsEventType_TRACK_SUBSCRIBED, room, participantID, track)
 		ev.Publisher = publisher
 		t.SendEvent(ctx, ev)
@@ -347,8 +335,7 @@ func (t *telemetryService) TrackSubscribed(
 
 func (t *telemetryService) TrackSubscribeFailed(
 	ctx context.Context,
-	roomID livekit.RoomID,
-	roomName livekit.RoomName,
+	room *livekit.Room,
 	participantID livekit.ParticipantID,
 	trackID livekit.TrackID,
 	err error,
@@ -357,7 +344,6 @@ func (t *telemetryService) TrackSubscribeFailed(
 	t.enqueue(func() {
 		prometheus.RecordTrackSubscribeFailure(err, isUserError)
 
-		room := toMinimalRoomProto(roomID, roomName)
 		ev := newTrackEvent(livekit.AnalyticsEventType_TRACK_SUBSCRIBE_FAILED, room, participantID, &livekit.TrackInfo{
 			Sid: string(trackID),
 		})
@@ -368,8 +354,7 @@ func (t *telemetryService) TrackSubscribeFailed(
 
 func (t *telemetryService) TrackUnsubscribed(
 	ctx context.Context,
-	roomID livekit.RoomID,
-	roomName livekit.RoomName,
+	room *livekit.Room,
 	participantID livekit.ParticipantID,
 	track *livekit.TrackInfo,
 	shouldSendEvent bool,
@@ -378,7 +363,6 @@ func (t *telemetryService) TrackUnsubscribed(
 		prometheus.RecordTrackUnsubscribed(track.Type.String())
 
 		if shouldSendEvent {
-			room := toMinimalRoomProto(roomID, roomName)
 			t.SendEvent(ctx, newTrackEvent(livekit.AnalyticsEventType_TRACK_UNSUBSCRIBED, room, participantID, track))
 		}
 	})
@@ -386,8 +370,7 @@ func (t *telemetryService) TrackUnsubscribed(
 
 func (t *telemetryService) TrackUnpublished(
 	ctx context.Context,
-	roomID livekit.RoomID,
-	roomName livekit.RoomName,
+	room *livekit.Room,
 	participantID livekit.ParticipantID,
 	identity livekit.ParticipantIdentity,
 	track *livekit.TrackInfo,
@@ -399,7 +382,6 @@ func (t *telemetryService) TrackUnpublished(
 			return
 		}
 
-		room := toMinimalRoomProto(roomID, roomName)
 		participant := &livekit.ParticipantInfo{
 			Sid:      string(participantID),
 			Identity: string(identity),
@@ -417,34 +399,29 @@ func (t *telemetryService) TrackUnpublished(
 
 func (t *telemetryService) TrackMuted(
 	ctx context.Context,
-	roomID livekit.RoomID,
-	roomName livekit.RoomName,
+	room *livekit.Room,
 	participantID livekit.ParticipantID,
 	track *livekit.TrackInfo,
 ) {
 	t.enqueue(func() {
-		room := toMinimalRoomProto(roomID, roomName)
 		t.SendEvent(ctx, newTrackEvent(livekit.AnalyticsEventType_TRACK_MUTED, room, participantID, track))
 	})
 }
 
 func (t *telemetryService) TrackUnmuted(
 	ctx context.Context,
-	roomID livekit.RoomID,
-	roomName livekit.RoomName,
+	room *livekit.Room,
 	participantID livekit.ParticipantID,
 	track *livekit.TrackInfo,
 ) {
 	t.enqueue(func() {
-		room := toMinimalRoomProto(roomID, roomName)
 		t.SendEvent(ctx, newTrackEvent(livekit.AnalyticsEventType_TRACK_UNMUTED, room, participantID, track))
 	})
 }
 
 func (t *telemetryService) TrackPublishRTPStats(
 	ctx context.Context,
-	roomID livekit.RoomID,
-	roomName livekit.RoomName,
+	room *livekit.Room,
 	participantID livekit.ParticipantID,
 	trackID livekit.TrackID,
 	mimeType mime.MimeType,
@@ -452,7 +429,6 @@ func (t *telemetryService) TrackPublishRTPStats(
 	stats *livekit.RTPStats,
 ) {
 	t.enqueue(func() {
-		room := toMinimalRoomProto(roomID, roomName)
 		ev := newRoomEvent(livekit.AnalyticsEventType_TRACK_PUBLISH_STATS, room)
 		ev.ParticipantId = string(participantID)
 		ev.TrackId = string(trackID)
@@ -465,15 +441,13 @@ func (t *telemetryService) TrackPublishRTPStats(
 
 func (t *telemetryService) TrackSubscribeRTPStats(
 	ctx context.Context,
-	roomID livekit.RoomID,
-	roomName livekit.RoomName,
+	room *livekit.Room,
 	participantID livekit.ParticipantID,
 	trackID livekit.TrackID,
 	mimeType mime.MimeType,
 	stats *livekit.RTPStats,
 ) {
 	t.enqueue(func() {
-		room := toMinimalRoomProto(roomID, roomName)
 		ev := newRoomEvent(livekit.AnalyticsEventType_TRACK_SUBSCRIBE_STATS, room)
 		ev.ParticipantId = string(participantID)
 		ev.TrackId = string(trackID)
@@ -488,6 +462,7 @@ func (t *telemetryService) NotifyEgressEvent(ctx context.Context, event string, 
 
 	t.NotifyEvent(ctx, &livekit.WebhookEvent{
 		Event:      event,
+		Room:       toMinimalRoomProto(livekit.RoomID(info.RoomId), livekit.RoomName(info.RoomName)),
 		EgressInfo: info,
 	}, opts...)
 }
@@ -533,6 +508,7 @@ func (t *telemetryService) IngressStarted(ctx context.Context, info *livekit.Ing
 	t.enqueue(func() {
 		t.NotifyEvent(ctx, &livekit.WebhookEvent{
 			Event:       webhook.EventIngressStarted,
+			Room:        toMinimalRoomProto("", livekit.RoomName(info.RoomName)),
 			IngressInfo: info,
 		})
 
@@ -550,6 +526,7 @@ func (t *telemetryService) IngressEnded(ctx context.Context, info *livekit.Ingre
 	t.enqueue(func() {
 		t.NotifyEvent(ctx, &livekit.WebhookEvent{
 			Event:       webhook.EventIngressEnded,
+			Room:        toMinimalRoomProto("", livekit.RoomName(info.RoomName)),
 			IngressInfo: info,
 		})
 
@@ -647,3 +624,4 @@ func toMinimalRoomProto(roomID livekit.RoomID, roomName livekit.RoomName) *livek
 		Name: string(roomName),
 	}
 }
+

--- a/pkg/telemetry/events_test.go
+++ b/pkg/telemetry/events_test.go
@@ -124,7 +124,7 @@ func Test_OnTrackUpdate_EventIsSent(t *testing.T) {
 	}
 
 	// do
-	fixture.sut.TrackPublishedUpdate(context.Background(), livekit.RoomID(roomID), livekit.RoomName(roomName), livekit.ParticipantID(partID), trackInfo)
+	fixture.sut.TrackPublishedUpdate(context.Background(), &livekit.Room{Sid: roomID, Name: roomName}, livekit.ParticipantID(partID), trackInfo)
 	time.Sleep(time.Millisecond * 500)
 
 	// test
@@ -228,7 +228,7 @@ func Test_OnTrackSubscribed_EventIsSent(t *testing.T) {
 	require.Equal(t, room, event.Room)
 
 	// do
-	fixture.sut.TrackSubscribed(context.Background(), livekit.RoomID(room.Sid), livekit.RoomName(room.Name), livekit.ParticipantID(partSID), trackInfo, publisherInfo, true)
+	fixture.sut.TrackSubscribed(context.Background(), room, livekit.ParticipantID(partSID), trackInfo, publisherInfo, true)
 	time.Sleep(time.Millisecond * 500)
 
 	require.Eventually(t, func() bool {

--- a/pkg/telemetry/stats_test.go
+++ b/pkg/telemetry/stats_test.go
@@ -479,7 +479,7 @@ func Test_OnUpstreamRTCP_SeveralTracks(t *testing.T) {
 	require.True(t, found2)
 
 	// remove 1 track - track stats were flushed above, so no more calls to SendStats
-	fixture.sut.TrackUnpublished(context.Background(), livekit.RoomID(room.Sid), livekit.RoomName(room.Name), partSID, identity, &livekit.TrackInfo{Sid: string(trackID2)}, true)
+	fixture.sut.TrackUnpublished(context.Background(), room, partSID, identity, &livekit.TrackInfo{Sid: string(trackID2)}, true)
 
 	// flush
 	fixture.flush()

--- a/pkg/telemetry/telemetryfakes/fake_telemetry_service.go
+++ b/pkg/telemetry/telemetryfakes/fake_telemetry_service.go
@@ -169,67 +169,61 @@ type FakeTelemetryService struct {
 		arg1 context.Context
 		arg2 []*livekit.AnalyticsStat
 	}
-	TrackMaxSubscribedVideoQualityStub        func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo, mime.MimeType, livekit.VideoQuality)
+	TrackMaxSubscribedVideoQualityStub        func(context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo, mime.MimeType, livekit.VideoQuality)
 	trackMaxSubscribedVideoQualityMutex       sync.RWMutex
 	trackMaxSubscribedVideoQualityArgsForCall []struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 *livekit.TrackInfo
-		arg6 mime.MimeType
-		arg7 livekit.VideoQuality
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 *livekit.TrackInfo
+		arg5 mime.MimeType
+		arg6 livekit.VideoQuality
 	}
-	TrackMutedStub        func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo)
+	TrackMutedStub        func(context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo)
 	trackMutedMutex       sync.RWMutex
 	trackMutedArgsForCall []struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 *livekit.TrackInfo
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 *livekit.TrackInfo
 	}
-	TrackPublishRTPStatsStub        func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.TrackID, mime.MimeType, int, *livekit.RTPStats)
+	TrackPublishRTPStatsStub        func(context.Context, *livekit.Room, livekit.ParticipantID, livekit.TrackID, mime.MimeType, int, *livekit.RTPStats)
 	trackPublishRTPStatsMutex       sync.RWMutex
 	trackPublishRTPStatsArgsForCall []struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 livekit.TrackID
-		arg6 mime.MimeType
-		arg7 int
-		arg8 *livekit.RTPStats
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 livekit.TrackID
+		arg5 mime.MimeType
+		arg6 int
+		arg7 *livekit.RTPStats
 	}
-	TrackPublishRequestedStub        func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo)
+	TrackPublishRequestedStub        func(context.Context, *livekit.Room, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo)
 	trackPublishRequestedMutex       sync.RWMutex
 	trackPublishRequestedArgsForCall []struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 livekit.ParticipantIdentity
-		arg6 *livekit.TrackInfo
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 livekit.ParticipantIdentity
+		arg5 *livekit.TrackInfo
 	}
-	TrackPublishedStub        func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, bool)
+	TrackPublishedStub        func(context.Context, *livekit.Room, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, bool)
 	trackPublishedMutex       sync.RWMutex
 	trackPublishedArgsForCall []struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 livekit.ParticipantIdentity
-		arg6 *livekit.TrackInfo
-		arg7 bool
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 livekit.ParticipantIdentity
+		arg5 *livekit.TrackInfo
+		arg6 bool
 	}
-	TrackPublishedUpdateStub        func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo)
+	TrackPublishedUpdateStub        func(context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo)
 	trackPublishedUpdateMutex       sync.RWMutex
 	trackPublishedUpdateArgsForCall []struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 *livekit.TrackInfo
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 *livekit.TrackInfo
 	}
 	TrackStatsStub        func(livekit.RoomID, livekit.RoomName, telemetry.StatsKey, *livekit.AnalyticsStat)
 	trackStatsMutex       sync.RWMutex
@@ -239,77 +233,70 @@ type FakeTelemetryService struct {
 		arg3 telemetry.StatsKey
 		arg4 *livekit.AnalyticsStat
 	}
-	TrackSubscribeFailedStub        func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.TrackID, error, bool)
+	TrackSubscribeFailedStub        func(context.Context, *livekit.Room, livekit.ParticipantID, livekit.TrackID, error, bool)
 	trackSubscribeFailedMutex       sync.RWMutex
 	trackSubscribeFailedArgsForCall []struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 livekit.TrackID
-		arg6 error
-		arg7 bool
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 livekit.TrackID
+		arg5 error
+		arg6 bool
 	}
-	TrackSubscribeRTPStatsStub        func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.TrackID, mime.MimeType, *livekit.RTPStats)
+	TrackSubscribeRTPStatsStub        func(context.Context, *livekit.Room, livekit.ParticipantID, livekit.TrackID, mime.MimeType, *livekit.RTPStats)
 	trackSubscribeRTPStatsMutex       sync.RWMutex
 	trackSubscribeRTPStatsArgsForCall []struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 livekit.TrackID
-		arg6 mime.MimeType
-		arg7 *livekit.RTPStats
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 livekit.TrackID
+		arg5 mime.MimeType
+		arg6 *livekit.RTPStats
 	}
-	TrackSubscribeRequestedStub        func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo)
+	TrackSubscribeRequestedStub        func(context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo)
 	trackSubscribeRequestedMutex       sync.RWMutex
 	trackSubscribeRequestedArgsForCall []struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 *livekit.TrackInfo
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 *livekit.TrackInfo
 	}
-	TrackSubscribedStub        func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo, *livekit.ParticipantInfo, bool)
+	TrackSubscribedStub        func(context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo, *livekit.ParticipantInfo, bool)
 	trackSubscribedMutex       sync.RWMutex
 	trackSubscribedArgsForCall []struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 *livekit.TrackInfo
-		arg6 *livekit.ParticipantInfo
-		arg7 bool
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 *livekit.TrackInfo
+		arg5 *livekit.ParticipantInfo
+		arg6 bool
 	}
-	TrackUnmutedStub        func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo)
+	TrackUnmutedStub        func(context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo)
 	trackUnmutedMutex       sync.RWMutex
 	trackUnmutedArgsForCall []struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 *livekit.TrackInfo
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 *livekit.TrackInfo
 	}
-	TrackUnpublishedStub        func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, bool)
+	TrackUnpublishedStub        func(context.Context, *livekit.Room, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, bool)
 	trackUnpublishedMutex       sync.RWMutex
 	trackUnpublishedArgsForCall []struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 livekit.ParticipantIdentity
-		arg6 *livekit.TrackInfo
-		arg7 bool
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 livekit.ParticipantIdentity
+		arg5 *livekit.TrackInfo
+		arg6 bool
 	}
-	TrackUnsubscribedStub        func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo, bool)
+	TrackUnsubscribedStub        func(context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo, bool)
 	trackUnsubscribedMutex       sync.RWMutex
 	trackUnsubscribedArgsForCall []struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 *livekit.TrackInfo
-		arg6 bool
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 *livekit.TrackInfo
+		arg5 bool
 	}
 	WebhookStub        func(context.Context, *livekit.WebhookInfo)
 	webhookMutex       sync.RWMutex
@@ -1120,22 +1107,21 @@ func (fake *FakeTelemetryService) SendStatsArgsForCall(i int) (context.Context, 
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeTelemetryService) TrackMaxSubscribedVideoQuality(arg1 context.Context, arg2 livekit.RoomID, arg3 livekit.RoomName, arg4 livekit.ParticipantID, arg5 *livekit.TrackInfo, arg6 mime.MimeType, arg7 livekit.VideoQuality) {
+func (fake *FakeTelemetryService) TrackMaxSubscribedVideoQuality(arg1 context.Context, arg2 *livekit.Room, arg3 livekit.ParticipantID, arg4 *livekit.TrackInfo, arg5 mime.MimeType, arg6 livekit.VideoQuality) {
 	fake.trackMaxSubscribedVideoQualityMutex.Lock()
 	fake.trackMaxSubscribedVideoQualityArgsForCall = append(fake.trackMaxSubscribedVideoQualityArgsForCall, struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 *livekit.TrackInfo
-		arg6 mime.MimeType
-		arg7 livekit.VideoQuality
-	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 *livekit.TrackInfo
+		arg5 mime.MimeType
+		arg6 livekit.VideoQuality
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
 	stub := fake.TrackMaxSubscribedVideoQualityStub
-	fake.recordInvocation("TrackMaxSubscribedVideoQuality", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	fake.recordInvocation("TrackMaxSubscribedVideoQuality", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.trackMaxSubscribedVideoQualityMutex.Unlock()
 	if stub != nil {
-		fake.TrackMaxSubscribedVideoQualityStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+		fake.TrackMaxSubscribedVideoQualityStub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 }
 
@@ -1145,33 +1131,32 @@ func (fake *FakeTelemetryService) TrackMaxSubscribedVideoQualityCallCount() int 
 	return len(fake.trackMaxSubscribedVideoQualityArgsForCall)
 }
 
-func (fake *FakeTelemetryService) TrackMaxSubscribedVideoQualityCalls(stub func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo, mime.MimeType, livekit.VideoQuality)) {
+func (fake *FakeTelemetryService) TrackMaxSubscribedVideoQualityCalls(stub func(context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo, mime.MimeType, livekit.VideoQuality)) {
 	fake.trackMaxSubscribedVideoQualityMutex.Lock()
 	defer fake.trackMaxSubscribedVideoQualityMutex.Unlock()
 	fake.TrackMaxSubscribedVideoQualityStub = stub
 }
 
-func (fake *FakeTelemetryService) TrackMaxSubscribedVideoQualityArgsForCall(i int) (context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo, mime.MimeType, livekit.VideoQuality) {
+func (fake *FakeTelemetryService) TrackMaxSubscribedVideoQualityArgsForCall(i int) (context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo, mime.MimeType, livekit.VideoQuality) {
 	fake.trackMaxSubscribedVideoQualityMutex.RLock()
 	defer fake.trackMaxSubscribedVideoQualityMutex.RUnlock()
 	argsForCall := fake.trackMaxSubscribedVideoQualityArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
-func (fake *FakeTelemetryService) TrackMuted(arg1 context.Context, arg2 livekit.RoomID, arg3 livekit.RoomName, arg4 livekit.ParticipantID, arg5 *livekit.TrackInfo) {
+func (fake *FakeTelemetryService) TrackMuted(arg1 context.Context, arg2 *livekit.Room, arg3 livekit.ParticipantID, arg4 *livekit.TrackInfo) {
 	fake.trackMutedMutex.Lock()
 	fake.trackMutedArgsForCall = append(fake.trackMutedArgsForCall, struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 *livekit.TrackInfo
-	}{arg1, arg2, arg3, arg4, arg5})
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 *livekit.TrackInfo
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.TrackMutedStub
-	fake.recordInvocation("TrackMuted", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("TrackMuted", []interface{}{arg1, arg2, arg3, arg4})
 	fake.trackMutedMutex.Unlock()
 	if stub != nil {
-		fake.TrackMutedStub(arg1, arg2, arg3, arg4, arg5)
+		fake.TrackMutedStub(arg1, arg2, arg3, arg4)
 	}
 }
 
@@ -1181,36 +1166,35 @@ func (fake *FakeTelemetryService) TrackMutedCallCount() int {
 	return len(fake.trackMutedArgsForCall)
 }
 
-func (fake *FakeTelemetryService) TrackMutedCalls(stub func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo)) {
+func (fake *FakeTelemetryService) TrackMutedCalls(stub func(context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo)) {
 	fake.trackMutedMutex.Lock()
 	defer fake.trackMutedMutex.Unlock()
 	fake.TrackMutedStub = stub
 }
 
-func (fake *FakeTelemetryService) TrackMutedArgsForCall(i int) (context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo) {
+func (fake *FakeTelemetryService) TrackMutedArgsForCall(i int) (context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo) {
 	fake.trackMutedMutex.RLock()
 	defer fake.trackMutedMutex.RUnlock()
 	argsForCall := fake.trackMutedArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeTelemetryService) TrackPublishRTPStats(arg1 context.Context, arg2 livekit.RoomID, arg3 livekit.RoomName, arg4 livekit.ParticipantID, arg5 livekit.TrackID, arg6 mime.MimeType, arg7 int, arg8 *livekit.RTPStats) {
+func (fake *FakeTelemetryService) TrackPublishRTPStats(arg1 context.Context, arg2 *livekit.Room, arg3 livekit.ParticipantID, arg4 livekit.TrackID, arg5 mime.MimeType, arg6 int, arg7 *livekit.RTPStats) {
 	fake.trackPublishRTPStatsMutex.Lock()
 	fake.trackPublishRTPStatsArgsForCall = append(fake.trackPublishRTPStatsArgsForCall, struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 livekit.TrackID
-		arg6 mime.MimeType
-		arg7 int
-		arg8 *livekit.RTPStats
-	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 livekit.TrackID
+		arg5 mime.MimeType
+		arg6 int
+		arg7 *livekit.RTPStats
+	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
 	stub := fake.TrackPublishRTPStatsStub
-	fake.recordInvocation("TrackPublishRTPStats", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
+	fake.recordInvocation("TrackPublishRTPStats", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
 	fake.trackPublishRTPStatsMutex.Unlock()
 	if stub != nil {
-		fake.TrackPublishRTPStatsStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+		fake.TrackPublishRTPStatsStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	}
 }
 
@@ -1220,34 +1204,33 @@ func (fake *FakeTelemetryService) TrackPublishRTPStatsCallCount() int {
 	return len(fake.trackPublishRTPStatsArgsForCall)
 }
 
-func (fake *FakeTelemetryService) TrackPublishRTPStatsCalls(stub func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.TrackID, mime.MimeType, int, *livekit.RTPStats)) {
+func (fake *FakeTelemetryService) TrackPublishRTPStatsCalls(stub func(context.Context, *livekit.Room, livekit.ParticipantID, livekit.TrackID, mime.MimeType, int, *livekit.RTPStats)) {
 	fake.trackPublishRTPStatsMutex.Lock()
 	defer fake.trackPublishRTPStatsMutex.Unlock()
 	fake.TrackPublishRTPStatsStub = stub
 }
 
-func (fake *FakeTelemetryService) TrackPublishRTPStatsArgsForCall(i int) (context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.TrackID, mime.MimeType, int, *livekit.RTPStats) {
+func (fake *FakeTelemetryService) TrackPublishRTPStatsArgsForCall(i int) (context.Context, *livekit.Room, livekit.ParticipantID, livekit.TrackID, mime.MimeType, int, *livekit.RTPStats) {
 	fake.trackPublishRTPStatsMutex.RLock()
 	defer fake.trackPublishRTPStatsMutex.RUnlock()
 	argsForCall := fake.trackPublishRTPStatsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7, argsForCall.arg8
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
 }
 
-func (fake *FakeTelemetryService) TrackPublishRequested(arg1 context.Context, arg2 livekit.RoomID, arg3 livekit.RoomName, arg4 livekit.ParticipantID, arg5 livekit.ParticipantIdentity, arg6 *livekit.TrackInfo) {
+func (fake *FakeTelemetryService) TrackPublishRequested(arg1 context.Context, arg2 *livekit.Room, arg3 livekit.ParticipantID, arg4 livekit.ParticipantIdentity, arg5 *livekit.TrackInfo) {
 	fake.trackPublishRequestedMutex.Lock()
 	fake.trackPublishRequestedArgsForCall = append(fake.trackPublishRequestedArgsForCall, struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 livekit.ParticipantIdentity
-		arg6 *livekit.TrackInfo
-	}{arg1, arg2, arg3, arg4, arg5, arg6})
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 livekit.ParticipantIdentity
+		arg5 *livekit.TrackInfo
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.TrackPublishRequestedStub
-	fake.recordInvocation("TrackPublishRequested", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
+	fake.recordInvocation("TrackPublishRequested", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.trackPublishRequestedMutex.Unlock()
 	if stub != nil {
-		fake.TrackPublishRequestedStub(arg1, arg2, arg3, arg4, arg5, arg6)
+		fake.TrackPublishRequestedStub(arg1, arg2, arg3, arg4, arg5)
 	}
 }
 
@@ -1257,35 +1240,34 @@ func (fake *FakeTelemetryService) TrackPublishRequestedCallCount() int {
 	return len(fake.trackPublishRequestedArgsForCall)
 }
 
-func (fake *FakeTelemetryService) TrackPublishRequestedCalls(stub func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo)) {
+func (fake *FakeTelemetryService) TrackPublishRequestedCalls(stub func(context.Context, *livekit.Room, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo)) {
 	fake.trackPublishRequestedMutex.Lock()
 	defer fake.trackPublishRequestedMutex.Unlock()
 	fake.TrackPublishRequestedStub = stub
 }
 
-func (fake *FakeTelemetryService) TrackPublishRequestedArgsForCall(i int) (context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo) {
+func (fake *FakeTelemetryService) TrackPublishRequestedArgsForCall(i int) (context.Context, *livekit.Room, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo) {
 	fake.trackPublishRequestedMutex.RLock()
 	defer fake.trackPublishRequestedMutex.RUnlock()
 	argsForCall := fake.trackPublishRequestedArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
-func (fake *FakeTelemetryService) TrackPublished(arg1 context.Context, arg2 livekit.RoomID, arg3 livekit.RoomName, arg4 livekit.ParticipantID, arg5 livekit.ParticipantIdentity, arg6 *livekit.TrackInfo, arg7 bool) {
+func (fake *FakeTelemetryService) TrackPublished(arg1 context.Context, arg2 *livekit.Room, arg3 livekit.ParticipantID, arg4 livekit.ParticipantIdentity, arg5 *livekit.TrackInfo, arg6 bool) {
 	fake.trackPublishedMutex.Lock()
 	fake.trackPublishedArgsForCall = append(fake.trackPublishedArgsForCall, struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 livekit.ParticipantIdentity
-		arg6 *livekit.TrackInfo
-		arg7 bool
-	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 livekit.ParticipantIdentity
+		arg5 *livekit.TrackInfo
+		arg6 bool
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
 	stub := fake.TrackPublishedStub
-	fake.recordInvocation("TrackPublished", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	fake.recordInvocation("TrackPublished", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.trackPublishedMutex.Unlock()
 	if stub != nil {
-		fake.TrackPublishedStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+		fake.TrackPublishedStub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 }
 
@@ -1295,33 +1277,32 @@ func (fake *FakeTelemetryService) TrackPublishedCallCount() int {
 	return len(fake.trackPublishedArgsForCall)
 }
 
-func (fake *FakeTelemetryService) TrackPublishedCalls(stub func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, bool)) {
+func (fake *FakeTelemetryService) TrackPublishedCalls(stub func(context.Context, *livekit.Room, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, bool)) {
 	fake.trackPublishedMutex.Lock()
 	defer fake.trackPublishedMutex.Unlock()
 	fake.TrackPublishedStub = stub
 }
 
-func (fake *FakeTelemetryService) TrackPublishedArgsForCall(i int) (context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, bool) {
+func (fake *FakeTelemetryService) TrackPublishedArgsForCall(i int) (context.Context, *livekit.Room, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, bool) {
 	fake.trackPublishedMutex.RLock()
 	defer fake.trackPublishedMutex.RUnlock()
 	argsForCall := fake.trackPublishedArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
-func (fake *FakeTelemetryService) TrackPublishedUpdate(arg1 context.Context, arg2 livekit.RoomID, arg3 livekit.RoomName, arg4 livekit.ParticipantID, arg5 *livekit.TrackInfo) {
+func (fake *FakeTelemetryService) TrackPublishedUpdate(arg1 context.Context, arg2 *livekit.Room, arg3 livekit.ParticipantID, arg4 *livekit.TrackInfo) {
 	fake.trackPublishedUpdateMutex.Lock()
 	fake.trackPublishedUpdateArgsForCall = append(fake.trackPublishedUpdateArgsForCall, struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 *livekit.TrackInfo
-	}{arg1, arg2, arg3, arg4, arg5})
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 *livekit.TrackInfo
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.TrackPublishedUpdateStub
-	fake.recordInvocation("TrackPublishedUpdate", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("TrackPublishedUpdate", []interface{}{arg1, arg2, arg3, arg4})
 	fake.trackPublishedUpdateMutex.Unlock()
 	if stub != nil {
-		fake.TrackPublishedUpdateStub(arg1, arg2, arg3, arg4, arg5)
+		fake.TrackPublishedUpdateStub(arg1, arg2, arg3, arg4)
 	}
 }
 
@@ -1331,17 +1312,17 @@ func (fake *FakeTelemetryService) TrackPublishedUpdateCallCount() int {
 	return len(fake.trackPublishedUpdateArgsForCall)
 }
 
-func (fake *FakeTelemetryService) TrackPublishedUpdateCalls(stub func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo)) {
+func (fake *FakeTelemetryService) TrackPublishedUpdateCalls(stub func(context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo)) {
 	fake.trackPublishedUpdateMutex.Lock()
 	defer fake.trackPublishedUpdateMutex.Unlock()
 	fake.TrackPublishedUpdateStub = stub
 }
 
-func (fake *FakeTelemetryService) TrackPublishedUpdateArgsForCall(i int) (context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo) {
+func (fake *FakeTelemetryService) TrackPublishedUpdateArgsForCall(i int) (context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo) {
 	fake.trackPublishedUpdateMutex.RLock()
 	defer fake.trackPublishedUpdateMutex.RUnlock()
 	argsForCall := fake.trackPublishedUpdateArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeTelemetryService) TrackStats(arg1 livekit.RoomID, arg2 livekit.RoomName, arg3 telemetry.StatsKey, arg4 *livekit.AnalyticsStat) {
@@ -1379,22 +1360,21 @@ func (fake *FakeTelemetryService) TrackStatsArgsForCall(i int) (livekit.RoomID, 
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeTelemetryService) TrackSubscribeFailed(arg1 context.Context, arg2 livekit.RoomID, arg3 livekit.RoomName, arg4 livekit.ParticipantID, arg5 livekit.TrackID, arg6 error, arg7 bool) {
+func (fake *FakeTelemetryService) TrackSubscribeFailed(arg1 context.Context, arg2 *livekit.Room, arg3 livekit.ParticipantID, arg4 livekit.TrackID, arg5 error, arg6 bool) {
 	fake.trackSubscribeFailedMutex.Lock()
 	fake.trackSubscribeFailedArgsForCall = append(fake.trackSubscribeFailedArgsForCall, struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 livekit.TrackID
-		arg6 error
-		arg7 bool
-	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 livekit.TrackID
+		arg5 error
+		arg6 bool
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
 	stub := fake.TrackSubscribeFailedStub
-	fake.recordInvocation("TrackSubscribeFailed", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	fake.recordInvocation("TrackSubscribeFailed", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.trackSubscribeFailedMutex.Unlock()
 	if stub != nil {
-		fake.TrackSubscribeFailedStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+		fake.TrackSubscribeFailedStub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 }
 
@@ -1404,35 +1384,34 @@ func (fake *FakeTelemetryService) TrackSubscribeFailedCallCount() int {
 	return len(fake.trackSubscribeFailedArgsForCall)
 }
 
-func (fake *FakeTelemetryService) TrackSubscribeFailedCalls(stub func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.TrackID, error, bool)) {
+func (fake *FakeTelemetryService) TrackSubscribeFailedCalls(stub func(context.Context, *livekit.Room, livekit.ParticipantID, livekit.TrackID, error, bool)) {
 	fake.trackSubscribeFailedMutex.Lock()
 	defer fake.trackSubscribeFailedMutex.Unlock()
 	fake.TrackSubscribeFailedStub = stub
 }
 
-func (fake *FakeTelemetryService) TrackSubscribeFailedArgsForCall(i int) (context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.TrackID, error, bool) {
+func (fake *FakeTelemetryService) TrackSubscribeFailedArgsForCall(i int) (context.Context, *livekit.Room, livekit.ParticipantID, livekit.TrackID, error, bool) {
 	fake.trackSubscribeFailedMutex.RLock()
 	defer fake.trackSubscribeFailedMutex.RUnlock()
 	argsForCall := fake.trackSubscribeFailedArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
-func (fake *FakeTelemetryService) TrackSubscribeRTPStats(arg1 context.Context, arg2 livekit.RoomID, arg3 livekit.RoomName, arg4 livekit.ParticipantID, arg5 livekit.TrackID, arg6 mime.MimeType, arg7 *livekit.RTPStats) {
+func (fake *FakeTelemetryService) TrackSubscribeRTPStats(arg1 context.Context, arg2 *livekit.Room, arg3 livekit.ParticipantID, arg4 livekit.TrackID, arg5 mime.MimeType, arg6 *livekit.RTPStats) {
 	fake.trackSubscribeRTPStatsMutex.Lock()
 	fake.trackSubscribeRTPStatsArgsForCall = append(fake.trackSubscribeRTPStatsArgsForCall, struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 livekit.TrackID
-		arg6 mime.MimeType
-		arg7 *livekit.RTPStats
-	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 livekit.TrackID
+		arg5 mime.MimeType
+		arg6 *livekit.RTPStats
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
 	stub := fake.TrackSubscribeRTPStatsStub
-	fake.recordInvocation("TrackSubscribeRTPStats", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	fake.recordInvocation("TrackSubscribeRTPStats", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.trackSubscribeRTPStatsMutex.Unlock()
 	if stub != nil {
-		fake.TrackSubscribeRTPStatsStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+		fake.TrackSubscribeRTPStatsStub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 }
 
@@ -1442,33 +1421,32 @@ func (fake *FakeTelemetryService) TrackSubscribeRTPStatsCallCount() int {
 	return len(fake.trackSubscribeRTPStatsArgsForCall)
 }
 
-func (fake *FakeTelemetryService) TrackSubscribeRTPStatsCalls(stub func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.TrackID, mime.MimeType, *livekit.RTPStats)) {
+func (fake *FakeTelemetryService) TrackSubscribeRTPStatsCalls(stub func(context.Context, *livekit.Room, livekit.ParticipantID, livekit.TrackID, mime.MimeType, *livekit.RTPStats)) {
 	fake.trackSubscribeRTPStatsMutex.Lock()
 	defer fake.trackSubscribeRTPStatsMutex.Unlock()
 	fake.TrackSubscribeRTPStatsStub = stub
 }
 
-func (fake *FakeTelemetryService) TrackSubscribeRTPStatsArgsForCall(i int) (context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.TrackID, mime.MimeType, *livekit.RTPStats) {
+func (fake *FakeTelemetryService) TrackSubscribeRTPStatsArgsForCall(i int) (context.Context, *livekit.Room, livekit.ParticipantID, livekit.TrackID, mime.MimeType, *livekit.RTPStats) {
 	fake.trackSubscribeRTPStatsMutex.RLock()
 	defer fake.trackSubscribeRTPStatsMutex.RUnlock()
 	argsForCall := fake.trackSubscribeRTPStatsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
-func (fake *FakeTelemetryService) TrackSubscribeRequested(arg1 context.Context, arg2 livekit.RoomID, arg3 livekit.RoomName, arg4 livekit.ParticipantID, arg5 *livekit.TrackInfo) {
+func (fake *FakeTelemetryService) TrackSubscribeRequested(arg1 context.Context, arg2 *livekit.Room, arg3 livekit.ParticipantID, arg4 *livekit.TrackInfo) {
 	fake.trackSubscribeRequestedMutex.Lock()
 	fake.trackSubscribeRequestedArgsForCall = append(fake.trackSubscribeRequestedArgsForCall, struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 *livekit.TrackInfo
-	}{arg1, arg2, arg3, arg4, arg5})
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 *livekit.TrackInfo
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.TrackSubscribeRequestedStub
-	fake.recordInvocation("TrackSubscribeRequested", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("TrackSubscribeRequested", []interface{}{arg1, arg2, arg3, arg4})
 	fake.trackSubscribeRequestedMutex.Unlock()
 	if stub != nil {
-		fake.TrackSubscribeRequestedStub(arg1, arg2, arg3, arg4, arg5)
+		fake.TrackSubscribeRequestedStub(arg1, arg2, arg3, arg4)
 	}
 }
 
@@ -1478,35 +1456,34 @@ func (fake *FakeTelemetryService) TrackSubscribeRequestedCallCount() int {
 	return len(fake.trackSubscribeRequestedArgsForCall)
 }
 
-func (fake *FakeTelemetryService) TrackSubscribeRequestedCalls(stub func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo)) {
+func (fake *FakeTelemetryService) TrackSubscribeRequestedCalls(stub func(context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo)) {
 	fake.trackSubscribeRequestedMutex.Lock()
 	defer fake.trackSubscribeRequestedMutex.Unlock()
 	fake.TrackSubscribeRequestedStub = stub
 }
 
-func (fake *FakeTelemetryService) TrackSubscribeRequestedArgsForCall(i int) (context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo) {
+func (fake *FakeTelemetryService) TrackSubscribeRequestedArgsForCall(i int) (context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo) {
 	fake.trackSubscribeRequestedMutex.RLock()
 	defer fake.trackSubscribeRequestedMutex.RUnlock()
 	argsForCall := fake.trackSubscribeRequestedArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeTelemetryService) TrackSubscribed(arg1 context.Context, arg2 livekit.RoomID, arg3 livekit.RoomName, arg4 livekit.ParticipantID, arg5 *livekit.TrackInfo, arg6 *livekit.ParticipantInfo, arg7 bool) {
+func (fake *FakeTelemetryService) TrackSubscribed(arg1 context.Context, arg2 *livekit.Room, arg3 livekit.ParticipantID, arg4 *livekit.TrackInfo, arg5 *livekit.ParticipantInfo, arg6 bool) {
 	fake.trackSubscribedMutex.Lock()
 	fake.trackSubscribedArgsForCall = append(fake.trackSubscribedArgsForCall, struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 *livekit.TrackInfo
-		arg6 *livekit.ParticipantInfo
-		arg7 bool
-	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 *livekit.TrackInfo
+		arg5 *livekit.ParticipantInfo
+		arg6 bool
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
 	stub := fake.TrackSubscribedStub
-	fake.recordInvocation("TrackSubscribed", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	fake.recordInvocation("TrackSubscribed", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.trackSubscribedMutex.Unlock()
 	if stub != nil {
-		fake.TrackSubscribedStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+		fake.TrackSubscribedStub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 }
 
@@ -1516,33 +1493,32 @@ func (fake *FakeTelemetryService) TrackSubscribedCallCount() int {
 	return len(fake.trackSubscribedArgsForCall)
 }
 
-func (fake *FakeTelemetryService) TrackSubscribedCalls(stub func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo, *livekit.ParticipantInfo, bool)) {
+func (fake *FakeTelemetryService) TrackSubscribedCalls(stub func(context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo, *livekit.ParticipantInfo, bool)) {
 	fake.trackSubscribedMutex.Lock()
 	defer fake.trackSubscribedMutex.Unlock()
 	fake.TrackSubscribedStub = stub
 }
 
-func (fake *FakeTelemetryService) TrackSubscribedArgsForCall(i int) (context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo, *livekit.ParticipantInfo, bool) {
+func (fake *FakeTelemetryService) TrackSubscribedArgsForCall(i int) (context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo, *livekit.ParticipantInfo, bool) {
 	fake.trackSubscribedMutex.RLock()
 	defer fake.trackSubscribedMutex.RUnlock()
 	argsForCall := fake.trackSubscribedArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
-func (fake *FakeTelemetryService) TrackUnmuted(arg1 context.Context, arg2 livekit.RoomID, arg3 livekit.RoomName, arg4 livekit.ParticipantID, arg5 *livekit.TrackInfo) {
+func (fake *FakeTelemetryService) TrackUnmuted(arg1 context.Context, arg2 *livekit.Room, arg3 livekit.ParticipantID, arg4 *livekit.TrackInfo) {
 	fake.trackUnmutedMutex.Lock()
 	fake.trackUnmutedArgsForCall = append(fake.trackUnmutedArgsForCall, struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 *livekit.TrackInfo
-	}{arg1, arg2, arg3, arg4, arg5})
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 *livekit.TrackInfo
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.TrackUnmutedStub
-	fake.recordInvocation("TrackUnmuted", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("TrackUnmuted", []interface{}{arg1, arg2, arg3, arg4})
 	fake.trackUnmutedMutex.Unlock()
 	if stub != nil {
-		fake.TrackUnmutedStub(arg1, arg2, arg3, arg4, arg5)
+		fake.TrackUnmutedStub(arg1, arg2, arg3, arg4)
 	}
 }
 
@@ -1552,35 +1528,34 @@ func (fake *FakeTelemetryService) TrackUnmutedCallCount() int {
 	return len(fake.trackUnmutedArgsForCall)
 }
 
-func (fake *FakeTelemetryService) TrackUnmutedCalls(stub func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo)) {
+func (fake *FakeTelemetryService) TrackUnmutedCalls(stub func(context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo)) {
 	fake.trackUnmutedMutex.Lock()
 	defer fake.trackUnmutedMutex.Unlock()
 	fake.TrackUnmutedStub = stub
 }
 
-func (fake *FakeTelemetryService) TrackUnmutedArgsForCall(i int) (context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo) {
+func (fake *FakeTelemetryService) TrackUnmutedArgsForCall(i int) (context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo) {
 	fake.trackUnmutedMutex.RLock()
 	defer fake.trackUnmutedMutex.RUnlock()
 	argsForCall := fake.trackUnmutedArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeTelemetryService) TrackUnpublished(arg1 context.Context, arg2 livekit.RoomID, arg3 livekit.RoomName, arg4 livekit.ParticipantID, arg5 livekit.ParticipantIdentity, arg6 *livekit.TrackInfo, arg7 bool) {
+func (fake *FakeTelemetryService) TrackUnpublished(arg1 context.Context, arg2 *livekit.Room, arg3 livekit.ParticipantID, arg4 livekit.ParticipantIdentity, arg5 *livekit.TrackInfo, arg6 bool) {
 	fake.trackUnpublishedMutex.Lock()
 	fake.trackUnpublishedArgsForCall = append(fake.trackUnpublishedArgsForCall, struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 livekit.ParticipantIdentity
-		arg6 *livekit.TrackInfo
-		arg7 bool
-	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 livekit.ParticipantIdentity
+		arg5 *livekit.TrackInfo
+		arg6 bool
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
 	stub := fake.TrackUnpublishedStub
-	fake.recordInvocation("TrackUnpublished", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	fake.recordInvocation("TrackUnpublished", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.trackUnpublishedMutex.Unlock()
 	if stub != nil {
-		fake.TrackUnpublishedStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+		fake.TrackUnpublishedStub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 }
 
@@ -1590,34 +1565,33 @@ func (fake *FakeTelemetryService) TrackUnpublishedCallCount() int {
 	return len(fake.trackUnpublishedArgsForCall)
 }
 
-func (fake *FakeTelemetryService) TrackUnpublishedCalls(stub func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, bool)) {
+func (fake *FakeTelemetryService) TrackUnpublishedCalls(stub func(context.Context, *livekit.Room, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, bool)) {
 	fake.trackUnpublishedMutex.Lock()
 	defer fake.trackUnpublishedMutex.Unlock()
 	fake.TrackUnpublishedStub = stub
 }
 
-func (fake *FakeTelemetryService) TrackUnpublishedArgsForCall(i int) (context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, bool) {
+func (fake *FakeTelemetryService) TrackUnpublishedArgsForCall(i int) (context.Context, *livekit.Room, livekit.ParticipantID, livekit.ParticipantIdentity, *livekit.TrackInfo, bool) {
 	fake.trackUnpublishedMutex.RLock()
 	defer fake.trackUnpublishedMutex.RUnlock()
 	argsForCall := fake.trackUnpublishedArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
-func (fake *FakeTelemetryService) TrackUnsubscribed(arg1 context.Context, arg2 livekit.RoomID, arg3 livekit.RoomName, arg4 livekit.ParticipantID, arg5 *livekit.TrackInfo, arg6 bool) {
+func (fake *FakeTelemetryService) TrackUnsubscribed(arg1 context.Context, arg2 *livekit.Room, arg3 livekit.ParticipantID, arg4 *livekit.TrackInfo, arg5 bool) {
 	fake.trackUnsubscribedMutex.Lock()
 	fake.trackUnsubscribedArgsForCall = append(fake.trackUnsubscribedArgsForCall, struct {
 		arg1 context.Context
-		arg2 livekit.RoomID
-		arg3 livekit.RoomName
-		arg4 livekit.ParticipantID
-		arg5 *livekit.TrackInfo
-		arg6 bool
-	}{arg1, arg2, arg3, arg4, arg5, arg6})
+		arg2 *livekit.Room
+		arg3 livekit.ParticipantID
+		arg4 *livekit.TrackInfo
+		arg5 bool
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.TrackUnsubscribedStub
-	fake.recordInvocation("TrackUnsubscribed", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
+	fake.recordInvocation("TrackUnsubscribed", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.trackUnsubscribedMutex.Unlock()
 	if stub != nil {
-		fake.TrackUnsubscribedStub(arg1, arg2, arg3, arg4, arg5, arg6)
+		fake.TrackUnsubscribedStub(arg1, arg2, arg3, arg4, arg5)
 	}
 }
 
@@ -1627,17 +1601,17 @@ func (fake *FakeTelemetryService) TrackUnsubscribedCallCount() int {
 	return len(fake.trackUnsubscribedArgsForCall)
 }
 
-func (fake *FakeTelemetryService) TrackUnsubscribedCalls(stub func(context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo, bool)) {
+func (fake *FakeTelemetryService) TrackUnsubscribedCalls(stub func(context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo, bool)) {
 	fake.trackUnsubscribedMutex.Lock()
 	defer fake.trackUnsubscribedMutex.Unlock()
 	fake.TrackUnsubscribedStub = stub
 }
 
-func (fake *FakeTelemetryService) TrackUnsubscribedArgsForCall(i int) (context.Context, livekit.RoomID, livekit.RoomName, livekit.ParticipantID, *livekit.TrackInfo, bool) {
+func (fake *FakeTelemetryService) TrackUnsubscribedArgsForCall(i int) (context.Context, *livekit.Room, livekit.ParticipantID, *livekit.TrackInfo, bool) {
 	fake.trackUnsubscribedMutex.RLock()
 	defer fake.trackUnsubscribedMutex.RUnlock()
 	argsForCall := fake.trackUnsubscribedArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeTelemetryService) Webhook(arg1 context.Context, arg2 *livekit.WebhookInfo) {

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -46,29 +46,29 @@ type TelemetryService interface {
 	// ParticipantLeft - the participant leaves the room, only sent if ParticipantActive has been called before
 	ParticipantLeft(ctx context.Context, room *livekit.Room, participant *livekit.ParticipantInfo, shouldSendEvent bool, guard *ReferenceGuard)
 	// TrackPublishRequested - a publication attempt has been received
-	TrackPublishRequested(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo)
+	TrackPublishRequested(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo)
 	// TrackPublished - a publication attempt has been successful
-	TrackPublished(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo, shouldSendEvent bool)
+	TrackPublished(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo, shouldSendEvent bool)
 	// TrackUnpublished - a participant unpublished a track
-	TrackUnpublished(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo, shouldSendEvent bool)
+	TrackUnpublished(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo, shouldSendEvent bool)
 	// TrackSubscribeRequested - a participant requested to subscribe to a track
-	TrackSubscribeRequested(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, track *livekit.TrackInfo)
+	TrackSubscribeRequested(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, track *livekit.TrackInfo)
 	// TrackSubscribed - a participant subscribed to a track successfully
-	TrackSubscribed(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, track *livekit.TrackInfo, publisher *livekit.ParticipantInfo, shouldSendEvent bool)
+	TrackSubscribed(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, track *livekit.TrackInfo, publisher *livekit.ParticipantInfo, shouldSendEvent bool)
 	// TrackUnsubscribed - a participant unsubscribed from a track successfully
-	TrackUnsubscribed(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, track *livekit.TrackInfo, shouldSendEvent bool)
+	TrackUnsubscribed(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, track *livekit.TrackInfo, shouldSendEvent bool)
 	// TrackSubscribeFailed - failure to subscribe to a track
-	TrackSubscribeFailed(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, trackID livekit.TrackID, err error, isUserError bool)
+	TrackSubscribeFailed(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, trackID livekit.TrackID, err error, isUserError bool)
 	// TrackMuted - the publisher has muted the Track
-	TrackMuted(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, track *livekit.TrackInfo)
+	TrackMuted(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, track *livekit.TrackInfo)
 	// TrackUnmuted - the publisher has muted the Track
-	TrackUnmuted(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, track *livekit.TrackInfo)
+	TrackUnmuted(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, track *livekit.TrackInfo)
 	// TrackPublishedUpdate - track metadata has been updated
-	TrackPublishedUpdate(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, track *livekit.TrackInfo)
+	TrackPublishedUpdate(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, track *livekit.TrackInfo)
 	// TrackMaxSubscribedVideoQuality - publisher is notified of the max quality subscribers desire
-	TrackMaxSubscribedVideoQuality(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, track *livekit.TrackInfo, mime mime.MimeType, maxQuality livekit.VideoQuality)
-	TrackPublishRTPStats(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, trackID livekit.TrackID, mimeType mime.MimeType, layer int, stats *livekit.RTPStats)
-	TrackSubscribeRTPStats(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, trackID livekit.TrackID, mimeType mime.MimeType, stats *livekit.RTPStats)
+	TrackMaxSubscribedVideoQuality(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, track *livekit.TrackInfo, mime mime.MimeType, maxQuality livekit.VideoQuality)
+	TrackPublishRTPStats(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, trackID livekit.TrackID, mimeType mime.MimeType, layer int, stats *livekit.RTPStats)
+	TrackSubscribeRTPStats(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, trackID livekit.TrackID, mimeType mime.MimeType, stats *livekit.RTPStats)
 
 	EgressStarted(ctx context.Context, info *livekit.EgressInfo)
 	EgressUpdated(ctx context.Context, info *livekit.EgressInfo)
@@ -114,31 +114,31 @@ func (n NullTelemetryService) ParticipantResumed(ctx context.Context, room *live
 }
 func (n NullTelemetryService) ParticipantLeft(ctx context.Context, room *livekit.Room, participant *livekit.ParticipantInfo, shouldSendEvent bool, guard *ReferenceGuard) {
 }
-func (n NullTelemetryService) TrackPublishRequested(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo) {
+func (n NullTelemetryService) TrackPublishRequested(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo) {
 }
-func (n NullTelemetryService) TrackPublished(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo, shouldSendEvent bool) {
+func (n NullTelemetryService) TrackPublished(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo, shouldSendEvent bool) {
 }
-func (n NullTelemetryService) TrackUnpublished(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo, shouldSendEvent bool) {
+func (n NullTelemetryService) TrackUnpublished(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, identity livekit.ParticipantIdentity, track *livekit.TrackInfo, shouldSendEvent bool) {
 }
-func (n NullTelemetryService) TrackSubscribeRequested(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, track *livekit.TrackInfo) {
+func (n NullTelemetryService) TrackSubscribeRequested(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, track *livekit.TrackInfo) {
 }
-func (n NullTelemetryService) TrackSubscribed(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, track *livekit.TrackInfo, publisher *livekit.ParticipantInfo, shouldSendEvent bool) {
+func (n NullTelemetryService) TrackSubscribed(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, track *livekit.TrackInfo, publisher *livekit.ParticipantInfo, shouldSendEvent bool) {
 }
-func (n NullTelemetryService) TrackUnsubscribed(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, track *livekit.TrackInfo, shouldSendEvent bool) {
+func (n NullTelemetryService) TrackUnsubscribed(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, track *livekit.TrackInfo, shouldSendEvent bool) {
 }
-func (n NullTelemetryService) TrackSubscribeFailed(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, trackID livekit.TrackID, err error, isUserError bool) {
+func (n NullTelemetryService) TrackSubscribeFailed(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, trackID livekit.TrackID, err error, isUserError bool) {
 }
-func (n NullTelemetryService) TrackMuted(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, track *livekit.TrackInfo) {
+func (n NullTelemetryService) TrackMuted(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, track *livekit.TrackInfo) {
 }
-func (n NullTelemetryService) TrackUnmuted(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, track *livekit.TrackInfo) {
+func (n NullTelemetryService) TrackUnmuted(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, track *livekit.TrackInfo) {
 }
-func (n NullTelemetryService) TrackPublishedUpdate(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, track *livekit.TrackInfo) {
+func (n NullTelemetryService) TrackPublishedUpdate(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, track *livekit.TrackInfo) {
 }
-func (n NullTelemetryService) TrackMaxSubscribedVideoQuality(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, track *livekit.TrackInfo, mime mime.MimeType, maxQuality livekit.VideoQuality) {
+func (n NullTelemetryService) TrackMaxSubscribedVideoQuality(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, track *livekit.TrackInfo, mime mime.MimeType, maxQuality livekit.VideoQuality) {
 }
-func (n NullTelemetryService) TrackPublishRTPStats(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, trackID livekit.TrackID, mimeType mime.MimeType, layer int, stats *livekit.RTPStats) {
+func (n NullTelemetryService) TrackPublishRTPStats(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, trackID livekit.TrackID, mimeType mime.MimeType, layer int, stats *livekit.RTPStats) {
 }
-func (n NullTelemetryService) TrackSubscribeRTPStats(ctx context.Context, roomID livekit.RoomID, roomName livekit.RoomName, participantID livekit.ParticipantID, trackID livekit.TrackID, mimeType mime.MimeType, stats *livekit.RTPStats) {
+func (n NullTelemetryService) TrackSubscribeRTPStats(ctx context.Context, room *livekit.Room, participantID livekit.ParticipantID, trackID livekit.TrackID, mimeType mime.MimeType, stats *livekit.RTPStats) {
 }
 func (n NullTelemetryService) EgressStarted(ctx context.Context, info *livekit.EgressInfo)          {}
 func (n NullTelemetryService) EgressUpdated(ctx context.Context, info *livekit.EgressInfo)          {}


### PR DESCRIPTION
Passes the full room proto directly to telemetry methods instead of just roomID/roomName, so webhook events include complete room metadata rather than a minimal stub. Does not apply to EgressInfo/IngressInfo.

In our use case, we need to retrieve an external session ID stored in the room metadata.