### PR TITLE
Fix getRefLayerRTPTimestamp off-by-one that can panic on max layer index

### DIFF
--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -1792,7 +1792,7 @@ func (f *Forwarder) GetTranslationParams(extPkt *buffer.ExtPacket, layer int32) 
 }
 
 func (f *Forwarder) getRefLayerRTPTimestamp(ts uint32, refLayer, targetLayer int32) (uint32, error) {
-	if refLayer < 0 || int(refLayer) > len(f.refInfos) || targetLayer < 0 || int(targetLayer) > len(f.refInfos) {
+	if refLayer < 0 || int(refLayer) >= len(f.refInfos) || targetLayer < 0 || int(targetLayer) >= len(f.refInfos) {
 		return 0, fmt.Errorf("invalid layer(s), refLayer: %d, targetLayer: %d", refLayer, targetLayer)
 	}
 

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -2193,7 +2193,6 @@ func TestGetRefLayerRTPTimestampBounds(t *testing.T) {
 
 	layerCount := int32(len(f.refInfos))
 
-	// layer == len(refInfos) used to pass the old `>` check and then panic on index
 	_, err := f.getRefLayerRTPTimestamp(1000, layerCount, 0)
 	require.Error(t, err)
 

--- a/pkg/sfu/forwarder_test.go
+++ b/pkg/sfu/forwarder_test.go
@@ -2187,3 +2187,32 @@ func TestForwarderInitialAcquisitionGrace(t *testing.T) {
 	require.Equal(t, int32(1), alloc.TargetLayer.Spatial)
 	require.Equal(t, int32(1), alloc.RequestLayerSpatial)
 }
+
+func TestGetRefLayerRTPTimestampBounds(t *testing.T) {
+	f := newForwarder(testutils.TestVP8Codec, webrtc.RTPCodecTypeVideo)
+
+	layerCount := int32(len(f.refInfos))
+
+	// layer == len(refInfos) used to pass the old `>` check and then panic on index
+	_, err := f.getRefLayerRTPTimestamp(1000, layerCount, 0)
+	require.Error(t, err)
+
+	_, err = f.getRefLayerRTPTimestamp(1000, 0, layerCount)
+	require.Error(t, err)
+
+	_, err = f.getRefLayerRTPTimestamp(1000, -1, 0)
+	require.Error(t, err)
+
+	_, err = f.getRefLayerRTPTimestamp(1000, 0, -1)
+	require.Error(t, err)
+
+	// same-layer translation does not need sender reports
+	ts, err := f.getRefLayerRTPTimestamp(1000, 0, 0)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1000), ts)
+
+	// last valid index must be accepted by the bounds check (may still error for missing SR)
+	_, err = f.getRefLayerRTPTimestamp(1000, layerCount-1, 0)
+	require.Error(t, err) // unavailable sender report, not invalid layer
+	require.Contains(t, err.Error(), "unavailable")
+}


### PR DESCRIPTION
## Summary
- Bounds check used `>` against `len(refInfos)`, so `layer == len(refInfos)` passed validation then panicked on indexing.
- Align with other forwarder checks: reject with `>= len(refInfos)`.

## Test plan
- [x] `go test ./pkg/sfu/ -run TestGetRefLayerRTPTimestampBounds`