### PR TITLE
Do not call telemetry listener under pending track lock.

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1353,6 +1353,7 @@ func (p *ParticipantImpl) AddTrack(req *livekit.AddTrackRequest) {
 	if ti == nil {
 		return
 	}
+	p.params.TelemetryListener.OnTrackPublishRequested(p.ID(), p.Identity(), utils.CloneProto(ti))
 
 	p.sendTrackPublished(req.Cid, ti)
 
@@ -3059,8 +3060,6 @@ func (p *ParticipantImpl) addPendingTrack(req *livekit.AddTrackRequest) *livekit
 			}
 		}
 	}
-
-	p.params.TelemetryListener.OnTrackPublishRequested(p.ID(), p.Identity(), utils.CloneProto(ti))
 
 	if p.supervisor != nil {
 		p.supervisor.AddPublication(livekit.TrackID(ti.Sid))

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -1353,7 +1353,6 @@ func (p *ParticipantImpl) AddTrack(req *livekit.AddTrackRequest) {
 	if ti == nil {
 		return
 	}
-	p.params.TelemetryListener.OnTrackPublishRequested(p.ID(), p.Identity(), utils.CloneProto(ti))
 
 	p.sendTrackPublished(req.Cid, ti)
 
@@ -2877,8 +2876,6 @@ func (p *ParticipantImpl) onSubscribedAudioCodecChange(
 
 func (p *ParticipantImpl) addPendingTrack(req *livekit.AddTrackRequest) *livekit.TrackInfo {
 	p.pendingTracksLock.Lock()
-	defer p.pendingTracksLock.Unlock()
-
 	if req.Sid != "" {
 		track := p.GetPublishedTrack(livekit.TrackID(req.Sid))
 		if track == nil {
@@ -2889,11 +2886,14 @@ func (p *ParticipantImpl) addPendingTrack(req *livekit.AddTrackRequest) *livekit
 					AddTrack: utils.CloneProto(req),
 				},
 			})
+			p.pendingTracksLock.Unlock()
 			return nil
 		}
 
 		track.(*MediaTrack).UpdateCodecInfo(req.SimulcastCodecs)
-		return track.ToProto()
+		ti := track.ToProto()
+		p.pendingTracksLock.Unlock()
+		return ti
 	}
 
 	backupCodecPolicy := req.BackupCodecPolicy
@@ -3092,6 +3092,8 @@ func (p *ParticipantImpl) addPendingTrack(req *livekit.AddTrackRequest) *livekit
 				AddTrack: utils.CloneProto(req),
 			},
 		})
+		p.pendingTracksLock.Unlock()
+		p.params.TelemetryListener.OnTrackPublishRequested(p.ID(), p.Identity(), utils.CloneProto(ti))
 		return nil
 	}
 
@@ -3109,6 +3111,8 @@ func (p *ParticipantImpl) addPendingTrack(req *livekit.AddTrackRequest) *livekit
 		"request", logger.Proto(req),
 		"pendingTrack", p.pendingTracks[req.Cid],
 	)
+	p.pendingTracksLock.Unlock()
+	p.params.TelemetryListener.OnTrackPublishRequested(p.ID(), p.Identity(), utils.CloneProto(ti))
 	return ti
 }
 


### PR DESCRIPTION
Fix the TrackPublishRequested call of telemetry listener.

Audited other callbacks to ensure that it is not under lock.