### PR TITLE
Don't require media sections when joining

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -80,9 +80,6 @@ const (
 
 	PingIntervalSeconds = 5
 	PingTimeoutSeconds  = 15
-
-	audioSectionsCountWithJoinResponse = 3
-	videoSectionsCountWithJoinResponse = 3
 )
 
 var (
@@ -177,57 +174,56 @@ type ParticipantParams struct {
 	PLIThrottleConfig       sfu.PLIThrottleConfig
 	CongestionControlConfig config.CongestionControlConfig
 	// codecs that are enabled for this room
-	PublishEnabledCodecs                []*livekit.Codec
-	SubscribeEnabledCodecs              []*livekit.Codec
-	Logger                              logger.Logger
-	LoggerResolver                      logger.DeferredFieldResolver
-	Reporter                            roomobs.ParticipantSessionReporter
-	ReporterResolver                    roomobs.ParticipantReporterResolver
-	SimTracks                           map[uint32]interceptor.SimulcastTrackInfo
-	Grants                              *auth.ClaimGrants
-	InitialVersion                      uint32
-	ClientConf                          *livekit.ClientConfiguration
-	ClientInfo                          ClientInfo
-	Region                              string
-	Migration                           bool
-	Reconnect                           bool
-	AdaptiveStream                      bool
-	AllowTCPFallback                    bool
-	TCPFallbackRTTThreshold             int
-	AllowUDPUnstableFallback            bool
-	TURNSEnabled                        bool
-	ParticipantListener                 types.LocalParticipantListener
-	ParticipantHelper                   types.LocalParticipantHelper
-	DisableSupervisor                   bool
-	ReconnectOnPublicationError         bool
-	ReconnectOnSubscriptionError        bool
-	ReconnectOnDataChannelError         bool
-	VersionGenerator                    utils.TimedVersionGenerator
-	DisableDynacast                     bool
-	SubscriberAllowPause                bool
-	SubscriptionLimitAudio              int32
-	SubscriptionLimitVideo              int32
-	PlayoutDelay                        *livekit.PlayoutDelay
-	SyncStreams                         bool
-	ForwardStats                        *sfu.ForwardStats
-	DisableSenderReportPassThrough      bool
-	MetricConfig                        metric.MetricConfig
-	UseOneShotSignallingMode            bool
-	EnableMetrics                       bool
-	DataChannelMaxBufferedAmount        uint64
-	DatachannelSlowThreshold            int
-	DatachannelLossyTargetLatency       time.Duration
-	FireOnTrackBySdp                    bool
-	DisableCodecRegression              bool
-	LastPubReliableSeq                  uint32
-	Country                             string
-	PreferVideoSizeFromMedia            bool
-	UseSinglePeerConnection             bool
-	EnableDataTracks                    bool
-	EnableRTPStreamRestartDetection     bool
-	ForceBackupCodecPolicySimulcast     bool
-	RequireMediaSectionWithJoinResponse bool
-	DisableTransceiverReuseForE2EE      bool
+	PublishEnabledCodecs            []*livekit.Codec
+	SubscribeEnabledCodecs          []*livekit.Codec
+	Logger                          logger.Logger
+	LoggerResolver                  logger.DeferredFieldResolver
+	Reporter                        roomobs.ParticipantSessionReporter
+	ReporterResolver                roomobs.ParticipantReporterResolver
+	SimTracks                       map[uint32]interceptor.SimulcastTrackInfo
+	Grants                          *auth.ClaimGrants
+	InitialVersion                  uint32
+	ClientConf                      *livekit.ClientConfiguration
+	ClientInfo                      ClientInfo
+	Region                          string
+	Migration                       bool
+	Reconnect                       bool
+	AdaptiveStream                  bool
+	AllowTCPFallback                bool
+	TCPFallbackRTTThreshold         int
+	AllowUDPUnstableFallback        bool
+	TURNSEnabled                    bool
+	ParticipantListener             types.LocalParticipantListener
+	ParticipantHelper               types.LocalParticipantHelper
+	DisableSupervisor               bool
+	ReconnectOnPublicationError     bool
+	ReconnectOnSubscriptionError    bool
+	ReconnectOnDataChannelError     bool
+	VersionGenerator                utils.TimedVersionGenerator
+	DisableDynacast                 bool
+	SubscriberAllowPause            bool
+	SubscriptionLimitAudio          int32
+	SubscriptionLimitVideo          int32
+	PlayoutDelay                    *livekit.PlayoutDelay
+	SyncStreams                     bool
+	ForwardStats                    *sfu.ForwardStats
+	DisableSenderReportPassThrough  bool
+	MetricConfig                    metric.MetricConfig
+	UseOneShotSignallingMode        bool
+	EnableMetrics                   bool
+	DataChannelMaxBufferedAmount    uint64
+	DatachannelSlowThreshold        int
+	DatachannelLossyTargetLatency   time.Duration
+	FireOnTrackBySdp                bool
+	DisableCodecRegression          bool
+	LastPubReliableSeq              uint32
+	Country                         string
+	PreferVideoSizeFromMedia        bool
+	UseSinglePeerConnection         bool
+	EnableDataTracks                bool
+	EnableRTPStreamRestartDetection bool
+	ForceBackupCodecPolicySimulcast bool
+	DisableTransceiverReuseForE2EE  bool
 }
 
 type ParticipantImpl struct {

--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -67,10 +67,6 @@ func (p *ParticipantImpl) SendJoinResponse(joinResponse *livekit.JoinResponse) e
 	p.queuedUpdates = nil
 	p.updateLock.Unlock()
 
-	if p.params.RequireMediaSectionWithJoinResponse && p.params.UseSinglePeerConnection {
-		p.sendMediaSectionsRequirement(audioSectionsCountWithJoinResponse, videoSectionsCountWithJoinResponse)
-	}
-
 	if len(queuedUpdates) > 0 {
 		return p.SendParticipantUpdate(queuedUpdates)
 	}

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -440,10 +440,7 @@ func newPeerConnection(
 		}
 	}
 
-	lf := pionlogger.NewLoggerFactory(params.Logger)
-	if lf != nil {
-		se.LoggerFactory = lf
-	}
+	se.LoggerFactory = pionlogger.NewLoggerFactory(params.Logger)
 
 	ir := &interceptor.Registry{}
 	if params.IsSendSide {


### PR DESCRIPTION
Client except browser (rust/libwebrtc is known) could have problem to fire ontrack event when reuses extra media section to subscribe track, so disable this feature in server side and let client determine if extra media sections are needed.

revert #4347