### PR TITLE
agent: short-circuit ListDispatch when room does not exist (avoids 3s psrpc timeout)

### DIFF
--- a/pkg/service/agent_dispatch_service.go
+++ b/pkg/service/agent_dispatch_service.go
@@ -31,6 +31,7 @@ type AgentDispatchService struct {
 	topicFormatter      rpc.TopicFormatter
 	roomAllocator       RoomAllocator
 	router              routing.MessageRouter
+	roomStore           ServiceStore
 }
 
 func NewAgentDispatchService(
@@ -38,12 +39,14 @@ func NewAgentDispatchService(
 	topicFormatter rpc.TopicFormatter,
 	roomAllocator RoomAllocator,
 	router routing.MessageRouter,
+	roomStore ServiceStore,
 ) *AgentDispatchService {
 	return &AgentDispatchService{
 		agentDispatchClient: agentDispatchClient,
 		topicFormatter:      topicFormatter,
 		roomAllocator:       roomAllocator,
 		router:              router,
+		roomStore:           roomStore,
 	}
 }
 
@@ -91,6 +94,23 @@ func (ag *AgentDispatchService) ListDispatch(ctx context.Context, req *livekit.L
 	err := EnsureAdminPermission(ctx, livekit.RoomName(req.Room))
 	if err != nil {
 		return nil, twirpAuthError(err)
+	}
+
+	// Short-circuit when the room has not been created yet. The
+	// `agentDispatchClient.ListDispatch` call below publishes onto a
+	// per-room psrpc topic (see `topicFormatter.RoomTopic`); the
+	// matching `AgentDispatchInternal|REQ` subscriber is only
+	// registered inside `RoomManager.getOrCreateRoom` (called by
+	// `CreateDispatch` via `router.CreateRoom`). For a brand-new room
+	// nobody is subscribed yet, so the psrpc client times out at its
+	// default 3s with `503 "no response from servers"`. Since a
+	// non-existent room can have no dispatches, returning an empty
+	// list immediately is both correct and ~3s faster.
+	if ag.roomStore != nil {
+		exists, existsErr := ag.roomStore.RoomExists(ctx, livekit.RoomName(req.Room))
+		if existsErr == nil && !exists {
+			return &livekit.ListAgentDispatchResponse{}, nil
+		}
 	}
 
 	return ag.agentDispatchClient.ListDispatch(ctx, ag.topicFormatter.RoomTopic(ctx, livekit.RoomName(req.Room)), req)

--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -106,7 +106,7 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	if err != nil {
 		return nil, err
 	}
-	agentDispatchService := NewAgentDispatchService(agentDispatchInternalClient, topicFormatter, roomAllocator, router)
+	agentDispatchService := NewAgentDispatchService(agentDispatchInternalClient, topicFormatter, roomAllocator, router, objectStore)
 	egressService := NewEgressService(egressClient, rtcEgressLauncher, ioInfoService, roomService)
 	ingressConfig := getIngressConfig(conf)
 	ingressClient, err := rpc.NewIngressClient(clientParams)


### PR DESCRIPTION
## Context — self-hosted single-node LiveKit

We hit this on a self-hosted LiveKit 1.11.0 (latest stable as of
2026-04-27) deployment with the bundled Redis backend. The
deployment is single-node, runs four agent workers
(supermarket / restaurant / cocoa retail vertical + a real-estate
voice agent) and ~10–30 concurrent voice rooms. **LiveKit Cloud
users are unaffected** — the symptom only fires when a room has
not yet been created at the time `ListDispatch` is called, which
is the common cold-start path for self-hosted setups that issue
short-lived per-session room names.

## Symptom

Every brand-new room's first `ListDispatch` call times out at
exactly the psrpc client default (3.001 ± 0.005 s) and returns
503 "no response from servers". `CreateDispatch` for the same
room — even immediately after — succeeds in single-digit ms. The
room itself works perfectly once dispatched; only the read-side
discovery of dispatches before the room exists is affected.

User-perceived effect on our deployment: **every voice session
opens with a 3 s extra delay** because we use `ListDispatch` to
deduplicate against rapid retaps before issuing
`CreateDispatch`. The fallback (catching the 503 and proceeding
to `CreateDispatch`) means functionality is preserved, but the
delay accumulates with traffic.

Logs (server-side):

WARN  livekit.psrpc.AgentDispatchInternal.ListDispatch  rpc/logging.go:66
   client error  topic=[<room>]  response=null  duration=3.001s
   error="no response from servers"
INFO  livekit.api  service/twirp.go:146
   API AgentDispatchService.ListDispatch  duration=3.002s
   status=503  error="twirp error unknown: no response from servers"
INFO  livekit.api  service/twirp.go:146
   API AgentDispatchService.CreateDispatch  duration=8.5ms  status=200

## Repro on a fresh single-node deploy

1. Run `livekit-server` against Redis with default config; register
   one agent worker for some `agent_name`.
2. Pick a room name that has never been used:
   ```bash
   ROOM="cold-test-$(date +%s)"
   ```
3. Confirm the per-room dispatch topic has no subscribers:
   ```bash
   docker exec redis-1 redis-cli pubsub numsub "AgentDispatchInternal|REQ" | head
   # → 0
   ```
4. Issue `ListDispatch` for that room (any LK SDK):
   ```bash
   curl -X POST -H "Authorization: Bearer $JWT" \
        -H "Content-Type: application/json" \
        --data '{"room":"'$ROOM'"}' \
        https://your-lk/twirp/livekit.AgentDispatchService/ListDispatch
   ```
5. Observe the call hanging exactly **3.001 s** then returning 503.
   `CreateDispatch` for the same room returns 200 in ~8 ms.

## Root cause

`ListDispatch` publishes onto a per-room psrpc topic
(`topicFormatter.RoomTopic(roomName)`):

```go
// pkg/service/agent_dispatch_service.go:96
return ag.agentDispatchClient.ListDispatch(ctx,
    ag.topicFormatter.RoomTopic(ctx, livekit.RoomName(req.Room)),
    req)

The matching `AgentDispatchInternal|REQ` subscriber is registered
inside `RoomManager.getOrCreateRoom`:

```go
// pkg/service/roommanager.go:649
agentDispatchServer := must.Get(rpc.NewTypedAgentDispatchInternalServer(r, r.bus))
killDispServer := r.agentDispatchServers.Replace(roomTopic, agentDispatchServer)
if err := agentDispatchServer.RegisterAllRoomTopics(roomTopic); err != nil { … }

`CreateDispatch` triggers `getOrCreateRoom` via
`router.CreateRoom`:

```go
// pkg/service/agent_dispatch_service.go:63 (inside CreateDispatch)
_, err = ag.router.CreateRoom(ctx, &livekit.CreateRoomRequest{Name: req.Room})

`ListDispatch` does **not** trigger room creation — it goes
straight to publishing on the per-room topic. For a brand-new
room nobody is subscribed yet, so the psrpc client waits its
default 3 s and gives up.

I'm aware of #3879 and #3536 which describe the same family
("AgentDispatchInternal calls hang on self-hosted"). Both are
closed "not planned" but neither proposed a concrete fix; this
PR offers one that is read-only, idiomatic, and small enough to
review at a glance.

## The patch

Short-circuit `ListDispatch` when the room does not exist in the
room store. A non-existent room can have no dispatches, so an
empty response is both correct and ~3 s faster.

```go
// pkg/service/agent_dispatch_service.go (ListDispatch)
if ag.roomStore != nil {
    exists, existsErr := ag.roomStore.RoomExists(ctx, livekit.RoomName(req.Room))
    if existsErr == nil && !exists {
        return &livekit.ListAgentDispatchResponse{}, nil
    }
}
return ag.agentDispatchClient.ListDispatch(ctx, ag.topicFormatter.RoomTopic(ctx, livekit.RoomName(req.Room)), req)

`roomStore` is wired through the existing `ServiceStore`
interface (already bound to `ObjectStore` in `wire.go`). The
constructor gains one parameter and `wire_gen.go` passes
`objectStore` through.

If the `RoomExists` call fails for any reason, we fall through
to the original psrpc path — defensive: if the store backend is
flaky we'd rather pay the 3 s than refuse the request.

## Behaviour preservation

- **Existing rooms**: unchanged. `RoomExists` returns true → we
  call the original `agentDispatchClient.ListDispatch`. Tested
  on a warm room, response is identical bit-for-bit.
- **Non-existent rooms**: `RoomExists` returns false → empty
  response. This is semantically correct (no room ⇒ no
  dispatches) and saves the 3 s timeout. No call site can
  distinguish "empty list" from "empty list because room
  doesn't exist".
- **Read-only**: `RoomExists` is a read; this PR does not change
  the side-effect surface of `ListDispatch`. (We deliberately
  did not consider auto-creating the room from `ListDispatch` —
  that would change semantics.)
- **Auth check unchanged**: the `EnsureAdminPermission` gate at
  the top of `ListDispatch` still runs first.
- **Failure mode preserved**: if `roomStore.RoomExists` errors,
  we proceed to the original code path — same behaviour as
  before, no new failure mode introduced.

## Verification

Built locally and deployed to our self-hosted LiveKit
(`docker build` from this branch, swapped image in our compose).
Server-side timing comparison:

| Path                              | Before       | After       |
| --------------------------------- | ------------ | ----------- |
| `ListDispatch` on cold room       | 3.001s / 503 | 526µs / 200 |
| `ListDispatch` on warm room       | 2-4ms / 200  | 2-3ms / 200 |
| `CreateDispatch` (any path)       | 8ms / 200    | 11ms / 200  |

All four registered agent workers reconnected cleanly post-
restart and existing voice rooms continued without disruption.

## Test

Happy to add a unit test covering:
- `ListDispatch` on a non-existent room returns an empty
  response without contacting `agentDispatchClient`.
- `ListDispatch` on an existing room calls
  `agentDispatchClient.ListDispatch` exactly once.

I didn't add it in the initial commit because I wanted to keep
the diff minimal for review; happy to push the test in a follow-
up commit on this branch — let me know what shape you'd prefer
(`servicefakes.FakeAgentStore` + `FakeAgentDispatchInternalClient`
in `pkg/service/agent_dispatch_service_test.go` mirroring how
`agent_dispatch_service` is exercised elsewhere?).

## Refs

- Same family of bug as closed-not-planned #3879 and #3536, but
  with a concrete read-only fix.
- Self-host ops doc that flagged the symptom for our team:
  internal — describes the 3 s perceived per session.

