### PR TITLE
Use simulcast constructor for VP9 if simulcasted.

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -407,7 +407,7 @@ func (f *Forwarder) DetermineCodec(codec webrtc.RTPCodecCapability, extensions [
 			if f.vls != nil {
 				f.vls = videolayerselector.NewSimulcastFromOther(f.vls)
 			} else {
-				f.vls = videolayerselector.NewDependencyDescriptor(f.logger)
+				f.vls = videolayerselector.NewSimulcast(f.logger)
 			}
 		} else {
 			f.isDDAvailable = ddAvailable(extensions)


### PR DESCRIPTION
Not active path, but noticed it while reviewing a bug report. Just fixing it for correctness in code.