### PR TITLE
fix: track bitrate on successful writes in writeUnreliable

### DIFF
--- a/pkg/sfu/datachannel/datachannel_writer.go
+++ b/pkg/sfu/datachannel/datachannel_writer.go
@@ -130,7 +130,7 @@ func (w *DataChannelWriter[T]) writeUnreliable(p []byte) (n int, err error) {
 		return 0, err
 	}
 	n, err = w.rawDC.Write(p)
-	if err != nil {
+	if err == nil {
 		w.rate.AddBytes(n, int(w.bufferGetter.BufferedAmount()), mono.Now())
 	}
 


### PR DESCRIPTION
I think this condition is reversed. `writeUnreliable()` calls `rate.AddBytes()` inside `if err != nil`, meaning the bitrate calculator is only fed on write failures. Since successful writes never contribute samples, `rate.Bitrate()` almost always returns `ok == false`, and the `DatachannelLossyTargetLatency` buffer control check is permanently skipped.

The condition should be if `err == nil`, matching how `writeReliable()` unconditionally calls `rate.AddBytes()` after every write.