### PR TITLE
fix: don't undercount data channel bitrate over idle gaps

### DIFF
--- a/pkg/sfu/datachannel/bitrate.go
+++ b/pkg/sfu/datachannel/bitrate.go
@@ -18,26 +18,16 @@ const (
 type BitrateMode int
 
 const (
-	// BitrateModeBusyOnly measures the drain rate over backlogged ("busy") time
-	// only -- idle gaps between sparse writes are excluded from the denominator,
-	// so a fast channel fed sparsely is not mistaken for a slow one. All bytes
-	// that drained are counted in the numerator. In a mixed window (idle drain
-	// followed by a backlog) this can transiently over-estimate the rate
-	// (bounded by the window); the bias errs towards not dropping and preserves
-	// the reliable path's burst-credit retry behaviour. This is the default for
-	// the data channel writers.
+	// BitrateModeBusyOnly divides drained bytes by backlogged ("busy") time
+	// only; idle gaps are excluded from the denominator. All drained bytes count.
 	BitrateModeBusyOnly BitrateMode = iota
 
-	// BitrateModeExcludeIdleDrain is like BitrateModeBusyOnly but additionally
-	// drops bytes that drained across a NON-backlogged interval (the buffer
-	// emptied and the link went idle). The result reflects only intervals where
-	// the buffer stayed backlogged the whole time -- a clean drain-capacity
-	// estimate with no idle contamination.
+	// BitrateModeExcludeIdleDrain is like BitrateModeBusyOnly but also excludes
+	// bytes drained across a non-backlogged interval from the numerator.
 	BitrateModeExcludeIdleDrain
 
-	// BitrateModeWallClock measures throughput over elapsed wall-clock time and
-	// counts all bytes. For consumers that have no send buffer to observe (e.g.
-	// a receiver measuring its own incoming rate), where backlog has no meaning.
+	// BitrateModeWallClock divides all bytes by elapsed wall-clock time. For
+	// consumers with no send buffer, e.g. a receiver measuring its incoming rate.
 	BitrateModeWallClock
 )
 
@@ -59,8 +49,7 @@ type BitrateCalculator struct {
 }
 
 // NewBitrateCalculator creates a calculator. See BitrateMode for how mode
-// governs the numerator (which drained bytes count) and denominator (busy time
-// vs wall clock).
+// governs the numerator and denominator.
 func NewBitrateCalculator(duration time.Duration, window time.Duration, mode BitrateMode) *BitrateCalculator {
 	windowCnt := int((duration + (window - 1)) / window)
 	if windowCnt == 0 {
@@ -83,25 +72,10 @@ func (c *BitrateCalculator) AddBytes(bytes int, bufferedAmout int, ts time.Time)
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	// Count the interval since the previous sample towards the rate denominator
-	// only if the channel was backlogged for the whole interval, i.e. it was
-	// actively draining rather than sitting idle. Idle gaps must be excluded:
-	// otherwise a fast channel fed sparsely reports its (low) offered load
-	// instead of its drain capacity. When no backlog is ever observed no busy
-	// time accrues and Bitrate() reports "no estimate" (ok == false) rather
-	// than a confidently-low number that would throttle bursts.
-	//
-	// The right signal is the buffer occupancy *just before* this write: no
-	// bytes are added between writes, so the buffer only drains across an
-	// interval and its pre-write level is the interval minimum -- if that is
-	// > 0 the buffer never emptied and the full interval was busy. bufferedAmout
-	// is sampled right after the write, so it includes the bytes we just
-	// enqueued (not yet SACKed); subtract them to recover the pre-write level.
-	//
-	// NOTE: gating on the post-write buffered amount would be wrong -- right
-	// after any write the buffer holds the just-enqueued bytes, so it is ~never
-	// zero and every idle gap would be counted, collapsing the estimate back to
-	// wall-clock throughput.
+	// bufferedAmout is sampled right after the write, so it includes the bytes
+	// just enqueued; subtracting them gives the buffer occupancy before the
+	// write. Between writes the buffer only drains, so a non-zero pre-write
+	// level means it stayed backlogged for the whole interval.
 	backlogged := bufferedAmout-bytes > 0
 	var busy time.Duration
 	if !c.last.IsZero() && backlogged {
@@ -120,10 +94,8 @@ func (c *BitrateCalculator) AddBytes(bytes int, bufferedAmout int, ts time.Time)
 	c.lastBufferedAmount = bufferedAmout
 
 	if c.mode == BitrateModeExcludeIdleDrain && !backlogged {
-		// The buffer emptied during this interval (the link went idle), so the
-		// bytes that drained are not clean drain-capacity evidence -- the drain
-		// finished at an unknown point in the interval. Drop them so they don't
-		// inflate the rate. (In busy-only mode they are kept.)
+		// drain across a non-backlogged interval finished at an unknown point,
+		// so it is not a reliable rate sample
 		bytes = 0
 	}
 
@@ -167,9 +139,7 @@ func (c *BitrateCalculator) ForceBitrate(ts time.Time) (int, bool) {
 func (c *BitrateCalculator) bitrate(ts time.Time, force bool) (int, bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	// In busy modes the denominator is backlogged (busy) time only, not wall
-	// clock, so idle gaps don't dilute the estimate of the channel's drain
-	// capacity. In wall-clock mode it is the elapsed window.
+	// busy modes divide by backlogged time; wall-clock mode by elapsed time
 	denom := c.busy
 	if c.mode == BitrateModeWallClock {
 		denom = ts.Sub(c.start)

--- a/pkg/sfu/datachannel/bitrate.go
+++ b/pkg/sfu/datachannel/bitrate.go
@@ -14,6 +14,33 @@ const (
 	BitrateWindow   = 100 * time.Millisecond
 )
 
+// BitrateMode selects how the sliding-window rate is computed.
+type BitrateMode int
+
+const (
+	// BitrateModeBusyOnly measures the drain rate over backlogged ("busy") time
+	// only -- idle gaps between sparse writes are excluded from the denominator,
+	// so a fast channel fed sparsely is not mistaken for a slow one. All bytes
+	// that drained are counted in the numerator. In a mixed window (idle drain
+	// followed by a backlog) this can transiently over-estimate the rate
+	// (bounded by the window); the bias errs towards not dropping and preserves
+	// the reliable path's burst-credit retry behaviour. This is the default for
+	// the data channel writers.
+	BitrateModeBusyOnly BitrateMode = iota
+
+	// BitrateModeExcludeIdleDrain is like BitrateModeBusyOnly but additionally
+	// drops bytes that drained across a NON-backlogged interval (the buffer
+	// emptied and the link went idle). The result reflects only intervals where
+	// the buffer stayed backlogged the whole time -- a clean drain-capacity
+	// estimate with no idle contamination.
+	BitrateModeExcludeIdleDrain
+
+	// BitrateModeWallClock measures throughput over elapsed wall-clock time and
+	// counts all bytes. For consumers that have no send buffer to observe (e.g.
+	// a receiver measuring its own incoming rate), where backlog has no meaning.
+	BitrateModeWallClock
+)
+
 // BitrateCalculator calculates bitrate over sliding window
 type BitrateCalculator struct {
 	lock           sync.Mutex
@@ -24,11 +51,17 @@ type BitrateCalculator struct {
 	active  bitrateWindow
 
 	bytes              int
+	busy               time.Duration
 	lastBufferedAmount int
+	last               time.Time
 	start              time.Time
+	mode               BitrateMode
 }
 
-func NewBitrateCalculator(duration time.Duration, window time.Duration) *BitrateCalculator {
+// NewBitrateCalculator creates a calculator. See BitrateMode for how mode
+// governs the numerator (which drained bytes count) and denominator (busy time
+// vs wall clock).
+func NewBitrateCalculator(duration time.Duration, window time.Duration, mode BitrateMode) *BitrateCalculator {
 	windowCnt := int((duration + (window - 1)) / window)
 	if windowCnt == 0 {
 		windowCnt = 1
@@ -39,6 +72,7 @@ func NewBitrateCalculator(duration time.Duration, window time.Duration) *Bitrate
 		windowDuration: window,
 		start:          now,
 		active:         bitrateWindow{start: now},
+		mode:           mode,
 	}
 	c.windows.SetBaseCap(windowCnt + 1)
 
@@ -49,21 +83,61 @@ func (c *BitrateCalculator) AddBytes(bytes int, bufferedAmout int, ts time.Time)
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
+	// Count the interval since the previous sample towards the rate denominator
+	// only if the channel was backlogged for the whole interval, i.e. it was
+	// actively draining rather than sitting idle. Idle gaps must be excluded:
+	// otherwise a fast channel fed sparsely reports its (low) offered load
+	// instead of its drain capacity. When no backlog is ever observed no busy
+	// time accrues and Bitrate() reports "no estimate" (ok == false) rather
+	// than a confidently-low number that would throttle bursts.
+	//
+	// The right signal is the buffer occupancy *just before* this write: no
+	// bytes are added between writes, so the buffer only drains across an
+	// interval and its pre-write level is the interval minimum -- if that is
+	// > 0 the buffer never emptied and the full interval was busy. bufferedAmout
+	// is sampled right after the write, so it includes the bytes we just
+	// enqueued (not yet SACKed); subtract them to recover the pre-write level.
+	//
+	// NOTE: gating on the post-write buffered amount would be wrong -- right
+	// after any write the buffer holds the just-enqueued bytes, so it is ~never
+	// zero and every idle gap would be counted, collapsing the estimate back to
+	// wall-clock throughput.
+	backlogged := bufferedAmout-bytes > 0
+	var busy time.Duration
+	if !c.last.IsZero() && backlogged {
+		if busy = ts.Sub(c.last); busy < 0 {
+			busy = 0
+		}
+	}
+	c.last = ts
+
+	// bytes that actually drained since the previous sample
 	bytes -= bufferedAmout - c.lastBufferedAmount
 	if bytes < 0 {
 		// it is possible that internal buffering (non-data like DCEP packet from webrtc) caused bytes to be negative
 		bytes = 0
 	}
 	c.lastBufferedAmount = bufferedAmout
+
+	if c.mode == BitrateModeExcludeIdleDrain && !backlogged {
+		// The buffer emptied during this interval (the link went idle), so the
+		// bytes that drained are not clean drain-capacity evidence -- the drain
+		// finished at an unknown point in the interval. Drop them so they don't
+		// inflate the rate. (In busy-only mode they are kept.)
+		bytes = 0
+	}
+
 	if ts.Sub(c.active.start) >= c.windowDuration {
 		c.windows.PushBack(c.active)
 		c.active.start = ts
 		c.active.bytes = 0
+		c.active.busy = 0
 
 		for c.windows.Len() > 0 {
 			// pop expired windows
 			if w := c.windows.Front(); ts.Sub(w.start) > (c.duration + c.windowDuration) {
 				c.bytes -= w.bytes
+				c.busy -= w.busy
 				c.windows.PopFront()
 			} else {
 				c.start = w.start
@@ -73,11 +147,13 @@ func (c *BitrateCalculator) AddBytes(bytes int, bufferedAmout int, ts time.Time)
 		if c.windows.Len() == 0 {
 			c.start = ts
 			c.bytes = 0
+			c.busy = 0
 		}
 	}
 	c.bytes += bytes
 	c.active.bytes += bytes
-
+	c.busy += busy
+	c.active.busy += busy
 }
 
 func (c *BitrateCalculator) Bitrate(ts time.Time) (int, bool) {
@@ -91,19 +167,26 @@ func (c *BitrateCalculator) ForceBitrate(ts time.Time) (int, bool) {
 func (c *BitrateCalculator) bitrate(ts time.Time, force bool) (int, bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	duration := ts.Sub(c.start)
-	if duration < c.windowDuration {
+	// In busy modes the denominator is backlogged (busy) time only, not wall
+	// clock, so idle gaps don't dilute the estimate of the channel's drain
+	// capacity. In wall-clock mode it is the elapsed window.
+	denom := c.busy
+	if c.mode == BitrateModeWallClock {
+		denom = ts.Sub(c.start)
+	}
+	if denom < c.windowDuration {
 		if force {
-			duration = c.windowDuration
+			denom = c.windowDuration
 		} else {
 			return 0, false
 		}
 	}
 
-	return c.bytes * 8 * 1000 / int(duration.Milliseconds()), true
+	return c.bytes * 8 * 1000 / int(denom.Milliseconds()), true
 }
 
 type bitrateWindow struct {
 	start time.Time
 	bytes int
+	busy  time.Duration
 }

--- a/pkg/sfu/datachannel/bitrate.go
+++ b/pkg/sfu/datachannel/bitrate.go
@@ -31,6 +31,19 @@ const (
 	BitrateModeWallClock
 )
 
+func (m BitrateMode) String() string {
+	switch m {
+	case BitrateModeBusyOnly:
+		return "busyOnly"
+	case BitrateModeExcludeIdleDrain:
+		return "excludeIdleDrain"
+	case BitrateModeWallClock:
+		return "wallClock"
+	default:
+		return "unknown"
+	}
+}
+
 // BitrateCalculator calculates bitrate over sliding window
 type BitrateCalculator struct {
 	lock           sync.Mutex

--- a/pkg/sfu/datachannel/bitrate_test.go
+++ b/pkg/sfu/datachannel/bitrate_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// busyModes are the two writer-facing modes; the pure scenarios below behave
-// identically under both, so they are exercised with each.
 var busyModes = []BitrateMode{BitrateModeBusyOnly, BitrateModeExcludeIdleDrain}
 
 func modeName(m BitrateMode) string {
@@ -24,11 +22,8 @@ func modeName(m BitrateMode) string {
 	}
 }
 
-// A fast channel fed sparsely (e.g. 1 KB every second, acknowledged in a few
-// ms) is never backlogged, so there is nothing to measure the drain capacity
-// against. The calculator must report "no estimate" rather than the low
-// offered load, otherwise the latency-based drop threshold in the writer would
-// collapse and drop bursts on a channel that is actually keeping up.
+// 1 KB written every second, each fully drained before the next write: never
+// backlogged, so there is no estimate.
 func TestBitrateCalculatorSparseFastAck(t *testing.T) {
 	for _, mode := range busyModes {
 		t.Run(modeName(mode), func(t *testing.T) {
@@ -38,33 +33,22 @@ func TestBitrateCalculatorSparseFastAck(t *testing.T) {
 			t0 := time.Now()
 			for i := 0; i < 5; i++ {
 				ts := t0.Add(time.Duration(i) * time.Second)
-				// The previous write was already SACKed, so sampled right after
-				// this write the buffer holds only the 1000 bytes we just
-				// enqueued: pre-write occupancy is zero => the channel was never
-				// backlogged => no estimate.
 				c.AddBytes(1000, 1000, ts)
 				_, ok := c.Bitrate(ts)
-				require.False(t, ok, "no backlog observed => no estimate")
+				require.False(t, ok)
 			}
 		})
 	}
 }
 
-// Under a sustained backlog the buffer never drains to empty between writes, so
-// the full inter-write interval is busy time. The reported rate then reflects
-// the real drain capacity (bytes drained / busy time), independent of how much
-// idle time surrounds the congested period.
+// Standing backlog of 1000 bytes; every 100ms write 800 and 800 drain, sampled
+// buffer 1000+800=1800. 800 B / 100ms = 64000 bps.
 func TestBitrateCalculatorSustainedBacklog(t *testing.T) {
 	for _, mode := range busyModes {
 		t.Run(modeName(mode), func(t *testing.T) {
 			c := NewBitrateCalculator(BitrateDuration, BitrateWindow, mode)
 
 			t0 := time.Now()
-			// A standing backlog of 1000 bytes never fully drains. Every 100ms
-			// we write 800 bytes and 800 drain, so the buffer sampled right
-			// after each write is 1000 (standing) + 800 (just enqueued) = 1800;
-			// pre-write occupancy is 1000 > 0 so the interval counts as busy.
-			// 800 bytes / 100ms = 8000 B/s = 64000 bps.
 			c.AddBytes(800, 1800, t0)
 			for i := 1; i <= 30; i++ {
 				c.AddBytes(800, 1800, t0.Add(time.Duration(i)*100*time.Millisecond))
@@ -77,10 +61,8 @@ func TestBitrateCalculatorSustainedBacklog(t *testing.T) {
 	}
 }
 
-// When the connection stalls (e.g. before ICE failure is detected) the app
-// keeps writing but nothing is SACKed, so the buffer only climbs: pre-write
-// occupancy stays > 0 (backlogged) while nothing drains, and the estimate
-// converges to ~0 so the writer starts shedding load.
+// Buffer only climbs and nothing drains (stalled connection): the estimate
+// converges to ~0.
 func TestBitrateCalculatorStalledConnection(t *testing.T) {
 	for _, mode := range busyModes {
 		t.Run(modeName(mode), func(t *testing.T) {
@@ -100,30 +82,25 @@ func TestBitrateCalculatorStalledConnection(t *testing.T) {
 	}
 }
 
-// A write that fully drains to empty before the next sample is not measurable
-// capacity: we only know the drain finished sometime within the interval, not
-// how long it took, so the interval is excluded (pre-write occupancy 0).
-// Neither busy mode produces an estimate from it. Precise accounting of such
-// intervals would need a drain-completion signal (e.g. OnBufferedAmountLow).
+// A single write that drains to empty is not backlogged at the next sample, so
+// no estimate is produced.
 func TestBitrateCalculatorFlushNotCounted(t *testing.T) {
 	for _, mode := range busyModes {
 		t.Run(modeName(mode), func(t *testing.T) {
 			c := NewBitrateCalculator(BitrateDuration, BitrateWindow, mode)
 
 			t0 := time.Now()
-			c.AddBytes(100, 100, t0) // 100 enqueued, nothing drained yet
+			c.AddBytes(100, 100, t0)
 			ts := t0.Add(100 * time.Millisecond)
-			c.AddBytes(0, 0, ts) // the 100 flushed; pre-write occupancy 0 => excluded
+			c.AddBytes(0, 0, ts)
 			_, ok := c.Bitrate(ts)
 			require.False(t, ok)
 		})
 	}
 }
 
-// In a mixed window -- bytes drained across an idle gap, then a sustained
-// backlog -- busy-only counts the idle-drained bytes against the backlog's busy
-// time and over-estimates the rate, while exclude-idle-drain does not. This is
-// the gap the two modes exist to trade off.
+// An idle drain followed by a backlog: BusyOnly counts the idle-drained bytes
+// over busy time only and reports a higher rate than ExcludeIdleDrain.
 func TestBitrateCalculatorMixedIdleThenBacklog(t *testing.T) {
 	off := NewBitrateCalculator(BitrateDuration, BitrateWindow, BitrateModeBusyOnly)
 	on := NewBitrateCalculator(BitrateDuration, BitrateWindow, BitrateModeExcludeIdleDrain)
@@ -134,13 +111,10 @@ func TestBitrateCalculatorMixedIdleThenBacklog(t *testing.T) {
 		on.AddBytes(written, buffered, ts)
 	}
 
-	// Enqueue 5000, which fully drains during an idle gap, then enqueue another
-	// 5000: this interval drained 5000 but was NOT backlogged (pre-write
-	// occupancy 0).
+	// 5000 drains during an idle gap (not backlogged), then a sustained backlog
+	// of 800 every 100ms over a standing 5000.
 	feed(5000, 5000, t0)
 	feed(5000, 5000, t0.Add(100*time.Millisecond))
-
-	// Now a sustained backlog: standing 5000, write 800 every 100ms, 800 drains.
 	for i := 1; i <= 5; i++ {
 		feed(800, 5800, t0.Add(time.Duration(100+i*100)*time.Millisecond))
 	}
@@ -150,16 +124,15 @@ func TestBitrateCalculatorMixedIdleThenBacklog(t *testing.T) {
 	rOn, okOn := on.Bitrate(queryTs)
 	require.True(t, okOff)
 	require.True(t, okOn)
-	require.Greater(t, rOff, rOn, "busy-only over-estimates by counting idle-drained bytes")
+	require.Greater(t, rOff, rOn)
 }
 
-// Wall-clock mode has no notion of backlog (buffered is always reported as 0):
-// it measures throughput over elapsed wall-clock time and counts all bytes.
+// No observable buffer: throughput over elapsed time. 1000 B every 100ms =
+// 80000 bps.
 func TestBitrateCalculatorWallClock(t *testing.T) {
 	c := NewBitrateCalculator(BitrateDuration, BitrateWindow, BitrateModeWallClock)
 
 	t0 := time.Now()
-	// 1000 bytes every 100ms with no observable buffer = 10000 B/s = 80000 bps.
 	for i := 0; i < 20; i++ {
 		c.AddBytes(1000, 0, t0.Add(time.Duration(i)*100*time.Millisecond))
 	}

--- a/pkg/sfu/datachannel/bitrate_test.go
+++ b/pkg/sfu/datachannel/bitrate_test.go
@@ -9,24 +9,11 @@ import (
 
 var busyModes = []BitrateMode{BitrateModeBusyOnly, BitrateModeExcludeIdleDrain}
 
-func modeName(m BitrateMode) string {
-	switch m {
-	case BitrateModeBusyOnly:
-		return "busyOnly"
-	case BitrateModeExcludeIdleDrain:
-		return "excludeIdleDrain"
-	case BitrateModeWallClock:
-		return "wallClock"
-	default:
-		return "unknown"
-	}
-}
-
 // 1 KB written every second, each fully drained before the next write: never
 // backlogged, so there is no estimate.
 func TestBitrateCalculatorSparseFastAck(t *testing.T) {
 	for _, mode := range busyModes {
-		t.Run(modeName(mode), func(t *testing.T) {
+		t.Run(mode.String(), func(t *testing.T) {
 			c := NewBitrateCalculator(BitrateDuration, BitrateWindow, mode)
 			require.NotNil(t, c)
 
@@ -45,7 +32,7 @@ func TestBitrateCalculatorSparseFastAck(t *testing.T) {
 // buffer 1000+800=1800. 800 B / 100ms = 64000 bps.
 func TestBitrateCalculatorSustainedBacklog(t *testing.T) {
 	for _, mode := range busyModes {
-		t.Run(modeName(mode), func(t *testing.T) {
+		t.Run(mode.String(), func(t *testing.T) {
 			c := NewBitrateCalculator(BitrateDuration, BitrateWindow, mode)
 
 			t0 := time.Now()
@@ -65,7 +52,7 @@ func TestBitrateCalculatorSustainedBacklog(t *testing.T) {
 // converges to ~0.
 func TestBitrateCalculatorStalledConnection(t *testing.T) {
 	for _, mode := range busyModes {
-		t.Run(modeName(mode), func(t *testing.T) {
+		t.Run(mode.String(), func(t *testing.T) {
 			c := NewBitrateCalculator(BitrateDuration, BitrateWindow, mode)
 
 			t0 := time.Now()
@@ -86,7 +73,7 @@ func TestBitrateCalculatorStalledConnection(t *testing.T) {
 // no estimate is produced.
 func TestBitrateCalculatorFlushNotCounted(t *testing.T) {
 	for _, mode := range busyModes {
-		t.Run(modeName(mode), func(t *testing.T) {
+		t.Run(mode.String(), func(t *testing.T) {
 			c := NewBitrateCalculator(BitrateDuration, BitrateWindow, mode)
 
 			t0 := time.Now()

--- a/pkg/sfu/datachannel/bitrate_test.go
+++ b/pkg/sfu/datachannel/bitrate_test.go
@@ -7,30 +7,164 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBitrateCalculator(t *testing.T) {
-	c := NewBitrateCalculator(BitrateDuration, BitrateWindow)
-	require.NotNil(t, c)
+// busyModes are the two writer-facing modes; the pure scenarios below behave
+// identically under both, so they are exercised with each.
+var busyModes = []BitrateMode{BitrateModeBusyOnly, BitrateModeExcludeIdleDrain}
+
+func modeName(m BitrateMode) string {
+	switch m {
+	case BitrateModeBusyOnly:
+		return "busyOnly"
+	case BitrateModeExcludeIdleDrain:
+		return "excludeIdleDrain"
+	case BitrateModeWallClock:
+		return "wallClock"
+	default:
+		return "unknown"
+	}
+}
+
+// A fast channel fed sparsely (e.g. 1 KB every second, acknowledged in a few
+// ms) is never backlogged, so there is nothing to measure the drain capacity
+// against. The calculator must report "no estimate" rather than the low
+// offered load, otherwise the latency-based drop threshold in the writer would
+// collapse and drop bursts on a channel that is actually keeping up.
+func TestBitrateCalculatorSparseFastAck(t *testing.T) {
+	for _, mode := range busyModes {
+		t.Run(modeName(mode), func(t *testing.T) {
+			c := NewBitrateCalculator(BitrateDuration, BitrateWindow, mode)
+			require.NotNil(t, c)
+
+			t0 := time.Now()
+			for i := 0; i < 5; i++ {
+				ts := t0.Add(time.Duration(i) * time.Second)
+				// The previous write was already SACKed, so sampled right after
+				// this write the buffer holds only the 1000 bytes we just
+				// enqueued: pre-write occupancy is zero => the channel was never
+				// backlogged => no estimate.
+				c.AddBytes(1000, 1000, ts)
+				_, ok := c.Bitrate(ts)
+				require.False(t, ok, "no backlog observed => no estimate")
+			}
+		})
+	}
+}
+
+// Under a sustained backlog the buffer never drains to empty between writes, so
+// the full inter-write interval is busy time. The reported rate then reflects
+// the real drain capacity (bytes drained / busy time), independent of how much
+// idle time surrounds the congested period.
+func TestBitrateCalculatorSustainedBacklog(t *testing.T) {
+	for _, mode := range busyModes {
+		t.Run(modeName(mode), func(t *testing.T) {
+			c := NewBitrateCalculator(BitrateDuration, BitrateWindow, mode)
+
+			t0 := time.Now()
+			// A standing backlog of 1000 bytes never fully drains. Every 100ms
+			// we write 800 bytes and 800 drain, so the buffer sampled right
+			// after each write is 1000 (standing) + 800 (just enqueued) = 1800;
+			// pre-write occupancy is 1000 > 0 so the interval counts as busy.
+			// 800 bytes / 100ms = 8000 B/s = 64000 bps.
+			c.AddBytes(800, 1800, t0)
+			for i := 1; i <= 30; i++ {
+				c.AddBytes(800, 1800, t0.Add(time.Duration(i)*100*time.Millisecond))
+			}
+
+			bitrate, ok := c.Bitrate(t0.Add(3 * time.Second))
+			require.True(t, ok)
+			require.InDelta(t, 64000, bitrate, 2000)
+		})
+	}
+}
+
+// When the connection stalls (e.g. before ICE failure is detected) the app
+// keeps writing but nothing is SACKed, so the buffer only climbs: pre-write
+// occupancy stays > 0 (backlogged) while nothing drains, and the estimate
+// converges to ~0 so the writer starts shedding load.
+func TestBitrateCalculatorStalledConnection(t *testing.T) {
+	for _, mode := range busyModes {
+		t.Run(modeName(mode), func(t *testing.T) {
+			c := NewBitrateCalculator(BitrateDuration, BitrateWindow, mode)
+
+			t0 := time.Now()
+			buffered := 0
+			for i := 0; i < 20; i++ {
+				buffered += 1000 // wrote 1000, nothing drained
+				c.AddBytes(1000, buffered, t0.Add(time.Duration(i)*50*time.Millisecond))
+			}
+
+			bitrate, ok := c.Bitrate(t0.Add(time.Second))
+			require.True(t, ok)
+			require.Less(t, bitrate, 1000)
+		})
+	}
+}
+
+// A write that fully drains to empty before the next sample is not measurable
+// capacity: we only know the drain finished sometime within the interval, not
+// how long it took, so the interval is excluded (pre-write occupancy 0).
+// Neither busy mode produces an estimate from it. Precise accounting of such
+// intervals would need a drain-completion signal (e.g. OnBufferedAmountLow).
+func TestBitrateCalculatorFlushNotCounted(t *testing.T) {
+	for _, mode := range busyModes {
+		t.Run(modeName(mode), func(t *testing.T) {
+			c := NewBitrateCalculator(BitrateDuration, BitrateWindow, mode)
+
+			t0 := time.Now()
+			c.AddBytes(100, 100, t0) // 100 enqueued, nothing drained yet
+			ts := t0.Add(100 * time.Millisecond)
+			c.AddBytes(0, 0, ts) // the 100 flushed; pre-write occupancy 0 => excluded
+			_, ok := c.Bitrate(ts)
+			require.False(t, ok)
+		})
+	}
+}
+
+// In a mixed window -- bytes drained across an idle gap, then a sustained
+// backlog -- busy-only counts the idle-drained bytes against the backlog's busy
+// time and over-estimates the rate, while exclude-idle-drain does not. This is
+// the gap the two modes exist to trade off.
+func TestBitrateCalculatorMixedIdleThenBacklog(t *testing.T) {
+	off := NewBitrateCalculator(BitrateDuration, BitrateWindow, BitrateModeBusyOnly)
+	on := NewBitrateCalculator(BitrateDuration, BitrateWindow, BitrateModeExcludeIdleDrain)
 
 	t0 := time.Now()
-	c.AddBytes(100, 0, t0)
-	// bytes buffered
-	c.AddBytes(100, 100, t0.Add(50*time.Millisecond))
-	bitrate, ok := c.Bitrate(t0.Add(50 * time.Millisecond))
-	require.Equal(t, 0, bitrate)
-	require.False(t, ok)
-	// 50 bytes sent (50 bytes buffer flushed)
-	c.AddBytes(100, 50, t0.Add(time.Second))
+	feed := func(written, buffered int, ts time.Time) {
+		off.AddBytes(written, buffered, ts)
+		on.AddBytes(written, buffered, ts)
+	}
 
-	// 250 bytes sent in 1 second
-	bitrate, ok = c.Bitrate(t0.Add(time.Second))
-	require.Equal(t, 2000, bitrate)
-	require.True(t, ok)
+	// Enqueue 5000, which fully drains during an idle gap, then enqueue another
+	// 5000: this interval drained 5000 but was NOT backlogged (pre-write
+	// occupancy 0).
+	feed(5000, 5000, t0)
+	feed(5000, 5000, t0.Add(100*time.Millisecond))
 
-	// silence for long time
-	t1 := t0.Add(2 * BitrateDuration)
-	// 150 bytes sent (50 bytes buffer flushed)
-	c.AddBytes(100, 0, t1)
-	bitrate, ok = c.Bitrate(t1.Add(time.Second))
-	require.Equal(t, 1200, bitrate)
+	// Now a sustained backlog: standing 5000, write 800 every 100ms, 800 drains.
+	for i := 1; i <= 5; i++ {
+		feed(800, 5800, t0.Add(time.Duration(100+i*100)*time.Millisecond))
+	}
+	queryTs := t0.Add(700 * time.Millisecond)
+
+	rOff, okOff := off.Bitrate(queryTs)
+	rOn, okOn := on.Bitrate(queryTs)
+	require.True(t, okOff)
+	require.True(t, okOn)
+	require.Greater(t, rOff, rOn, "busy-only over-estimates by counting idle-drained bytes")
+}
+
+// Wall-clock mode has no notion of backlog (buffered is always reported as 0):
+// it measures throughput over elapsed wall-clock time and counts all bytes.
+func TestBitrateCalculatorWallClock(t *testing.T) {
+	c := NewBitrateCalculator(BitrateDuration, BitrateWindow, BitrateModeWallClock)
+
+	t0 := time.Now()
+	// 1000 bytes every 100ms with no observable buffer = 10000 B/s = 80000 bps.
+	for i := 0; i < 20; i++ {
+		c.AddBytes(1000, 0, t0.Add(time.Duration(i)*100*time.Millisecond))
+	}
+
+	bitrate, ok := c.Bitrate(t0.Add(2 * time.Second))
 	require.True(t, ok)
+	require.InDelta(t, 80000, bitrate, 8000)
 }

--- a/pkg/sfu/datachannel/datachannel_writer.go
+++ b/pkg/sfu/datachannel/datachannel_writer.go
@@ -41,7 +41,7 @@ type DataChannelWriter[T BufferedAmountGetter] struct {
 func NewDataChannelWriterReliable[T BufferedAmountGetter](bufferGetter T, rawDC datachannel.ReadWriteCloserDeadliner, slowThreshold int) *DataChannelWriter[T] {
 	var rate *BitrateCalculator
 	if slowThreshold > 0 {
-		rate = NewBitrateCalculator(BitrateDuration, BitrateWindow)
+		rate = NewBitrateCalculator(BitrateDuration, BitrateWindow, BitrateModeBusyOnly)
 	}
 	return &DataChannelWriter[T]{
 		bufferGetter:  bufferGetter,
@@ -59,7 +59,7 @@ func NewDataChannelWriterReliable[T BufferedAmountGetter](bufferGetter T, rawDC 
 func NewDataChannelWriterUnreliable[T BufferedAmountGetter](bufferGetter T, rawDC datachannel.ReadWriteCloserDeadliner, targetLatency time.Duration, minBufferedAmount uint64) *DataChannelWriter[T] {
 	var rate *BitrateCalculator
 	if targetLatency > 0 {
-		rate = NewBitrateCalculator(BitrateDuration, BitrateWindow)
+		rate = NewBitrateCalculator(BitrateDuration, BitrateWindow, BitrateModeBusyOnly)
 	}
 	return &DataChannelWriter[T]{
 		bufferGetter:      bufferGetter,

--- a/pkg/sfu/datachannel/datachannel_writer_test.go
+++ b/pkg/sfu/datachannel/datachannel_writer_test.go
@@ -93,9 +93,7 @@ func (m *mockDataChannelWriter) BufferedAmount() uint64 {
 }
 
 func (m *mockDataChannelWriter) Write(b []byte) (int, error) {
-	// Data handed to the channel stays buffered until the write completes
-	// (i.e. the receiver drains it). A slow/stalled receiver keeps it buffered,
-	// which is what the bitrate calculator observes as backlog.
+	// buffered while the write is in flight, cleared once it completes
 	m.buffered.Store(int64(len(b)))
 	wait := time.Until(m.nextWriteCompleteAt)
 	if wait <= 0 {

--- a/pkg/sfu/datachannel/datachannel_writer_test.go
+++ b/pkg/sfu/datachannel/datachannel_writer_test.go
@@ -79,6 +79,7 @@ type mockDataChannelWriter struct {
 	datachannel.ReadWriteCloserDeadliner
 	nextWriteCompleteAt time.Time
 	deadline            *deadline.Deadline
+	buffered            atomic.Int64
 }
 
 func newMockDataChannelWriter() *mockDataChannelWriter {
@@ -88,18 +89,24 @@ func newMockDataChannelWriter() *mockDataChannelWriter {
 }
 
 func (m *mockDataChannelWriter) BufferedAmount() uint64 {
-	return 0
+	return uint64(m.buffered.Load())
 }
 
 func (m *mockDataChannelWriter) Write(b []byte) (int, error) {
+	// Data handed to the channel stays buffered until the write completes
+	// (i.e. the receiver drains it). A slow/stalled receiver keeps it buffered,
+	// which is what the bitrate calculator observes as backlog.
+	m.buffered.Store(int64(len(b)))
 	wait := time.Until(m.nextWriteCompleteAt)
 	if wait <= 0 {
+		m.buffered.Store(0)
 		return len(b), nil
 	}
 	select {
 	case <-m.deadline.Done():
 		return 0, m.deadline.Err()
 	case <-time.After(wait):
+		m.buffered.Store(0)
 		return len(b), nil
 	}
 }

--- a/test/client/datachannel_reader.go
+++ b/test/client/datachannel_reader.go
@@ -14,7 +14,7 @@ type DataChannelReader struct {
 func NewDataChannelReader(bitrate int) *DataChannelReader {
 	return &DataChannelReader{
 		target:  bitrate,
-		bitrate: datachannel.NewBitrateCalculator(datachannel.BitrateDuration*5, datachannel.BitrateWindow),
+		bitrate: datachannel.NewBitrateCalculator(datachannel.BitrateDuration*5, datachannel.BitrateWindow, datachannel.BitrateModeWallClock),
 	}
 }
 


### PR DESCRIPTION
## Human note 

Have been looking at data track test failures after adding the target latency setting to data track data channel. While I don't think this is going to fix it, but found the case of sparse feed estimating low bitrate and potentially causing drops. Have been working with Claude for the last couple of hours telling it about different conditions and addressing the gap. 

## Problem

`BitrateCalculator` (used by the data channel writers) divided drained bytes by **wall-clock time**, including the idle gaps between sparse writes. So a fast channel that is fed sparsely — e.g. 1 KB every second, acknowledged in a few ms — reported its low *offered load* (~8 kbps) rather than its *drain capacity* (~800 kbps).

In the unreliable/data-track writer that estimate feeds `targetLatencyLimit = bitrate · targetLatency / 8`. Undercounting it shrinks the limit and drops bursts on a channel that is actually keeping up.

An earlier attempt gated on the *post-write* buffered amount, but as noted in review that is wrong: right after any write the SCTP buffer still holds the just-enqueued bytes (not yet SACKed), so it is ~never zero and every idle gap gets counted — collapsing the estimate straight back to wall-clock.

## Fix

Measure the rate over **backlogged ("busy") time only**. Backlog is detected from the buffer occupancy *just before* a write, recovered as `bufferedAmount - bytesWritten`: since nothing is added between writes the buffer only drains, so a non-zero pre-write level means it never emptied and the whole interval was genuinely busy. When no backlog is ever observed the calculator reports **no estimate** (`ok=false`) instead of a confidently-low number, so the writer falls back to `minBufferedAmount` rather than throttling.

This also correctly handles a stalled/disconnected connection (pre-ICE-failure): the buffer only climbs, every interval is busy, and the rate converges to ~0 so the writer sheds load.

### `BitrateMode`

- **`BusyOnly`** (writer default): busy denominator, all drained bytes counted. In a mixed window it can transiently over-estimate (bounded by the window); the bias errs toward *not* dropping and preserves the reliable path's burst-credit retry behaviour.
- **`ExcludeIdleDrain`**: also drops bytes that drained across non-backlogged intervals, for a clean drain-capacity estimate with no idle contamination. Available as an option; not enabled at call sites.
- **`WallClock`**: elapsed-time denominator, all bytes. For the test-client reader, which has no send buffer to observe.

Call sites keep the conservative behaviour (writers `BusyOnly`, reader `WallClock`).

## Tests

- Sparse-fast-ack, sustained-backlog, stalled-connection, and flush-not-counted scenarios run under **both** writer modes.
- `MixedIdleThenBacklog` demonstrates the idle-drain-then-backlog window where `BusyOnly` over-estimates and `ExcludeIdleDrain` does not.
- `WallClock` covers the reader mode.
- The reliable writer mock now reports a realistic `BufferedAmount()` during stalls (the old always-0 stub no longer reflects a stalled SCTP buffer).

## Follow-up (not in this PR)

The residual mixed-window over-estimate under `BusyOnly` could be eliminated by wiring `OnBufferedAmountLow` (exposed by `*webrtc.DataChannel`) to timestamp the exact drain-to-empty instant, or by switching the unreliable path to `ExcludeIdleDrain`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)