### PR TITLE
Add ability to run pprof on dedicated HTTP server/port

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -170,6 +170,11 @@ rtc:
 # when enabled, LiveKit will expose prometheus metrics on :6789/metrics
 # prometheus_port: 6789
 
+# expose /debug/pprof (and /debug/goroutine, /debug/rooms) on a dedicated port,
+# separate from the public signalling port. only enabled when port is set.
+# debug_handler_port:
+#   port: 7070
+
 # API key / secret pairs.
 # Keys are used for JWT authentication, server APIs would require a keypair in order to generate access tokens
 # and make calls to the server

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	// PrometheusPort is deprecated
 	PrometheusPort uint32                   `yaml:"prometheus_port,omitempty"`
 	Prometheus     PrometheusConfig         `yaml:"prometheus,omitempty"`
+	DebugHandler   DebugHandlerConfig       `yaml:"debug_handler,omitempty"`
 	RTC            RTCConfig                `yaml:"rtc,omitempty"`
 	Redis          redisLiveKit.RedisConfig `yaml:"redis,omitempty"`
 	Audio          sfu.AudioConfig          `yaml:"audio,omitempty"`
@@ -346,6 +347,10 @@ type PrometheusConfig struct {
 	Port     uint32 `yaml:"port,omitempty"`
 	Username string `yaml:"username,omitempty"`
 	Password string `yaml:"password,omitempty"`
+}
+
+type DebugHandlerConfig struct {
+	Port uint32 `yaml:"port,omitempty"`
 }
 
 type ForwardStatsConfig struct {

--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	_ "net/http/pprof"
+	httppprof "net/http/pprof"
 	"runtime"
 	"runtime/pprof"
 	"strconv"
@@ -53,6 +53,7 @@ type LivekitServer struct {
 	agentService *AgentService
 	httpServer   *http.Server
 	promServer   *http.Server
+	debugServer  *http.Server
 	router       routing.Router
 	roomManager  *RoomManager
 	signalServer *SignalServer
@@ -171,6 +172,20 @@ func NewLivekitServer(conf *config.Config,
 		}
 	}
 
+	if conf.DebugHandler.Port > 0 {
+		debugMux := http.NewServeMux()
+		debugMux.HandleFunc("/debug/pprof/", httppprof.Index)
+		debugMux.HandleFunc("/debug/pprof/cmdline", httppprof.Cmdline)
+		debugMux.HandleFunc("/debug/pprof/profile", httppprof.Profile)
+		debugMux.HandleFunc("/debug/pprof/symbol", httppprof.Symbol)
+		debugMux.HandleFunc("/debug/pprof/trace", httppprof.Trace)
+		debugMux.HandleFunc("/debug/goroutine", s.debugGoroutines)
+		debugMux.HandleFunc("/debug/rooms", s.debugInfo)
+		s.debugServer = &http.Server{
+			Handler: http.Handler(debugMux),
+		}
+	}
+
 	if err = router.RemoveDeadNodes(); err != nil {
 		return
 	}
@@ -221,6 +236,7 @@ func (s *LivekitServer) Start() error {
 	// ensure we could listen
 	listeners := make([]net.Listener, 0)
 	promListeners := make([]net.Listener, 0)
+	debugListeners := make([]net.Listener, 0)
 	for _, addr := range addresses {
 		ln, err := net.Listen("tcp", net.JoinHostPort(addr, strconv.Itoa(int(s.config.Port))))
 		if err != nil {
@@ -234,6 +250,14 @@ func (s *LivekitServer) Start() error {
 				return err
 			}
 			promListeners = append(promListeners, ln)
+		}
+
+		if s.debugServer != nil {
+			ln, err = net.Listen("tcp", net.JoinHostPort(addr, strconv.Itoa(int(s.config.DebugHandler.Port))))
+			if err != nil {
+				return err
+			}
+			debugListeners = append(debugListeners, ln)
 		}
 	}
 
@@ -259,6 +283,9 @@ func (s *LivekitServer) Start() error {
 	if s.config.Prometheus.Port != 0 {
 		values = append(values, "portPrometheus", s.config.Prometheus.Port)
 	}
+	if s.config.DebugHandler.Port != 0 {
+		values = append(values, "portDebugHandler", s.config.DebugHandler.Port)
+	}
 	if s.config.Region != "" {
 		values = append(values, "region", s.config.Region)
 	}
@@ -269,6 +296,10 @@ func (s *LivekitServer) Start() error {
 
 	for _, promLn := range promListeners {
 		go s.promServer.Serve(promLn)
+	}
+
+	for _, debugLn := range debugListeners {
+		go s.debugServer.Serve(debugLn)
 	}
 
 	if err := s.signalServer.Start(); err != nil {
@@ -302,6 +333,9 @@ func (s *LivekitServer) Start() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	_ = s.httpServer.Shutdown(ctx)
+	if s.debugServer != nil {
+		_ = s.debugServer.Shutdown(ctx)
+	}
 
 	if s.turnServer != nil {
 		_ = s.turnServer.Close()


### PR DESCRIPTION
This allows exposing the pprof/debug endpoints in a production environment more easily, where it shouldn't be exposed publically.