### PR TITLE
Start tracking Twirp method request latency in prometheus too, not just in logs

### DIFF
--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -120,6 +120,7 @@ func NewLivekitServer(conf *config.Config,
 			TwirpLogger(),
 			TwirpEgressID(),
 			TwirpRequestStatusReporter(),
+			TwirpMetrics(),
 		)),
 	}
 	for _, opt := range xtwirp.DefaultServerOptions() {

--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -120,7 +120,6 @@ func NewLivekitServer(conf *config.Config,
 			TwirpLogger(),
 			TwirpEgressID(),
 			TwirpRequestStatusReporter(),
-			TwirpMetrics(),
 		)),
 	}
 	for _, opt := range xtwirp.DefaultServerOptions() {

--- a/pkg/service/twirp.go
+++ b/pkg/service/twirp.go
@@ -126,7 +126,8 @@ func loggerResponseSent(ctx context.Context, twirpLoggerPool *sync.Pool) {
 		return
 	}
 
-	r.fields = append(r.fields, "duration", time.Since(r.startedAt))
+	duration := time.Since(r.startedAt)
+	r.fields = append(r.fields, "duration", duration)
 	if !r.deadline.IsZero() {
 		r.fields = append(r.fields, "requestedTimeout", r.deadline.Sub(r.startedAt))
 	}
@@ -144,6 +145,7 @@ func loggerResponseSent(ctx context.Context, twirpLoggerPool *sync.Pool) {
 
 	serviceMethod := "API " + r.service + "." + r.method
 	utils.GetLogger(ctx).WithComponent(utils.ComponentAPI).Infow(serviceMethod, r.fields...)
+	prometheus.RecordTwirpRequestLatency(r.service, r.method, duration)
 
 	// reset fields and return to pool
 	r.reset()
@@ -231,26 +233,6 @@ func statusReporterErrorReceived(ctx context.Context, e twirp.Error) context.Con
 
 	r.error = e
 	return ctx
-}
-
-// --------------------------------------------------------------------------
-
-func TwirpMetrics() *twirp.ServerHooks {
-	return &twirp.ServerHooks{
-		ResponseSent: func(ctx context.Context) {
-			metricsResponseSent(ctx)
-		},
-	}
-}
-
-func metricsResponseSent(ctx context.Context) {
-	r, ok := ctx.Value(twirpLoggerKey{}).(*twirpLogger)
-	if !ok || r == nil {
-		return
-	}
-
-	duration := time.Since(r.startedAt)
-	prometheus.RecordTwirpRequestLatency(r.service, r.method, duration)
 }
 
 // --------------------------------------------------------------------------

--- a/pkg/service/twirp.go
+++ b/pkg/service/twirp.go
@@ -235,6 +235,26 @@ func statusReporterErrorReceived(ctx context.Context, e twirp.Error) context.Con
 
 // --------------------------------------------------------------------------
 
+func TwirpMetrics() *twirp.ServerHooks {
+	return &twirp.ServerHooks{
+		ResponseSent: func(ctx context.Context) {
+			metricsResponseSent(ctx)
+		},
+	}
+}
+
+func metricsResponseSent(ctx context.Context) {
+	r, ok := ctx.Value(twirpLoggerKey{}).(*twirpLogger)
+	if !ok || r == nil {
+		return
+	}
+
+	duration := time.Since(r.startedAt)
+	prometheus.RecordTwirpRequestLatency(r.service, r.method, duration)
+}
+
+// --------------------------------------------------------------------------
+
 type twirpTelemetryKey struct{}
 
 func TwirpTelemetry(

--- a/pkg/telemetry/prometheus/node.go
+++ b/pkg/telemetry/prometheus/node.go
@@ -37,6 +37,7 @@ var (
 	promMessageCounter            *prometheus.CounterVec
 	promServiceOperationCounter   *prometheus.CounterVec
 	promTwirpRequestStatusCounter *prometheus.CounterVec
+	promTwirpRequestLatency       *prometheus.HistogramVec
 
 	sysPacketsStart        uint32
 	sysDroppedPacketsStart uint32
@@ -81,6 +82,17 @@ func Init(nodeID string, nodeType livekit.NodeType) error {
 		[]string{"service", "method", "status", "code"},
 	)
 
+	promTwirpRequestLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace:   livekitNamespace,
+			Subsystem:   "node",
+			Name:        "twirp_request_latency_ms",
+			ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
+			Buckets:     []float64{5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000},
+		},
+		[]string{"service", "method"},
+	)
+
 	promSysPacketGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace:   livekitNamespace,
@@ -95,6 +107,7 @@ func Init(nodeID string, nodeType livekit.NodeType) error {
 	prometheus.MustRegister(promMessageCounter)
 	prometheus.MustRegister(promServiceOperationCounter)
 	prometheus.MustRegister(promTwirpRequestStatusCounter)
+	prometheus.MustRegister(promTwirpRequestLatency)
 	prometheus.MustRegister(promSysPacketGauge)
 
 	sysPacketsStart, sysDroppedPacketsStart, _ = getTCStats()
@@ -286,4 +299,8 @@ func RecordServiceOperationError(op string, error string) {
 
 func RecordTwirpRequestStatus(service string, method string, statusFamily string, code twirp.ErrorCode) {
 	promTwirpRequestStatusCounter.WithLabelValues(service, method, statusFamily, string(code)).Add(1)
+}
+
+func RecordTwirpRequestLatency(service, method string, duration time.Duration) {
+	promTwirpRequestLatency.WithLabelValues(service, method).Observe(float64(duration.Milliseconds()))
 }


### PR DESCRIPTION
Adds another method on the `ResponseSent` server hook that measures the amount of time each Twirp request took, and then emits it as a histogram metric on prometheus.