### PR TITLE
rtc: report participant session end time on room move

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -4069,6 +4069,7 @@ func (p *ParticipantImpl) MoveToRoom(params types.MoveToRoomParams) {
 	p.telemetryGuard = &telemetry.ReferenceGuard{}
 	p.lock.Unlock()
 
+	p.params.Reporter.ReportEndTime(time.Now())
 	p.params.LoggerResolver.Reset()
 	p.params.ReporterResolver.Reset()
 	p.setListener(params.Listener)


### PR DESCRIPTION
## Summary

- `MoveToRoom` resets the participant reporter resolver to remap the participant to its destination room and a fresh `participant_session_id`. Today, the source room's participant_session row never receives an `end_time` — the periodic duration scrape only emits `ReportEndTime` once `disconnectedAt` is set, and a move doesn't transition the participant to `DISCONNECTED`.
- Add a `Reporter.ReportEndTime(time.Now())` call immediately before `ReporterResolver.Reset()` so the source row is closed out cleanly. Safe because a fresh `participant_session_id` is minted on every move (even round-trips A→B→A), so the row being closed is genuinely retired.

## Test plan

- [ ] `go build ./pkg/rtc/...` (passes locally)
- [ ] Trigger a `MoveParticipant` (or SIP warm-transfer) against a dev cluster and verify the source-room `participant_session` row in ClickHouse now has `end_time != 0` at the move moment, while the destination row's `end_time` remains 0 until the participant truly disconnects.
- [ ] Confirm the normal disconnect path (no move) is unaffected: `disconnectedAt`-driven `ReportEndTime` in the registered scrape continues to be the source of truth.