### PR TITLE
rtc: route answer to publisher in single-PC / one-shot mode (follow-up to #4680)

### DIFF
--- a/pkg/rtc/transportmanager.go
+++ b/pkg/rtc/transportmanager.go
@@ -560,12 +560,11 @@ func (t *TransportManager) ProcessPendingPublisherOffer() {
 }
 
 func (t *TransportManager) HandleAnswer(answer webrtc.SessionDescription, answerId uint32) {
-	if t.subscriber == nil {
-		// no subscriber transport in single-PC / one-shot signalling mode
-		t.params.Logger.Warnw("answer received, but no subscriber peer connection", nil)
-		return
+	if t.params.UseOneShotSignallingMode || t.params.UseSinglePeerConnection {
+		t.publisher.HandleRemoteDescription(answer, answerId)
+	} else {
+		t.subscriber.HandleRemoteDescription(answer, answerId)
 	}
-	t.subscriber.HandleRemoteDescription(answer, answerId)
 }
 
 // AddICECandidate adds candidates for remote peer


### PR DESCRIPTION
Follow-up to #4680, which merged with an incomplete fix.

## Background

#4680 addressed a production crash where an SDP answer reached `TransportManager.HandleAnswer` while `t.subscriber` was nil (single-PC / one-shot signalling modes never create the subscriber transport):

```
[signal SIGSEGV] (*PCTransport).HandleRemoteDescription(0x0, ...)
  (*TransportManager).HandleAnswer(...)
  (*ParticipantImpl).HandleAnswer(...)
  signalling.(*signalhandler).HandleMessage(...)
```

It merged as a nil-guard that **drops** the answer. That stops the crash but is incorrect: the answer is part of a **legitimate** flow, not a bad client. In persistent single-PC mode the single publisher PC carries both directions, and when the server renegotiates to push a subscribed track it offers on that PC —

```
Negotiate -> NegotiateSubscriber -> t.publisher.Negotiate(force) -> signalSendOffer
```

— so the client's answer must be applied to the publisher. Dropping it silently breaks subscribe renegotiation.

## Fix

Route the answer to the publisher in single-PC / one-shot mode, matching the pattern every other subscriber-path method in `TransportManager` already uses (`GetSubscriberRTT`, `AddTrackLocal`, `AddSubscribedTrack`, `WriteSubscriberRTCP`, `NegotiateSubscriber`, …). This prevents the crash *and* completes the negotiation. `t.publisher` is created unconditionally, so no nil-guard is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)