### PR TITLE
Fix goroutine leak from orphaned signal relay streams

### DIFF
--- a/pkg/service/signal.go
+++ b/pkg/service/signal.go
@@ -16,6 +16,7 @@ package service
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
@@ -131,9 +132,23 @@ type signalService struct {
 }
 
 func (r *signalService) RelaySignal(stream psrpc.ServerStream[*rpc.RelaySignalResponse, *rpc.RelaySignalRequest]) (err error) {
-	req, ok := <-stream.Channel()
-	if !ok {
-		return nil
+	// Wait for the first (StartSession) message, but not forever. If the stream is
+	// opened but the client goes away before sending StartSession, psrpc only closes
+	// the stream after this handler returns (see streamHandler.handleOpenRequest),
+	// which never happens while we block on <-stream.Channel(). That leaks one
+	// goroutine per orphaned stream (observed piling up under mass reconnects).
+	// Returning here (before Hijack) lets psrpc call ss.Close() and free the goroutine.
+	var req *rpc.RelaySignalRequest
+	var ok bool
+	select {
+	case req, ok = <-stream.Channel():
+		if !ok {
+			return nil
+		}
+	case <-stream.Context().Done():
+		return stream.Context().Err()
+	case <-time.After(r.config.RetryTimeout):
+		return errors.New("timeout waiting for start session")
 	}
 
 	ss := req.StartSession

--- a/pkg/service/signal.go
+++ b/pkg/service/signal.go
@@ -132,12 +132,6 @@ type signalService struct {
 }
 
 func (r *signalService) RelaySignal(stream psrpc.ServerStream[*rpc.RelaySignalResponse, *rpc.RelaySignalRequest]) (err error) {
-	// Wait for the first (StartSession) message, but not forever. If the stream is
-	// opened but the client goes away before sending StartSession, psrpc only closes
-	// the stream after this handler returns (see streamHandler.handleOpenRequest),
-	// which never happens while we block on <-stream.Channel(). That leaks one
-	// goroutine per orphaned stream (observed piling up under mass reconnects).
-	// Returning here (before Hijack) lets psrpc call ss.Close() and free the goroutine.
 	var req *rpc.RelaySignalRequest
 	var ok bool
 	select {


### PR DESCRIPTION
## Problem

Under high churn (many participants connecting/disconnecting), `livekit-server` accumulates goroutines that are never released until the process is restarted. In the worst case they reach tens of thousands, pinning several GB of heap that GC cannot reclaim.

## Root cause

`signalService.RelaySignal` blocks on the very first message:

```go
req, ok := <-stream.Channel()
```

psrpc's `streamHandler.handleOpenRequest` only closes the stream **after** the handler returns:

```go
err := h.handler(ss)
if !ss.Hijacked() {
    _ = ss.Close(err)
}
```

So if a stream is opened but the client goes away before sending `StartSession`, the recv channel is never fed and never closed, and `RelaySignal` blocks on `<-stream.Channel()` forever. The stream is never closed (that only happens once the handler returns), so this leaks one goroutine per orphaned stream. They only clear on process restart.

A goroutine dump from a leaked instance shows them all parked at the same spot:

```
<N> @ ...
#	.../psrpc/pkg/server.(*streamHandler[...]).handleRequest
#	.../livekit-server/pkg/service.(*signalService).RelaySignal
#		pkg/service/signal.go:134   runtime.chanrecv2
[chan receive, <minutes>]
```

## Reproduction

Drive a single room past its retransmit "death-spiral" knee (~1000 subscribers in a 5x5 layout on one node) with `lk load-test`, hold briefly, then disconnect all clients at once. After the room drains to 0 participants and 0 rooms, `go_goroutines` stays elevated (hundreds to tens of thousands depending on how deep the overload got) and never returns to baseline.

## Fix

Wrap the initial receive in a `select` that also returns when the stream context is cancelled or after `config.SignalRelay.RetryTimeout`. An orphaned stream then returns from the handler **before** `Hijack()`, so psrpc calls `ss.Close()` and the goroutine exits. This is safe because `StartSession` is always the immediate first message a client sends after opening the stream, so a legitimate client never approaches the timeout.

## Validation

Built from this branch and run on a test node. Under conditions that left ~1000 goroutines stuck on the stock build, the patched build returned to baseline (~150) after the same mass disconnect, with heap released back to the OS.

> Note: the deeper gap is arguably in psrpc — the stream's recv channel / context isn't torn down when the open request expires — but bounding the pre-hijack wait here is minimal and low-risk. Happy to move it into psrpc or add a regression test if maintainers prefer.
