### PR TITLE
fix: pass PSRPC client options to agent internal client

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -88,8 +88,8 @@ type agentClient struct {
 	subDone       chan struct{}
 }
 
-func NewAgentClient(bus psrpc.MessageBus, config Config) (Client, error) {
-	client, err := rpc.NewAgentInternalClient(bus)
+func NewAgentClient(bus psrpc.MessageBus, config Config, opts ...psrpc.ClientOption) (Client, error) {
+	client, err := rpc.NewAgentInternalClient(bus, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/wire.go
+++ b/pkg/service/wire.go
@@ -83,7 +83,7 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 		NewAgentService,
 		NewAgentDispatchService,
 		getAgentConfig,
-		agent.NewAgentClient,
+		newAgentClient,
 		getAgentStore,
 		getSignalRelayConfig,
 		NewDefaultSignalServer,
@@ -236,6 +236,10 @@ func newSIPClient(p rpc.ClientParams) (rpc.SIPClient, error) {
 			otelpsrpc.ClientOptions(otelpsrpc.Config{}),
 		},
 	})
+}
+
+func newAgentClient(p rpc.ClientParams, config agent.Config) (agent.Client, error) {
+	return agent.NewAgentClient(p.Bus, config, p.Options()...)
 }
 
 func getSIPStore(s ObjectStore) SIPStore {

--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -134,7 +134,7 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 		return nil, err
 	}
 	agentConfig := getAgentConfig(conf)
-	client, err := agent.NewAgentClient(messageBus, agentConfig)
+	client, err := newAgentClient(clientParams, agentConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

The agent internal client (`NewAgentClient` in `pkg/agent/client.go`) is the **only** PSRPC client in the codebase that does not receive `ClientParams` options. Every other client (Egress, Ingress, SIP, Room, Participant, AgentDispatch, WHIP, Keepalive) gets the full set of options from `ClientParams.Options()`, which includes:

- Retry middleware (`max_attempts`, `timeout`, `backoff` from `psrpc:` config)
- Metrics middleware (`PSRPCMetricsObserver`)
- Logging middleware
- OpenTelemetry tracing
- Buffer size configuration

This means the `psrpc:` section in `livekit.yaml` has **no effect** on agent job dispatch RPCs (`CheckEnabled`, `JobRequest`, `WorkerRegistered`).

## Problem

In multi-node self-hosted deployments where agent workers connect through a load balancer (ALB), the cross-node PSRPC `JobRequest` uses the hardcoded 3-second `DefaultClientTimeout` from [psrpc/client.go](https://github.com/livekit/psrpc/blob/main/client.go). When network latency between the requesting node and the node hosting the worker is non-trivial (e.g., workers in a different region connected via ALB), this timeout can be too tight.

We observed a production incident where:
1. Room was created on Node A (Shanghai)
2. PSRPC routed `JobRequest` to Node B (also Shanghai) where the worker was registered
3. The worker (in Hong Kong, ~160ms RTT) responded with availability **99ms after** the 3-second deadline
4. Server logged: `failed to assign job to worker ... "error": "context deadline exceeded"`
5. The late response was discarded: `received availability response for unknown job`
6. `retry: false` — no second attempt was made

This is consistent with reports in:
- #3645 (distributed agent dispatch issues)
- #3858 (Redis PSRPC latency causing timeouts)
- #4269 / #4309 (same `DefaultPSRPCConfig` 3s timeout broke SIP calls — fixed for SIP but not for agents)

## Changes

- **`pkg/agent/client.go`**: Add variadic `...psrpc.ClientOption` parameter to `NewAgentClient`, pass through to `rpc.NewAgentInternalClient`
- **`pkg/service/wire_gen.go`**: Pass `clientParams.Options()...` when creating the agent client

This follows the exact same pattern used by all other PSRPC clients in the codebase.

## After this change

Operators can tune agent dispatch timeouts via `livekit.yaml`:

```yaml
psrpc:
  timeout: 10s      # default: 3s — increase for cross-region deployments
  max_attempts: 3   # default: 3
  backoff: 2s       # default: 2s
```

The agent client also gains metrics, logging, and OpenTelemetry tracing, consistent with other PSRPC clients.

## Backward compatibility

- The `...psrpc.ClientOption` parameter is variadic, so existing callers that don't pass options continue to work unchanged
- The default `PSRPCConfig` values (`3s timeout, 3 attempts, 2s backoff`) are applied when no custom `psrpc:` config is set — this is the same behavior other clients already have
- Note: this does change agent dispatch behavior for deployments that use the default config, as the retry middleware (3 attempts with backoff) will now be active. Previously, a single timeout was terminal; now it will retry up to 3 times