### PR TITLE
fix(service, routing): sanitize auth errors, fix response header order, and pass parent ctx

### DIFF
--- a/pkg/routing/redisrouter.go
+++ b/pkg/routing/redisrouter.go
@@ -113,8 +113,8 @@ func (r *RedisRouter) SetNodeForRoom(_ context.Context, roomName livekit.RoomNam
 	return r.rc.HSet(r.ctx, NodeRoomKey, string(roomName), string(nodeID)).Err()
 }
 
-func (r *RedisRouter) ClearRoomState(_ context.Context, roomName livekit.RoomName) error {
-	if err := r.rc.HDel(context.Background(), NodeRoomKey, string(roomName)).Err(); err != nil {
+func (r *RedisRouter) ClearRoomState(ctx context.Context, roomName livekit.RoomName) error {
+	if err := r.rc.HDel(ctx, NodeRoomKey, string(roomName)).Err(); err != nil {
 		return errors.Wrap(err, "could not clear room state")
 	}
 	return nil

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -88,13 +88,13 @@ func (m *APIKeyAuthMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request,
 
 		secret := m.provider.GetSecret(v.APIKey())
 		if secret == "" {
-			HandleError(w, r, http.StatusUnauthorized, errors.New("invalid API key: "+v.APIKey()))
+			HandleError(w, r, http.StatusUnauthorized, ErrInvalidAPIKey)
 			return
 		}
 
 		claims, grants, err := v.Verify(secret)
 		if err != nil {
-			HandleError(w, r, http.StatusUnauthorized, errors.New("invalid token: "+authToken+", error: "+err.Error()))
+			HandleError(w, r, http.StatusUnauthorized, ErrInvalidAuthorizationToken)
 			return
 		}
 

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -86,13 +86,13 @@ func HandleError(w http.ResponseWriter, r *http.Request, status int, err error, 
 }
 
 func HandleErrorJson(w http.ResponseWriter, r *http.Request, status int, err error, keysAndValues ...any) {
+	w.Header().Set("Content-Type", "application/json")
 	handleError(w, r, status, err, keysAndValues...)
 	json.NewEncoder(w).Encode(struct {
 		Error string `json:"error"`
 	}{
 		Error: err.Error(),
 	})
-	w.Header().Add("Content-type", "application/json")
 }
 
 func boolValue(s string) bool {


### PR DESCRIPTION
1. **Fix `Content-Type` header ordering in `HandleErrorJson`** (`pkg/service/utils.go`)
   Right now `w.Header().Add("Content-type", ...)` is called after `handleError()` (which calls `w.WriteHeader()`) and after writing the response body. In Go's `net/http`, any header modifications after `WriteHeader` or writing the body get ignored by the runtime. Moved `w.Header().Set("Content-Type", "application/json")` to before headers are written to the connection.

2. **Sanitize HTTP 401 error payloads in `APIKeyAuthMiddleware`** (`pkg/service/auth.go`)
   Currently when token parsing or verification fails in auth middleware, the raw `authToken` string and API key are concatenated directly into the error payload returned in the 401 body (`errors.New("invalid token: "+authToken...)`). This can reflect raw tokens back to clients or proxy logs unnecessarily. Swapped these to use the already defined package errors (`ErrInvalidAPIKey` and `ErrInvalidAuthorizationToken`).

3. **Pass caller `ctx` in `RedisRouter.ClearRoomState`** (`pkg/routing/redisrouter.go`)
   `ClearRoomState` was accepting `_ context.Context` but hardcoding `context.Background()` for the Redis `HDel` call. Replaced `context.Background()` with the passed `ctx` so parent cancellation, timeouts, and tracing spans are preserved.

Let me know if anything looks off or if you'd prefer any of these split out into separate PRs. Thanks!
