### PR TITLE
service: cap all metadata at 512 KiB; enforce on join, agent dispatch, and embedded agents

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -287,6 +287,7 @@ type LimitConfig struct {
 	SubscriptionLimitVideo int32   `yaml:"subscription_limit_video,omitempty"`
 	SubscriptionLimitAudio int32   `yaml:"subscription_limit_audio,omitempty"`
 	MaxMetadataSize        uint32  `yaml:"max_metadata_size,omitempty"`
+	MaxRoomMetadataSize    uint32  `yaml:"max_room_metadata_size,omitempty"`
 	// total size of all attributes on a participant
 	MaxAttributesSize            uint32 `yaml:"max_attributes_size,omitempty"`
 	MaxRoomNameLength            int    `yaml:"max_room_name_length,omitempty"`
@@ -308,6 +309,10 @@ func (l LimitConfig) CheckParticipantNameLength(name string) bool {
 
 func (l LimitConfig) CheckMetadataSize(metadata string) bool {
 	return l.MaxMetadataSize == 0 || uint32(len(metadata)) <= l.MaxMetadataSize
+}
+
+func (l LimitConfig) CheckRoomMetadataSize(metadata string) bool {
+	return l.MaxRoomMetadataSize == 0 || uint32(len(metadata)) <= l.MaxRoomMetadataSize
 }
 
 func (l LimitConfig) CheckAttributesSize(attributes map[string]string) bool {
@@ -440,7 +445,8 @@ var DefaultConfig = Config{
 		UpdateBatchTargetSize: 128 * 1024,
 	},
 	Limit: LimitConfig{
-		MaxMetadataSize:              512 * 1024,
+		MaxMetadataSize:              64000,
+		MaxRoomMetadataSize:          512 * 1024,
 		MaxAttributesSize:            64000,
 		MaxRoomNameLength:            256,
 		MaxParticipantIdentityLength: 256,
@@ -546,7 +552,7 @@ func NewConfig(confString string, strictMode bool, c *cli.Command, baseFlags []c
 
 	// copy over legacy limits
 	if conf.Room.MaxMetadataSize != 0 {
-		conf.Limit.MaxMetadataSize = conf.Room.MaxMetadataSize
+		conf.Limit.MaxRoomMetadataSize = conf.Room.MaxMetadataSize
 	}
 	if conf.Room.MaxParticipantIdentityLength != 0 {
 		conf.Limit.MaxParticipantIdentityLength = conf.Room.MaxParticipantIdentityLength

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -441,7 +441,7 @@ var DefaultConfig = Config{
 	},
 	Limit: LimitConfig{
 		MaxMetadataSize:              512 * 1024,
-		MaxAttributesSize:            64000,
+		MaxAttributesSize:            64 * 1024,
 		MaxRoomNameLength:            256,
 		MaxParticipantIdentityLength: 256,
 		MaxParticipantNameLength:     256,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -287,7 +287,6 @@ type LimitConfig struct {
 	SubscriptionLimitVideo int32   `yaml:"subscription_limit_video,omitempty"`
 	SubscriptionLimitAudio int32   `yaml:"subscription_limit_audio,omitempty"`
 	MaxMetadataSize        uint32  `yaml:"max_metadata_size,omitempty"`
-	MaxRoomMetadataSize    uint32  `yaml:"max_room_metadata_size,omitempty"`
 	// total size of all attributes on a participant
 	MaxAttributesSize            uint32 `yaml:"max_attributes_size,omitempty"`
 	MaxRoomNameLength            int    `yaml:"max_room_name_length,omitempty"`
@@ -309,10 +308,6 @@ func (l LimitConfig) CheckParticipantNameLength(name string) bool {
 
 func (l LimitConfig) CheckMetadataSize(metadata string) bool {
 	return l.MaxMetadataSize == 0 || uint32(len(metadata)) <= l.MaxMetadataSize
-}
-
-func (l LimitConfig) CheckRoomMetadataSize(metadata string) bool {
-	return l.MaxRoomMetadataSize == 0 || uint32(len(metadata)) <= l.MaxRoomMetadataSize
 }
 
 func (l LimitConfig) CheckAttributesSize(attributes map[string]string) bool {
@@ -445,8 +440,7 @@ var DefaultConfig = Config{
 		UpdateBatchTargetSize: 128 * 1024,
 	},
 	Limit: LimitConfig{
-		MaxMetadataSize:              64000,
-		MaxRoomMetadataSize:          512 * 1024,
+		MaxMetadataSize:              512 * 1024,
 		MaxAttributesSize:            64000,
 		MaxRoomNameLength:            256,
 		MaxParticipantIdentityLength: 256,
@@ -552,7 +546,7 @@ func NewConfig(confString string, strictMode bool, c *cli.Command, baseFlags []c
 
 	// copy over legacy limits
 	if conf.Room.MaxMetadataSize != 0 {
-		conf.Limit.MaxRoomMetadataSize = conf.Room.MaxMetadataSize
+		conf.Limit.MaxMetadataSize = conf.Room.MaxMetadataSize
 	}
 	if conf.Room.MaxParticipantIdentityLength != 0 {
 		conf.Limit.MaxParticipantIdentityLength = conf.Room.MaxParticipantIdentityLength

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -440,7 +440,7 @@ var DefaultConfig = Config{
 		UpdateBatchTargetSize: 128 * 1024,
 	},
 	Limit: LimitConfig{
-		MaxMetadataSize:              64000,
+		MaxMetadataSize:              512 * 1024,
 		MaxAttributesSize:            64000,
 		MaxRoomNameLength:            256,
 		MaxParticipantIdentityLength: 256,

--- a/pkg/service/agent_dispatch_service.go
+++ b/pkg/service/agent_dispatch_service.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/livekit/livekit-server/pkg/config"
 	"github.com/livekit/livekit-server/pkg/routing"
 	"github.com/livekit/protocol/agent"
 	"github.com/livekit/protocol/livekit"
@@ -29,6 +30,7 @@ import (
 )
 
 type AgentDispatchService struct {
+	limitConf           config.LimitConfig
 	agentDispatchClient rpc.TypedAgentDispatchInternalClient
 	topicFormatter      rpc.TopicFormatter
 	roomAllocator       RoomAllocator
@@ -36,12 +38,14 @@ type AgentDispatchService struct {
 }
 
 func NewAgentDispatchService(
+	limitConf config.LimitConfig,
 	agentDispatchClient rpc.TypedAgentDispatchInternalClient,
 	topicFormatter rpc.TopicFormatter,
 	roomAllocator RoomAllocator,
 	router routing.MessageRouter,
 ) *AgentDispatchService {
 	return &AgentDispatchService{
+		limitConf:           limitConf,
 		agentDispatchClient: agentDispatchClient,
 		topicFormatter:      topicFormatter,
 		roomAllocator:       roomAllocator,
@@ -58,6 +62,13 @@ func (ag *AgentDispatchService) CreateDispatch(ctx context.Context, req *livekit
 
 	if err := agent.ValidateDeployment(req.GetDeployment()); err != nil {
 		return nil, psrpc.NewError(psrpc.InvalidArgument, err)
+	}
+
+	if !ag.limitConf.CheckMetadataSize(req.Metadata) {
+		return nil, ErrMetadataExceedsLimits
+	}
+	if !ag.limitConf.CheckAttributesSize(req.Attributes) {
+		return nil, ErrAttributeExceedsLimits
 	}
 
 	if ag.roomAllocator.AutoCreateEnabled(ctx) {

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -293,6 +293,15 @@ func (r *RoomManager) StartSession(
 ) error {
 	sessionStartTime := time.Now()
 
+	if pi.Identity != "" && pi.Grants != nil {
+		if !r.config.Limit.CheckMetadataSize(pi.Grants.Metadata) {
+			return ErrMetadataExceedsLimits
+		}
+		if !r.config.Limit.CheckAttributesSize(pi.Grants.Attributes) {
+			return ErrAttributeExceedsLimits
+		}
+	}
+
 	createRoom := pi.CreateRoom
 	room, err := r.getOrCreateRoom(ctx, createRoom)
 	if err != nil {

--- a/pkg/service/roomservice.go
+++ b/pkg/service/roomservice.go
@@ -84,6 +84,10 @@ func (s *RoomService) CreateRoom(ctx context.Context, req *livekit.CreateRoomReq
 		return nil, fmt.Errorf("%w: max length %d", ErrRoomNameExceedsLimits, s.limitConf.MaxRoomNameLength)
 	}
 
+	if !s.limitConf.CheckMetadataSize(req.Metadata) {
+		return nil, twirp.InvalidArgumentError(ErrMetadataExceedsLimits.Error(), strconv.Itoa(int(s.limitConf.MaxMetadataSize)))
+	}
+
 	err := s.roomAllocator.SelectRoomNode(ctx, livekit.RoomName(req.Name), livekit.NodeID(req.NodeId))
 	if err != nil {
 		return nil, err

--- a/pkg/service/roomservice.go
+++ b/pkg/service/roomservice.go
@@ -84,8 +84,17 @@ func (s *RoomService) CreateRoom(ctx context.Context, req *livekit.CreateRoomReq
 		return nil, fmt.Errorf("%w: max length %d", ErrRoomNameExceedsLimits, s.limitConf.MaxRoomNameLength)
 	}
 
-	if !s.limitConf.CheckMetadataSize(req.Metadata) {
-		return nil, twirp.InvalidArgumentError(ErrMetadataExceedsLimits.Error(), strconv.Itoa(int(s.limitConf.MaxMetadataSize)))
+	if !s.limitConf.CheckRoomMetadataSize(req.Metadata) {
+		return nil, twirp.InvalidArgumentError(ErrMetadataExceedsLimits.Error(), strconv.Itoa(int(s.limitConf.MaxRoomMetadataSize)))
+	}
+
+	for _, ad := range req.Agents {
+		if !s.limitConf.CheckMetadataSize(ad.Metadata) {
+			return nil, twirp.InvalidArgumentError(ErrMetadataExceedsLimits.Error(), strconv.Itoa(int(s.limitConf.MaxMetadataSize)))
+		}
+		if !s.limitConf.CheckAttributesSize(ad.Attributes) {
+			return nil, twirp.InvalidArgumentError(ErrAttributeExceedsLimits.Error(), strconv.Itoa(int(s.limitConf.MaxAttributesSize)))
+		}
 	}
 
 	err := s.roomAllocator.SelectRoomNode(ctx, livekit.RoomName(req.Name), livekit.NodeID(req.NodeId))
@@ -324,9 +333,8 @@ func (s *RoomService) UpdateRoomMetadata(ctx context.Context, req *livekit.Updat
 	RecordRequest(ctx, req)
 
 	AppendLogFields(ctx, "room", req.Room, "size", len(req.Metadata))
-	maxMetadataSize := int(s.limitConf.MaxMetadataSize)
-	if maxMetadataSize > 0 && len(req.Metadata) > maxMetadataSize {
-		return nil, twirp.InvalidArgumentError(ErrMetadataExceedsLimits.Error(), strconv.Itoa(maxMetadataSize))
+	if !s.limitConf.CheckRoomMetadataSize(req.Metadata) {
+		return nil, twirp.InvalidArgumentError(ErrMetadataExceedsLimits.Error(), strconv.Itoa(int(s.limitConf.MaxRoomMetadataSize)))
 	}
 
 	if err := EnsureAdminPermission(ctx, livekit.RoomName(req.Room)); err != nil {

--- a/pkg/service/roomservice.go
+++ b/pkg/service/roomservice.go
@@ -84,8 +84,8 @@ func (s *RoomService) CreateRoom(ctx context.Context, req *livekit.CreateRoomReq
 		return nil, fmt.Errorf("%w: max length %d", ErrRoomNameExceedsLimits, s.limitConf.MaxRoomNameLength)
 	}
 
-	if !s.limitConf.CheckRoomMetadataSize(req.Metadata) {
-		return nil, twirp.InvalidArgumentError(ErrMetadataExceedsLimits.Error(), strconv.Itoa(int(s.limitConf.MaxRoomMetadataSize)))
+	if !s.limitConf.CheckMetadataSize(req.Metadata) {
+		return nil, twirp.InvalidArgumentError(ErrMetadataExceedsLimits.Error(), strconv.Itoa(int(s.limitConf.MaxMetadataSize)))
 	}
 
 	for _, ad := range req.Agents {
@@ -333,8 +333,8 @@ func (s *RoomService) UpdateRoomMetadata(ctx context.Context, req *livekit.Updat
 	RecordRequest(ctx, req)
 
 	AppendLogFields(ctx, "room", req.Room, "size", len(req.Metadata))
-	if !s.limitConf.CheckRoomMetadataSize(req.Metadata) {
-		return nil, twirp.InvalidArgumentError(ErrMetadataExceedsLimits.Error(), strconv.Itoa(int(s.limitConf.MaxRoomMetadataSize)))
+	if !s.limitConf.CheckMetadataSize(req.Metadata) {
+		return nil, twirp.InvalidArgumentError(ErrMetadataExceedsLimits.Error(), strconv.Itoa(int(s.limitConf.MaxMetadataSize)))
 	}
 
 	if err := EnsureAdminPermission(ctx, livekit.RoomName(req.Room)); err != nil {

--- a/pkg/service/roomservice_test.go
+++ b/pkg/service/roomservice_test.go
@@ -47,55 +47,79 @@ func TestDeleteRoom(t *testing.T) {
 }
 
 func TestMetaDataLimits(t *testing.T) {
-	t.Run("metadata exceed limits", func(t *testing.T) {
+	adminCtx := func() context.Context {
+		return service.WithGrants(context.Background(), &auth.ClaimGrants{Video: &auth.VideoGrant{}}, "")
+	}
+	createCtx := func() context.Context {
+		return service.WithGrants(context.Background(), &auth.ClaimGrants{Video: &auth.VideoGrant{RoomCreate: true}}, "")
+	}
+	requireInvalidArg := func(t *testing.T, err error) {
+		t.Helper()
+		terr, ok := err.(twirp.Error)
+		require.True(t, ok, "expected twirp error, got %T (%v)", err, err)
+		require.Equal(t, twirp.InvalidArgument, terr.Code())
+	}
+
+	t.Run("participant metadata exceeds limits", func(t *testing.T) {
 		svc := newTestRoomService(config.LimitConfig{MaxMetadataSize: 5})
-		grant := &auth.ClaimGrants{
-			Video: &auth.VideoGrant{},
-		}
-		ctx := service.WithGrants(context.Background(), grant, "")
-		_, err := svc.UpdateParticipant(ctx, &livekit.UpdateParticipantRequest{
+		_, err := svc.UpdateParticipant(adminCtx(), &livekit.UpdateParticipantRequest{
 			Room:     "testroom",
 			Identity: "123",
 			Metadata: "abcdefg",
 		})
-		terr, ok := err.(twirp.Error)
-		require.True(t, ok)
-		require.Equal(t, twirp.InvalidArgument, terr.Code())
+		requireInvalidArg(t, err)
+	})
 
-		_, err = svc.UpdateRoomMetadata(ctx, &livekit.UpdateRoomMetadataRequest{
+	t.Run("room metadata exceeds limits", func(t *testing.T) {
+		svc := newTestRoomService(config.LimitConfig{MaxRoomMetadataSize: 5})
+
+		_, err := svc.UpdateRoomMetadata(adminCtx(), &livekit.UpdateRoomMetadataRequest{
 			Room:     "testroom",
 			Metadata: "abcdefg",
 		})
-		terr, ok = err.(twirp.Error)
-		require.True(t, ok)
-		require.Equal(t, twirp.InvalidArgument, terr.Code())
+		requireInvalidArg(t, err)
 
-		createGrant := &auth.ClaimGrants{
-			Video: &auth.VideoGrant{RoomCreate: true},
-		}
-		createCtx := service.WithGrants(context.Background(), createGrant, "")
-		_, err = svc.CreateRoom(createCtx, &livekit.CreateRoomRequest{
+		_, err = svc.CreateRoom(createCtx(), &livekit.CreateRoomRequest{
 			Name:     "testroom",
 			Metadata: "abcdefg",
 		})
-		terr, ok = err.(twirp.Error)
-		require.True(t, ok)
-		require.Equal(t, twirp.InvalidArgument, terr.Code())
+		requireInvalidArg(t, err)
+	})
+
+	t.Run("embedded agent dispatch in CreateRoom exceeds metadata limit", func(t *testing.T) {
+		svc := newTestRoomService(config.LimitConfig{MaxMetadataSize: 5})
+		_, err := svc.CreateRoom(createCtx(), &livekit.CreateRoomRequest{
+			Name: "testroom",
+			Agents: []*livekit.RoomAgentDispatch{
+				{AgentName: "bot", Metadata: "abcdefg"},
+			},
+		})
+		requireInvalidArg(t, err)
+	})
+
+	t.Run("embedded agent dispatch in CreateRoom exceeds attributes limit", func(t *testing.T) {
+		svc := newTestRoomService(config.LimitConfig{MaxAttributesSize: 5})
+		_, err := svc.CreateRoom(createCtx(), &livekit.CreateRoomRequest{
+			Name: "testroom",
+			Agents: []*livekit.RoomAgentDispatch{
+				{AgentName: "bot", Attributes: map[string]string{"key": "abcdefg"}},
+			},
+		})
+		requireInvalidArg(t, err)
 	})
 
 	notExceedsLimitsSvc := map[string]*TestRoomService{
-		"metadata exceeds limits": newTestRoomService(config.LimitConfig{MaxMetadataSize: 5}),
-		"metadata no limits":      newTestRoomService(config.LimitConfig{}), // no limits
+		"metadata exceeds limits": newTestRoomService(config.LimitConfig{
+			MaxMetadataSize:     5,
+			MaxRoomMetadataSize: 5,
+			MaxAttributesSize:   5,
+		}),
+		"metadata no limits": newTestRoomService(config.LimitConfig{}),
 	}
 
-	for n, s := range notExceedsLimitsSvc {
-		svc := s
+	for n, svc := range notExceedsLimitsSvc {
 		t.Run(n, func(t *testing.T) {
-			grant := &auth.ClaimGrants{
-				Video: &auth.VideoGrant{},
-			}
-			ctx := service.WithGrants(context.Background(), grant, "")
-			_, err := svc.UpdateParticipant(ctx, &livekit.UpdateParticipantRequest{
+			_, err := svc.UpdateParticipant(adminCtx(), &livekit.UpdateParticipantRequest{
 				Room:     "testroom",
 				Identity: "123",
 				Metadata: "abc",
@@ -104,7 +128,7 @@ func TestMetaDataLimits(t *testing.T) {
 			require.True(t, ok)
 			require.NotEqual(t, twirp.InvalidArgument, terr.Code())
 
-			_, err = svc.UpdateRoomMetadata(ctx, &livekit.UpdateRoomMetadataRequest{
+			_, err = svc.UpdateRoomMetadata(adminCtx(), &livekit.UpdateRoomMetadataRequest{
 				Room:     "testroom",
 				Metadata: "abc",
 			})
@@ -112,13 +136,12 @@ func TestMetaDataLimits(t *testing.T) {
 			require.True(t, ok)
 			require.NotEqual(t, twirp.InvalidArgument, terr.Code())
 
-			createGrant := &auth.ClaimGrants{
-				Video: &auth.VideoGrant{RoomCreate: true},
-			}
-			createCtx := service.WithGrants(context.Background(), createGrant, "")
-			_, err = svc.CreateRoom(createCtx, &livekit.CreateRoomRequest{
+			_, err = svc.CreateRoom(createCtx(), &livekit.CreateRoomRequest{
 				Name:     "testroom",
 				Metadata: "abc",
+				Agents: []*livekit.RoomAgentDispatch{
+					{AgentName: "bot", Metadata: "abc", Attributes: map[string]string{"k": "v"}},
+				},
 			})
 			if err != nil {
 				terr, ok = err.(twirp.Error)
@@ -126,8 +149,37 @@ func TestMetaDataLimits(t *testing.T) {
 				require.NotEqual(t, twirp.InvalidArgument, terr.Code())
 			}
 		})
-
 	}
+}
+
+func TestAgentDispatchMetadataLimits(t *testing.T) {
+	ctx := service.WithGrants(context.Background(), &auth.ClaimGrants{
+		Video: &auth.VideoGrant{Room: "testroom", RoomAdmin: true},
+	}, "")
+
+	t.Run("metadata exceeds limits", func(t *testing.T) {
+		svc := newTestAgentDispatchService(config.LimitConfig{MaxMetadataSize: 5})
+		_, err := svc.CreateDispatch(ctx, &livekit.CreateAgentDispatchRequest{
+			Room:     "testroom",
+			Metadata: "abcdefg",
+		})
+		require.ErrorIs(t, err, service.ErrMetadataExceedsLimits)
+	})
+
+	t.Run("attributes exceeds limits", func(t *testing.T) {
+		svc := newTestAgentDispatchService(config.LimitConfig{MaxAttributesSize: 5})
+		_, err := svc.CreateDispatch(ctx, &livekit.CreateAgentDispatchRequest{
+			Room:       "testroom",
+			Attributes: map[string]string{"key": "abcdefg"},
+		})
+		require.ErrorIs(t, err, service.ErrAttributeExceedsLimits)
+	})
+}
+
+func newTestAgentDispatchService(limitConf config.LimitConfig) *service.AgentDispatchService {
+	allocator := &servicefakes.FakeRoomAllocator{}
+	allocator.AutoCreateEnabledReturns(false)
+	return service.NewAgentDispatchService(limitConf, nil, rpc.NewTopicFormatter(), allocator, &routingfakes.FakeRouter{})
 }
 
 func newTestRoomService(limitConf config.LimitConfig) *TestRoomService {

--- a/pkg/service/roomservice_test.go
+++ b/pkg/service/roomservice_test.go
@@ -69,6 +69,18 @@ func TestMetaDataLimits(t *testing.T) {
 		terr, ok = err.(twirp.Error)
 		require.True(t, ok)
 		require.Equal(t, twirp.InvalidArgument, terr.Code())
+
+		createGrant := &auth.ClaimGrants{
+			Video: &auth.VideoGrant{RoomCreate: true},
+		}
+		createCtx := service.WithGrants(context.Background(), createGrant, "")
+		_, err = svc.CreateRoom(createCtx, &livekit.CreateRoomRequest{
+			Name:     "testroom",
+			Metadata: "abcdefg",
+		})
+		terr, ok = err.(twirp.Error)
+		require.True(t, ok)
+		require.Equal(t, twirp.InvalidArgument, terr.Code())
 	})
 
 	notExceedsLimitsSvc := map[string]*TestRoomService{
@@ -99,6 +111,20 @@ func TestMetaDataLimits(t *testing.T) {
 			terr, ok = err.(twirp.Error)
 			require.True(t, ok)
 			require.NotEqual(t, twirp.InvalidArgument, terr.Code())
+
+			createGrant := &auth.ClaimGrants{
+				Video: &auth.VideoGrant{RoomCreate: true},
+			}
+			createCtx := service.WithGrants(context.Background(), createGrant, "")
+			_, err = svc.CreateRoom(createCtx, &livekit.CreateRoomRequest{
+				Name:     "testroom",
+				Metadata: "abc",
+			})
+			if err != nil {
+				terr, ok = err.(twirp.Error)
+				require.True(t, ok)
+				require.NotEqual(t, twirp.InvalidArgument, terr.Code())
+			}
 		})
 
 	}

--- a/pkg/service/roomservice_test.go
+++ b/pkg/service/roomservice_test.go
@@ -60,20 +60,17 @@ func TestMetaDataLimits(t *testing.T) {
 		require.Equal(t, twirp.InvalidArgument, terr.Code())
 	}
 
-	t.Run("participant metadata exceeds limits", func(t *testing.T) {
+	t.Run("metadata exceeds limit", func(t *testing.T) {
 		svc := newTestRoomService(config.LimitConfig{MaxMetadataSize: 5})
+
 		_, err := svc.UpdateParticipant(adminCtx(), &livekit.UpdateParticipantRequest{
 			Room:     "testroom",
 			Identity: "123",
 			Metadata: "abcdefg",
 		})
 		requireInvalidArg(t, err)
-	})
 
-	t.Run("room metadata exceeds limits", func(t *testing.T) {
-		svc := newTestRoomService(config.LimitConfig{MaxRoomMetadataSize: 5})
-
-		_, err := svc.UpdateRoomMetadata(adminCtx(), &livekit.UpdateRoomMetadataRequest{
+		_, err = svc.UpdateRoomMetadata(adminCtx(), &livekit.UpdateRoomMetadataRequest{
 			Room:     "testroom",
 			Metadata: "abcdefg",
 		})
@@ -84,11 +81,8 @@ func TestMetaDataLimits(t *testing.T) {
 			Metadata: "abcdefg",
 		})
 		requireInvalidArg(t, err)
-	})
 
-	t.Run("embedded agent dispatch in CreateRoom exceeds metadata limit", func(t *testing.T) {
-		svc := newTestRoomService(config.LimitConfig{MaxMetadataSize: 5})
-		_, err := svc.CreateRoom(createCtx(), &livekit.CreateRoomRequest{
+		_, err = svc.CreateRoom(createCtx(), &livekit.CreateRoomRequest{
 			Name: "testroom",
 			Agents: []*livekit.RoomAgentDispatch{
 				{AgentName: "bot", Metadata: "abcdefg"},
@@ -110,9 +104,8 @@ func TestMetaDataLimits(t *testing.T) {
 
 	notExceedsLimitsSvc := map[string]*TestRoomService{
 		"metadata exceeds limits": newTestRoomService(config.LimitConfig{
-			MaxMetadataSize:     5,
-			MaxRoomMetadataSize: 5,
-			MaxAttributesSize:   5,
+			MaxMetadataSize:   5,
+			MaxAttributesSize: 5,
 		}),
 		"metadata no limits": newTestRoomService(config.LimitConfig{}),
 	}

--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -102,7 +102,7 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	if err != nil {
 		return nil, err
 	}
-	agentDispatchService := NewAgentDispatchService(agentDispatchInternalClient, topicFormatter, roomAllocator, router)
+	agentDispatchService := NewAgentDispatchService(limitConfig, agentDispatchInternalClient, topicFormatter, roomAllocator, router)
 	egressService := NewEgressService(egressClient, rtcEgressLauncher, ioInfoService, roomService)
 	ingressConfig := getIngressConfig(conf)
 	ingressClient, err := rpc.NewIngressClient(clientParams)


### PR DESCRIPTION
## Summary

Caps all metadata fields uniformly at **512 KiB** via the existing `LimitConfig.MaxMetadataSize` (default `524288`, yaml `limits.max_metadata_size`). Adds enforcement at every API entry point that takes metadata; attributes continue to be gated separately at 64 KB by `MaxAttributesSize`.

### Metadata enforcement (`MaxMetadataSize`)

- `RoomService.CreateRoom` — `req.Metadata` *(new)*
- `RoomService.UpdateRoomMetadata` — `req.Metadata` *(previously enforced; now uses the `CheckMetadataSize` helper instead of an inlined check)*
- `RoomService.UpdateParticipant` — `req.Metadata` *(already enforced)*
- Signal `UpdateMetadata` (`participant.checkMetadataLimits`) — *(already enforced)*
- `RoomManager.StartSession` — `pi.Grants.Metadata` from JWT *(new — previously the join path bypassed any metadata check)*
- `AgentDispatchService.CreateDispatch` — `req.Metadata` *(new)*
- `RoomService.CreateRoom` embedded `req.Agents[i].Metadata` *(new)*

### Attributes enforcement (`MaxAttributesSize`, unchanged at 64 KB)

- `RoomService.UpdateParticipant` — `req.Attributes` *(already enforced)*
- Signal `UpdateMetadata` — *(already enforced)*
- `RoomManager.StartSession` — `pi.Grants.Attributes` from JWT *(new)*
- `AgentDispatchService.CreateDispatch` — `req.Attributes` *(new)*
- `RoomService.CreateRoom` embedded `req.Agents[i].Attributes` *(new)*

### Wiring

- Default `LimitConfig.MaxMetadataSize` bumped from `64000` to `524288`.
- `NewAgentDispatchService` gains a `LimitConfig` parameter; both `wire_gen.go` callsites updated.
- `StartSession` rejections reuse the existing `ErrMetadataExceedsLimits` / `ErrAttributeExceedsLimits` (`psrpc.InvalidArgument`) errors and propagate through the signal layer like other early-failure paths (auth, missing room).

## Test plan

- [x] `go test ./pkg/service/ -run "TestMetaDataLimits|TestAgentDispatchMetadataLimits" -count=1` — exercises all the entry points listed above.
- [x] `go build ./pkg/service/... ./pkg/config/...`
- [ ] e2e (run a local livekit-cloud, Twirp + signal client): oversized room/participant/agent-dispatch metadata each return `InvalidArgument` referencing the 524288 limit; oversized JWT grants on join are rejected; oversized attributes are rejected against the unchanged 64 KB limit.