### PR TITLE
Preserve original expiry when refreshing token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
 	github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0
-	github.com/livekit/protocol v1.46.7-0.20260605212020-c0615a2f6f84
+	github.com/livekit/protocol v1.46.7-0.20260610055838-1459c54aadf6
 	github.com/livekit/psrpc v0.7.2
 	github.com/mackerelio/go-osstat v0.2.7
 	github.com/magefile/mage v1.17.2

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5AT
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0 h1:XHNNzebIKZRkLimla/hFGrAIX5EMWHctrgt3hLw7s+I=
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
-github.com/livekit/protocol v1.46.7-0.20260605212020-c0615a2f6f84 h1:dkHHthyor9dwxxdBmbeG1ZUI4bPHpTEk9DjYJSSSIl4=
-github.com/livekit/protocol v1.46.7-0.20260605212020-c0615a2f6f84/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
+github.com/livekit/protocol v1.46.7-0.20260610055838-1459c54aadf6 h1:AK8JNLn2H3+ixSfh9gdFDqI+IpBV1YASGAusqaV5gFs=
+github.com/livekit/protocol v1.46.7-0.20260610055838-1459c54aadf6/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
 github.com/livekit/psrpc v0.7.2 h1:6oZ+NODJ2pLyaT6VqDq1F4Qc/3TpDUSpyphj/P9MhQc=
 github.com/livekit/psrpc v0.7.2/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
 github.com/mackerelio/go-osstat v0.2.7 h1:TCavZi10wF49bT6iQZ9eT2keGZQpC69MTDfdJej5e94=

--- a/pkg/routing/interfaces.go
+++ b/pkg/routing/interfaces.go
@@ -17,6 +17,7 @@ package routing
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/atomic"
@@ -192,6 +193,7 @@ type ParticipantInit struct {
 	AutoSubscribeDataTrack  *bool
 	Client                  *livekit.ClientInfo
 	Grants                  *auth.ClaimGrants
+	TokenExpiresAt          time.Time
 	Region                  string
 	AdaptiveStream          bool
 	ID                      livekit.ParticipantID
@@ -224,6 +226,9 @@ func (pi *ParticipantInit) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	logBoolPtr("AutoSubscribeDataTrack", pi.AutoSubscribeDataTrack)
 	e.AddObject("Client", logger.Proto(utils.ClientInfoWithoutAddress(pi.Client)))
 	e.AddObject("Grants", pi.Grants)
+	if !pi.TokenExpiresAt.IsZero() {
+		e.AddTime("TokenExpiresAt", pi.TokenExpiresAt)
+	}
 	e.AddString("Region", pi.Region)
 	logBoolPtr("AdaptiveStream", &pi.AdaptiveStream)
 	e.AddString("ID", string(pi.ID))
@@ -243,6 +248,11 @@ func (pi *ParticipantInit) ToStartSession(roomName livekit.RoomName, connectionI
 		return nil, err
 	}
 
+	var tokenExpiresAt int64
+	if !pi.TokenExpiresAt.IsZero() {
+		tokenExpiresAt = pi.TokenExpiresAt.Unix()
+	}
+
 	ss := &livekit.StartSession{
 		RoomName:                string(roomName),
 		Identity:                string(pi.Identity),
@@ -253,6 +263,7 @@ func (pi *ParticipantInit) ToStartSession(roomName livekit.RoomName, connectionI
 		AutoSubscribe:           pi.AutoSubscribe,
 		Client:                  pi.Client,
 		GrantsJson:              string(claims),
+		TokenExpiresAt:          tokenExpiresAt,
 		AdaptiveStream:          pi.AdaptiveStream,
 		ParticipantId:           string(pi.ID),
 		DisableIceLite:          pi.DisableICELite,
@@ -279,6 +290,10 @@ func ParticipantInitFromStartSession(ss *livekit.StartSession, region string) (*
 	if err := json.Unmarshal([]byte(ss.GrantsJson), claims); err != nil {
 		return nil, err
 	}
+	var tokenExpiresAt time.Time
+	if ss.TokenExpiresAt > 0 {
+		tokenExpiresAt = time.Unix(ss.TokenExpiresAt, 0)
+	}
 
 	pi := &ParticipantInit{
 		Identity:                livekit.ParticipantIdentity(ss.Identity),
@@ -288,6 +303,7 @@ func ParticipantInitFromStartSession(ss *livekit.StartSession, region string) (*
 		Client:                  ss.Client,
 		AutoSubscribe:           ss.AutoSubscribe,
 		Grants:                  claims,
+		TokenExpiresAt:          tokenExpiresAt,
 		Region:                  region,
 		AdaptiveStream:          ss.AdaptiveStream,
 		ID:                      livekit.ParticipantID(ss.ParticipantId),

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -182,6 +182,7 @@ type ParticipantParams struct {
 	ReporterResolver                roomobs.ParticipantReporterResolver
 	SimTracks                       map[uint32]interceptor.SimulcastTrackInfo
 	Grants                          *auth.ClaimGrants
+	TokenExpiresAt                  time.Time
 	InitialVersion                  uint32
 	ClientConf                      *livekit.ClientConfiguration
 	ClientInfo                      ClientInfo
@@ -779,6 +780,10 @@ func (p *ParticipantImpl) SetAttributes(attrs map[string]string) {
 
 func (p *ParticipantImpl) ClaimGrants() *auth.ClaimGrants {
 	return p.grants.Load()
+}
+
+func (p *ParticipantImpl) TokenExpiresAt() time.Time {
+	return p.params.TokenExpiresAt
 }
 
 func (p *ParticipantImpl) SetPermission(permission *livekit.ParticipantPermission) bool {

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -441,6 +441,7 @@ type LocalParticipant interface {
 
 	// permissions
 	ClaimGrants() *auth.ClaimGrants
+	TokenExpiresAt() time.Time
 	SetPermission(permission *livekit.ParticipantPermission) bool
 	CanPublish() bool
 	CanPublishSource(source livekit.TrackSource) bool

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -1342,6 +1342,16 @@ type FakeLocalParticipant struct {
 		result1 *livekit.ParticipantInfo
 		result2 utils.TimedVersion
 	}
+	TokenExpiresAtStub        func() time.Time
+	tokenExpiresAtMutex       sync.RWMutex
+	tokenExpiresAtArgsForCall []struct {
+	}
+	tokenExpiresAtReturns struct {
+		result1 time.Time
+	}
+	tokenExpiresAtReturnsOnCall map[int]struct {
+		result1 time.Time
+	}
 	UncacheDownTrackStub        func(*webrtc.RTPTransceiver)
 	uncacheDownTrackMutex       sync.RWMutex
 	uncacheDownTrackArgsForCall []struct {
@@ -8614,6 +8624,59 @@ func (fake *FakeLocalParticipant) ToProtoWithVersionReturnsOnCall(i int, result1
 		result1 *livekit.ParticipantInfo
 		result2 utils.TimedVersion
 	}{result1, result2}
+}
+
+func (fake *FakeLocalParticipant) TokenExpiresAt() time.Time {
+	fake.tokenExpiresAtMutex.Lock()
+	ret, specificReturn := fake.tokenExpiresAtReturnsOnCall[len(fake.tokenExpiresAtArgsForCall)]
+	fake.tokenExpiresAtArgsForCall = append(fake.tokenExpiresAtArgsForCall, struct {
+	}{})
+	stub := fake.TokenExpiresAtStub
+	fakeReturns := fake.tokenExpiresAtReturns
+	fake.recordInvocation("TokenExpiresAt", []interface{}{})
+	fake.tokenExpiresAtMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLocalParticipant) TokenExpiresAtCallCount() int {
+	fake.tokenExpiresAtMutex.RLock()
+	defer fake.tokenExpiresAtMutex.RUnlock()
+	return len(fake.tokenExpiresAtArgsForCall)
+}
+
+func (fake *FakeLocalParticipant) TokenExpiresAtCalls(stub func() time.Time) {
+	fake.tokenExpiresAtMutex.Lock()
+	defer fake.tokenExpiresAtMutex.Unlock()
+	fake.TokenExpiresAtStub = stub
+}
+
+func (fake *FakeLocalParticipant) TokenExpiresAtReturns(result1 time.Time) {
+	fake.tokenExpiresAtMutex.Lock()
+	defer fake.tokenExpiresAtMutex.Unlock()
+	fake.TokenExpiresAtStub = nil
+	fake.tokenExpiresAtReturns = struct {
+		result1 time.Time
+	}{result1}
+}
+
+func (fake *FakeLocalParticipant) TokenExpiresAtReturnsOnCall(i int, result1 time.Time) {
+	fake.tokenExpiresAtMutex.Lock()
+	defer fake.tokenExpiresAtMutex.Unlock()
+	fake.TokenExpiresAtStub = nil
+	if fake.tokenExpiresAtReturnsOnCall == nil {
+		fake.tokenExpiresAtReturnsOnCall = make(map[int]struct {
+			result1 time.Time
+		})
+	}
+	fake.tokenExpiresAtReturnsOnCall[i] = struct {
+		result1 time.Time
+	}{result1}
 }
 
 func (fake *FakeLocalParticipant) UncacheDownTrack(arg1 *webrtc.RTPTransceiver) {

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/twitchtv/twirp"
 
@@ -35,8 +36,9 @@ const (
 type grantsKey struct{}
 
 type grantsValue struct {
-	claims *auth.ClaimGrants
-	apiKey string
+	claims    *auth.ClaimGrants
+	apiKey    string
+	expiresAt time.Time
 }
 
 var (
@@ -90,17 +92,23 @@ func (m *APIKeyAuthMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request,
 			return
 		}
 
-		_, grants, err := v.Verify(secret)
+		claims, grants, err := v.Verify(secret)
 		if err != nil {
 			HandleError(w, r, http.StatusUnauthorized, errors.New("invalid token: "+authToken+", error: "+err.Error()))
 			return
 		}
 
+		var expiresAt time.Time
+		if claims != nil && claims.ExpiresAt != nil {
+			expiresAt = claims.ExpiresAt.Time
+		}
+
 		// set grants in context
 		ctx := r.Context()
 		r = r.WithContext(context.WithValue(ctx, grantsKey{}, &grantsValue{
-			claims: grants,
-			apiKey: v.APIKey(),
+			claims:    grants,
+			apiKey:    v.APIKey(),
+			expiresAt: expiresAt,
 		}))
 	}
 
@@ -121,6 +129,15 @@ func GetGrants(ctx context.Context) *auth.ClaimGrants {
 		return nil
 	}
 	return v.claims
+}
+
+func GetTokenExpiresAt(ctx context.Context) time.Time {
+	val := ctx.Value(grantsKey{})
+	v, ok := val.(*grantsValue)
+	if !ok {
+		return time.Time{}
+	}
+	return v.expiresAt
 }
 
 func GetAPIKey(ctx context.Context) string {

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -489,6 +489,7 @@ func (r *RoomManager) StartSession(
 		PublishEnabledCodecs:     enabledCodecs,
 		SubscribeEnabledCodecs:   enabledCodecs,
 		Grants:                   pi.Grants,
+		TokenExpiresAt:           pi.TokenExpiresAt,
 		Reconnect:                pi.Reconnect,
 		Logger:                   pLogger,
 		Reporter:                 roomobs.NewNoopParticipantSessionReporter(),
@@ -1124,11 +1125,20 @@ func (r *RoomManager) refreshToken(participant types.LocalParticipant) error {
 	}
 
 	grants := participant.ClaimGrants()
+
+	// Preserve the original token's expiry
+	validFor := tokenDefaultTTL
+	if expiresAt := participant.TokenExpiresAt(); !expiresAt.IsZero() {
+		if remaining := time.Until(expiresAt); remaining > validFor {
+			validFor = remaining
+		}
+	}
+
 	token := auth.NewAccessToken(key, secret)
 	token.SetName(grants.Name).
 		SetIdentity(string(participant.Identity())).
 		SetKind(grants.GetParticipantKind()).
-		SetValidFor(tokenDefaultTTL).
+		SetValidFor(validFor).
 		SetMetadata(grants.Metadata).
 		SetAttributes(grants.Attributes).
 		SetVideoGrant(grants.Video).

--- a/pkg/service/rtcservice.go
+++ b/pkg/service/rtcservice.go
@@ -218,6 +218,7 @@ func (s *RTCService) validateInternal(
 		Identity:                livekit.ParticipantIdentity(res.grants.Identity),
 		Name:                    livekit.ParticipantName(res.grants.Name),
 		Grants:                  res.grants,
+		TokenExpiresAt:          res.tokenExpiresAt,
 		Region:                  res.region,
 		CreateRoom:              res.createRoomRequest,
 		UseSinglePeerConnection: useSinglePeerConnection,

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ua-parser/uap-go/uaparser"
 	"gopkg.in/yaml.v3"
@@ -289,6 +290,7 @@ type ValidateConnectRequestParams struct {
 type ValidateConnectRequestResult struct {
 	roomName          livekit.RoomName
 	grants            *auth.ClaimGrants
+	tokenExpiresAt    time.Time
 	region            string
 	createRoomRequest *livekit.CreateRoomRequest
 }
@@ -402,6 +404,7 @@ func ValidateConnectRequest(
 	}
 
 	res.grants = claims
+	res.tokenExpiresAt = GetTokenExpiresAt(r.Context())
 	return res, http.StatusOK, nil
 }
 


### PR DESCRIPTION
To avoid shortening the token expiration time during refreshing cause client reconnect failed after network down for a long time (>5min).