### PR TITLE
Add IsIntentionalDisconnect helper

### DIFF
--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -225,6 +225,23 @@ func (p ParticipantCloseReason) ToDisconnectReason() livekit.DisconnectReason {
 	}
 }
 
+// IsIntentionalDisconnect reports whether a disconnect reason represents an
+// intentional/expected closure (client leaving, admin action, room teardown,
+// migration, etc.) as opposed to a connection failure.
+func IsIntentionalDisconnect(reason livekit.DisconnectReason) bool {
+	switch reason {
+	case livekit.DisconnectReason_CLIENT_INITIATED,
+		livekit.DisconnectReason_SERVER_SHUTDOWN,
+		livekit.DisconnectReason_DUPLICATE_IDENTITY,
+		livekit.DisconnectReason_MIGRATION,
+		livekit.DisconnectReason_PARTICIPANT_REMOVED,
+		livekit.DisconnectReason_ROOM_DELETED,
+		livekit.DisconnectReason_ROOM_CLOSED:
+		return true
+	}
+	return false
+}
+
 // ---------------------------------------------
 
 type SignallingCloseReason int


### PR DESCRIPTION
## Summary

- Adds `types.IsIntentionalDisconnect(livekit.DisconnectReason) bool` next to the existing `ToDisconnectReason` switch.
- Extracted from cloud's `cloudrtcagent/manager.go:IsClosedIntentionally` so cloud-side code paths can share a single source of truth for "intentional vs. failure" classification (used both by the agent restart/end logic and the new connection-failure rollup in cloud#4365).

## Test plan

- [x] `go build ./pkg/rtc/types/...`