### PR TITLE
Fix VP9 FPS calculator never completing with fewer than 3 spatial layers

### DIFF
--- a/pkg/sfu/buffer/buffer_base.go
+++ b/pkg/sfu/buffer/buffer_base.go
@@ -1271,7 +1271,7 @@ func (b *BufferBase) maybeGrowBucket(now int64) {
 }
 
 func (b *BufferBase) doFpsCalc(ep *ExtPacket) {
-	if b.isPaused || b.frameRateCalculated || len(ep.Packet.Payload) == 0 {
+	if b.isPaused || len(ep.Packet.Payload) == 0 {
 		return
 	}
 
@@ -1280,20 +1280,27 @@ func (b *BufferBase) doFpsCalc(ep *ExtPacket) {
 		spatial = 0
 	}
 	if fr := b.frameRateCalculator[spatial]; fr != nil {
-		if fr.RecvPacket(ep) {
-			complete := true
-			for _, fr2 := range b.frameRateCalculator {
-				if fr2 != nil && !fr2.Completed() {
-					complete = false
-					break
-				}
+		if !fr.RecvPacket(ep) {
+			return
+		}
+
+		complete := true
+		for _, fr2 := range b.frameRateCalculator {
+			if fr2 != nil && !fr2.Completed() {
+				complete = false
+				break
 			}
-			if complete {
+		}
+		if complete {
+			if !b.frameRateCalculated {
 				b.frameRateCalculated = true
 				if f := b.onFpsChanged; f != nil {
 					go f()
 				}
 			}
+		} else {
+			// e.g. VP9 observed a new spatial layer after an earlier completion
+			b.frameRateCalculated = false
 		}
 	}
 }

--- a/pkg/sfu/buffer/buffer_base.go
+++ b/pkg/sfu/buffer/buffer_base.go
@@ -1279,29 +1279,33 @@ func (b *BufferBase) doFpsCalc(ep *ExtPacket) {
 	if spatial < 0 || int(spatial) >= len(b.frameRateCalculator) {
 		spatial = 0
 	}
-	if fr := b.frameRateCalculator[spatial]; fr != nil {
-		if !fr.RecvPacket(ep) {
-			return
-		}
+	fr := b.frameRateCalculator[spatial]
+	if fr == nil {
+		return
+	}
 
-		complete := true
-		for _, fr2 := range b.frameRateCalculator {
-			if fr2 != nil && !fr2.Completed() {
-				complete = false
-				break
+	// Always re-evaluate completion after feeding the packet. RecvPacket may return
+	// false while still changing state (e.g. VP9 reopens on a late higher SID and
+	// then measures that layer). Gating on the return value would leave
+	// frameRateCalculated stuck true and skip onFpsChanged when measurement finishes.
+	_ = fr.RecvPacket(ep)
+
+	complete := true
+	for _, fr2 := range b.frameRateCalculator {
+		if fr2 != nil && !fr2.Completed() {
+			complete = false
+			break
+		}
+	}
+	if complete {
+		if !b.frameRateCalculated {
+			b.frameRateCalculated = true
+			if f := b.onFpsChanged; f != nil {
+				go f()
 			}
 		}
-		if complete {
-			if !b.frameRateCalculated {
-				b.frameRateCalculated = true
-				if f := b.onFpsChanged; f != nil {
-					go f()
-				}
-			}
-		} else {
-			// e.g. VP9 observed a new spatial layer after an earlier completion
-			b.frameRateCalculated = false
-		}
+	} else {
+		b.frameRateCalculated = false
 	}
 }
 

--- a/pkg/sfu/buffer/fps.go
+++ b/pkg/sfu/buffer/fps.go
@@ -253,10 +253,6 @@ func (f *FrameRateCalculatorVP9) Completed() bool {
 }
 
 func (f *FrameRateCalculatorVP9) RecvPacket(ep *ExtPacket) bool {
-	if f.completed {
-		return true
-	}
-
 	vp9, ok := ep.Payload.(codecs.VP9Packet)
 	if !ok {
 		f.logger.Debugw("no vp9 payload", "sn", ep.Packet.SequenceNumber)
@@ -268,8 +264,15 @@ func (f *FrameRateCalculatorVP9) RecvPacket(ep *ExtPacket) bool {
 		return false
 	}
 
+	// Higher SIDs can appear after lower layers already completed (e.g. VP9 SVC
+	// bandwidth ramp-up). Re-open measurement so those layers are not stuck at 0 fps.
 	if ep.Spatial > f.maxSpatial {
 		f.maxSpatial = ep.Spatial
+		f.completed = false
+	}
+
+	if f.completed {
+		return true
 	}
 
 	success := f.frameRateCalculatorsVPx[ep.Spatial].RecvPacket(ep, vp9.PictureID)

--- a/pkg/sfu/buffer/fps.go
+++ b/pkg/sfu/buffer/fps.go
@@ -228,17 +228,17 @@ func (f *FrameRateCalculatorVP8) RecvPacket(ep *ExtPacket) bool {
 
 // FrameRateCalculator based on PictureID in VP9
 type FrameRateCalculatorVP9 struct {
-	logger    logger.Logger
-	completed bool
+	logger     logger.Logger
+	completed  bool
+	maxSpatial int32 // inclusive; expands as SIDs are observed, or via SetMaxLayer
 
-	// VP9-TODO - this is assuming three spatial layers. As `completed` marker relies on all layers being finished, have to assume this. FIX.
-	//            Maybe look at number of layers in livekit.TrackInfo and declare completed once advertised layers are measured
 	frameRateCalculatorsVPx [DefaultMaxLayerSpatial + 1]*frameRateCalculatorVPx
 }
 
 func NewFrameRateCalculatorVP9(clockRate uint32, logger logger.Logger) *FrameRateCalculatorVP9 {
 	f := &FrameRateCalculatorVP9{
-		logger: logger,
+		logger:     logger,
+		maxSpatial: 0, // assume single-layer until higher SIDs or SetMaxLayer
 	}
 
 	for i := range f.frameRateCalculatorsVPx {
@@ -250,6 +250,20 @@ func NewFrameRateCalculatorVP9(clockRate uint32, logger logger.Logger) *FrameRat
 
 func (f *FrameRateCalculatorVP9) Completed() bool {
 	return f.completed
+}
+
+// SetMaxLayer sets the highest spatial layer that must complete for FPS calculation.
+// Mirrors FrameRateCalculatorDD so callers can declare advertised layer count.
+func (f *FrameRateCalculatorVP9) SetMaxLayer(spatial int32) {
+	if spatial < 0 {
+		spatial = 0
+	}
+	if spatial > DefaultMaxLayerSpatial {
+		spatial = DefaultMaxLayerSpatial
+	}
+	if spatial > f.maxSpatial {
+		f.maxSpatial = spatial
+	}
 }
 
 func (f *FrameRateCalculatorVP9) RecvPacket(ep *ExtPacket) bool {
@@ -268,11 +282,15 @@ func (f *FrameRateCalculatorVP9) RecvPacket(ep *ExtPacket) bool {
 		return false
 	}
 
+	if ep.Spatial > f.maxSpatial {
+		f.maxSpatial = ep.Spatial
+	}
+
 	success := f.frameRateCalculatorsVPx[ep.Spatial].RecvPacket(ep, vp9.PictureID)
 
 	completed := true
-	for _, frc := range f.frameRateCalculatorsVPx {
-		if !frc.Completed() {
+	for i := int32(0); i <= f.maxSpatial; i++ {
+		if !f.frameRateCalculatorsVPx[i].Completed() {
 			completed = false
 			break
 		}
@@ -282,10 +300,10 @@ func (f *FrameRateCalculatorVP9) RecvPacket(ep *ExtPacket) bool {
 		f.completed = true
 
 		var frameRates [DefaultMaxLayerSpatial + 1][]float32
-		for i := range f.frameRateCalculatorsVPx {
+		for i := int32(0); i <= f.maxSpatial; i++ {
 			frameRates[i] = f.frameRateCalculatorsVPx[i].GetFrameRate()
 		}
-		f.logger.Debugw("frame rate calculated", "rate", frameRates)
+		f.logger.Debugw("frame rate calculated", "rate", frameRates, "maxSpatial", f.maxSpatial)
 	}
 
 	return success

--- a/pkg/sfu/buffer/fps.go
+++ b/pkg/sfu/buffer/fps.go
@@ -230,7 +230,7 @@ func (f *FrameRateCalculatorVP8) RecvPacket(ep *ExtPacket) bool {
 type FrameRateCalculatorVP9 struct {
 	logger     logger.Logger
 	completed  bool
-	maxSpatial int32 // inclusive; expands as SIDs are observed, or via SetMaxLayer
+	maxSpatial int32 // inclusive; expands as SIDs are observed
 
 	frameRateCalculatorsVPx [DefaultMaxLayerSpatial + 1]*frameRateCalculatorVPx
 }
@@ -238,7 +238,7 @@ type FrameRateCalculatorVP9 struct {
 func NewFrameRateCalculatorVP9(clockRate uint32, logger logger.Logger) *FrameRateCalculatorVP9 {
 	f := &FrameRateCalculatorVP9{
 		logger:     logger,
-		maxSpatial: 0, // assume single-layer until higher SIDs or SetMaxLayer
+		maxSpatial: 0, // assume single-layer until higher SIDs are observed
 	}
 
 	for i := range f.frameRateCalculatorsVPx {
@@ -250,20 +250,6 @@ func NewFrameRateCalculatorVP9(clockRate uint32, logger logger.Logger) *FrameRat
 
 func (f *FrameRateCalculatorVP9) Completed() bool {
 	return f.completed
-}
-
-// SetMaxLayer sets the highest spatial layer that must complete for FPS calculation.
-// Mirrors FrameRateCalculatorDD so callers can declare advertised layer count.
-func (f *FrameRateCalculatorVP9) SetMaxLayer(spatial int32) {
-	if spatial < 0 {
-		spatial = 0
-	}
-	if spatial > DefaultMaxLayerSpatial {
-		spatial = DefaultMaxLayerSpatial
-	}
-	if spatial > f.maxSpatial {
-		f.maxSpatial = spatial
-	}
 }
 
 func (f *FrameRateCalculatorVP9) RecvPacket(ep *ExtPacket) bool {

--- a/pkg/sfu/buffer/fps_test.go
+++ b/pkg/sfu/buffer/fps_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/pion/rtp"
+	"github.com/pion/rtp/codecs"
 	"github.com/stretchr/testify/require"
 
 	dd "github.com/livekit/livekit-server/pkg/sfu/rtpextension/dependencydescriptor"
@@ -62,6 +63,16 @@ func (f *testFrameInfo) toH26x() *ExtPacket {
 	return &ExtPacket{
 		Packet:     &rtp.Packet{Header: f.header},
 		VideoLayer: VideoLayer{Spatial: InvalidLayerSpatial, Temporal: int32(f.temporal)},
+	}
+}
+
+func (f *testFrameInfo) toVP9() *ExtPacket {
+	return &ExtPacket{
+		Packet: &rtp.Packet{Header: f.header},
+		Payload: codecs.VP9Packet{
+			PictureID: f.framenumber,
+		},
+		VideoLayer: VideoLayer{Spatial: int32(f.spatial), Temporal: int32(f.temporal)},
 	}
 }
 
@@ -434,5 +445,60 @@ func TestFpsH26x(t *testing.T) {
 			fpsGot := calc.GetFrameRate()
 			verifyFps(t, fpsExpected, fpsGot[:len(fpsExpected)])
 		}
+	})
+}
+
+func TestFpsVP9CompletesWithFewerThanThreeSpatialLayers(t *testing.T) {
+	t.Run("single spatial layer", func(t *testing.T) {
+		fps := [][]float32{{7.5, 15, 30}}
+		frames := createFrames(100, 12345678, 10, 500, fps, false)
+		vp9calc := NewFrameRateCalculatorVP9(90000, logger.GetLogger())
+
+		var frameratesGot bool
+		for _, f := range frames[0] {
+			if vp9calc.RecvPacket(f.toVP9()) && vp9calc.Completed() {
+				frameratesGot = true
+				break
+			}
+		}
+		require.True(t, frameratesGot, "VP9 FPS should complete with a single spatial layer")
+		fpsGot := vp9calc.GetFrameRateForSpatial(0)
+		verifyFps(t, fps[0], fpsGot[:len(fps[0])])
+	})
+
+	t.Run("SetMaxLayer waits for declared layers", func(t *testing.T) {
+		fps := [][]float32{{7.5, 15, 30}}
+		frames := createFrames(100, 12345678, 10, 500, fps, false)
+		vp9calc := NewFrameRateCalculatorVP9(90000, logger.GetLogger())
+		vp9calc.SetMaxLayer(1) // require spatial 0 and 1
+
+		for _, f := range frames[0] {
+			vp9calc.RecvPacket(f.toVP9())
+		}
+		require.False(t, vp9calc.Completed(), "should not complete when only spatial 0 is received but maxSpatial is 1")
+	})
+
+	t.Run("observed higher spatial expands requirement", func(t *testing.T) {
+		// Build independent picture-ID sequences per spatial layer (simulcast-style).
+		fps := [][]float32{{15, 30}}
+		frames0 := createFrames(100, 12345678, 10, 500, fps, false)
+		frames1 := createFrames(100, 12345678, 10, 500, fps, false)
+		for _, f := range frames1[0] {
+			f.spatial = 1
+		}
+
+		vp9calc := NewFrameRateCalculatorVP9(90000, logger.GetLogger())
+		var frameratesGot bool
+		n := len(frames0[0])
+		for i := 0; i < n; i++ {
+			vp9calc.RecvPacket(frames0[0][i].toVP9())
+			vp9calc.RecvPacket(frames1[0][i].toVP9())
+			if vp9calc.Completed() {
+				frameratesGot = true
+				break
+			}
+		}
+		require.True(t, frameratesGot, "VP9 FPS should complete after both observed spatial layers finish")
+		require.EqualValues(t, 1, vp9calc.maxSpatial)
 	})
 }

--- a/pkg/sfu/buffer/fps_test.go
+++ b/pkg/sfu/buffer/fps_test.go
@@ -466,18 +466,6 @@ func TestFpsVP9CompletesWithFewerThanThreeSpatialLayers(t *testing.T) {
 		verifyFps(t, fps[0], fpsGot[:len(fps[0])])
 	})
 
-	t.Run("SetMaxLayer waits for declared layers", func(t *testing.T) {
-		fps := [][]float32{{7.5, 15, 30}}
-		frames := createFrames(100, 12345678, 10, 500, fps, false)
-		vp9calc := NewFrameRateCalculatorVP9(90000, logger.GetLogger())
-		vp9calc.SetMaxLayer(1) // require spatial 0 and 1
-
-		for _, f := range frames[0] {
-			vp9calc.RecvPacket(f.toVP9())
-		}
-		require.False(t, vp9calc.Completed(), "should not complete when only spatial 0 is received but maxSpatial is 1")
-	})
-
 	t.Run("observed higher spatial expands requirement", func(t *testing.T) {
 		// Build independent picture-ID sequences per spatial layer (simulcast-style).
 		fps := [][]float32{{15, 30}}

--- a/pkg/sfu/buffer/fps_test.go
+++ b/pkg/sfu/buffer/fps_test.go
@@ -16,6 +16,7 @@ package buffer
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pion/rtp"
 	"github.com/pion/rtp/codecs"
@@ -523,4 +524,59 @@ func TestFpsVP9CompletesWithFewerThanThreeSpatialLayers(t *testing.T) {
 		require.NotNil(t, fpsGot)
 		verifyFps(t, fps[0], fpsGot[:len(fps[0])])
 	})
+}
+
+func TestDoFpsCalcNotifiesOnLateHigherSpatial(t *testing.T) {
+	fps := [][]float32{{15, 30}}
+	frames0 := createFrames(100, 12345678, 10, 500, fps, false)
+	frames1 := createFrames(100, 12345678, 10, 500, fps, false)
+	for _, f := range frames1[0] {
+		f.spatial = 1
+	}
+
+	vp9calc := NewFrameRateCalculatorVP9(90000, logger.GetLogger())
+	b := &BufferBase{logger: logger.GetLogger()}
+	for i := range b.frameRateCalculator {
+		b.frameRateCalculator[i] = vp9calc.GetFrameRateCalculatorForSpatial(int32(i))
+	}
+
+	notifications := make(chan struct{}, 8)
+	b.onFpsChanged = func() {
+		notifications <- struct{}{}
+	}
+
+	withPayload := func(ep *ExtPacket) *ExtPacket {
+		// doFpsCalc ignores packets with empty RTP payload
+		ep.Packet.Payload = []byte{0x01}
+		return ep
+	}
+
+	waitNotify := func(msg string) {
+		t.Helper()
+		select {
+		case <-notifications:
+		case <-time.After(2 * time.Second):
+			t.Fatal(msg)
+		}
+	}
+
+	for _, f := range frames0[0] {
+		b.doFpsCalc(withPayload(f.toVP9()))
+		if b.frameRateCalculated {
+			break
+		}
+	}
+	require.True(t, b.frameRateCalculated)
+	waitNotify("expected onFpsChanged after spatial 0 completion")
+
+	// Feed only the late higher layer. RecvPacket returns false until that layer is
+	// measured; completion must still clear/re-set frameRateCalculated and notify.
+	for _, f := range frames1[0] {
+		b.doFpsCalc(withPayload(f.toVP9()))
+		if b.frameRateCalculated && vp9calc.maxSpatial >= 1 && vp9calc.Completed() {
+			break
+		}
+	}
+	require.True(t, b.frameRateCalculated)
+	waitNotify("onFpsChanged should fire again after late spatial completes")
 }

--- a/pkg/sfu/buffer/fps_test.go
+++ b/pkg/sfu/buffer/fps_test.go
@@ -489,4 +489,38 @@ func TestFpsVP9CompletesWithFewerThanThreeSpatialLayers(t *testing.T) {
 		require.True(t, frameratesGot, "VP9 FPS should complete after both observed spatial layers finish")
 		require.EqualValues(t, 1, vp9calc.maxSpatial)
 	})
+
+	t.Run("late higher spatial reopens after completion", func(t *testing.T) {
+		fps := [][]float32{{15, 30}}
+		frames0 := createFrames(100, 12345678, 10, 500, fps, false)
+		frames1 := createFrames(100, 12345678, 10, 500, fps, false)
+		for _, f := range frames1[0] {
+			f.spatial = 1
+		}
+
+		vp9calc := NewFrameRateCalculatorVP9(90000, logger.GetLogger())
+		for _, f := range frames0[0] {
+			vp9calc.RecvPacket(f.toVP9())
+			if vp9calc.Completed() {
+				break
+			}
+		}
+		require.True(t, vp9calc.Completed(), "should complete on spatial 0 alone")
+
+		var recompleted bool
+		for _, f := range frames1[0] {
+			vp9calc.RecvPacket(f.toVP9())
+			if !vp9calc.Completed() {
+				// re-opened while measuring the late spatial layer
+			} else if vp9calc.maxSpatial >= 1 {
+				recompleted = true
+				break
+			}
+		}
+		require.True(t, recompleted, "should re-complete after late spatial 1 is measured")
+		require.EqualValues(t, 1, vp9calc.maxSpatial)
+		fpsGot := vp9calc.GetFrameRateForSpatial(1)
+		require.NotNil(t, fpsGot)
+		verifyFps(t, fps[0], fpsGot[:len(fps[0])])
+	})
 }


### PR DESCRIPTION
## Summary
- Non-DD VP9 `FrameRateCalculatorVP9` required all three default spatial layer calculators to complete before marking FPS ready.
- Single-layer / two-layer VP9 streams never finished unused slots, so `frameRateCalculated` / `onFpsChanged` never fired.
- Track max spatial from observed SIDs and `SetMaxLayer` (same idea as DD), and only wait on layers `0..maxSpatial`.

## Test plan
- [x] `go test ./pkg/sfu/buffer/ -run TestFpsVP9CompletesWithFewerThanThreeSpatialLayers`
- [x] Publish single-layer VP9 without DD and confirm FPS is reported for allocation/stats