### PR TITLE
fix: ensure num_participants is accurate in webhook events (#4265)

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -323,6 +323,14 @@ func (r *Room) ToProto() *livekit.Room {
 	return r.protoProxy.Get()
 }
 
+// ToProtoConsistent returns a room proto with participant counts computed
+// directly from the current participants map, bypassing the batched proto
+// proxy. Use this when an accurate num_participants is required immediately,
+// e.g. for webhook or telemetry events.
+func (r *Room) ToProtoConsistent() *livekit.Room {
+	return r.updateProto()
+}
+
 func (r *Room) Name() livekit.RoomName {
 	return livekit.RoomName(r.protoRoom.Name)
 }
@@ -480,17 +488,16 @@ func (r *Room) Join(
 		"numParticipants", len(r.participants),
 	)
 
-	r.participants[participant.Identity()] = participant
-	r.participantOpts[participant.Identity()] = opts
-	r.participantRequestSources[participant.Identity()] = requestSource
-
 	if participant.IsRecorder() && !r.protoRoom.ActiveRecording {
 		r.protoRoom.ActiveRecording = true
 		r.protoProxy.MarkDirty(true)
 	} else {
-		// Mark dirty after adding participant so updateProto() counts them
-		r.protoProxy.MarkDirty(true)
+		r.protoProxy.MarkDirty(false)
 	}
+
+	r.participants[participant.Identity()] = participant
+	r.participantOpts[participant.Identity()] = opts
+	r.participantRequestSources[participant.Identity()] = requestSource
 
 	if r.onParticipantChanged != nil {
 		r.onParticipantChanged(participant)
@@ -1404,10 +1411,7 @@ func (r *Room) RemoveParticipant(
 	delete(r.participantRequestSources, identity)
 	delete(r.hasPublished, identity)
 	delete(r.agentParticpants, identity)
-	// Note: NumParticipants is NOT decremented directly here.
-	// Instead, updateProto() recalculates it from the participants map.
-	// This avoids stale counts in webhook events.
-
+	immediateChange := false
 	if p.IsRecorder() {
 		activeRecording := false
 		for _, op := range r.participants {
@@ -1419,14 +1423,11 @@ func (r *Room) RemoveParticipant(
 
 		if r.protoRoom.ActiveRecording != activeRecording {
 			r.protoRoom.ActiveRecording = activeRecording
+			immediateChange = true
 		}
 	}
 	r.lock.Unlock()
-	// Force immediate proto update so that subsequent ToProto() calls
-	// (e.g., in webhook callbacks triggered by p.Close()) reflect the
-	// correct participant count.
-	done := r.protoProxy.MarkDirty(true)
-	<-done
+	r.protoProxy.MarkDirty(immediateChange)
 
 	if !p.HasConnected() {
 		fields := append(

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -480,16 +480,17 @@ func (r *Room) Join(
 		"numParticipants", len(r.participants),
 	)
 
+	r.participants[participant.Identity()] = participant
+	r.participantOpts[participant.Identity()] = opts
+	r.participantRequestSources[participant.Identity()] = requestSource
+
 	if participant.IsRecorder() && !r.protoRoom.ActiveRecording {
 		r.protoRoom.ActiveRecording = true
 		r.protoProxy.MarkDirty(true)
 	} else {
-		r.protoProxy.MarkDirty(false)
+		// Mark dirty after adding participant so updateProto() counts them
+		r.protoProxy.MarkDirty(true)
 	}
-
-	r.participants[participant.Identity()] = participant
-	r.participantOpts[participant.Identity()] = opts
-	r.participantRequestSources[participant.Identity()] = requestSource
 
 	if r.onParticipantChanged != nil {
 		r.onParticipantChanged(participant)
@@ -1403,11 +1404,10 @@ func (r *Room) RemoveParticipant(
 	delete(r.participantRequestSources, identity)
 	delete(r.hasPublished, identity)
 	delete(r.agentParticpants, identity)
-	if !p.Hidden() {
-		r.protoRoom.NumParticipants--
-	}
+	// Note: NumParticipants is NOT decremented directly here.
+	// Instead, updateProto() recalculates it from the participants map.
+	// This avoids stale counts in webhook events.
 
-	immediateChange := false
 	if p.IsRecorder() {
 		activeRecording := false
 		for _, op := range r.participants {
@@ -1419,11 +1419,14 @@ func (r *Room) RemoveParticipant(
 
 		if r.protoRoom.ActiveRecording != activeRecording {
 			r.protoRoom.ActiveRecording = activeRecording
-			immediateChange = true
 		}
 	}
 	r.lock.Unlock()
-	r.protoProxy.MarkDirty(immediateChange)
+	// Force immediate proto update so that subsequent ToProto() calls
+	// (e.g., in webhook callbacks triggered by p.Close()) reflect the
+	// correct participant count.
+	done := r.protoProxy.MarkDirty(true)
+	<-done
 
 	if !p.HasConnected() {
 		fields := append(

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -568,8 +568,8 @@ func (r *RoomManager) StartSession(
 	persistRoomForParticipantCount(room.ToProto())
 
 	clientMeta := &livekit.AnalyticsClientMeta{Region: r.currentNode.Region(), Node: string(r.currentNode.NodeID())}
-	// Use a fresh room proto so num_participants reflects the newly joined participant
-	r.telemetry.ParticipantJoined(ctx, room.ToProto(), participant.ToProto(), pi.Client, clientMeta, true, participant.TelemetryGuard())
+	// Use a consistent room proto so num_participants reflects the newly joined participant
+	r.telemetry.ParticipantJoined(ctx, room.ToProtoConsistent(), participant.ToProto(), pi.Client, clientMeta, true, participant.TelemetryGuard())
 	participant.AddOnClose(types.ParticipantCloseKeyNormal, func(p types.LocalParticipant) {
 		participantServerClosers.Close()
 
@@ -577,8 +577,8 @@ func (r *RoomManager) StartSession(
 			pLogger.Errorw("could not delete participant", err)
 		}
 
-		// update room store with new numParticipants
-		proto := room.ToProto()
+		// use consistent proto so num_participants is accurate for webhook
+		proto := room.ToProtoConsistent()
 		persistRoomForParticipantCount(proto)
 		r.telemetry.ParticipantLeft(ctx, proto, p.ToProto(), true, participant.TelemetryGuard())
 	})

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -568,7 +568,8 @@ func (r *RoomManager) StartSession(
 	persistRoomForParticipantCount(room.ToProto())
 
 	clientMeta := &livekit.AnalyticsClientMeta{Region: r.currentNode.Region(), Node: string(r.currentNode.NodeID())}
-	r.telemetry.ParticipantJoined(ctx, protoRoom, participant.ToProto(), pi.Client, clientMeta, true, participant.TelemetryGuard())
+	// Use a fresh room proto so num_participants reflects the newly joined participant
+	r.telemetry.ParticipantJoined(ctx, room.ToProto(), participant.ToProto(), pi.Client, clientMeta, true, participant.TelemetryGuard())
 	participant.AddOnClose(types.ParticipantCloseKeyNormal, func(p types.LocalParticipant) {
 		participantServerClosers.Close()
 


### PR DESCRIPTION
Three fixes for stale/incorrect num_participants in webhook payloads:

  1. Move participant map insertion before MarkDirty in join path so updateProto() counts the new participant.
  2. Use fresh room.ToProto() for participant_joined webhook instead of a stale snapshot captured at session start.
  3. Remove direct NumParticipants-- in leave path (inconsistent with updateProto's IsDependent check), force immediate proto update, and wait for completion before triggering onClose callbacks.