### PR TITLE
Add prom metrics for peer connectino state.

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -232,6 +232,8 @@ type PCTransport struct {
 	resetShortConnOnICERestart atomic.Bool
 	signalingRTT               atomic.Uint32 // milliseconds
 
+	hasFullyEstablishedRecorded bool
+
 	debouncedNegotiate *sfuutils.Debouncer
 	debouncePending    bool
 	lastNegotiate      time.Time
@@ -288,17 +290,16 @@ type PCTransport struct {
 	numRequestSentVideos uint32
 
 	// the following should be accessed only in event processing go routine
-	hasStartedConnectionSequence atomic.Bool
-	cacheLocalCandidates         bool
-	cachedLocalCandidates        []*webrtc.ICECandidate
-	pendingRemoteCandidates      []*webrtc.ICECandidateInit
-	restartAfterGathering        bool
-	restartAtNextOffer           bool
-	negotiationState             transport.NegotiationState
-	negotiateCounter             atomic.Int32
-	signalStateCheckTimer        *time.Timer
-	currentOfferIceCredential    string // ice user:pwd, for publish side ice restart checking
-	pendingRestartIceOffer       *webrtc.SessionDescription
+	cacheLocalCandidates      bool
+	cachedLocalCandidates     []*webrtc.ICECandidate
+	pendingRemoteCandidates   []*webrtc.ICECandidateInit
+	restartAfterGathering     bool
+	restartAtNextOffer        bool
+	negotiationState          transport.NegotiationState
+	negotiateCounter          atomic.Int32
+	signalStateCheckTimer     *time.Timer
+	currentOfferIceCredential string // ice user:pwd, for publish side ice restart checking
+	pendingRestartIceOffer    *webrtc.SessionDescription
 }
 
 type TransportParams struct {
@@ -968,7 +969,13 @@ func (t *PCTransport) onDataChannel(dc *webrtc.DataChannel) {
 func (t *PCTransport) maybeNotifyFullyEstablished() {
 	if t.isFullyEstablished() {
 		t.params.Handler.OnFullyEstablished()
-		prometheus.RecordPeerConnectionState(t.params.Transport, "data_channels_established")
+
+		t.lock.Lock()
+		if !t.hasFullyEstablishedRecorded {
+			t.hasFullyEstablishedRecorded = true
+			prometheus.RecordPeerConnectionState(t.params.Transport, "fully_established")
+		}
+		t.lock.Unlock()
 	}
 }
 
@@ -2609,6 +2616,11 @@ func (t *PCTransport) createAndSendOffer(options *webrtc.OfferOptions) error {
 		t.params.Logger.Debugw("local offer (unfiltered)", "sdp", offer.SDP)
 	}
 
+	isStartOfConnectionSequence := false
+	if t.pc.LocalDescription() == nil {
+		isStartOfConnectionSequence = true
+	}
+
 	err = t.pc.SetLocalDescription(offer)
 	if err != nil {
 		if errors.Is(err, webrtc.ErrConnectionClosed) {
@@ -2619,7 +2631,8 @@ func (t *PCTransport) createAndSendOffer(options *webrtc.OfferOptions) error {
 		prometheus.RecordServiceOperationError("offer", "local_description")
 		return errors.Wrap(err, "setting local description failed")
 	}
-	if !t.hasStartedConnectionSequence.Swap(true) {
+
+	if isStartOfConnectionSequence {
 		prometheus.RecordPeerConnectionState(t.params.Transport, "started")
 	}
 
@@ -2868,12 +2881,19 @@ func (t *PCTransport) handleRemoteOfferReceived(sd *webrtc.SessionDescription, o
 		t.outputAndClearICEStats()
 	}
 
+	isStartOfConnectionSequence := false
+	if t.pc.RemoteDescription() == nil {
+		isStartOfConnectionSequence = true
+	}
+
 	if err := t.setRemoteDescription(*sd); err != nil {
 		return err
 	}
-	if !t.hasStartedConnectionSequence.Swap(true) {
+
+	if isStartOfConnectionSequence {
 		prometheus.RecordPeerConnectionState(t.params.Transport, "started")
 	}
+
 	t.params.Handler.OnSetRemoteDescriptionOffer()
 	t.processSendersPendingConfig()
 

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -288,16 +288,17 @@ type PCTransport struct {
 	numRequestSentVideos uint32
 
 	// the following should be accessed only in event processing go routine
-	cacheLocalCandidates      bool
-	cachedLocalCandidates     []*webrtc.ICECandidate
-	pendingRemoteCandidates   []*webrtc.ICECandidateInit
-	restartAfterGathering     bool
-	restartAtNextOffer        bool
-	negotiationState          transport.NegotiationState
-	negotiateCounter          atomic.Int32
-	signalStateCheckTimer     *time.Timer
-	currentOfferIceCredential string // ice user:pwd, for publish side ice restart checking
-	pendingRestartIceOffer    *webrtc.SessionDescription
+	hasStartedConnectionSequence atomic.Bool
+	cacheLocalCandidates         bool
+	cachedLocalCandidates        []*webrtc.ICECandidate
+	pendingRemoteCandidates      []*webrtc.ICECandidateInit
+	restartAfterGathering        bool
+	restartAtNextOffer           bool
+	negotiationState             transport.NegotiationState
+	negotiateCounter             atomic.Int32
+	signalStateCheckTimer        *time.Timer
+	currentOfferIceCredential    string // ice user:pwd, for publish side ice restart checking
+	pendingRestartIceOffer       *webrtc.SessionDescription
 }
 
 type TransportParams struct {
@@ -717,6 +718,8 @@ func (t *PCTransport) setICEConnectedAt(at time.Time) {
 			t.tcpICETimer.Stop()
 			t.tcpICETimer = nil
 		}
+
+		prometheus.RecordPeerConnectionState(t.params.Transport, "connected")
 	}
 
 	if t.mayFailedICEStatsTimer != nil {
@@ -2614,6 +2617,9 @@ func (t *PCTransport) createAndSendOffer(options *webrtc.OfferOptions) error {
 		prometheus.RecordServiceOperationError("offer", "local_description")
 		return errors.Wrap(err, "setting local description failed")
 	}
+	if !t.hasStartedConnectionSequence.Swap(true) {
+		prometheus.RecordPeerConnectionState(t.params.Transport, "started")
+	}
 
 	//
 	// Filter after setting local description as pion expects the offer
@@ -2788,7 +2794,7 @@ func (t *PCTransport) createAndSendAnswer() error {
 		return errors.Wrap(err, "could not send answer")
 	}
 	t.localAnswerId.Store(answerId)
-	prometheus.RecordServiceOperationSuccess("asnwer")
+	prometheus.RecordServiceOperationSuccess("answer")
 
 	if err := t.sendUnmatchedMediaRequirement(false); err != nil {
 		return err
@@ -2862,6 +2868,9 @@ func (t *PCTransport) handleRemoteOfferReceived(sd *webrtc.SessionDescription, o
 
 	if err := t.setRemoteDescription(*sd); err != nil {
 		return err
+	}
+	if !t.hasStartedConnectionSequence.Swap(true) {
+		prometheus.RecordPeerConnectionState(t.params.Transport, "started")
 	}
 	t.params.Handler.OnSetRemoteDescriptionOffer()
 	t.processSendersPendingConfig()

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -2616,10 +2616,7 @@ func (t *PCTransport) createAndSendOffer(options *webrtc.OfferOptions) error {
 		t.params.Logger.Debugw("local offer (unfiltered)", "sdp", offer.SDP)
 	}
 
-	isStartOfConnectionSequence := false
-	if t.pc.LocalDescription() == nil {
-		isStartOfConnectionSequence = true
-	}
+	isStartOfConnectionSequence := t.pc.LocalDescription() == nil
 
 	err = t.pc.SetLocalDescription(offer)
 	if err != nil {
@@ -2881,10 +2878,7 @@ func (t *PCTransport) handleRemoteOfferReceived(sd *webrtc.SessionDescription, o
 		t.outputAndClearICEStats()
 	}
 
-	isStartOfConnectionSequence := false
-	if t.pc.RemoteDescription() == nil {
-		isStartOfConnectionSequence = true
-	}
+	isStartOfConnectionSequence := t.pc.RemoteDescription() == nil
 
 	if err := t.setRemoteDescription(*sd); err != nil {
 		return err

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -719,7 +719,7 @@ func (t *PCTransport) setICEConnectedAt(at time.Time) {
 			t.tcpICETimer = nil
 		}
 
-		prometheus.RecordPeerConnectionState(t.params.Transport, "connected")
+		prometheus.RecordPeerConnectionState(t.params.Transport, "ice_connected")
 	}
 
 	if t.mayFailedICEStatsTimer != nil {
@@ -804,6 +804,7 @@ func (t *PCTransport) setConnectedAt(at time.Time) bool {
 
 	t.firstConnectedAt = at
 	prometheus.RecordServiceOperationSuccess("peer_connection")
+	prometheus.RecordPeerConnectionState(t.params.Transport, "connected")
 	t.lock.Unlock()
 	return true
 }
@@ -967,6 +968,7 @@ func (t *PCTransport) onDataChannel(dc *webrtc.DataChannel) {
 func (t *PCTransport) maybeNotifyFullyEstablished() {
 	if t.isFullyEstablished() {
 		t.params.Handler.OnFullyEstablished()
+		prometheus.RecordPeerConnectionState(t.params.Transport, "data_channels_established")
 	}
 }
 

--- a/pkg/telemetry/prometheus/rooms.go
+++ b/pkg/telemetry/prometheus/rooms.go
@@ -49,6 +49,8 @@ var (
 	promSessionStartTime       *prometheus.HistogramVec
 	promSessionDuration        *prometheus.HistogramVec
 	promPubSubTime             *prometheus.HistogramVec
+
+	promPeerConnection *prometheus.CounterVec
 )
 
 func initRoomStats(nodeID string, nodeType livekit.NodeType) {
@@ -118,6 +120,12 @@ func initRoomStats(nodeID string, nodeType livekit.NodeType) {
 		ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
 		Buckets:     []float64{100, 200, 500, 700, 1000, 5000, 10000},
 	}, append(promStreamLabels, "sdk", "kind", "count"))
+	promPeerConnection = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace:   livekitNamespace,
+		Subsystem:   "peer_connection",
+		Name:        "state",
+		ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
+	}, []string{"transport", "state"})
 
 	prometheus.MustRegister(promRoomCurrent)
 	prometheus.MustRegister(promRoomDuration)
@@ -129,6 +137,7 @@ func initRoomStats(nodeID string, nodeType livekit.NodeType) {
 	prometheus.MustRegister(promSessionStartTime)
 	prometheus.MustRegister(promSessionDuration)
 	prometheus.MustRegister(promPubSubTime)
+	prometheus.MustRegister(promPeerConnection)
 }
 
 func RoomStarted() {
@@ -268,4 +277,8 @@ func RecordSessionStartTime(protocolVersion int, d time.Duration) {
 
 func RecordSessionDuration(protocolVersion int, d time.Duration) {
 	promSessionDuration.WithLabelValues(strconv.Itoa(protocolVersion)).Observe(float64(d.Milliseconds()))
+}
+
+func RecordPeerConnectionState(transport livekit.SignalTarget, state string) {
+	promPeerConnection.WithLabelValues(transport.String(), state).Inc()
 }


### PR DESCRIPTION
By direction (PUBLISHER vs SUBSCRIBER) and state ("started" -> "ice_connected" -> "connected" -> "data_channels_established"). This gives a way to track peer connections failing to finish establishment.

The RTC active count can be useful for primary peer connection, but not for non-primary. This counter can be used to track any and can generally be used to understand success/failure rate of peer connection establishment.