### PR TITLE
Export migration to LocalParticipant interface.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1426,6 +1426,10 @@ func (p *ParticipantImpl) IsReconnect() bool {
 	return p.params.Reconnect
 }
 
+func (p *ParticipantImpl) IsMigration() bool {
+	return p.params.Migration
+}
+
 func (p *ParticipantImpl) maybeRecordRTCanceled(closeReason types.ParticipantCloseReason) {
 	if p.HasConnected() {
 		return

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -527,6 +527,7 @@ type LocalParticipant interface {
 		dataTracks []*livekit.PublishDataTrackResponse,
 	)
 	IsReconnect() bool
+	IsMigration() bool
 	MoveToRoom(params MoveToRoomParams)
 
 	UpdateMediaRTT(rtt uint32)

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -882,6 +882,16 @@ type FakeLocalParticipant struct {
 	isIdleReturnsOnCall map[int]struct {
 		result1 bool
 	}
+	IsMigrationStub        func() bool
+	isMigrationMutex       sync.RWMutex
+	isMigrationArgsForCall []struct {
+	}
+	isMigrationReturns struct {
+		result1 bool
+	}
+	isMigrationReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	IsPublisherStub        func() bool
 	isPublisherMutex       sync.RWMutex
 	isPublisherArgsForCall []struct {
@@ -6173,6 +6183,59 @@ func (fake *FakeLocalParticipant) IsIdleReturnsOnCall(i int, result1 bool) {
 		})
 	}
 	fake.isIdleReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeLocalParticipant) IsMigration() bool {
+	fake.isMigrationMutex.Lock()
+	ret, specificReturn := fake.isMigrationReturnsOnCall[len(fake.isMigrationArgsForCall)]
+	fake.isMigrationArgsForCall = append(fake.isMigrationArgsForCall, struct {
+	}{})
+	stub := fake.IsMigrationStub
+	fakeReturns := fake.isMigrationReturns
+	fake.recordInvocation("IsMigration", []interface{}{})
+	fake.isMigrationMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLocalParticipant) IsMigrationCallCount() int {
+	fake.isMigrationMutex.RLock()
+	defer fake.isMigrationMutex.RUnlock()
+	return len(fake.isMigrationArgsForCall)
+}
+
+func (fake *FakeLocalParticipant) IsMigrationCalls(stub func() bool) {
+	fake.isMigrationMutex.Lock()
+	defer fake.isMigrationMutex.Unlock()
+	fake.IsMigrationStub = stub
+}
+
+func (fake *FakeLocalParticipant) IsMigrationReturns(result1 bool) {
+	fake.isMigrationMutex.Lock()
+	defer fake.isMigrationMutex.Unlock()
+	fake.IsMigrationStub = nil
+	fake.isMigrationReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeLocalParticipant) IsMigrationReturnsOnCall(i int, result1 bool) {
+	fake.isMigrationMutex.Lock()
+	defer fake.isMigrationMutex.Unlock()
+	fake.IsMigrationStub = nil
+	if fake.isMigrationReturnsOnCall == nil {
+		fake.isMigrationReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.isMigrationReturnsOnCall[i] = struct {
 		result1 bool
 	}{result1}
 }

--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -86,23 +86,23 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	}
 	rtcEgressLauncher := NewEgressLauncher(egressClient, ioInfoService, objectStore)
 	topicFormatter := rpc.NewTopicFormatter()
-	roomClient, err := rpc.NewTypedRoomClient(clientParams)
+	v, err := rpc.NewTypedRoomClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	participantClient, err := rpc.NewTypedParticipantClient(clientParams)
+	v2, err := rpc.NewTypedParticipantClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	roomService, err := NewRoomService(limitConfig, apiConfig, router, roomAllocator, objectStore, rtcEgressLauncher, topicFormatter, roomClient, participantClient)
+	roomService, err := NewRoomService(limitConfig, apiConfig, router, roomAllocator, objectStore, rtcEgressLauncher, topicFormatter, v, v2)
 	if err != nil {
 		return nil, err
 	}
-	agentDispatchInternalClient, err := rpc.NewTypedAgentDispatchInternalClient(clientParams)
+	v3, err := rpc.NewTypedAgentDispatchInternalClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	agentDispatchService := NewAgentDispatchService(limitConfig, agentDispatchInternalClient, topicFormatter, roomAllocator, router)
+	agentDispatchService := NewAgentDispatchService(limitConfig, v3, topicFormatter, roomAllocator, router)
 	egressService := NewEgressService(egressClient, rtcEgressLauncher, ioInfoService, roomService)
 	ingressConfig := getIngressConfig(conf)
 	ingressClient, err := rpc.NewIngressClient(clientParams)
@@ -117,11 +117,11 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	}
 	sipService := NewSIPService(sipConfig, nodeID, messageBus, sipClient, sipStore, roomService, telemetryService)
 	rtcService := NewRTCService(conf, roomAllocator, router, telemetryService)
-	whipParticipantClient, err := rpc.NewTypedWHIPParticipantClient(clientParams)
+	v4, err := rpc.NewTypedWHIPParticipantClient(clientParams)
 	if err != nil {
 		return nil, err
 	}
-	serviceWHIPService, err := NewWHIPService(conf, router, roomAllocator, clientParams, topicFormatter, whipParticipantClient)
+	serviceWHIPService, err := NewWHIPService(conf, router, roomAllocator, clientParams, topicFormatter, v4)
 	if err != nil {
 		return nil, err
 	}
@@ -146,8 +146,8 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	if err != nil {
 		return nil, err
 	}
-	authHandler := getTURNAuthHandlerFunc(turnAuthHandler)
-	server, err := newInProcessTurnServer(conf, authHandler)
+	v5 := getTURNAuthHandlerFunc(turnAuthHandler)
+	server, err := newInProcessTurnServer(conf, v5)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Can be used during delayed egress start.