### PR TITLE
route outbound SIP calls by cluster using participant attributes

### DIFF
--- a/pkg/service/sip.go
+++ b/pkg/service/sip.go
@@ -610,7 +610,11 @@ func (s *SIPService) CreateSIPParticipant(ctx context.Context, req *livekit.Crea
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
-	resp, err := s.psrpcClient.CreateSIPParticipant(ctx, "", ireq, psrpc.WithRequestTimeout(timeout))
+	clusterID := ""
+	if v, ok := req.ParticipantAttributes["sip.cluster"]; ok {
+		clusterID = v
+	}
+	resp, err := s.psrpcClient.CreateSIPParticipant(ctx, clusterID, ireq, psrpc.WithRequestTimeout(timeout))
 	if err != nil {
 		unlikelyLogger.Errorw("cannot create sip participant", err)
 		return nil, err


### PR DESCRIPTION
## Summary
- Allow routing outbound SIP calls to specific livekit-sip instances based on the `sip.cluster` participant attribute
- When `sip.cluster` is set in `ParticipantAttributes`, its value is used as the psrpc topic for `CreateSIPParticipant`, targeting only SIP nodes registered with a matching `cluster_id`
- When unset, the default behavior (empty topic = any available SIP node) is preserved

## Usage
Agent sets participant attribute when creating an outbound SIP call:
```json
{
  "participant_attributes": {
    "sip.cluster": "klient_A"
  }
}
```

livekit-sip instances register with matching `cluster_id` in their config:
```yaml
cluster_id: klient_A
```

## Test plan
- [ ] Verify outbound calls without `sip.cluster` attribute still route to any SIP node (backward compatibility)
- [ ] Verify outbound calls with `sip.cluster: X` only reach SIP nodes with `cluster_id: X`
- [ ] Verify inbound calls are unaffected (they use IOInfoClient, not SIPInternal)