### PR TITLE
feat(pion/ice): replace deprecated NAT1To1 with SetAddressRewriteRules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/jellydator/ttlcache/v3 v3.4.0
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
-	github.com/livekit/mediatransportutil v0.0.0-20260409104613-0fcb3771c3d5
+	github.com/livekit/mediatransportutil v0.0.0-20260422071032-c2eb358ac882
 	github.com/livekit/protocol v1.45.3
 	github.com/livekit/psrpc v0.7.1
 	github.com/mackerelio/go-osstat v0.2.7

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/lithammer/shortuuid/v4 v4.2.0 h1:LMFOzVB3996a7b8aBuEXxqOBflbfPQAiVzkI
 github.com/lithammer/shortuuid/v4 v4.2.0/go.mod h1:D5noHZ2oFw/YaKCfGy0YxyE7M0wMbezmMjPdhyEFe6Y=
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5ATTo469PQPkqzdoU7be46ryiCDO3boc=
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
-github.com/livekit/mediatransportutil v0.0.0-20260409104613-0fcb3771c3d5 h1:Fm3HrfY6xTbZxo1vY/5Dlq34BjRugEHE6fIvGkt1caI=
-github.com/livekit/mediatransportutil v0.0.0-20260409104613-0fcb3771c3d5/go.mod h1:RCd46PT+6sEztld6XpkCrG1xskb0u3SqxIjy4G897Ss=
+github.com/livekit/mediatransportutil v0.0.0-20260422071032-c2eb358ac882 h1:HHG7ogGrxU/cCQ7mq6zT8V684+BSWPAaW3N5906FU/c=
+github.com/livekit/mediatransportutil v0.0.0-20260422071032-c2eb358ac882/go.mod h1:RCd46PT+6sEztld6XpkCrG1xskb0u3SqxIjy4G897Ss=
 github.com/livekit/protocol v1.45.3 h1:8G6tgnjSSKw9wI7fNRIIErN8+id60xtQPCr+kgBR8ns=
 github.com/livekit/protocol v1.45.3/go.mod h1:e6QdWDkfot+M2nRh0eitJUS0ZLuwvKCsfiz2pWWSG3s=
 github.com/livekit/psrpc v0.7.1 h1:ms37az0QTD3UXIWuUC5D/SkmKOlRMVRsI261eBWu/Vw=

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -409,6 +409,8 @@ func newPeerConnection(
 
 	// if client don't support prflx over relay, we should not expose private address to it, use single external ip as host candidate
 	if !params.ClientInfo.SupportsPrflxOverRelay() && len(params.Config.NAT1To1IPs) > 0 {
+		var rewriteRules []webrtc.ICEAddressRewriteRule
+		var catchAllExternal []string
 		var nat1to1Ips []string
 		var includeIps []string
 		for _, mapping := range params.Config.NAT1To1IPs {
@@ -416,12 +418,24 @@ func newPeerConnection(
 				if ips[0] != ips[1] {
 					nat1to1Ips = append(nat1to1Ips, mapping)
 					includeIps = append(includeIps, ips[1])
+					rewriteRules = append(rewriteRules, webrtc.ICEAddressRewriteRule{
+						External:        []string{ips[0]},
+						Local:           ips[1],
+						AsCandidateType: webrtc.ICECandidateTypeHost,
+					})
+					catchAllExternal = append(catchAllExternal, ips[0])
 				}
 			}
 		}
-		if len(nat1to1Ips) > 0 {
+		if len(rewriteRules) > 0 {
+			rewriteRules = append(rewriteRules, webrtc.ICEAddressRewriteRule{
+				External:        catchAllExternal,
+				AsCandidateType: webrtc.ICECandidateTypeHost,
+			})
 			params.Logger.Infow("client doesn't support prflx over relay, use external ip only as host candidate", "ips", nat1to1Ips)
-			se.SetNAT1To1IPs(nat1to1Ips, webrtc.ICECandidateTypeHost)
+			if err := se.SetICEAddressRewriteRules(rewriteRules...); err != nil {
+				params.Logger.Warnw("failed to set ICE address rewrite rules", err, "ips", nat1to1Ips)
+			}
 			se.SetIPFilter(func(ip net.IP) bool {
 				if ip.To4() == nil {
 					return true

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -57,6 +57,7 @@ import (
 	"github.com/livekit/livekit-server/pkg/telemetry/prometheus"
 	"github.com/livekit/livekit-server/pkg/utils"
 	lkinterceptor "github.com/livekit/mediatransportutil/pkg/interceptor"
+	"github.com/livekit/mediatransportutil/pkg/rtcconfig"
 	lktwcc "github.com/livekit/mediatransportutil/pkg/twcc"
 	"github.com/livekit/protocol/codecs/mime"
 	"github.com/livekit/protocol/livekit"
@@ -409,8 +410,6 @@ func newPeerConnection(
 
 	// if client don't support prflx over relay, we should not expose private address to it, use single external ip as host candidate
 	if !params.ClientInfo.SupportsPrflxOverRelay() && len(params.Config.NAT1To1IPs) > 0 {
-		var rewriteRules []webrtc.ICEAddressRewriteRule
-		var catchAllExternal []string
 		var nat1to1Ips []string
 		var includeIps []string
 		for _, mapping := range params.Config.NAT1To1IPs {
@@ -418,22 +417,12 @@ func newPeerConnection(
 				if ips[0] != ips[1] {
 					nat1to1Ips = append(nat1to1Ips, mapping)
 					includeIps = append(includeIps, ips[1])
-					rewriteRules = append(rewriteRules, webrtc.ICEAddressRewriteRule{
-						External:        []string{ips[0]},
-						Local:           ips[1],
-						AsCandidateType: webrtc.ICECandidateTypeHost,
-					})
-					catchAllExternal = append(catchAllExternal, ips[0])
 				}
 			}
 		}
-		if len(rewriteRules) > 0 {
-			rewriteRules = append(rewriteRules, webrtc.ICEAddressRewriteRule{
-				External:        catchAllExternal,
-				AsCandidateType: webrtc.ICECandidateTypeHost,
-			})
+		if len(nat1to1Ips) > 0 {
 			params.Logger.Infow("client doesn't support prflx over relay, use external ip only as host candidate", "ips", nat1to1Ips)
-			if err := se.SetICEAddressRewriteRules(rewriteRules...); err != nil {
+			if err := rtcconfig.SetNAT1To1AddressRewriteRules(&se, nat1to1Ips, webrtc.ICECandidateTypeHost); err != nil {
 				params.Logger.Warnw("failed to set ICE address rewrite rules", err, "ips", nat1to1Ips)
 			}
 			se.SetIPFilter(func(ip net.IP) bool {


### PR DESCRIPTION
Taken from: https://github.com/pion/webrtc/blame/main/icegatherer.go#L382