### PR TITLE
agent: thread attributes map from dispatch to job

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
 	github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0
-	github.com/livekit/protocol v1.46.7-0.20260611165352-04a0fe5b5051
+	github.com/livekit/protocol v1.46.9-0.20260616073539-41307adc158e
 	github.com/livekit/psrpc v0.7.2
 	github.com/mackerelio/go-osstat v0.2.7
 	github.com/magefile/mage v1.17.2

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
 	github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0
-	github.com/livekit/protocol v1.46.9-0.20260616081943-becadc8d18bd
+	github.com/livekit/protocol v1.46.9-0.20260616084954-6bd536c5c6d4
 	github.com/livekit/psrpc v0.7.2
 	github.com/mackerelio/go-osstat v0.2.7
 	github.com/magefile/mage v1.17.2

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
 	github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0
-	github.com/livekit/protocol v1.46.9-0.20260616073539-41307adc158e
+	github.com/livekit/protocol v1.46.9-0.20260616081943-becadc8d18bd
 	github.com/livekit/psrpc v0.7.2
 	github.com/mackerelio/go-osstat v0.2.7
 	github.com/magefile/mage v1.17.2

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5AT
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0 h1:XHNNzebIKZRkLimla/hFGrAIX5EMWHctrgt3hLw7s+I=
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
-github.com/livekit/protocol v1.46.9-0.20260616081943-becadc8d18bd h1:rmqoTnRSxUQ/x7c3legv0FcKoCgssuRuayj8rh9mXMU=
-github.com/livekit/protocol v1.46.9-0.20260616081943-becadc8d18bd/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
+github.com/livekit/protocol v1.46.9-0.20260616084954-6bd536c5c6d4 h1:5YChJaYTXdVsz7zIZ12vOY2ToLVq3Bzs8xZxmv5SA+0=
+github.com/livekit/protocol v1.46.9-0.20260616084954-6bd536c5c6d4/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
 github.com/livekit/psrpc v0.7.2 h1:6oZ+NODJ2pLyaT6VqDq1F4Qc/3TpDUSpyphj/P9MhQc=
 github.com/livekit/psrpc v0.7.2/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
 github.com/mackerelio/go-osstat v0.2.7 h1:TCavZi10wF49bT6iQZ9eT2keGZQpC69MTDfdJej5e94=

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5AT
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0 h1:XHNNzebIKZRkLimla/hFGrAIX5EMWHctrgt3hLw7s+I=
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
-github.com/livekit/protocol v1.46.7-0.20260611165352-04a0fe5b5051 h1:IYqiW7z5pblZBn6o0OHNz8MHd3wJ/TLJG4gh6lCI0/s=
-github.com/livekit/protocol v1.46.7-0.20260611165352-04a0fe5b5051/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
+github.com/livekit/protocol v1.46.9-0.20260616073539-41307adc158e h1:B1R5GX5EvY9O/3hwmvZ9wmgf0YwpskcLRBi5io3F2S4=
+github.com/livekit/protocol v1.46.9-0.20260616073539-41307adc158e/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
 github.com/livekit/psrpc v0.7.2 h1:6oZ+NODJ2pLyaT6VqDq1F4Qc/3TpDUSpyphj/P9MhQc=
 github.com/livekit/psrpc v0.7.2/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
 github.com/mackerelio/go-osstat v0.2.7 h1:TCavZi10wF49bT6iQZ9eT2keGZQpC69MTDfdJej5e94=

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5AT
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0 h1:XHNNzebIKZRkLimla/hFGrAIX5EMWHctrgt3hLw7s+I=
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
-github.com/livekit/protocol v1.46.9-0.20260616073539-41307adc158e h1:B1R5GX5EvY9O/3hwmvZ9wmgf0YwpskcLRBi5io3F2S4=
-github.com/livekit/protocol v1.46.9-0.20260616073539-41307adc158e/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
+github.com/livekit/protocol v1.46.9-0.20260616081943-becadc8d18bd h1:rmqoTnRSxUQ/x7c3legv0FcKoCgssuRuayj8rh9mXMU=
+github.com/livekit/protocol v1.46.9-0.20260616081943-becadc8d18bd/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
 github.com/livekit/psrpc v0.7.2 h1:6oZ+NODJ2pLyaT6VqDq1F4Qc/3TpDUSpyphj/P9MhQc=
 github.com/livekit/psrpc v0.7.2/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
 github.com/mackerelio/go-osstat v0.2.7 h1:TCavZi10wF49bT6iQZ9eT2keGZQpC69MTDfdJej5e94=

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -64,6 +64,7 @@ type JobRequest struct {
 	Metadata    string
 	AgentName  string
 	Deployment string
+	Simulation bool
 }
 
 type agentClient struct {
@@ -172,6 +173,7 @@ func (c *agentClient) LaunchJob(ctx context.Context, desc *JobRequest) *serverut
 				Metadata:        desc.Metadata,
 				EnableRecording: c.config.EnableUserDataRecording,
 				Deployment:      desc.Deployment,
+				Simulation:      desc.Simulation,
 			}
 			resp, err := c.client.JobRequest(context.Background(), topic, jobTypeTopic, job)
 			if err != nil {

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -64,7 +64,7 @@ type JobRequest struct {
 	Metadata    string
 	AgentName  string
 	Deployment string
-	Simulation bool
+	Attributes map[string]string
 }
 
 type agentClient struct {
@@ -173,7 +173,7 @@ func (c *agentClient) LaunchJob(ctx context.Context, desc *JobRequest) *serverut
 				Metadata:        desc.Metadata,
 				EnableRecording: c.config.EnableUserDataRecording,
 				Deployment:      desc.Deployment,
-				Simulation:      desc.Simulation,
+				Attributes:      desc.Attributes,
 			}
 			resp, err := c.client.JobRequest(context.Background(), topic, jobTypeTopic, job)
 			if err != nil {

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -1779,7 +1779,7 @@ func (r *Room) launchRoomAgents(ads []*agentDispatch) {
 				AgentName:  ad.AgentName,
 				DispatchId: ad.Id,
 				Deployment: ad.Deployment,
-				Simulation: ad.Simulation,
+				Attributes: ad.Attributes,
 			})
 			r.handleNewJobs(ad.AgentDispatch, inc)
 			done()
@@ -1804,7 +1804,7 @@ func (r *Room) launchTargetAgents(ads []*agentDispatch, p types.Participant, job
 				AgentName:   ad.AgentName,
 				DispatchId:  ad.Id,
 				Deployment:  ad.Deployment,
-				Simulation:  ad.Simulation,
+				Attributes:  ad.Attributes,
 			})
 			r.handleNewJobs(ad.AgentDispatch, inc)
 			done()
@@ -1871,7 +1871,7 @@ func (r *Room) createAgentDispatchFromRoomDispatch(rad *livekit.RoomAgentDispatc
 		Room:          r.protoRoom.Name,
 		RestartPolicy: rad.GetRestartPolicy(),
 		Deployment:    rad.GetDeployment(),
-		Simulation:    rad.GetSimulation(),
+		Attributes:    rad.GetAttributes(),
 	})
 }
 

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -1779,6 +1779,7 @@ func (r *Room) launchRoomAgents(ads []*agentDispatch) {
 				AgentName:  ad.AgentName,
 				DispatchId: ad.Id,
 				Deployment: ad.Deployment,
+				Simulation: ad.Simulation,
 			})
 			r.handleNewJobs(ad.AgentDispatch, inc)
 			done()
@@ -1803,6 +1804,7 @@ func (r *Room) launchTargetAgents(ads []*agentDispatch, p types.Participant, job
 				AgentName:   ad.AgentName,
 				DispatchId:  ad.Id,
 				Deployment:  ad.Deployment,
+				Simulation:  ad.Simulation,
 			})
 			r.handleNewJobs(ad.AgentDispatch, inc)
 			done()
@@ -1869,6 +1871,7 @@ func (r *Room) createAgentDispatchFromRoomDispatch(rad *livekit.RoomAgentDispatc
 		Room:          r.protoRoom.Name,
 		RestartPolicy: rad.GetRestartPolicy(),
 		Deployment:    rad.GetDeployment(),
+		Simulation:    rad.GetSimulation(),
 	})
 }
 

--- a/pkg/service/agent_dispatch_service.go
+++ b/pkg/service/agent_dispatch_service.go
@@ -79,6 +79,7 @@ func (ag *AgentDispatchService) CreateDispatch(ctx context.Context, req *livekit
 		Metadata:      req.Metadata,
 		RestartPolicy: req.RestartPolicy,
 		Deployment:    req.Deployment,
+		Simulation:    req.Simulation,
 	}
 	return ag.agentDispatchClient.CreateDispatch(ctx, ag.topicFormatter.RoomTopic(ctx, livekit.RoomName(req.Room)), dispatch)
 }

--- a/pkg/service/agent_dispatch_service.go
+++ b/pkg/service/agent_dispatch_service.go
@@ -79,7 +79,7 @@ func (ag *AgentDispatchService) CreateDispatch(ctx context.Context, req *livekit
 		Metadata:      req.Metadata,
 		RestartPolicy: req.RestartPolicy,
 		Deployment:    req.Deployment,
-		Simulation:    req.Simulation,
+		Attributes:    req.Attributes,
 	}
 	return ag.agentDispatchClient.CreateDispatch(ctx, ag.topicFormatter.RoomTopic(ctx, livekit.RoomName(req.Room)), dispatch)
 }


### PR DESCRIPTION
## Summary

- Copies `attributes` from `AgentDispatch` / `RoomAgentDispatch` onto `Job` in `agent.LaunchJob` and the inline room-agent path so workers see the map.
- Adds `Attributes map[string]string` to the internal `agent.JobRequest`.
- Updates `go.mod` to the protocol pseudo-version that carries the new field.

Stacked on top of livekit/protocol#1629.

## Test plan

- [ ] CI passes against the bumped protocol version.
- [ ] cloud stacked PR builds against this pseudo-version.