### PR TITLE
Potential fix for code scanning alert no. 42: Incorrect conversion between integer types

### DIFF
--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -3178,7 +3178,7 @@ func offerAudioPayloadTypes(parsed *sdp.SessionDescription) map[mime.MimeType]we
 			if len(fields) < 2 {
 				continue
 			}
-			pt, err := strconv.Atoi(fields[0])
+			pt, err := strconv.ParseUint(fields[0], 10, 8)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
Potential fix for [https://github.com/livekit/livekit/security/code-scanning/42](https://github.com/livekit/livekit/security/code-scanning/42)

Use `strconv.ParseUint` with an explicit bit size of 8 (base 10), then cast to `webrtc.PayloadType`. This removes architecture-dependent `int` parsing and guarantees the parsed value is already in the representable range for `uint8` (and thus `webrtc.PayloadType`), while preserving current behavior of skipping invalid `rtpmap` entries.

**Specific change in `pkg/rtc/transport.go` (around lines 3181–3193):**
- Replace:
  - `pt, err := strconv.Atoi(fields[0])`
  - `out[mt] = webrtc.PayloadType(pt)`
- With:
  - `pt, err := strconv.ParseUint(fields[0], 10, 8)`
  - `out[mt] = webrtc.PayloadType(pt)`

No new imports are needed (`strconv` is already imported). No other functionality changes: invalid/out-of-range payload types continue to be ignored via `continue`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
