### PR TITLE
Fix AgentHandler.DrainConnections deadlock on worker close

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -218,3 +218,41 @@ func TestConnectionClosedOnDispatchError(t *testing.T) {
 		}
 	})
 }
+
+func TestDrainConnectionsDoesNotDeadlock(t *testing.T) {
+	for _, force := range []bool{false, true} {
+		t.Run(fmt.Sprintf("force=%v", force), func(t *testing.T) {
+			bus := psrpc.NewLocalMessageBus()
+			server := testutils.NewTestServer(bus)
+			t.Cleanup(server.Close)
+
+			worker := server.SimulateAgentWorker()
+			worker.Register("drain_agent", livekit.JobType_JT_ROOM)
+			responses := worker.RegisterWorkerResponses.Observe()
+			select {
+			case <-responses.Events():
+			case <-time.After(time.Second):
+				require.Fail(t, "registration timeout")
+			}
+			responses.Stop()
+
+			done := make(chan struct{})
+			go func() {
+				server.DrainConnections(time.Millisecond, force)
+				close(done)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				require.Fail(t, "DrainConnections deadlocked while closing workers")
+			}
+
+			select {
+			case <-worker.Closed():
+			case <-time.After(time.Second):
+				require.Fail(t, "worker should be closed after drain")
+			}
+		})
+	}
+}

--- a/pkg/service/agentservice.go
+++ b/pkg/service/agentservice.go
@@ -486,6 +486,16 @@ func (h *AgentHandler) CheckEnabled(ctx context.Context, req *rpc.CheckEnabledRe
 }
 
 func (h *AgentHandler) DrainConnections(interval time.Duration, force bool) {
+	// Snapshot workers and release the lock before Close. Worker.Close closes the
+	// signal connection, which unblocks HandleConnection's read loop so it can call
+	// deregisterWorker — that needs h.mu. Holding the lock across Close deadlocks drain.
+	h.mu.Lock()
+	workers := make([]*agent.Worker, 0, len(h.workers))
+	for _, w := range h.workers {
+		workers = append(workers, w)
+	}
+	h.mu.Unlock()
+
 	if !force {
 		// jitter drain start
 		time.Sleep(time.Duration(rand.Int63n(int64(interval))))
@@ -493,19 +503,13 @@ func (h *AgentHandler) DrainConnections(interval time.Duration, force bool) {
 		t := time.NewTicker(interval)
 		defer t.Stop()
 
-		h.mu.Lock()
-		defer h.mu.Unlock()
-
-		for _, w := range h.workers {
+		for _, w := range workers {
 			w.Close()
 			<-t.C
 		}
 	} else {
 		// drain as quickly as possible when forced
-		h.mu.Lock()
-		defer h.mu.Unlock()
-
-		for _, w := range h.workers {
+		for _, w := range workers {
 			w.Close()
 		}
 	}


### PR DESCRIPTION
## Summary
- `AgentHandler.DrainConnections` held `h.mu` while calling `Worker.Close()` and waiting on the drain ticker.
- Closing the worker closes the signal connection, which unblocks `HandleConnection` so it can call `deregisterWorker` — that also needs `h.mu`, causing a deadlock (especially on non-force drain with long intervals).
- Match `RTCService.DrainConnections`: snapshot workers, unlock, then close.

## Test plan
- [x] `go test ./pkg/agent/ -run TestDrainConnectionsDoesNotDeadlock` (force=false and force=true)
- [x] Rolling restart / drain of a node with connected agent workers completes without hanging