### PR TITLE
Avoid duplicate template selection in dependency descriptor marshal

### DIFF
--- a/pkg/sfu/rtpextension/dependencydescriptor/dependencydescriptorextension.go
+++ b/pkg/sfu/rtpextension/dependencydescriptor/dependencydescriptorextension.go
@@ -48,7 +48,7 @@ func (d *DependencyDescriptorExtension) MarshalWithActiveChains(activeChains uin
 	}
 	buf := make([]byte, int(math.Ceil(float64(writer.ValueSizeBits())/8)))
 	writer.ResetBuf(buf)
-	if err = writer.Write(); err != nil {
+	if err = writer.writeWithoutSelection(); err != nil {
 		return nil, err
 	}
 	return buf, nil

--- a/pkg/sfu/rtpextension/dependencydescriptor/dependencydescriptorwriter.go
+++ b/pkg/sfu/rtpextension/dependencydescriptor/dependencydescriptorwriter.go
@@ -57,6 +57,10 @@ func (w *DependencyDescriptorWriter) Write() error {
 		return err
 	}
 
+	return w.writeWithoutSelection()
+}
+
+func (w *DependencyDescriptorWriter) writeWithoutSelection() error {
 	if err := w.writeMandatoryFields(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- **Context**: The dependency descriptor extension marshalling path executes once per forwarded AV1/VP9 dependency-descriptor packet per subscriber, handling critical low-latency media forwarding.
- **Problem**: During private marshalling, `MarshalWithActiveChains` constructs a `DependencyDescriptorWriter` (which selects a template to size the output buffer) and then immediately calls the public `Write()` method, which redundantly performs the exact same template-selection pass again.
- **Implementation**: We extracted the serialization logic from the public `DependencyDescriptorWriter.Write` method into a private `writeWithoutSelection` method. `MarshalWithActiveChains` now calls `writeWithoutSelection` directly, bypassing the second selection. The public `Write()` method retains its template selection logic to support mutated writer lifecycles.
- **Payload Details**: The captured AV1/VP9 L3T3 dependency structure used in the benchmark marshals to a payload size of 5 bytes (golden hex "86017340fc").
- **Confidence**: We publish this finding with **medium confidence**, as it is a structural hypothesis lacking production telemetry or CPU/allocation profiles.

## Test plan
- [x] Run the co-measured benchmark:
  ```bash
  GOMAXPROCS=1 go test -run '^$' -bench '^BenchmarkPerfloopDependencyDescriptorMarshal$' -benchmem -count 1 -cpu=1 ./pkg/sfu/rtpextension/dependencydescriptor
  ```
- [x] Run the writer mutation contract check:
  ```bash
  GOMAXPROCS=1 go test -v -run '^TestPerfloopWriterMutationContract$' -count 1 ./pkg/sfu/rtpextension/dependencydescriptor
  ```

### Environment
- **OS**: Linux
- **Architecture**: amd64
- **Runtime**: go1.26.4
- **CPU**: VirtualApple @ 2.50GHz

### Performance Proof Results (baseline 44323799bc970cc8dafe5c5235bd37d1d6b18074 -> candidate a3d69208b57f116900ff037beed9c376d03d893c)
- **Primary Win**:
  - `BenchmarkPerfloopDependencyDescriptorMarshal` ns/op: 546.7 -> 396.35 (effect 27.5014%, p=1.08251e-05, significant, candidate n=10) [outcome=won]
- **Guardrails**:
  - `BenchmarkPerfloopDependencyDescriptorMarshal` B/op: 165 -> 165 (effect 0%, p=1, not significant, candidate n=10) [outcome=held]
  - `BenchmarkPerfloopDependencyDescriptorMarshal` allocs/op: 4 -> 4 (effect 0%, p=1, not significant, candidate n=10) [outcome=held]

### Correctness Checks Passed
- pairing
- environment_consistent
- baseline_valid
- benchmark_passed
- writer-mutation-contract
- measurements_sane
- metric_present
- sample_sufficiency
- sample_independence

Full proof details: http://127.0.0.1:60134/t/demo/case_mrate4mb7r

---
This is an automated, human-reviewed Perfloop contribution opened by perfloop-agent. The body links to reproducible proof for the change. The change was benchmarked on perfloop-agent/livekit, an automation fork of livekit/livekit; the commit on this PR's head branch carries the proof.

Assisted-by: PerfloopAgent:gemini-3.5-flash