### PR TITLE
Apply ICE preference when switching to TCP on unstable UDP

### DIFF
--- a/pkg/rtc/transportmanager.go
+++ b/pkg/rtc/transportmanager.go
@@ -976,6 +976,11 @@ func (t *TransportManager) onMediaLossUpdate(loss uint8) {
 				t.lock.Unlock()
 
 				t.params.Logger.Infow("udp connection unstable, switch to tcp", "signalingRTT", t.signalingRTT)
+				// switch ICE preference to TCP before asking the client to resume,
+				// the raw params handler only sends a leave request and does not
+				// reconfigure the transport, so the client would reconnect over UDP
+				// again and this path would keep firing
+				t.handleConnectionFailed(true)
 				if t.params.UseSinglePeerConnection {
 					t.params.PublisherHandler.OnFailed(true, t.publisher.GetICEConnectionInfo())
 				} else {


### PR DESCRIPTION
Fixes livekit/livekit#4702

onMediaLossUpdate calls the raw handler from params which only sends a leave request with resume action to the client. handleConnectionFailed that actually switches the ICE preference to TCP/TLS is called only inside TransportManagerTransportHandler wrapper and this path never goes through it. So the client reconnects over udp again and the fallback keeps firing forever

Added handleConnectionFailed(true) before notifying the handler, same as the wrapper does for real ICE failures. Repeated triggers should also stop after the switch because of isTransportReconfigured check

I'm rolling out this patch on my deployment now, will report back how the migration behaves with real users