### PR TITLE
Tighten up publish latency stat.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -3248,11 +3248,11 @@ func (p *ParticipantImpl) mediaTrackReceived(
 		mt = p.addMediaTrack(signalCid, ti)
 		newTrack = true
 
-		// if the addTrackRequest is sent before participant active then it means the client tries to publish
-		// before fully connected, in this case we only record the time when the participant is active since
+		// if the addTrackRequest is sent before publisher peer connection is established, then it means the client tries to publish
+		// before fully connected, in this case we only record the time when publisher peer connection is established since
 		// we want this metric to represent the time cost by publishing.
-		if activeAt := p.lastActiveAt.Load(); activeAt != nil && createdAt.Before(*activeAt) {
-			createdAt = *activeAt
+		if connectedAt := p.TransportManager.PublisherFirstConnectedAt(); !connectedAt.IsZero() && createdAt.Before(connectedAt) {
+			createdAt = connectedAt
 		}
 		pubTime = time.Since(createdAt)
 		p.dirty.Store(true)

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -1432,6 +1432,13 @@ func (t *PCTransport) HasEverConnected() bool {
 	return !t.firstConnectedAt.IsZero()
 }
 
+func (t *PCTransport) FirstConnectedAt() time.Time {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	return t.firstConnectedAt
+}
+
 func (t *PCTransport) GetICEConnectionInfo() *types.ICEConnectionInfo {
 	return t.connectionDetails.GetInfo()
 }

--- a/pkg/rtc/transportmanager.go
+++ b/pkg/rtc/transportmanager.go
@@ -227,6 +227,10 @@ func (t *TransportManager) HasPublisherEverConnected() bool {
 	return t.publisher.HasEverConnected()
 }
 
+func (t *TransportManager) PublisherFirstConnectedAt() time.Time {
+	return t.publisher.FirstConnectedAt()
+}
+
 func (t *TransportManager) IsPublisherEstablished() bool {
 	return t.publisher.IsEstablished()
 }
@@ -264,6 +268,14 @@ func (t *TransportManager) HasSubscriberEverConnected() bool {
 		return t.publisher.HasEverConnected()
 	} else {
 		return t.subscriber.HasEverConnected()
+	}
+}
+
+func (t *TransportManager) SubscriberFirstConnectedAt() time.Time {
+	if t.params.UseOneShotSignallingMode || t.params.UseSinglePeerConnection {
+		return t.publisher.FirstConnectedAt()
+	} else {
+		return t.subscriber.FirstConnectedAt()
 	}
 }
 


### PR DESCRIPTION
Previously it was anchored to participant transitioning to `ACTIVE` if the add track request happened before that. But, that has a few issues 1.`ACTIVE` is for primary peer connection which could be subscriber peer connection.
2. `ACTIVE` also include data channel establishment.

Switch to first connected time of publisher peer connection for that to get a more accurate measure of track publish time.