### PR TITLE
agent: extend JobRequest RPC timeout to 12s

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -39,6 +39,7 @@ const (
 	DefaultHandlerNamespace = ""
 
 	CheckEnabledTimeout = 5 * time.Second
+	JobRequestTimeout   = 12 * time.Second
 )
 
 var jobTypeTopics = map[livekit.JobType]string{
@@ -173,7 +174,7 @@ func (c *agentClient) LaunchJob(ctx context.Context, desc *JobRequest) *serverut
 				EnableRecording: c.config.EnableUserDataRecording,
 				Deployment:      desc.Deployment,
 			}
-			resp, err := c.client.JobRequest(context.Background(), topic, jobTypeTopic, job)
+			resp, err := c.client.JobRequest(context.Background(), topic, jobTypeTopic, job, psrpc.WithRequestTimeout(JobRequestTimeout))
 			if err != nil {
 				logger.Infow("failed to send job request", "error", err, "namespace", curNs, "jobType", desc.JobType, "agentName", desc.AgentName)
 				return


### PR DESCRIPTION
Hi. 
We faced an issue when job assignment took longer then 3s. And jobs were lost. Example:
```
  2026-05-24T12:12:31.035Z INFO livekit service/roomallocator.go:166 selected node for room {"room": "<ROOM_ID>", "selectedNodeID": "<NODE_ID>"}
  2026-05-24T12:12:31.046Z INFO livekit.api service/twirp.go:128 API AgentDispatchService.CreateDispatch {"service": "AgentDispatchService", "method":
  "CreateDispatch", "room": "<ROOM_ID>", "request": {"agentName": "<AGENT_NAME>", "room": "<ROOM_ID>", "metadata": "__size: 8457"}, "duration": "12.40495ms", "status":
   "200"}
  2026-05-24T12:12:34.051Z WARN livekit.agents service/agentservice.go:423 failed to assign job to worker {"jobID": "<JOB_ID>", "namespace": "", "agentName":
  "<AGENT_NAME>", "jobType": "JT_ROOM", "room": "<ROOM_ID>", "roomID": "<ROOM_SID>", "workerID": "<WORKER_ID>", "retry": false, "error": "context deadline exceeded"}
  2026-05-24T12:17:31.482Z INFO livekit.room rtc/room.go:860 closing room {"room": "<ROOM_ID>", "roomID": "<ROOM_SID>"}
  2026-05-24T12:17:31.482Z INFO livekit service/roommanager.go:184 deleting room state {"room": "<ROOM_ID>"}
  2026-05-24T12:17:31.483Z INFO livekit.room service/roommanager.go:655 room closed {"room": "<ROOM_ID>", "roomID": "<ROOM_SID>"}
  2026-05-24T12:17:31.483Z INFO livekit.room rtc/room.go:844 closing idle room {"room": "<ROOM_ID>", "roomID": "<ROOM_SID>", "reason": "empty timeout"}
```

`JobRequest` client timeout is 3s (`psrpc.DefaultClientTimeout`) but server-side timeout `AssignJobTimeout` is 10s. The client always gave up first, so the 10s timeout never fired.
Bump the clienr timeout to 12s so it outlasts `AssignJobTimeout`.