### PR TITLE
Log details of RTCP packets.

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -1434,7 +1434,7 @@ func (t *PCTransport) GetICEConnectionType() types.ICEConnectionType {
 func (t *PCTransport) WriteRTCP(pkts []rtcp.Packet) error {
 	// TODO-CLEANUP-PACKET-SIZE: remove after checking for large packets
 	raw, _ := rtcp.Marshal(pkts)
-	if len(raw) > 00 {
+	if len(raw) > 1400 {
 		t.params.Logger.Infow("large RTCP packet send", "size", len(raw), "numPkts", len(pkts), "pkts", pkts)
 	}
 	return t.pc.WriteRTCP(pkts)

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -1434,8 +1434,8 @@ func (t *PCTransport) GetICEConnectionType() types.ICEConnectionType {
 func (t *PCTransport) WriteRTCP(pkts []rtcp.Packet) error {
 	// TODO-CLEANUP-PACKET-SIZE: remove after checking for large packets
 	raw, _ := rtcp.Marshal(pkts)
-	if len(raw) > 1400 {
-		t.params.Logger.Infow("large RTCP packet send", "size", len(raw))
+	if len(raw) > 00 {
+		t.params.Logger.Infow("large RTCP packet send", "size", len(raw), "numPkts", len(pkts), "pkts", pkts)
 	}
 	return t.pc.WriteRTCP(pkts)
 }


### PR DESCRIPTION
Seeing large (> MTU) packets on publisher peer connection RTCP. The four types there are
- RTCP Receiver Reports
- NACK
- TWCC
- PLI

Can't think of what would be blowing up in size.

RTCP Receiver Report and PLI are fixed in size

NACKs vary, but the limit is 100 NACKs which should fit in 400 bytes even if all of them are spread apart in the sequence number space.

TWCC varies, but a feedback packet is sent every 100ms or when it holds 100 packets. So, that also should not be too big.

Logging packet details to understand this better.