### PR TITLE
fix: Use random weighted node selection instead of picking the node with max affinity.

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -17,6 +17,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -171,7 +172,11 @@ func (c *agentClient) LaunchJob(ctx context.Context, desc *JobRequest) *serverut
 				Metadata:        desc.Metadata,
 				EnableRecording: c.config.EnableUserDataRecording,
 			}
-			resp, err := c.client.JobRequest(context.Background(), topic, jobTypeTopic, job)
+			resp, err := c.client.JobRequest(context.Background(), topic, jobTypeTopic, job, psrpc.WithSelectionOpts(psrpc.SelectionOpts{
+				AffinityTimeout:     psrpc.DefaultAffinityTimeout,
+				ShortCircuitTimeout: psrpc.DefaultAffinityShortCircuit,
+				SelectionFunc:       weightedRandomSelection,
+			}))
 			if err != nil {
 				logger.Infow("failed to send job request", "error", err, "namespace", curNs, "jobType", desc.JobType, "agentName", desc.AgentName)
 				return
@@ -336,4 +341,29 @@ func GetAgentTopic(agentName, namespace string) string {
 	} else {
 		return fmt.Sprintf("%s_%s", agentName, namespace)
 	}
+}
+
+func weightedRandomSelection(claims []*psrpc.Claim) (serverID string, error error) {
+	if len(claims) == 0 {
+		return "", psrpc.ErrNoResponse
+	}
+
+	var totalWeight float32
+	for _, c := range claims {
+		totalWeight += c.Affinity
+	}
+
+	if totalWeight <= 0 {
+		return claims[rand.Intn(len(claims))].ServerID, nil
+	}
+
+	r := rand.Float32() * totalWeight
+	for _, c := range claims {
+		r -= c.Affinity
+		if r <= 0 {
+			return c.ServerID, nil
+		}
+	}
+
+	return claims[len(claims)-1].ServerID, nil
 }

--- a/pkg/agent/client_test.go
+++ b/pkg/agent/client_test.go
@@ -1,0 +1,81 @@
+package agent
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/psrpc"
+)
+
+func TestWeightedRandomSelection_EmptyClaims(t *testing.T) {
+	_, err := weightedRandomSelection(nil)
+	require.ErrorIs(t, err, psrpc.ErrNoResponse)
+
+	_, err = weightedRandomSelection([]*psrpc.Claim{})
+	require.ErrorIs(t, err, psrpc.ErrNoResponse)
+}
+
+func TestWeightedRandomSelection_ZeroAffinity(t *testing.T) {
+	claims := []*psrpc.Claim{
+		{ServerID: "a", Affinity: 0},
+		{ServerID: "b", Affinity: 0},
+		{ServerID: "c", Affinity: 0},
+	}
+
+	seen := make(map[string]bool)
+	for i := 0; i < 1000; i++ {
+		id, err := weightedRandomSelection(claims)
+		require.NoError(t, err)
+		seen[id] = true
+	}
+
+	for _, c := range claims {
+		require.True(t, seen[c.ServerID], "server %s was never selected", c.ServerID)
+	}
+}
+
+func TestWeightedRandomSelection_Distribution(t *testing.T) {
+	affinities := []float32{0, 0.1, 2, 5, 10, 20, 30, 35}
+	claims := make([]*psrpc.Claim, len(affinities))
+	for i, a := range affinities {
+		claims[i] = &psrpc.Claim{
+			ServerID: string(rune('A' + i)),
+			Affinity: a,
+		}
+	}
+
+	var totalWeight float64
+	for _, a := range affinities {
+		totalWeight += float64(a)
+	}
+
+	const iterations = 100_000
+	counts := make(map[string]int)
+	for i := 0; i < iterations; i++ {
+		id, err := weightedRandomSelection(claims)
+		require.NoError(t, err)
+		counts[id]++
+	}
+
+	// Server with 0 affinity should never be selected when others have positive weight.
+	require.Zero(t, counts[string(rune('A'))], "server with 0 affinity should never be selected")
+
+	for i, a := range affinities {
+		if a == 0 {
+			continue
+		}
+		id := string(rune('A' + i))
+		expected := float64(a) / totalWeight
+		actual := float64(counts[id]) / iterations
+
+		// Allow 2 percentage points of tolerance.
+		require.InDelta(t, expected, actual, 0.02,
+			"server %s: expected proportion %.4f, got %.4f (affinity %.1f)",
+			id, expected, actual, a,
+		)
+	}
+
+	_ = math.Abs // ensure import is used
+}


### PR DESCRIPTION
# Problem
When the client wants to launch a Job, it gathers affinities from all the livekit nodes and selects the one with the max affinity. The affinity for each node is calculated as sum of (1-worker.load) for each worker of the node.

This theoretically works ideally, as the Job is placed to the node with the highest free capacity.
However, the livekit agent workers update their load only every 2.5 seconds. It means in case of burst  - e.g. 100 jobs launched in a second, most of them will be placed on a single node, because the affinity of the node takes time until it gets updated.

As a result the load of the nodes and specially the workers is very imbalanced, some of the workers are overloaded and many others are not utilized - because they are registered to a node with small affinity (caused e.g. just by having less workers)

# Solution

One of the solutions can be not to select the node with the highest affinity, but to use random weighted selection based on the affinities. In this case higher the node affinity is, higher probability it gets the job is.

We confirmed this solution works in production, as after this change the workers load got evenly balanced.

Image 1
- shows the imbalance of the workers load before and after this change
<img width="1508" height="697" alt="image" src="https://github.com/user-attachments/assets/5372e089-a861-40d1-b122-21733b65098a" />

Image 2
- shows the node selection for jobs - many consecutive jobs are assigned to the same node, because the affinity haven't managed to get updated
<img width="1853" height="779" alt="image" src="https://github.com/user-attachments/assets/d0acaf4d-f343-45d3-b827-7f6f3a824ca0" />

Image 3
- after using the random weighted selection, consecutive jobs are assigned to random nodes
<img width="1854" height="781" alt="image" src="https://github.com/user-attachments/assets/7ef552e2-d469-44be-a4d1-20002e1a4a2b" />



