### PR TITLE
service: prevent nil deref in validate with wrapped join request

### DIFF
--- a/pkg/service/rtcservice.go
+++ b/pkg/service/rtcservice.go
@@ -254,6 +254,9 @@ func (s *RTCService) validateInternal(
 	} else {
 		lgr.Debugw("processing join request", "joinRequest", logger.Proto(joinRequest))
 
+		if joinRequest.ClientInfo == nil {
+			joinRequest.ClientInfo = &livekit.ClientInfo{}
+		}
 		AugmentClientInfo(joinRequest.ClientInfo, r)
 		pi.Client = joinRequest.ClientInfo
 


### PR DESCRIPTION
## Summary

- Guard against `nil` `JoinRequest.ClientInfo` in `RTCService.validateInternal` before calling `AugmentClientInfo`, which dereferences `ci.Address`.
- Matches the invariant already enforced on the non-wrapped branch via `ParseClientInfo` (which always returns a freshly-allocated `*livekit.ClientInfo`).

## Context

Cloud-controller has been catching panics from this path via Negroni's recovery middleware:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/livekit/livekit-server/pkg/service.AugmentClientInfo(0x0, ...)
    pkg/service/utils.go:250  →  ci.Address = GetClientIP(req)
github.com/livekit/livekit-server/pkg/service.(*RTCService).validateInternal
    pkg/service/rtcservice.go:257
```

Trigger: a client connects to `/rtc/v1/validate` (or `v0Validate`) with `?join_request=<base64 WrappedJoinRequest>` and the embedded `JoinRequest.ClientInfo` is unset (nilable in proto3). The wrapped-request branch added later in `validateInternal` skipped the allocation that `ParseClientInfo` does on the non-wrapped branch.

After this fix, both branches feed `AugmentClientInfo` a non-nil pointer and `pi.Client` is always populated with at least the resolved client `Address`.

## Test plan

- [x] `go build ./pkg/service/...`
- [x] `go vet ./pkg/service/...`
- [ ] CI green