### PR TITLE
fix: wrap IPv6 addresses in brackets in UDP TURN URLs (RFC 3986)

### DIFF
--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -21,8 +21,10 @@ import (
 	"encoding/base64"
 	"fmt"
 	"maps"
+	"net"
 	"os"
 	"slices"
+	"strconv"
 	"sync"
 	"time"
 
@@ -1025,7 +1027,7 @@ func (r *RoomManager) iceServersForParticipant(apiKey string, participant types.
 			// UDP TURN is used as STUN
 			hasSTUN = true
 			for _, ip := range r.config.RTC.NodeIP.ToStringSlice() {
-				urls = append(urls, fmt.Sprintf("turn:%s:%d?transport=udp", ip, r.config.TURN.UDPPort))
+				urls = append(urls, fmt.Sprintf("turn:%s?transport=udp", net.JoinHostPort(ip, strconv.Itoa(int(r.config.TURN.UDPPort)))))
 			}
 		}
 		if r.config.TURN.TLSPort > 0 {


### PR DESCRIPTION
`iceServersForParticipant` builds UDP TURN URLs by interpolating the node IP directly into a format string:

    fmt.Sprintf("turn:%s:%d?transport=udp", ip, port)

When `NodeIP.V6` is set, `ToStringSlice()` includes the bare IPv6 address, producing URLs like:

    turn:2a05:d014:ee4:1201:7039:38c:f652:a252:443?transport=udp

RFC 3986 §3.2.2 requires IPv6 addresses in URIs to be enclosed in square brackets. Without them the port is ambiguous and WebRTC clients (e.g. libdatachannel) reject the URL with "Invalid ICE server port".

Use `net.JoinHostPort` which handles bracketing for IPv6 and is a no-op for IPv4, producing well-formed URLs:

    turn:[2a05:d014:ee4:1201:7039:38c:f652:a252]:443?transport=udp
    turn:1.2.3.4:443?transport=udp