### PR TITLE
fix: agent session.shutdown(drain=True) incorrectly reported as JS_FA…

### DIFF
--- a/pkg/agent/worker.go
+++ b/pkg/agent/worker.go
@@ -517,6 +517,11 @@ func (w *Worker) UpdateJobStatus(update *livekit.UpdateJobStatus) (*livekit.JobS
 		return nil, psrpc.NewErrorf(psrpc.NotFound, "received job update for unknown job")
 	}
 
+	// Don't let a failure reason overwrite a job that already succeeded.
+	if job.State.Status == livekit.JobStatus_JS_SUCCESS && update.Status == livekit.JobStatus_JS_FAILED {
+		return proto.Clone(job.State).(*livekit.JobState), nil
+	}
+
 	now := time.Now()
 	job.State.UpdatedAt = now.UnixNano()
 

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -1451,7 +1451,11 @@ func (r *Room) RemoveParticipant(
 		agentJob.participantLeft()
 
 		go func() {
-			_, err := r.agentClient.TerminateJob(context.Background(), agentJob.Id, rpc.JobTerminateReason_AGENT_LEFT_ROOM)
+			// Use TERMINATION_REQUESTED when the agent leaves as part of a normal
+			// shutdown (session.shutdown(drain=True)), so that a successful
+			// UpdateJobStatus from the SDK is not overwritten with JS_FAILED.
+			// AGENT_LEFT_ROOM is reserved for unexpected disconnects.
+			_, err := r.agentClient.TerminateJob(context.Background(), agentJob.Id, rpc.JobTerminateReason_TERMINATION_REQUESTED)
 			if err != nil {
 				r.logger.Infow("failed sending TerminateJob RPC", "error", err, "jobID", agentJob.Id, "participant", identity)
 			}


### PR DESCRIPTION
Summary
Fixes a race condition where a successful agent session.shutdown(drain=True) is reported as JS_FAILED with "agent worker left the room" instead of JS_SUCCESS.

Closes #4447

Root Cause
Two independent paths both write the final job status and can arrive in either order:

SDK path — session.shutdown(drain=True) sends UpdateJobStatus(JS_SUCCESS) from the Python Agents SDK.
Room path — when the agent participant leaves the room, removeParticipant in room.go unconditionally fires TerminateJob(..., AGENT_LEFT_ROOM), which maps to JS_FAILED.
If the room path wins the race, the job is marked JS_FAILED and removed from runningJobs. When the SDK's JS_SUCCESS arrives next, the job is already gone — silently dropped as unknown — leaving the failure as the final recorded state.

Changes
pkg/agent/worker.go — Guard against success → failure downgrade
Added an early-return in UpdateJobStatus that prevents a JS_FAILED update from overwriting a job that already reached JS_SUCCESS. This covers the race regardless of which path wins.


// Don't let a failure reason overwrite a job that already succeeded.
if job.State.Status == livekit.JobStatus_JS_SUCCESS && update.Status == livekit.JobStatus_JS_FAILED {
    return proto.Clone(job.State).(*livekit.JobState), nil
}
pkg/rtc/room.go — Use correct termination reason on participant leave
Changed the reason in removeParticipant from AGENT_LEFT_ROOM → TERMINATION_REQUESTED.

AGENT_LEFT_ROOM was semantically wrong here — the server cannot distinguish a voluntary shutdown leave from a crash at removeParticipant. TERMINATION_REQUESTED maps to JS_SUCCESS, so even if the SDK's update hasn't arrived yet, the fallback is correct. AGENT_LEFT_ROOM should only fire when the worker WebSocket connection drops unexpectedly.