### PR TITLE
Report participant capabilities in ParticipantInfo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
 	github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0
-	github.com/livekit/protocol v1.47.1-0.20260617164816-2f8e4d6d263b
+	github.com/livekit/protocol v1.47.1-0.20260619130638-81f9c58f49db
 	github.com/livekit/psrpc v0.7.2
 	github.com/mackerelio/go-osstat v0.2.7
 	github.com/magefile/mage v1.17.2

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5AT
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0 h1:XHNNzebIKZRkLimla/hFGrAIX5EMWHctrgt3hLw7s+I=
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
-github.com/livekit/protocol v1.47.1-0.20260617164816-2f8e4d6d263b h1:7gH58XkJ0wtU+5d33Jkktmf4I3heKjQzDhwYHDSGmTo=
-github.com/livekit/protocol v1.47.1-0.20260617164816-2f8e4d6d263b/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
+github.com/livekit/protocol v1.47.1-0.20260619130638-81f9c58f49db h1:oSCQ0bqPo/dsDIi3PQCoBGXmWXIsi59XE2yD5Gp6jh8=
+github.com/livekit/protocol v1.47.1-0.20260619130638-81f9c58f49db/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
 github.com/livekit/psrpc v0.7.2 h1:6oZ+NODJ2pLyaT6VqDq1F4Qc/3TpDUSpyphj/P9MhQc=
 github.com/livekit/psrpc v0.7.2/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
 github.com/mackerelio/go-osstat v0.2.7 h1:TCavZi10wF49bT6iQZ9eT2keGZQpC69MTDfdJej5e94=

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -906,6 +906,7 @@ func (p *ParticipantImpl) ToProtoWithVersion() (*livekit.ParticipantInfo, utils.
 		KindDetails:      grants.GetKindDetails(),
 		DisconnectReason: p.CloseReason().ToDisconnectReason(),
 		ClientProtocol:   clientProtocol,
+		Capabilities:     p.params.ClientInfo.GetCapabilities(),
 	}
 	p.lock.RUnlock()
 


### PR DESCRIPTION
Per the rationale in the linked pull request, mirror each participant's capabilities in their associated `ParticipantInfo` struct so that other peer participants in the room can determine which support compression and which do not.

See https://github.com/livekit/protocol/pull/1637 for more context.

## Todo
- [x] Update to latest `livekit/protocol` version once https://github.com/livekit/protocol/pull/1637 is merged
- [x] Get ci build passing