### PR TITLE
Guard against nil TC qdisc stats to prevent SIGSEGV

### DIFF
--- a/pkg/telemetry/prometheus/node_linux.go
+++ b/pkg/telemetry/prometheus/node_linux.go
@@ -38,8 +38,17 @@ func getTCStats() (packets, drops uint32, err error) {
 	}
 
 	for _, qdisc := range qdiscs {
-		packets = packets + qdisc.Stats.Packets
-		drops = drops + qdisc.Stats.Drops
+		// Newer kernels report stats via TCA_STATS2 (Stats2), while older kernels
+		// only populate the legacy TCA_STATS attribute (Stats). Prefer Stats2 and
+		// fall back to Stats so counters are collected on both.
+		switch {
+		case qdisc.Stats2 != nil:
+			packets = packets + qdisc.Stats2.Packets
+			drops = drops + qdisc.Stats2.Drops
+		case qdisc.Stats != nil:
+			packets = packets + qdisc.Stats.Packets
+			drops = drops + qdisc.Stats.Drops
+		}
 	}
 
 	return


### PR DESCRIPTION
## Summary

Fixes a SIGSEGV during telemetry init when collecting TC (traffic control) qdisc stats on Linux.

Newer kernels report qdisc stats via `TCA_STATS2` (populating `qdisc.Stats2`), while older kernels only populate the legacy `TCA_STATS` attribute (`qdisc.Stats`). Whichever attribute is unused is left `nil`, so unconditionally dereferencing `qdisc.Stats` in `getTCStats()` crashed with a nil pointer dereference.

This change prefers `Stats2` and falls back to `Stats`, skipping the qdisc entirely when both are `nil`.

Closes [CS-1871](https://linear.app/livekit/issue/CS-1871/sigsegv-in-telemetry-init-when-trying-to-run-livekit-wo-telemetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)