### PR TITLE
Fix stale room reuse after DeleteRoom

### DIFF
--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -910,16 +910,22 @@ func (r *RoomManager) PerformRpc(ctx context.Context, req *livekit.PerformRpcReq
 }
 
 func (r *RoomManager) DeleteRoom(ctx context.Context, req *livekit.DeleteRoomRequest) (*livekit.DeleteRoomResponse, error) {
-	room := r.GetRoom(ctx, livekit.RoomName(req.Room))
+	roomName := livekit.RoomName(req.Room)
+	room := r.GetRoom(ctx, roomName)
 	if room == nil {
 		// special case of a non-RTC room e.g. room created but no participants joined
 		logger.Debugw("Deleting non-rtc room, loading from roomstore")
-		err := r.roomStore.DeleteRoom(ctx, livekit.RoomName(req.Room))
+		err := r.roomStore.DeleteRoom(ctx, roomName)
 		if err != nil {
 			logger.Debugw("Error deleting non-rtc room", "err", err)
 			return nil, err
 		}
 	} else {
+		// Clear room state before closing so a same-name recreate cannot reuse stale metadata
+		// while the old room is still winding down.
+		if err := r.deleteRoom(ctx, roomName); err != nil {
+			room.Logger().Errorw("could not delete room state before closing", err)
+		}
 		room.Logger().Infow("deleting room")
 		room.Close(types.ParticipantCloseReasonServiceRequestDeleteRoom)
 	}

--- a/test/delete_room_recreate_test.go
+++ b/test/delete_room_recreate_test.go
@@ -1,0 +1,59 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/protocol/livekit"
+)
+
+func TestSingleNodeDeleteRoomRecreateGetsNewSID(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+		return
+	}
+
+	_, finish := setupSingleNodeTest("TestSingleNodeDeleteRoomRecreateGetsNewSID")
+	defer finish()
+
+	createCtx := contextWithToken(createRoomToken())
+
+	for _, testRTCServicePath := range testRTCServicePaths {
+		t.Run(fmt.Sprintf("testRTCServicePath=%s", testRTCServicePath.String()), func(t *testing.T) {
+			firstRoom, err := roomClient.CreateRoom(createCtx, &livekit.CreateRoomRequest{
+				Name:             testRoom,
+				DepartureTimeout: 1,
+				EmptyTimeout:     30,
+			})
+			require.NoError(t, err)
+
+			c1 := createRTCClient("delete-recreate-1", defaultServerPort, testRTCServicePath, nil)
+			waitUntilConnected(t, c1)
+
+			_, err = roomClient.DeleteRoom(createCtx, &livekit.DeleteRoomRequest{
+				Room: testRoom,
+			})
+			require.NoError(t, err)
+
+			secondRoom, err := roomClient.CreateRoom(createCtx, &livekit.CreateRoomRequest{
+				Name:             testRoom,
+				DepartureTimeout: 1,
+				EmptyTimeout:     30,
+			})
+			require.NoError(t, err)
+			require.NotEqual(t, firstRoom.Sid, secondRoom.Sid)
+			require.GreaterOrEqual(t, secondRoom.CreationTimeMs, firstRoom.CreationTimeMs)
+
+			c2 := createRTCClient("delete-recreate-2", defaultServerPort, testRTCServicePath, nil)
+			waitUntilConnected(t, c2)
+			stopClients(c2)
+
+			_, err = roomClient.DeleteRoom(createCtx, &livekit.DeleteRoomRequest{
+				Room: testRoom,
+			})
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- clear persisted room state before closing an active room during `DeleteRoom`
- prevent same-name room recreation from reusing the previous room SID/metadata while the old room is still winding down
- add a regression test that verifies delete + recreate yields a new room SID and still allows a fresh join

## Problem
`DeleteRoom` closed the active RTC room first and relied on async cleanup to clear the room store afterwards. That left a window where a same-name `CreateRoom` could load stale room state and recreate the room with the previous SID and timestamps.

## Fix
Call `deleteRoom` before closing the active room so the room store and routing state are cleared synchronously before any same-name recreate can happen. `room.Close(...)` remains idempotent, so the later `OnClose` cleanup is safe.

Fixes #4558.

## Test
- `go test ./test -run 'TestSingleNode(DeleteRoomRecreateGetsNewSID|JoinAfterClose)$' -count=1`

## Notes
I did not run `go test ./pkg/service` in this environment because Docker socket access was unavailable.
