### PR TITLE
TEL-730: Log soft validation errors.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/jxskiss/base62 v1.1.0
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
 	github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0
-	github.com/livekit/protocol v1.49.1-0.20260712085342-8a3c109dc3c6
+	github.com/livekit/protocol v1.49.1-0.20260715002854-aae1fc92e07b
 	github.com/livekit/psrpc v0.7.2
 	github.com/mackerelio/go-osstat v0.2.7
 	github.com/magefile/mage v1.17.2

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,8 @@ github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0 h1:XHNN
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
 github.com/livekit/protocol v1.49.1-0.20260712085342-8a3c109dc3c6 h1:ANFafwVDRMeB3bGva/C9BFcWp/iAvSCwbTYWWVuners=
 github.com/livekit/protocol v1.49.1-0.20260712085342-8a3c109dc3c6/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
+github.com/livekit/protocol v1.49.1-0.20260715002854-aae1fc92e07b h1:7LAWCE4ZT7B17UHaiQafMNaTjwHe0EWgSWwzZUdMHJ4=
+github.com/livekit/protocol v1.49.1-0.20260715002854-aae1fc92e07b/go.mod h1:jO+y05AU9Ec4JswDyuzKCZ4bhziOS0CzMqgnbj60Dzs=
 github.com/livekit/psrpc v0.7.2 h1:6oZ+NODJ2pLyaT6VqDq1F4Qc/3TpDUSpyphj/P9MhQc=
 github.com/livekit/psrpc v0.7.2/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
 github.com/mackerelio/go-osstat v0.2.7 h1:TCavZi10wF49bT6iQZ9eT2keGZQpC69MTDfdJej5e94=

--- a/pkg/service/sip.go
+++ b/pkg/service/sip.go
@@ -63,6 +63,8 @@ func NewSIPService(
 	}
 }
 
+// Returns a new UnlikelyLogger, populated with values from the request context
+// (e.g. service, method, etc.).)
 func unlikelyLoggerFromCtx(ctx context.Context) logger.UnlikelyLogger {
 	var logFields []any
 	logCtx, ok := ctx.Value(twirpLoggerKey{}).(*twirpLogger)

--- a/pkg/service/sip.go
+++ b/pkg/service/sip.go
@@ -645,16 +645,13 @@ func (s *SIPService) CreateSIPParticipantRequest(ctx context.Context, req *livek
 	}
 	req.Upgrade()
 	callID := sip.NewCallID()
-	logValues := []string{
+	log := logger.GetLogger().WithUnlikelyValues(
 		"callID", callID,
 		"room", req.RoomName,
 		"sipTrunk", req.SipTrunkId,
 		"toUser", req.SipCallTo,
-	}
-	if projectID != "" {
-		logValues = append(logValues, "projectID", projectID)
-	}
-	log := logger.GetLogger().WithUnlikelyValues(logValues)
+		"projectID", projectID,
+	)
 	if err := req.ValidateResult().LogUnlikelySoftErrors(log); err != nil {
 		return nil, twirp.WrapError(twirp.NewError(twirp.InvalidArgument, err.Error()), err)
 	}

--- a/pkg/service/sip.go
+++ b/pkg/service/sip.go
@@ -63,6 +63,16 @@ func NewSIPService(
 	}
 }
 
+func unlikelyLoggerFromCtx(ctx context.Context) logger.UnlikelyLogger {
+	var logFields []any
+	logCtx, ok := ctx.Value(twirpLoggerKey{}).(*twirpLogger)
+	if ok {
+		logFields = logCtx.fields
+	}
+	return logger.GetLogger().WithUnlikelyValues(logFields...)
+
+}
+
 func (s *SIPService) CreateSIPTrunk(ctx context.Context, req *livekit.CreateSIPTrunkRequest) (*livekit.SIPTrunkInfo, error) {
 	if err := EnsureSIPAdminPermission(ctx); err != nil {
 		return nil, twirpAuthError(err)
@@ -116,7 +126,7 @@ func (s *SIPService) CreateSIPInboundTrunk(ctx context.Context, req *livekit.Cre
 	if s.store == nil {
 		return nil, ErrSIPNotConnected
 	}
-	if err := req.Validate(); err != nil {
+	if err := req.ValidateResult().LogUnlikelySoftErrors(unlikelyLoggerFromCtx(ctx)); err != nil {
 		return nil, twirp.WrapError(twirp.NewError(twirp.InvalidArgument, err.Error()), err)
 	}
 
@@ -155,7 +165,7 @@ func (s *SIPService) CreateSIPOutboundTrunk(ctx context.Context, req *livekit.Cr
 	if s.store == nil {
 		return nil, ErrSIPNotConnected
 	}
-	if err := req.Validate(); err != nil {
+	if err := req.ValidateResult().LogUnlikelySoftErrors(unlikelyLoggerFromCtx(ctx)); err != nil {
 		return nil, twirp.WrapError(twirp.NewError(twirp.InvalidArgument, err.Error()), err)
 	}
 
@@ -180,7 +190,7 @@ func (s *SIPService) UpdateSIPInboundTrunk(ctx context.Context, req *livekit.Upd
 	if s.store == nil {
 		return nil, ErrSIPNotConnected
 	}
-	if err := req.Validate(); err != nil {
+	if err := req.ValidateResult().LogUnlikelySoftErrors(unlikelyLoggerFromCtx(ctx)); err != nil {
 		return nil, twirp.WrapError(twirp.NewError(twirp.InvalidArgument, err.Error()), err)
 	}
 
@@ -201,8 +211,9 @@ func (s *SIPService) UpdateSIPInboundTrunk(ctx context.Context, req *livekit.Upd
 	default:
 		return nil, errors.New("missing or unsupported action")
 	case livekit.UpdateSIPInboundTrunkRequestAction:
-		info, err = a.Apply(info)
-		if err != nil {
+		var result livekit.ValidationResult
+		info, result = a.ApplyResult(info)
+		if err := result.LogUnlikelySoftErrors(unlikelyLoggerFromCtx(ctx)); err != nil {
 			return nil, err
 		}
 	}
@@ -235,7 +246,7 @@ func (s *SIPService) UpdateSIPOutboundTrunk(ctx context.Context, req *livekit.Up
 	if s.store == nil {
 		return nil, ErrSIPNotConnected
 	}
-	if err := req.Validate(); err != nil {
+	if err := req.ValidateResult().LogUnlikelySoftErrors(unlikelyLoggerFromCtx(ctx)); err != nil {
 		return nil, twirp.WrapError(twirp.NewError(twirp.InvalidArgument, err.Error()), err)
 	}
 
@@ -255,8 +266,9 @@ func (s *SIPService) UpdateSIPOutboundTrunk(ctx context.Context, req *livekit.Up
 	default:
 		return nil, errors.New("missing or unsupported action")
 	case livekit.UpdateSIPOutboundTrunkRequestAction:
-		info, err = a.Apply(info)
-		if err != nil {
+		var result livekit.ValidationResult
+		info, result = a.ApplyResult(info)
+		if err := result.LogUnlikelySoftErrors(unlikelyLoggerFromCtx(ctx)); err != nil {
 			return nil, err
 		}
 	}
@@ -631,9 +643,6 @@ func (s *SIPService) CreateSIPParticipantRequest(ctx context.Context, req *livek
 		return nil, ErrSIPNotConnected
 	}
 	req.Upgrade()
-	if err := req.Validate(); err != nil {
-		return nil, twirp.WrapError(twirp.NewError(twirp.InvalidArgument, err.Error()), err)
-	}
 	callID := sip.NewCallID()
 	log := logger.GetLogger().WithUnlikelyValues(
 		"callID", callID,
@@ -641,6 +650,10 @@ func (s *SIPService) CreateSIPParticipantRequest(ctx context.Context, req *livek
 		"sipTrunk", req.SipTrunkId,
 		"toUser", req.SipCallTo,
 	)
+	if err := req.ValidateResult().LogUnlikelySoftErrors(log); err != nil {
+		return nil, twirp.WrapError(twirp.NewError(twirp.InvalidArgument, err.Error()), err)
+	}
+
 	if projectID != "" {
 		log = log.WithValues("projectID", projectID)
 	}
@@ -662,7 +675,11 @@ func (s *SIPService) CreateSIPParticipantRequest(ctx context.Context, req *livek
 	} else if t := req.Trunk; t != nil && t.FromHost != "" {
 		host = t.FromHost
 	}
-	return rpc.NewCreateSIPParticipantRequest(projectID, callID, host, wsUrl, token, req, trunk)
+	internalReq, result := rpc.NewCreateSIPParticipantRequestResult(projectID, callID, host, wsUrl, token, req, trunk)
+	if err := result.LogUnlikelySoftErrors(log); err != nil {
+		return nil, err
+	}
+	return internalReq, nil
 }
 
 func (s *SIPService) TransferSIPParticipant(ctx context.Context, req *livekit.TransferSIPParticipantRequest) (*emptypb.Empty, error) {
@@ -730,7 +747,12 @@ func (s *SIPService) transferSIPParticipantRequest(ctx context.Context, req *liv
 	if err := EnsureAdminPermission(ctx, livekit.RoomName(req.RoomName)); err != nil {
 		return nil, twirpAuthError(err)
 	}
-	if err := req.Validate(); err != nil {
+
+	unlikelyLogger := logger.GetLogger().WithUnlikelyValues(
+		"room", req.RoomName,
+		"participant", req.ParticipantIdentity,
+	)
+	if err := req.ValidateResult().LogUnlikelySoftErrors(unlikelyLogger); err != nil {
 		return nil, twirp.WrapError(twirp.NewError(twirp.InvalidArgument, err.Error()), err)
 	}
 

--- a/pkg/service/sip.go
+++ b/pkg/service/sip.go
@@ -70,7 +70,6 @@ func unlikelyLoggerFromCtx(ctx context.Context) logger.UnlikelyLogger {
 		logFields = logCtx.fields
 	}
 	return logger.GetLogger().WithUnlikelyValues(logFields...)
-
 }
 
 func (s *SIPService) CreateSIPTrunk(ctx context.Context, req *livekit.CreateSIPTrunkRequest) (*livekit.SIPTrunkInfo, error) {

--- a/pkg/service/sip.go
+++ b/pkg/service/sip.go
@@ -645,18 +645,18 @@ func (s *SIPService) CreateSIPParticipantRequest(ctx context.Context, req *livek
 	}
 	req.Upgrade()
 	callID := sip.NewCallID()
-	log := logger.GetLogger().WithUnlikelyValues(
+	logValues := []string{
 		"callID", callID,
 		"room", req.RoomName,
 		"sipTrunk", req.SipTrunkId,
 		"toUser", req.SipCallTo,
-	)
+	}
+	if projectID != "" {
+		logValues = append(logValues, "projectID", projectID)
+	}
+	log := logger.GetLogger().WithUnlikelyValues(logValues)
 	if err := req.ValidateResult().LogUnlikelySoftErrors(log); err != nil {
 		return nil, twirp.WrapError(twirp.NewError(twirp.InvalidArgument, err.Error()), err)
-	}
-
-	if projectID != "" {
-		log = log.WithValues("projectID", projectID)
 	}
 
 	var trunk *livekit.SIPOutboundTrunkInfo
@@ -684,20 +684,15 @@ func (s *SIPService) CreateSIPParticipantRequest(ctx context.Context, req *livek
 }
 
 func (s *SIPService) TransferSIPParticipant(ctx context.Context, req *livekit.TransferSIPParticipantRequest) (*emptypb.Empty, error) {
-	log := logger.GetLogger().WithUnlikelyValues(
-		"room", req.RoomName,
-		"participant", req.ParticipantIdentity,
-		"transferTo", req.TransferTo,
-		"playDialtone", req.PlayDialtone,
-	)
 	AppendLogFields(ctx,
 		"room", req.RoomName,
 		"participant", req.ParticipantIdentity,
 		"transferTo", req.TransferTo,
 		"playDialtone", req.PlayDialtone,
 	)
+	log := unlikelyLoggerFromCtx(ctx)
 
-	ireq, err := s.transferSIPParticipantRequest(ctx, req)
+	ireq, err := s.transferSIPParticipantRequest(ctx, req, log)
 	if err != nil {
 		log.Errorw("cannot create transfer sip participant request", err)
 		return nil, wrapSIPContextError(err)
@@ -733,7 +728,7 @@ func (s *SIPService) TransferSIPParticipant(ctx context.Context, req *livekit.Tr
 	return &emptypb.Empty{}, nil
 }
 
-func (s *SIPService) transferSIPParticipantRequest(ctx context.Context, req *livekit.TransferSIPParticipantRequest) (*rpc.InternalTransferSIPParticipantRequest, error) {
+func (s *SIPService) transferSIPParticipantRequest(ctx context.Context, req *livekit.TransferSIPParticipantRequest, log logger.UnlikelyLogger) (*rpc.InternalTransferSIPParticipantRequest, error) {
 	if req.RoomName == "" {
 		return nil, psrpc.NewErrorf(psrpc.InvalidArgument, "Missing room name")
 	}
@@ -749,11 +744,7 @@ func (s *SIPService) transferSIPParticipantRequest(ctx context.Context, req *liv
 		return nil, twirpAuthError(err)
 	}
 
-	unlikelyLogger := logger.GetLogger().WithUnlikelyValues(
-		"room", req.RoomName,
-		"participant", req.ParticipantIdentity,
-	)
-	if err := req.ValidateResult().LogUnlikelySoftErrors(unlikelyLogger); err != nil {
+	if err := req.ValidateResult().LogUnlikelySoftErrors(log); err != nil {
 		return nil, twirp.WrapError(twirp.NewError(twirp.InvalidArgument, err.Error()), err)
 	}
 

--- a/pkg/service/sip.go
+++ b/pkg/service/sip.go
@@ -64,7 +64,7 @@ func NewSIPService(
 }
 
 // Returns a new UnlikelyLogger, populated with values from the request context
-// (e.g. service, method, etc.).)
+// (e.g. service, method, etc.).
 func unlikelyLoggerFromCtx(ctx context.Context) logger.UnlikelyLogger {
 	var logFields []any
 	logCtx, ok := ctx.Value(twirpLoggerKey{}).(*twirpLogger)


### PR DESCRIPTION
- Use new validation methods introduced in [livekit/protocol#1667](https://github.com/livekit/protocol/pull/1667) to log soft validation failures.
- Small cleanups / reordering of various log context code.