### PR TITLE
Clean up packet size logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [1.12.0] - 2026-05-16
 
-## ATTENTION: This releases introduces important changes to how TURN authentication and permissions are handled. These changes make the system more secure. This release maintains backwards compatibility. However, backwards compatibility will be removed in the next release. So, please plan accordingly.
+## ATTENTION: This release introduces important changes to how TURN authentication and permissions are handled. These changes make the system more secure. This release maintains backwards compatibility. However, backwards compatibility will be removed in the next release. So, please plan accordingly.
 
 ### TURN permission handling changes
 

--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -303,7 +303,6 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track sfu.TrackRe
 
 	var lastRR uint32
 	rtcpReader.OnPacket(func(bytes []byte) {
-		isLargePacket := len(bytes) > 1400
 		pkts, err := rtcp.Unmarshal(bytes)
 		if err != nil {
 			t.params.Logger.Errorw("could not unmarshal RTCP", err, "size", len(bytes))
@@ -313,13 +312,7 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track sfu.TrackRe
 		for _, pkt := range pkts {
 			switch pkt := pkt.(type) {
 			case *rtcp.SourceDescription:
-				if isLargePacket {
-					t.params.Logger.Infow("large RTCP packet received with SDES", "size", len(bytes))
-				}
 			case *rtcp.SenderReport:
-				if isLargePacket {
-					t.params.Logger.Infow("large RTCP packet received with sender report", "size", len(bytes), "SSRC", pkt.SSRC)
-				}
 				if pkt.SSRC == uint32(track.SSRC()) {
 					buff.SetSenderReportData(&livekit.RTCPSenderReportState{
 						RtpTimestamp: pkt.RTPTime,
@@ -330,9 +323,6 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track sfu.TrackRe
 					})
 				}
 			case *rtcp.ExtendedReport:
-				if isLargePacket {
-					t.params.Logger.Infow("large RTCP packet received with extendedreport", "size", len(bytes))
-				}
 			rttFromXR:
 				for _, report := range pkt.Reports {
 					if rr, ok := report.(*rtcp.DLRRReportBlock); ok {

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -1429,11 +1429,6 @@ func (t *PCTransport) GetICEConnectionType() types.ICEConnectionType {
 }
 
 func (t *PCTransport) WriteRTCP(pkts []rtcp.Packet) error {
-	// TODO-CLEANUP-PACKET-SIZE: remove after checking for large packets
-	raw, _ := rtcp.Marshal(pkts)
-	if len(raw) > 1400 {
-		t.params.Logger.Infow("large RTCP packet send", "size", len(raw), "numPkts", len(pkts), "pkts", pkts)
-	}
 	return t.pc.WriteRTCP(pkts)
 }
 

--- a/pkg/sfu/buffer/buffer.go
+++ b/pkg/sfu/buffer/buffer.go
@@ -139,10 +139,6 @@ func (b *Buffer) Bind(params webrtc.RTPParameters, codec webrtc.RTPCodecCapabili
 
 // Write adds an RTP Packet, ordering is not guaranteed, newer packets may arrive later
 func (b *Buffer) Write(pkt []byte) (n int, err error) {
-	if len(pkt) > 1400 {
-		b.logger.Infow("large RTP packet received", "size", len(pkt))
-	}
-
 	var rtpPacket rtp.Packet
 	err = rtpPacket.Unmarshal(pkt)
 	if err != nil {

--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -633,9 +633,6 @@ func (d *DownTrack) Bind(t webrtc.TrackLocalContext) (webrtc.RTPCodecParameters,
 		d.writeStream = t.WriteStream()
 		if rr := d.params.BufferFactory.GetOrNew(packetio.RTCPBufferPacket, d.ssrc).(*buffer.RTCPReader); rr != nil {
 			rr.OnPacket(func(pkt []byte) {
-				if len(pkt) > 1400 {
-					d.params.Logger.Infow("large RTCP packet received primary", "size", len(pkt))
-				}
 				d.handleRTCP(pkt)
 			})
 			d.rtcpReader = rr
@@ -643,9 +640,6 @@ func (d *DownTrack) Bind(t webrtc.TrackLocalContext) (webrtc.RTPCodecParameters,
 		if d.ssrcRTX != 0 {
 			if rr := d.params.BufferFactory.GetOrNew(packetio.RTCPBufferPacket, d.ssrcRTX).(*buffer.RTCPReader); rr != nil {
 				rr.OnPacket(func(pkt []byte) {
-					if len(pkt) > 1400 {
-						d.params.Logger.Infow("large RTCP packet received rtx", "size", len(pkt))
-					}
 					d.handleRTCPRTX(pkt)
 				})
 				d.rtcpReaderRTX = rr

--- a/pkg/sfu/pacer/base.go
+++ b/pkg/sfu/pacer/base.go
@@ -76,10 +76,6 @@ func (b *Base) SendPacket(p *Packet) (int, error) {
 		return 0, err
 	}
 
-	if (p.HeaderSize + len(p.Payload)) > 1400 {
-		b.logger.Infow("large RTP packet send", "size", p.HeaderSize+len(p.Payload))
-	}
-
 	var written int
 	written, err = p.WriteStream.WriteRTP(p.Header, p.Payload)
 	if err != nil {


### PR DESCRIPTION
Reverting
- https://github.com/livekit/livekit/pull/4521
- https://github.com/livekit/livekit/pull/4525

There are TWCC feedback packets that are larger than MTU. Seems to happen under a couple of conditions
1. Bad client data, i. e. severely out-of-order packets, bad sequence numbers, etc.
2. On an ICE restart - this is rare, but it seemed to be flaky network with some packets arriving and some not and causing a lot of gaps.

Either case, not much to do. If fargmentation/re-assembly back to publisher works, the feedback will make it through. If not, feedbacks will be missed and clients have to work with some missing data which is not unexpected and the protocol is designed to handle.

However, filed pion/interceptor issue just in case - https://github.com/pion/interceptor/issues/416