### PR TITLE
Adding metrics for frame metadata use

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -3289,8 +3289,6 @@ func (p *ParticipantImpl) mediaTrackReceived(
 	if newTrack {
 		go func() {
 			trackInfo := mt.ToProto()
-			packetTrailerFeatures := trackInfo.GetPacketTrailerFeatures()
-			packetTrailerEnabled := mt.Kind() == livekit.TrackType_VIDEO && len(packetTrailerFeatures) > 0
 
 			// TODO: remove this after we know where the high delay is coming from
 			if pubTime > 3*time.Second {
@@ -3302,8 +3300,6 @@ func (p *ParticipantImpl) mediaTrackReceived(
 					"rid", track.RID(),
 					"mime", track.Codec().MimeType,
 					"isMigrated", isMigrated,
-					"packetTrailerEnabled", packetTrailerEnabled,
-					"packetTrailerFeatures", packetTrailerFeatures,
 				)
 			} else {
 				p.pubLogger.Debugw(
@@ -3312,8 +3308,6 @@ func (p *ParticipantImpl) mediaTrackReceived(
 					"track", logger.Proto(trackInfo),
 					"cost", pubTime.Milliseconds(),
 					"isMigrated", isMigrated,
-					"packetTrailerEnabled", packetTrailerEnabled,
-					"packetTrailerFeatures", packetTrailerFeatures,
 				)
 			}
 

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -3288,14 +3288,12 @@ func (p *ParticipantImpl) mediaTrackReceived(
 
 	if newTrack {
 		go func() {
-			trackInfo := mt.ToProto()
-
 			// TODO: remove this after we know where the high delay is coming from
 			if pubTime > 3*time.Second {
 				p.pubLogger.Infow(
 					"track published with high delay",
 					"trackID", mt.ID(),
-					"track", logger.Proto(trackInfo),
+					"track", logger.Proto(mt.ToProto()),
 					"cost", pubTime.Milliseconds(),
 					"rid", track.RID(),
 					"mime", track.Codec().MimeType,
@@ -3305,7 +3303,7 @@ func (p *ParticipantImpl) mediaTrackReceived(
 				p.pubLogger.Debugw(
 					"track published",
 					"trackID", mt.ID(),
-					"track", logger.Proto(trackInfo),
+					"track", logger.Proto(mt.ToProto()),
 					"cost", pubTime.Milliseconds(),
 					"isMigrated", isMigrated,
 				)

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -3305,15 +3305,6 @@ func (p *ParticipantImpl) mediaTrackReceived(
 					"packetTrailerEnabled", packetTrailerEnabled,
 					"packetTrailerFeatures", packetTrailerFeatures,
 				)
-			} else if packetTrailerEnabled {
-				p.pubLogger.Infow(
-					"video track published with packet trailer",
-					"trackID", mt.ID(),
-					"track", logger.Proto(trackInfo),
-					"cost", pubTime.Milliseconds(),
-					"isMigrated", isMigrated,
-					"packetTrailerFeatures", packetTrailerFeatures,
-				)
 			} else {
 				p.pubLogger.Debugw(
 					"track published",
@@ -3321,6 +3312,8 @@ func (p *ParticipantImpl) mediaTrackReceived(
 					"track", logger.Proto(trackInfo),
 					"cost", pubTime.Milliseconds(),
 					"isMigrated", isMigrated,
+					"packetTrailerEnabled", packetTrailerEnabled,
+					"packetTrailerFeatures", packetTrailerFeatures,
 				)
 			}
 

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -3288,22 +3288,37 @@ func (p *ParticipantImpl) mediaTrackReceived(
 
 	if newTrack {
 		go func() {
+			trackInfo := mt.ToProto()
+			packetTrailerFeatures := trackInfo.GetPacketTrailerFeatures()
+			packetTrailerEnabled := mt.Kind() == livekit.TrackType_VIDEO && len(packetTrailerFeatures) > 0
+
 			// TODO: remove this after we know where the high delay is coming from
 			if pubTime > 3*time.Second {
 				p.pubLogger.Infow(
 					"track published with high delay",
 					"trackID", mt.ID(),
-					"track", logger.Proto(mt.ToProto()),
+					"track", logger.Proto(trackInfo),
 					"cost", pubTime.Milliseconds(),
 					"rid", track.RID(),
 					"mime", track.Codec().MimeType,
 					"isMigrated", isMigrated,
+					"packetTrailerEnabled", packetTrailerEnabled,
+					"packetTrailerFeatures", packetTrailerFeatures,
+				)
+			} else if packetTrailerEnabled {
+				p.pubLogger.Infow(
+					"video track published with packet trailer",
+					"trackID", mt.ID(),
+					"track", logger.Proto(trackInfo),
+					"cost", pubTime.Milliseconds(),
+					"isMigrated", isMigrated,
+					"packetTrailerFeatures", packetTrailerFeatures,
 				)
 			} else {
 				p.pubLogger.Debugw(
 					"track published",
 					"trackID", mt.ID(),
-					"track", logger.Proto(mt.ToProto()),
+					"track", logger.Proto(trackInfo),
 					"cost", pubTime.Milliseconds(),
 					"isMigrated", isMigrated,
 				)

--- a/pkg/telemetry/events.go
+++ b/pkg/telemetry/events.go
@@ -253,6 +253,7 @@ func (t *telemetryService) TrackPublished(
 ) {
 	t.enqueue(func() {
 		prometheus.AddPublishedTrack(track.Type.String())
+		prometheus.AddPacketTrailerTrack(track)
 		prometheus.RecordTrackPublishSuccess(track.Type.String())
 		if !shouldSendEvent {
 			return
@@ -396,6 +397,7 @@ func (t *telemetryService) TrackUnpublished(
 ) {
 	t.enqueue(func() {
 		prometheus.SubPublishedTrack(track.Type.String())
+		prometheus.SubPacketTrailerTrack(track)
 		if !shouldSendEvent {
 			return
 		}

--- a/pkg/telemetry/prometheus/rooms.go
+++ b/pkg/telemetry/prometheus/rooms.go
@@ -39,17 +39,19 @@ var (
 	// success rate by subtracting this from total attempts
 	trackSubscribeUserError atomic.Int32
 
-	promRoomCurrent            prometheus.Gauge
-	promRoomDuration           prometheus.Histogram
-	promParticipantCurrent     prometheus.Gauge
-	promTrackPublishedCurrent  *prometheus.GaugeVec
-	promTrackSubscribedCurrent *prometheus.GaugeVec
-	promTrackPublishCounter    *prometheus.CounterVec
-	promTrackSubscribeCounter  *prometheus.CounterVec
-	promSessionJoinLatency     *prometheus.HistogramVec
-	promSessionStartTime       *prometheus.HistogramVec
-	promSessionDuration        *prometheus.HistogramVec
-	promPubSubTime             *prometheus.HistogramVec
+	promRoomCurrent                 prometheus.Gauge
+	promRoomDuration                prometheus.Histogram
+	promParticipantCurrent          prometheus.Gauge
+	promTrackPublishedCurrent       *prometheus.GaugeVec
+	promTrackSubscribedCurrent      *prometheus.GaugeVec
+	promTrackPacketTrailer          prometheus.Gauge
+	promTrackPacketTrailerByFeature *prometheus.GaugeVec
+	promTrackPublishCounter         *prometheus.CounterVec
+	promTrackSubscribeCounter       *prometheus.CounterVec
+	promSessionJoinLatency          *prometheus.HistogramVec
+	promSessionStartTime            *prometheus.HistogramVec
+	promSessionDuration             *prometheus.HistogramVec
+	promPubSubTime                  *prometheus.HistogramVec
 
 	promPeerConnection *prometheus.CounterVec
 )
@@ -88,6 +90,24 @@ func initRoomStats(nodeID string, nodeType livekit.NodeType) {
 		Name:        "subscribed_total",
 		ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
 	}, []string{"kind"})
+	promTrackPacketTrailer = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace:   livekitNamespace,
+		Subsystem:   "track",
+		Name:        "packet_trailer_total",
+		Help:        "Current number of published video tracks with packet trailers enabled.",
+		ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
+	})
+	promTrackPacketTrailerByFeature = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace:   livekitNamespace,
+		Subsystem:   "track",
+		Name:        "packet_trailer_feature_total",
+		Help:        "Current number of published video tracks by enabled packet trailer feature.",
+		ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
+	}, []string{"feature"})
+	for value := range livekit.PacketTrailerFeature_name {
+		feature := livekit.PacketTrailerFeature(value)
+		promTrackPacketTrailerByFeature.WithLabelValues(feature.String()).Set(0)
+	}
 	promTrackPublishCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   livekitNamespace,
 		Subsystem:   "track",
@@ -140,6 +160,8 @@ func initRoomStats(nodeID string, nodeType livekit.NodeType) {
 	prometheus.MustRegister(promParticipantCurrent)
 	prometheus.MustRegister(promTrackPublishedCurrent)
 	prometheus.MustRegister(promTrackSubscribedCurrent)
+	prometheus.MustRegister(promTrackPacketTrailer)
+	prometheus.MustRegister(promTrackPacketTrailerByFeature)
 	prometheus.MustRegister(promTrackPublishCounter)
 	prometheus.MustRegister(promTrackSubscribeCounter)
 	prometheus.MustRegister(promSessionJoinLatency)
@@ -180,6 +202,48 @@ func AddPublishedTrack(kind string) {
 func SubPublishedTrack(kind string) {
 	promTrackPublishedCurrent.WithLabelValues(kind).Sub(1)
 	trackPublishedCurrent.Dec()
+}
+
+func AddPacketTrailerTrack(track *livekit.TrackInfo) {
+	updatePacketTrailerTracks(track, 1)
+}
+
+func SubPacketTrailerTrack(track *livekit.TrackInfo) {
+	updatePacketTrailerTracks(track, -1)
+}
+
+func updatePacketTrailerTracks(track *livekit.TrackInfo, delta float64) {
+	if track.GetType() != livekit.TrackType_VIDEO {
+		return
+	}
+
+	features := packetTrailerFeatureLabels(track.GetPacketTrailerFeatures())
+	if len(features) == 0 {
+		return
+	}
+
+	promTrackPacketTrailer.Add(delta)
+	for _, feature := range features {
+		promTrackPacketTrailerByFeature.WithLabelValues(feature).Add(delta)
+	}
+}
+
+func packetTrailerFeatureLabels(features []livekit.PacketTrailerFeature) []string {
+	labels := make([]string, 0, len(features))
+	seen := make(map[string]struct{}, len(features))
+	for _, feature := range features {
+		label := "UNKNOWN"
+		if _, ok := livekit.PacketTrailerFeature_name[int32(feature)]; ok {
+			label = feature.String()
+		}
+
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		labels = append(labels, label)
+	}
+	return labels
 }
 
 func RecordTrackPublishAttempt(kind string) {

--- a/pkg/telemetry/prometheus/rooms.go
+++ b/pkg/telemetry/prometheus/rooms.go
@@ -44,7 +44,8 @@ var (
 	promParticipantCurrent                 prometheus.Gauge
 	promTrackPublishedCurrent              *prometheus.GaugeVec
 	promTrackSubscribedCurrent             *prometheus.GaugeVec
-	promTrackPacketTrailerCurrent          *prometheus.GaugeVec
+	promTrackPacketTrailerCurrent          prometheus.Gauge
+	promTrackPacketTrailerByFeatureCurrent *prometheus.GaugeVec
 	promTrackPublishCounter                *prometheus.CounterVec
 	promTrackSubscribeCounter              *prometheus.CounterVec
 	promSessionJoinLatency                 *prometheus.HistogramVec
@@ -89,16 +90,23 @@ func initRoomStats(nodeID string, nodeType livekit.NodeType) {
 		Name:        "subscribed_total",
 		ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
 	}, []string{"kind"})
-	promTrackPacketTrailerCurrent = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	promTrackPacketTrailerCurrent = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:   livekitNamespace,
 		Subsystem:   "track",
 		Name:        "packet_trailer_total",
+		Help:        "Current number of published video tracks with packet trailers enabled.",
+		ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
+	})
+	promTrackPacketTrailerByFeatureCurrent = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace:   livekitNamespace,
+		Subsystem:   "track",
+		Name:        "packet_trailer_feature_total",
 		Help:        "Current number of published video tracks by enabled packet trailer feature.",
 		ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
 	}, []string{"feature"})
 	for value := range livekit.PacketTrailerFeature_name {
 		feature := livekit.PacketTrailerFeature(value)
-		promTrackPacketTrailerCurrent.WithLabelValues(feature.String()).Set(0)
+		promTrackPacketTrailerByFeatureCurrent.WithLabelValues(feature.String()).Set(0)
 	}
 	promTrackPublishCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   livekitNamespace,
@@ -153,6 +161,7 @@ func initRoomStats(nodeID string, nodeType livekit.NodeType) {
 	prometheus.MustRegister(promTrackPublishedCurrent)
 	prometheus.MustRegister(promTrackSubscribedCurrent)
 	prometheus.MustRegister(promTrackPacketTrailerCurrent)
+	prometheus.MustRegister(promTrackPacketTrailerByFeatureCurrent)
 	prometheus.MustRegister(promTrackPublishCounter)
 	prometheus.MustRegister(promTrackSubscribeCounter)
 	prometheus.MustRegister(promSessionJoinLatency)
@@ -213,8 +222,9 @@ func updatePacketTrailerTracks(track *livekit.TrackInfo, delta float64) {
 		return
 	}
 
+	promTrackPacketTrailerCurrent.Add(delta)
 	for _, feature := range features {
-		promTrackPacketTrailerCurrent.WithLabelValues(feature).Add(delta)
+		promTrackPacketTrailerByFeatureCurrent.WithLabelValues(feature).Add(delta)
 	}
 }
 

--- a/pkg/telemetry/prometheus/rooms.go
+++ b/pkg/telemetry/prometheus/rooms.go
@@ -39,19 +39,19 @@ var (
 	// success rate by subtracting this from total attempts
 	trackSubscribeUserError atomic.Int32
 
-	promRoomCurrent                 prometheus.Gauge
-	promRoomDuration                prometheus.Histogram
-	promParticipantCurrent          prometheus.Gauge
-	promTrackPublishedCurrent       *prometheus.GaugeVec
-	promTrackSubscribedCurrent      *prometheus.GaugeVec
-	promTrackPacketTrailer          prometheus.Gauge
-	promTrackPacketTrailerByFeature *prometheus.GaugeVec
-	promTrackPublishCounter         *prometheus.CounterVec
-	promTrackSubscribeCounter       *prometheus.CounterVec
-	promSessionJoinLatency          *prometheus.HistogramVec
-	promSessionStartTime            *prometheus.HistogramVec
-	promSessionDuration             *prometheus.HistogramVec
-	promPubSubTime                  *prometheus.HistogramVec
+	promRoomCurrent                        prometheus.Gauge
+	promRoomDuration                       prometheus.Histogram
+	promParticipantCurrent                 prometheus.Gauge
+	promTrackPublishedCurrent              *prometheus.GaugeVec
+	promTrackSubscribedCurrent             *prometheus.GaugeVec
+	promTrackPacketTrailerCurrent          prometheus.Gauge
+	promTrackPacketTrailerByFeatureCurrent *prometheus.GaugeVec
+	promTrackPublishCounter                *prometheus.CounterVec
+	promTrackSubscribeCounter              *prometheus.CounterVec
+	promSessionJoinLatency                 *prometheus.HistogramVec
+	promSessionStartTime                   *prometheus.HistogramVec
+	promSessionDuration                    *prometheus.HistogramVec
+	promPubSubTime                         *prometheus.HistogramVec
 
 	promPeerConnection *prometheus.CounterVec
 )
@@ -90,14 +90,14 @@ func initRoomStats(nodeID string, nodeType livekit.NodeType) {
 		Name:        "subscribed_total",
 		ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
 	}, []string{"kind"})
-	promTrackPacketTrailer = prometheus.NewGauge(prometheus.GaugeOpts{
+	promTrackPacketTrailerCurrent = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace:   livekitNamespace,
 		Subsystem:   "track",
 		Name:        "packet_trailer_total",
 		Help:        "Current number of published video tracks with packet trailers enabled.",
 		ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
 	})
-	promTrackPacketTrailerByFeature = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	promTrackPacketTrailerByFeatureCurrent = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:   livekitNamespace,
 		Subsystem:   "track",
 		Name:        "packet_trailer_feature_total",
@@ -106,7 +106,7 @@ func initRoomStats(nodeID string, nodeType livekit.NodeType) {
 	}, []string{"feature"})
 	for value := range livekit.PacketTrailerFeature_name {
 		feature := livekit.PacketTrailerFeature(value)
-		promTrackPacketTrailerByFeature.WithLabelValues(feature.String()).Set(0)
+		promTrackPacketTrailerByFeatureCurrent.WithLabelValues(feature.String()).Set(0)
 	}
 	promTrackPublishCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   livekitNamespace,
@@ -160,8 +160,8 @@ func initRoomStats(nodeID string, nodeType livekit.NodeType) {
 	prometheus.MustRegister(promParticipantCurrent)
 	prometheus.MustRegister(promTrackPublishedCurrent)
 	prometheus.MustRegister(promTrackSubscribedCurrent)
-	prometheus.MustRegister(promTrackPacketTrailer)
-	prometheus.MustRegister(promTrackPacketTrailerByFeature)
+	prometheus.MustRegister(promTrackPacketTrailerCurrent)
+	prometheus.MustRegister(promTrackPacketTrailerByFeatureCurrent)
 	prometheus.MustRegister(promTrackPublishCounter)
 	prometheus.MustRegister(promTrackSubscribeCounter)
 	prometheus.MustRegister(promSessionJoinLatency)
@@ -222,9 +222,9 @@ func updatePacketTrailerTracks(track *livekit.TrackInfo, delta float64) {
 		return
 	}
 
-	promTrackPacketTrailer.Add(delta)
+	promTrackPacketTrailerCurrent.Add(delta)
 	for _, feature := range features {
-		promTrackPacketTrailerByFeature.WithLabelValues(feature).Add(delta)
+		promTrackPacketTrailerByFeatureCurrent.WithLabelValues(feature).Add(delta)
 	}
 }
 

--- a/pkg/telemetry/prometheus/rooms.go
+++ b/pkg/telemetry/prometheus/rooms.go
@@ -44,8 +44,7 @@ var (
 	promParticipantCurrent                 prometheus.Gauge
 	promTrackPublishedCurrent              *prometheus.GaugeVec
 	promTrackSubscribedCurrent             *prometheus.GaugeVec
-	promTrackPacketTrailerCurrent          prometheus.Gauge
-	promTrackPacketTrailerByFeatureCurrent *prometheus.GaugeVec
+	promTrackPacketTrailerCurrent          *prometheus.GaugeVec
 	promTrackPublishCounter                *prometheus.CounterVec
 	promTrackSubscribeCounter              *prometheus.CounterVec
 	promSessionJoinLatency                 *prometheus.HistogramVec
@@ -90,23 +89,16 @@ func initRoomStats(nodeID string, nodeType livekit.NodeType) {
 		Name:        "subscribed_total",
 		ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
 	}, []string{"kind"})
-	promTrackPacketTrailerCurrent = prometheus.NewGauge(prometheus.GaugeOpts{
+	promTrackPacketTrailerCurrent = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:   livekitNamespace,
 		Subsystem:   "track",
 		Name:        "packet_trailer_total",
-		Help:        "Current number of published video tracks with packet trailers enabled.",
-		ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
-	})
-	promTrackPacketTrailerByFeatureCurrent = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace:   livekitNamespace,
-		Subsystem:   "track",
-		Name:        "packet_trailer_feature_total",
 		Help:        "Current number of published video tracks by enabled packet trailer feature.",
 		ConstLabels: prometheus.Labels{"node_id": nodeID, "node_type": nodeType.String()},
 	}, []string{"feature"})
 	for value := range livekit.PacketTrailerFeature_name {
 		feature := livekit.PacketTrailerFeature(value)
-		promTrackPacketTrailerByFeatureCurrent.WithLabelValues(feature.String()).Set(0)
+		promTrackPacketTrailerCurrent.WithLabelValues(feature.String()).Set(0)
 	}
 	promTrackPublishCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   livekitNamespace,
@@ -161,7 +153,6 @@ func initRoomStats(nodeID string, nodeType livekit.NodeType) {
 	prometheus.MustRegister(promTrackPublishedCurrent)
 	prometheus.MustRegister(promTrackSubscribedCurrent)
 	prometheus.MustRegister(promTrackPacketTrailerCurrent)
-	prometheus.MustRegister(promTrackPacketTrailerByFeatureCurrent)
 	prometheus.MustRegister(promTrackPublishCounter)
 	prometheus.MustRegister(promTrackSubscribeCounter)
 	prometheus.MustRegister(promSessionJoinLatency)
@@ -222,9 +213,8 @@ func updatePacketTrailerTracks(track *livekit.TrackInfo, delta float64) {
 		return
 	}
 
-	promTrackPacketTrailerCurrent.Add(delta)
 	for _, feature := range features {
-		promTrackPacketTrailerByFeatureCurrent.WithLabelValues(feature).Add(delta)
+		promTrackPacketTrailerCurrent.WithLabelValues(feature).Add(delta)
 	}
 }
 

--- a/pkg/telemetry/prometheus/rooms_test.go
+++ b/pkg/telemetry/prometheus/rooms_test.go
@@ -39,36 +39,36 @@ func TestPacketTrailerTrackMetrics(t *testing.T) {
 		},
 	}
 
-	trailerBefore := gaugeValue(t, promTrackPacketTrailer)
-	timestampBefore := gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_USER_TIMESTAMP"))
-	frameIDBefore := gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_FRAME_ID"))
-	userDataBefore := gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_USER_DATA"))
-	unknownBefore := gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("UNKNOWN"))
+	trailerBefore := gaugeValue(t, promTrackPacketTrailerCurrent)
+	timestampBefore := gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_TIMESTAMP"))
+	frameIDBefore := gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_FRAME_ID"))
+	userDataBefore := gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_DATA"))
+	unknownBefore := gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("UNKNOWN"))
 
 	AddPacketTrailerTrack(track)
-	require.Equal(t, trailerBefore+1, gaugeValue(t, promTrackPacketTrailer))
-	require.Equal(t, timestampBefore+1, gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_USER_TIMESTAMP")))
-	require.Equal(t, frameIDBefore+1, gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_FRAME_ID")))
-	require.Equal(t, userDataBefore+1, gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_USER_DATA")))
-	require.Equal(t, unknownBefore+1, gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("UNKNOWN")))
+	require.Equal(t, trailerBefore+1, gaugeValue(t, promTrackPacketTrailerCurrent))
+	require.Equal(t, timestampBefore+1, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_TIMESTAMP")))
+	require.Equal(t, frameIDBefore+1, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_FRAME_ID")))
+	require.Equal(t, userDataBefore+1, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_DATA")))
+	require.Equal(t, unknownBefore+1, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("UNKNOWN")))
 
 	SubPacketTrailerTrack(track)
-	require.Equal(t, trailerBefore, gaugeValue(t, promTrackPacketTrailer))
-	require.Equal(t, timestampBefore, gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_USER_TIMESTAMP")))
-	require.Equal(t, frameIDBefore, gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_FRAME_ID")))
-	require.Equal(t, userDataBefore, gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_USER_DATA")))
-	require.Equal(t, unknownBefore, gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("UNKNOWN")))
+	require.Equal(t, trailerBefore, gaugeValue(t, promTrackPacketTrailerCurrent))
+	require.Equal(t, timestampBefore, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_TIMESTAMP")))
+	require.Equal(t, frameIDBefore, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_FRAME_ID")))
+	require.Equal(t, userDataBefore, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_DATA")))
+	require.Equal(t, unknownBefore, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("UNKNOWN")))
 }
 
 func TestPacketTrailerTrackMetricsIgnoreAudio(t *testing.T) {
 	require.NoError(t, Init("test", livekit.NodeType_SERVER))
 
-	before := gaugeValue(t, promTrackPacketTrailer)
+	before := gaugeValue(t, promTrackPacketTrailerCurrent)
 	AddPacketTrailerTrack(&livekit.TrackInfo{
 		Type:                  livekit.TrackType_AUDIO,
 		PacketTrailerFeatures: []livekit.PacketTrailerFeature{livekit.PacketTrailerFeature_PTF_USER_DATA},
 	})
-	require.Equal(t, before, gaugeValue(t, promTrackPacketTrailer))
+	require.Equal(t, before, gaugeValue(t, promTrackPacketTrailerCurrent))
 }
 
 func gaugeValue(t *testing.T, gauge promclient.Gauge) float64 {

--- a/pkg/telemetry/prometheus/rooms_test.go
+++ b/pkg/telemetry/prometheus/rooms_test.go
@@ -39,36 +39,33 @@ func TestPacketTrailerTrackMetrics(t *testing.T) {
 		},
 	}
 
-	trailerBefore := gaugeValue(t, promTrackPacketTrailerCurrent)
-	timestampBefore := gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_TIMESTAMP"))
-	frameIDBefore := gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_FRAME_ID"))
-	userDataBefore := gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_DATA"))
-	unknownBefore := gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("UNKNOWN"))
+	timestampBefore := gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_USER_TIMESTAMP"))
+	frameIDBefore := gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_FRAME_ID"))
+	userDataBefore := gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_USER_DATA"))
+	unknownBefore := gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("UNKNOWN"))
 
 	AddPacketTrailerTrack(track)
-	require.Equal(t, trailerBefore+1, gaugeValue(t, promTrackPacketTrailerCurrent))
-	require.Equal(t, timestampBefore+1, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_TIMESTAMP")))
-	require.Equal(t, frameIDBefore+1, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_FRAME_ID")))
-	require.Equal(t, userDataBefore+1, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_DATA")))
-	require.Equal(t, unknownBefore+1, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("UNKNOWN")))
+	require.Equal(t, timestampBefore+1, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_USER_TIMESTAMP")))
+	require.Equal(t, frameIDBefore+1, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_FRAME_ID")))
+	require.Equal(t, userDataBefore+1, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_USER_DATA")))
+	require.Equal(t, unknownBefore+1, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("UNKNOWN")))
 
 	SubPacketTrailerTrack(track)
-	require.Equal(t, trailerBefore, gaugeValue(t, promTrackPacketTrailerCurrent))
-	require.Equal(t, timestampBefore, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_TIMESTAMP")))
-	require.Equal(t, frameIDBefore, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_FRAME_ID")))
-	require.Equal(t, userDataBefore, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_DATA")))
-	require.Equal(t, unknownBefore, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("UNKNOWN")))
+	require.Equal(t, timestampBefore, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_USER_TIMESTAMP")))
+	require.Equal(t, frameIDBefore, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_FRAME_ID")))
+	require.Equal(t, userDataBefore, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_USER_DATA")))
+	require.Equal(t, unknownBefore, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("UNKNOWN")))
 }
 
 func TestPacketTrailerTrackMetricsIgnoreAudio(t *testing.T) {
 	require.NoError(t, Init("test", livekit.NodeType_SERVER))
 
-	before := gaugeValue(t, promTrackPacketTrailerCurrent)
+	before := gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_USER_DATA"))
 	AddPacketTrailerTrack(&livekit.TrackInfo{
 		Type:                  livekit.TrackType_AUDIO,
 		PacketTrailerFeatures: []livekit.PacketTrailerFeature{livekit.PacketTrailerFeature_PTF_USER_DATA},
 	})
-	require.Equal(t, before, gaugeValue(t, promTrackPacketTrailerCurrent))
+	require.Equal(t, before, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_USER_DATA")))
 }
 
 func gaugeValue(t *testing.T, gauge promclient.Gauge) float64 {

--- a/pkg/telemetry/prometheus/rooms_test.go
+++ b/pkg/telemetry/prometheus/rooms_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"testing"
+
+	promclient "github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/protocol/livekit"
+)
+
+func TestPacketTrailerTrackMetrics(t *testing.T) {
+	require.NoError(t, Init("test", livekit.NodeType_SERVER))
+
+	track := &livekit.TrackInfo{
+		Type: livekit.TrackType_VIDEO,
+		PacketTrailerFeatures: []livekit.PacketTrailerFeature{
+			livekit.PacketTrailerFeature_PTF_USER_TIMESTAMP,
+			livekit.PacketTrailerFeature_PTF_USER_TIMESTAMP,
+			livekit.PacketTrailerFeature_PTF_FRAME_ID,
+			livekit.PacketTrailerFeature_PTF_USER_DATA,
+			livekit.PacketTrailerFeature(99),
+			livekit.PacketTrailerFeature(100),
+		},
+	}
+
+	trailerBefore := gaugeValue(t, promTrackPacketTrailer)
+	timestampBefore := gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_USER_TIMESTAMP"))
+	frameIDBefore := gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_FRAME_ID"))
+	userDataBefore := gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_USER_DATA"))
+	unknownBefore := gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("UNKNOWN"))
+
+	AddPacketTrailerTrack(track)
+	require.Equal(t, trailerBefore+1, gaugeValue(t, promTrackPacketTrailer))
+	require.Equal(t, timestampBefore+1, gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_USER_TIMESTAMP")))
+	require.Equal(t, frameIDBefore+1, gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_FRAME_ID")))
+	require.Equal(t, userDataBefore+1, gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_USER_DATA")))
+	require.Equal(t, unknownBefore+1, gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("UNKNOWN")))
+
+	SubPacketTrailerTrack(track)
+	require.Equal(t, trailerBefore, gaugeValue(t, promTrackPacketTrailer))
+	require.Equal(t, timestampBefore, gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_USER_TIMESTAMP")))
+	require.Equal(t, frameIDBefore, gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_FRAME_ID")))
+	require.Equal(t, userDataBefore, gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("PTF_USER_DATA")))
+	require.Equal(t, unknownBefore, gaugeValue(t, promTrackPacketTrailerByFeature.WithLabelValues("UNKNOWN")))
+}
+
+func TestPacketTrailerTrackMetricsIgnoreAudio(t *testing.T) {
+	require.NoError(t, Init("test", livekit.NodeType_SERVER))
+
+	before := gaugeValue(t, promTrackPacketTrailer)
+	AddPacketTrailerTrack(&livekit.TrackInfo{
+		Type:                  livekit.TrackType_AUDIO,
+		PacketTrailerFeatures: []livekit.PacketTrailerFeature{livekit.PacketTrailerFeature_PTF_USER_DATA},
+	})
+	require.Equal(t, before, gaugeValue(t, promTrackPacketTrailer))
+}
+
+func gaugeValue(t *testing.T, gauge promclient.Gauge) float64 {
+	t.Helper()
+
+	metric := &dto.Metric{}
+	require.NoError(t, gauge.Write(metric))
+	return metric.GetGauge().GetValue()
+}

--- a/pkg/telemetry/prometheus/rooms_test.go
+++ b/pkg/telemetry/prometheus/rooms_test.go
@@ -39,33 +39,36 @@ func TestPacketTrailerTrackMetrics(t *testing.T) {
 		},
 	}
 
-	timestampBefore := gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_USER_TIMESTAMP"))
-	frameIDBefore := gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_FRAME_ID"))
-	userDataBefore := gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_USER_DATA"))
-	unknownBefore := gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("UNKNOWN"))
+	trailerBefore := gaugeValue(t, promTrackPacketTrailerCurrent)
+	timestampBefore := gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_TIMESTAMP"))
+	frameIDBefore := gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_FRAME_ID"))
+	userDataBefore := gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_DATA"))
+	unknownBefore := gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("UNKNOWN"))
 
 	AddPacketTrailerTrack(track)
-	require.Equal(t, timestampBefore+1, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_USER_TIMESTAMP")))
-	require.Equal(t, frameIDBefore+1, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_FRAME_ID")))
-	require.Equal(t, userDataBefore+1, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_USER_DATA")))
-	require.Equal(t, unknownBefore+1, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("UNKNOWN")))
+	require.Equal(t, trailerBefore+1, gaugeValue(t, promTrackPacketTrailerCurrent))
+	require.Equal(t, timestampBefore+1, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_TIMESTAMP")))
+	require.Equal(t, frameIDBefore+1, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_FRAME_ID")))
+	require.Equal(t, userDataBefore+1, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_DATA")))
+	require.Equal(t, unknownBefore+1, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("UNKNOWN")))
 
 	SubPacketTrailerTrack(track)
-	require.Equal(t, timestampBefore, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_USER_TIMESTAMP")))
-	require.Equal(t, frameIDBefore, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_FRAME_ID")))
-	require.Equal(t, userDataBefore, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_USER_DATA")))
-	require.Equal(t, unknownBefore, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("UNKNOWN")))
+	require.Equal(t, trailerBefore, gaugeValue(t, promTrackPacketTrailerCurrent))
+	require.Equal(t, timestampBefore, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_TIMESTAMP")))
+	require.Equal(t, frameIDBefore, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_FRAME_ID")))
+	require.Equal(t, userDataBefore, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("PTF_USER_DATA")))
+	require.Equal(t, unknownBefore, gaugeValue(t, promTrackPacketTrailerByFeatureCurrent.WithLabelValues("UNKNOWN")))
 }
 
 func TestPacketTrailerTrackMetricsIgnoreAudio(t *testing.T) {
 	require.NoError(t, Init("test", livekit.NodeType_SERVER))
 
-	before := gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_USER_DATA"))
+	before := gaugeValue(t, promTrackPacketTrailerCurrent)
 	AddPacketTrailerTrack(&livekit.TrackInfo{
 		Type:                  livekit.TrackType_AUDIO,
 		PacketTrailerFeatures: []livekit.PacketTrailerFeature{livekit.PacketTrailerFeature_PTF_USER_DATA},
 	})
-	require.Equal(t, before, gaugeValue(t, promTrackPacketTrailerCurrent.WithLabelValues("PTF_USER_DATA")))
+	require.Equal(t, before, gaugeValue(t, promTrackPacketTrailerCurrent))
 }
 
 func gaugeValue(t *testing.T, gauge promclient.Gauge) float64 {


### PR DESCRIPTION
- adding 2 metrics for # of tracks that have packet trailer enabled & # of tracks with specific feature enabled.