### PR TITLE
telemetry: split webhook-processed hook out of NewTelemetryService

### DIFF
--- a/pkg/service/wire.go
+++ b/pkg/service/wire.go
@@ -60,7 +60,7 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 		wire.Bind(new(routing.MessageRouter), new(routing.Router)),
 		wire.Bind(new(livekit.RoomService), new(*RoomService)),
 		telemetry.NewAnalyticsService,
-		telemetry.NewTelemetryService,
+		createTelemetryService,
 		getMessageBus,
 		NewIOInfoService,
 		wire.Bind(new(IOClient), new(*IOInfoService)),
@@ -169,6 +169,12 @@ func createWebhookNotifier(conf *config.Config, provider auth.KeyProvider) (webh
 	}
 
 	return webhook.NewDefaultNotifier(wc, provider)
+}
+
+func createTelemetryService(notifier webhook.QueuedNotifier, analytics telemetry.AnalyticsService) telemetry.TelemetryService {
+	svc := telemetry.NewTelemetryService(notifier, analytics)
+	telemetry.RegisterWebhookHook(svc, notifier)
+	return svc
 }
 
 func createRedisClient(conf *config.Config) (redis.UniversalClient, error) {

--- a/pkg/service/wire.go
+++ b/pkg/service/wire.go
@@ -173,7 +173,9 @@ func createWebhookNotifier(conf *config.Config, provider auth.KeyProvider) (webh
 
 func createTelemetryService(notifier webhook.QueuedNotifier, analytics telemetry.AnalyticsService) telemetry.TelemetryService {
 	svc := telemetry.NewTelemetryService(notifier, analytics)
-	telemetry.RegisterWebhookHook(svc, notifier)
+	if notifier != nil {
+		notifier.RegisterProcessedHook(svc.Webhook)
+	}
 	return svc
 }
 

--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -90,23 +90,23 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	}
 	rtcEgressLauncher := NewEgressLauncher(egressClient, ioInfoService, objectStore)
 	topicFormatter := rpc.NewTopicFormatter()
-	roomClient, err := rpc.NewTypedRoomClient(clientParams)
+	v, err := rpc.NewTypedRoomClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	participantClient, err := rpc.NewTypedParticipantClient(clientParams)
+	v2, err := rpc.NewTypedParticipantClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	roomService, err := NewRoomService(limitConfig, apiConfig, router, roomAllocator, objectStore, rtcEgressLauncher, topicFormatter, roomClient, participantClient)
+	roomService, err := NewRoomService(limitConfig, apiConfig, router, roomAllocator, objectStore, rtcEgressLauncher, topicFormatter, v, v2)
 	if err != nil {
 		return nil, err
 	}
-	agentDispatchInternalClient, err := rpc.NewTypedAgentDispatchInternalClient(clientParams)
+	v3, err := rpc.NewTypedAgentDispatchInternalClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	agentDispatchService := NewAgentDispatchService(agentDispatchInternalClient, topicFormatter, roomAllocator, router)
+	agentDispatchService := NewAgentDispatchService(v3, topicFormatter, roomAllocator, router)
 	egressService := NewEgressService(egressClient, rtcEgressLauncher, ioInfoService, roomService)
 	ingressConfig := getIngressConfig(conf)
 	ingressClient, err := rpc.NewIngressClient(clientParams)
@@ -121,11 +121,11 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	}
 	sipService := NewSIPService(sipConfig, nodeID, messageBus, sipClient, sipStore, roomService, telemetryService)
 	rtcService := NewRTCService(conf, roomAllocator, router, telemetryService)
-	whipParticipantClient, err := rpc.NewTypedWHIPParticipantClient(clientParams)
+	v4, err := rpc.NewTypedWHIPParticipantClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	serviceWHIPService, err := NewWHIPService(conf, router, roomAllocator, clientParams, topicFormatter, whipParticipantClient)
+	serviceWHIPService, err := NewWHIPService(conf, router, roomAllocator, clientParams, topicFormatter, v4)
 	if err != nil {
 		return nil, err
 	}
@@ -150,8 +150,8 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	if err != nil {
 		return nil, err
 	}
-	authHandler := getTURNAuthHandlerFunc(turnAuthHandler)
-	server, err := newInProcessTurnServer(conf, authHandler)
+	v5 := getTURNAuthHandlerFunc(turnAuthHandler)
+	server, err := newInProcessTurnServer(conf, v5)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -83,7 +83,7 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 		return nil, err
 	}
 	analyticsService := telemetry.NewAnalyticsService(conf, currentNode)
-	telemetryService := telemetry.NewTelemetryService(queuedNotifier, analyticsService)
+	telemetryService := createTelemetryService(queuedNotifier, analyticsService)
 	ioInfoService, err := NewIOInfoService(messageBus, egressStore, ingressStore, sipStore, telemetryService)
 	if err != nil {
 		return nil, err
@@ -234,6 +234,12 @@ func createWebhookNotifier(conf *config.Config, provider auth.KeyProvider) (webh
 	}
 
 	return webhook.NewDefaultNotifier(wc, provider)
+}
+
+func createTelemetryService(notifier webhook.QueuedNotifier, analytics telemetry.AnalyticsService) telemetry.TelemetryService {
+	svc := telemetry.NewTelemetryService(notifier, analytics)
+	telemetry.RegisterWebhookHook(svc, notifier)
+	return svc
 }
 
 func createRedisClient(conf *config.Config) (redis.UniversalClient, error) {

--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -238,7 +238,9 @@ func createWebhookNotifier(conf *config.Config, provider auth.KeyProvider) (webh
 
 func createTelemetryService(notifier webhook.QueuedNotifier, analytics telemetry.AnalyticsService) telemetry.TelemetryService {
 	svc := telemetry.NewTelemetryService(notifier, analytics)
-	telemetry.RegisterWebhookHook(svc, notifier)
+	if notifier != nil {
+		notifier.RegisterProcessedHook(svc.Webhook)
+	}
 	return svc
 }
 

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -195,16 +195,23 @@ func NewTelemetryService(notifier webhook.QueuedNotifier, analytics AnalyticsSer
 		}),
 		workers: make(map[statsWorkerKey]*StatsWorker),
 	}
-	if t.notifier != nil {
-		t.notifier.RegisterProcessedHook(func(ctx context.Context, whi *livekit.WebhookInfo) {
-			t.Webhook(ctx, whi)
-		})
-	}
 
 	t.jobsQueue.Start()
 	go t.run()
 
 	return t
+}
+
+// RegisterWebhookHook wires the notifier's processed-webhook callback to
+// svc.Webhook. Call this after constructing the (possibly wrapped) service so
+// any outer Webhook overrides are honored. No-op if notifier is nil.
+func RegisterWebhookHook(svc TelemetryService, notifier webhook.QueuedNotifier) {
+	if notifier == nil {
+		return
+	}
+	notifier.RegisterProcessedHook(func(ctx context.Context, whi *livekit.WebhookInfo) {
+		svc.Webhook(ctx, whi)
+	})
 }
 
 func (t *telemetryService) FlushStats() {

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -202,18 +202,6 @@ func NewTelemetryService(notifier webhook.QueuedNotifier, analytics AnalyticsSer
 	return t
 }
 
-// RegisterWebhookHook wires the notifier's processed-webhook callback to
-// svc.Webhook. Call this after constructing the (possibly wrapped) service so
-// any outer Webhook overrides are honored. No-op if notifier is nil.
-func RegisterWebhookHook(svc TelemetryService, notifier webhook.QueuedNotifier) {
-	if notifier == nil {
-		return
-	}
-	notifier.RegisterProcessedHook(func(ctx context.Context, whi *livekit.WebhookInfo) {
-		svc.Webhook(ctx, whi)
-	})
-}
-
 func (t *telemetryService) FlushStats() {
 	t.flushMu.Lock()
 	defer t.flushMu.Unlock()


### PR DESCRIPTION
## Summary
- `NewTelemetryService` previously registered the notifier's processed-webhook hook against the inner `*telemetryService` directly. That bound the callback to a specific concrete type, so any downstream wrapper that overrides `Webhook` could not be invoked from the notifier path without registering a second hook — which would double-fire the legacy `AnalyticsEvent{Type: WEBHOOK}` emission.
- Move the registration into a new exported helper `RegisterWebhookHook(svc TelemetryService, notifier webhook.QueuedNotifier)`. Callers register the hook against the outermost service in their wrapping chain.
- Standalone server's wire provider (`createTelemetryService` in `pkg/service/wire.go` / `wire_gen.go`) now constructs the service and immediately calls `RegisterWebhookHook`, so behavior is unchanged for in-tree consumers.

Downstream `livekit/cloud` will use `RegisterWebhookHook` to wire the hook against its outer wrapper, so the wrapper's `Webhook` override (which fans out to the v3 observability pipeline) fires for notifier-driven webhook completions.

## Test plan
- [x] `go build ./pkg/telemetry/... ./pkg/service/...`
- [x] `go test -short ./pkg/telemetry/...` passes
- [ ] Local standalone server boots and continues to emit `AnalyticsEvent{Type: WEBHOOK}` after a webhook delivery completes
- [ ] Cloud companion PR (livekit/cloud#4379) confirms `RegisterWebhookHook` on the outer wrapper fires correctly without double-emission