### PR TITLE
Fix receiver load balance threshold initialization

### DIFF
--- a/pkg/sfu/receiver_base.go
+++ b/pkg/sfu/receiver_base.go
@@ -311,6 +311,7 @@ func (r *ReceiverBase) SetEnableRTPStreamRestartDetection(enableRTPStremRestartD
 
 func (r *ReceiverBase) SetLBThreshold(lbThreshold int) {
 	r.lbThreshold = lbThreshold
+	r.downTrackSpreader.SetThreshold(lbThreshold)
 }
 
 func (r *ReceiverBase) SetForwardStats(forwardStats *ForwardStats) {

--- a/pkg/sfu/utils/downtrackspreader.go
+++ b/pkg/sfu/utils/downtrackspreader.go
@@ -91,12 +91,14 @@ func (d *DownTrackSpreader[T]) HasDownTrack(subscriberID livekit.ParticipantID) 
 }
 
 func (d *DownTrackSpreader[T]) Broadcast(writer func(T)) {
-	downTracks := d.GetDownTracks()
+	d.downTrackMu.RLock()
+	downTracks := d.downTracksShadow
+	threshold := uint64(d.params.Threshold)
+	d.downTrackMu.RUnlock()
+
 	if len(downTracks) == 0 {
 		return
 	}
-
-	threshold := uint64(d.params.Threshold)
 	if threshold == 0 {
 		threshold = 1000000
 	}
@@ -118,4 +120,10 @@ func (d *DownTrackSpreader[T]) shadowDownTracks() {
 	for _, dt := range d.downTracks {
 		d.downTracksShadow = append(d.downTracksShadow, dt)
 	}
+}
+
+func (d *DownTrackSpreader[T]) SetThreshold(threshold int) {
+	d.downTrackMu.Lock()
+	d.params.Threshold = threshold
+	d.downTrackMu.Unlock()
 }

--- a/pkg/sfu/utils/downtrackspreader_test.go
+++ b/pkg/sfu/utils/downtrackspreader_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/livekit/protocol/livekit"
+	"github.com/stretchr/testify/require"
+)
+
+type testSender struct {
+	subscriberID livekit.ParticipantID
+}
+
+func (t testSender) SubscriberID() livekit.ParticipantID {
+	return t.subscriberID
+}
+
+func TestDownTrackSpreaderSetThreshold(t *testing.T) {
+	spreader := NewDownTrackSpreader[testSender](DownTrackSpreaderParams{})
+
+	spreader.SetThreshold(20)
+
+	spreader.downTrackMu.RLock()
+	threshold := spreader.params.Threshold
+	spreader.downTrackMu.RUnlock()
+
+	require.Equal(t, 20, threshold)
+}


### PR DESCRIPTION
## Problem

`NewReceiverBase` creates the `DownTrackSpreader` before receiver options
are applied.

The spreader is therefore initialized with the default `lbThreshold` of
zero. `WithLoadBalanceThreshold(20)` is applied afterward, but
`SetLBThreshold` previously updated only the `ReceiverBase` field and not
the already-created spreader.

A zero spreader threshold is treated as 1,000,000, effectively disabling
parallel DownTrack writes for large rooms. This can cause forwarding
latency and packet queue buildup with large subscriber counts, especially
for single-layer screen share tracks.

## Fix

- Propagate `SetLBThreshold` updates to the active `DownTrackSpreader`.
- Protect threshold reads and writes with the spreader mutex.
- Add a regression test for updating the threshold.

## Testing

- `go test ./pkg/sfu ./pkg/sfu/utils ./pkg/rtc -count=1`
- `go test -race ./pkg/sfu ./pkg/sfu/utils -count=1`