### PR TITLE
Revert "fix: ensure num_participants is accurate in webhook events (#4265)"

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -323,14 +323,6 @@ func (r *Room) ToProto() *livekit.Room {
 	return r.protoProxy.Get()
 }
 
-// ToProtoConsistent returns a room proto with participant counts computed
-// directly from the current participants map, bypassing the batched proto
-// proxy. Use this when an accurate num_participants is required immediately,
-// e.g. for webhook or telemetry events.
-func (r *Room) ToProtoConsistent() *livekit.Room {
-	return r.updateProto()
-}
-
 func (r *Room) Name() livekit.RoomName {
 	return livekit.RoomName(r.protoRoom.Name)
 }
@@ -1411,6 +1403,10 @@ func (r *Room) RemoveParticipant(
 	delete(r.participantRequestSources, identity)
 	delete(r.hasPublished, identity)
 	delete(r.agentParticpants, identity)
+	if !p.Hidden() {
+		r.protoRoom.NumParticipants--
+	}
+
 	immediateChange := false
 	if p.IsRecorder() {
 		activeRecording := false

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -569,8 +569,7 @@ func (r *RoomManager) StartSession(
 	persistRoomForParticipantCount(room.ToProto())
 
 	clientMeta := &livekit.AnalyticsClientMeta{Region: r.currentNode.Region(), Node: string(r.currentNode.NodeID())}
-	// Use a consistent room proto so num_participants reflects the newly joined participant
-	r.telemetry.ParticipantJoined(ctx, room.ToProtoConsistent(), participant.ToProto(), pi.Client, clientMeta, true, participant.TelemetryGuard())
+	r.telemetry.ParticipantJoined(ctx, protoRoom, participant.ToProto(), pi.Client, clientMeta, true, participant.TelemetryGuard())
 	participant.AddOnClose(types.ParticipantCloseKeyNormal, func(p types.LocalParticipant) {
 		participantServerClosers.Close()
 
@@ -578,8 +577,8 @@ func (r *RoomManager) StartSession(
 			pLogger.Errorw("could not delete participant", err)
 		}
 
-		// use consistent proto so num_participants is accurate for webhook
-		proto := room.ToProtoConsistent()
+		// update room store with new numParticipants
+		proto := room.ToProto()
 		persistRoomForParticipantCount(proto)
 		r.telemetry.ParticipantLeft(ctx, proto, p.ToProto(), true, participant.TelemetryGuard())
 	})


### PR DESCRIPTION
Reverts livekit/livekit#4422

When a room is hosted by multi nodes in cloud service, the node sends webhook could have stale `num_participants` state when the remote participant is updating that can't be accurate in this case. Revert the change here since we should have same behavior for both opensource and cloud to make sure application can migrate between them seamlessly.