### PR TITLE
fix: Clear the enableStartAtDesiredQuality flags in MaybeExpireAcquireGrace

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -330,6 +330,8 @@ func (f *Forwarder) MaybeExpireAcquireGrace() bool {
 		return false
 	}
 	f.acquireDeadline = 0
+	f.enableStartAtDesiredQuality = false
+	f.vls.SetEnableStartAtDesiredQuality(false)
 	return !f.vls.GetCurrent().IsValid()
 }
 


### PR DESCRIPTION
### Background

Steps:
1 The publisher joins with sufficient bandwidth.
2 Subscriber 1 joins and can subscribe to 720p HIGH.
3 Add bandwidth limitation to 500kbps for Publisher -> SFU.
4 Subscriber 1 will receive video downgraded to MEDIUM or LOW.
5 Subscriber 2 joins the room and gets stuck requesting HIGH for a while, unable to receive video.

Comparing the steps,

Add the clearing flags in MaybeExpireAcquireGrace.

Step 5. Subscriber 2 joins, and although still requesting HIGH, will actually receive MEDIUM or LOW.