### PR TITLE
Turn off transceiver re-use on Safari.

### DIFF
--- a/pkg/rtc/clientinfo.go
+++ b/pkg/rtc/clientinfo.go
@@ -114,6 +114,10 @@ func (c ClientInfo) SupportsSctpZeroChecksum() bool {
 		(!c.isGo() || c.compareVersion("2.4.0") >= 0)
 }
 
+func (c ClientInfo) SupportsTransceiverReuse() bool {
+	return !c.isSafari()
+}
+
 // compareVersion compares a semver against the current client SDK version
 // returning 1 if current version is greater than version
 // 0 if they are the same, and -1 if it's an earlier version

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -3756,6 +3756,10 @@ func (p *ParticipantImpl) SupportsSyncStreamID() bool {
 }
 
 func (p *ParticipantImpl) SupportsTransceiverReuse(mt types.MediaTrack) bool {
+	if !p.params.ClientInfo.SupportsTransceiverReuse() {
+		return false
+	}
+
 	if p.params.UseOneShotSignallingMode {
 		return p.ProtocolVersion().SupportsTransceiverReuse()
 	}


### PR DESCRIPTION
There are issues with insertable streams + Safari which causes tracks to go missing mid-stream sometimes.