### PR TITLE
rtc: emit per-data-track bytes via BytesTrackStats

### DIFF
--- a/pkg/rtc/datadowntrack.go
+++ b/pkg/rtc/datadowntrack.go
@@ -33,6 +33,7 @@ type DataDownTrackParams struct {
 	PublishDataTrack types.DataTrack
 	Handle           uint16
 	Transport        types.DataTrackTransport
+	BytesTrackStats  *BytesTrackStats
 }
 
 type DataDownTrack struct {
@@ -59,6 +60,9 @@ func NewDataDownTrack(params DataDownTrackParams) (*DataDownTrack, error) {
 
 func (d *DataDownTrack) Close() {
 	d.logger.Infow("closing data down track")
+	if d.params.BytesTrackStats != nil {
+		d.params.BytesTrackStats.Stop()
+	}
 	d.params.PublishDataTrack.DeleteDataDownTrack(d.SubscriberID())
 }
 
@@ -93,6 +97,10 @@ func (d *DataDownTrack) WritePacket(data []byte, packet *datatrack.Packet, _arri
 	}
 	if err := d.params.Transport.SendDataTrackMessage(buf); err != nil {
 		d.logger.Warnw("could not send data track message", err)
+		return
+	}
+	if d.params.BytesTrackStats != nil {
+		d.params.BytesTrackStats.AddBytes(uint64(len(buf)), true)
 	}
 }
 

--- a/pkg/rtc/datatrack.go
+++ b/pkg/rtc/datatrack.go
@@ -37,6 +37,7 @@ type DataTrackParams struct {
 	Logger              logger.Logger
 	ParticipantID       func() livekit.ParticipantID
 	ParticipantIdentity livekit.ParticipantIdentity
+	BytesTrackStats     *BytesTrackStats
 }
 
 type DataTrack struct {
@@ -76,6 +77,9 @@ func (d *DataTrack) Close() {
 	d.closed.Break()
 
 	d.stats.Close()
+	if d.params.BytesTrackStats != nil {
+		d.params.BytesTrackStats.Stop()
+	}
 }
 
 func (d *DataTrack) PublisherID() livekit.ParticipantID {
@@ -110,14 +114,25 @@ func (d *DataTrack) AddSubscriber(sub types.LocalParticipant) (types.DataDownTra
 		return nil, errAlreadySubscribed
 	}
 
+	bytesStats := NewBytesTrackStats(
+		sub.GetCountry(),
+		d.ID(),
+		sub.ID(),
+		sub.Kind(),
+		sub.KindDetails(),
+		sub.GetTelemetryListener(),
+		sub.GetReporter(),
+	)
 	dataDownTrack, err := NewDataDownTrack(DataDownTrackParams{
 		Logger:           sub.GetLogger().WithValues("trackID", d.ID()),
 		SubscriberID:     sub.ID(),
 		PublishDataTrack: d,
 		Handle:           sub.GetNextSubscribedDataTrackHandle(),
 		Transport:        sub.GetDataTrackTransport(),
+		BytesTrackStats:  bytesStats,
 	})
 	if err != nil {
+		bytesStats.Stop()
 		return nil, err
 	}
 
@@ -165,6 +180,9 @@ func (d *DataTrack) DeleteDataDownTrack(subscriberID livekit.ParticipantID) {
 
 func (d *DataTrack) HandlePacket(data []byte, packet *datatrack.Packet, arrivalTime int64) {
 	d.stats.Update(packet, arrivalTime, len(data))
+	if d.params.BytesTrackStats != nil {
+		d.params.BytesTrackStats.AddBytes(uint64(len(data)), false)
+	}
 
 	d.downTrackSpreader.Broadcast(func(dts types.DataTrackSender) {
 		dts.WritePacket(data, packet, arrivalTime)

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1365,6 +1365,15 @@ func (p *ParticipantImpl) SetMigrateInfo(
 				Logger:              p.params.Logger.WithValues("trackID", dti.Sid),
 				ParticipantID:       p.ID,
 				ParticipantIdentity: p.params.Identity,
+				BytesTrackStats: NewBytesTrackStats(
+					p.params.Country,
+					livekit.TrackID(dti.Sid),
+					p.ID(),
+					p.Kind(),
+					p.KindDetails(),
+					p.params.TelemetryListener,
+					p.params.Reporter,
+				),
 			},
 			dti,
 		)

--- a/pkg/rtc/participant_data_track.go
+++ b/pkg/rtc/participant_data_track.go
@@ -99,6 +99,15 @@ func (p *ParticipantImpl) HandlePublishDataTrackRequest(req *livekit.PublishData
 			Logger:              p.params.Logger.WithValues("trackID", dti.Sid),
 			ParticipantID:       p.ID,
 			ParticipantIdentity: p.params.Identity,
+			BytesTrackStats: NewBytesTrackStats(
+				p.params.Country,
+				livekit.TrackID(dti.Sid),
+				p.ID(),
+				p.Kind(),
+				p.KindDetails(),
+				p.params.TelemetryListener,
+				p.params.Reporter,
+			),
 		},
 		dti,
 	)


### PR DESCRIPTION
## Summary
- Data tracks (the new `_data_track` datachannel) previously only updated a private `dataTrackStats` that logged a single summary at `Close`. Bytes never reached the `OnTrackStats → TelemetryService.TrackStats` pipeline that media tracks and signal channels feed.
- Wires `DataTrack` (UPSTREAM, at the publisher's home node where `HandlePacket` fires) and `DataDownTrack` (DOWNSTREAM, per local subscriber, at `WritePacket` post-marshal) into `BytesTrackStats` on the established 5s cadence.
- Mirrors the media-track convention: DOWNSTREAM uses the subscriber's country/ID and the publisher's track ID; UPSTREAM uses the publisher's. `BytesTrackStats` for DOWNSTREAM is constructed inside `DataTrack.AddSubscriber` from the subscriber's `LocalParticipant` accessors; UPSTREAM is constructed at the two publisher-home `NewDataTrack` call sites (`HandlePublishDataTrackRequest` and the migration path).
- Cross-region proxy `DataTrack` instances (e.g. cloud's `RemoteParticipant`) leave the new params field nil — they have no publisher reporter on that node, and relayed bytes routed through `HandlePacket` would double-count.
- Legacy `dataTrackStats` packet-loss / out-of-order / frame counters are preserved unchanged.

## Test plan
- [x] `go test -short ./pkg/rtc/...` passes
- [x] Cloud workspace builds + `go test -short ./pkg/rtc/...` passes (no cloud edits needed — additive params field defaults to nil at proxy and replay sites)
- [ ] End-to-end: publish a data track + subscribe, confirm `OnTrackStats` receives both `StatsKeyForData(UPSTREAM, publisherID, dataTrackID)` (publisher node) and `StatsKeyForData(DOWNSTREAM, subscriberID, dataTrackID)` (subscriber node) on ~5s cadence with a final flush on Close
- [ ] Cross-region replay: confirm proxy `DataTrack` on subscriber node emits no UPSTREAM (no nil panic, no double accounting)