### PR TITLE
Fix nil pointer dereference in AddOnClose

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -965,7 +965,7 @@ func (p *ParticipantImpl) GetTelemetryListener() types.ParticipantTelemetryListe
 }
 
 func (p *ParticipantImpl) AddOnClose(key string, callback func(types.LocalParticipant)) {
-	if p.isClosed.Load() {
+	if p.isClosed.Load() && callback != nil {
 		go callback(p)
 		return
 	}


### PR DESCRIPTION
## Summary
- When `AddOnClose` was called with a nil callback (the delete path) on a participant whose `isClosed` flag was already set, the fast path would launch `go callback(p)` with a nil callback and panic.
- Skip the fast path when the callback is nil so the deletion runs through the map path instead.

Fixes [CS-1831](https://linear.app/livekit/issue/CS-1831/bug-report-cloud-panic-from-nil-pointer-dereference).

## Test plan
- [ ] Existing rtc tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)