### PR TITLE
fix: malformed TURN URL when NodeIP struct is used in iceServers

### DIFF
--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -992,7 +992,7 @@ func (r *RoomManager) iceServersForParticipant(apiKey string, participant types.
 		if r.config.TURN.UDPPort > 0 && !tlsOnly {
 			// UDP TURN is used as STUN
 			hasSTUN = true
-			urls = append(urls, fmt.Sprintf("turn:%s:%d?transport=udp", r.config.RTC.NodeIP, r.config.TURN.UDPPort))
+			urls = append(urls, fmt.Sprintf("turn:%s:%d?transport=udp", r.config.RTC.NodeIP.V4, r.config.TURN.UDPPort))
 		}
 		if r.config.TURN.TLSPort > 0 {
 			urls = append(urls, fmt.Sprintf("turns:%s:443?transport=tcp", r.config.TURN.Domain))


### PR DESCRIPTION
NodeIP is an IPsConfig struct, not a string. Printing it with %s in fmt.Sprintf produces "turn:{80.76.236.86 }:3478" (Go struct formatting with curly braces and trailing space), which is an invalid TURN URI.

WebRTC clients reject the malformed URL and createPeerConnection() returns null, causing all calls to fail immediately with "peer connection creation failed?" on Android (and likely other platforms).

Fix: use NodeIP.V4 (the string field), consistent with how turn.go already uses it at line 66 for RelayAddress.