### PR TITLE
Fix agent worker load balancer falling back to an ineligible worker

### DIFF
--- a/pkg/service/agentservice.go
+++ b/pkg/service/agentservice.go
@@ -533,13 +533,26 @@ func (h *AgentHandler) selectWorkerWeightedByLoad(key workerKey, ignore map[*age
 		return nil, errors.New("no workers with sufficient capacity")
 	}
 
-	currentSum := rand.Float32() * availableSum
+	selected := pickWorkerWeightedByLoad(normalizedLoads, availableSum, rand.Float32())
+	if selected == nil {
+		return nil, errors.New("no workers with sufficient capacity")
+	}
+	return selected, nil
+}
+
+// pickWorkerWeightedByLoad selects a worker using weighted random choice over normalizedLoads.
+// r should be in [0, 1). On floating-point residual after walking all loads, returns an eligible
+// worker from normalizedLoads — never an arbitrary entry from the raw worker list.
+func pickWorkerWeightedByLoad(normalizedLoads map[*agent.Worker]float32, availableSum float32, r float32) *agent.Worker {
+	currentSum := r * availableSum
+	var fallback *agent.Worker
 	for w, load := range normalizedLoads {
+		fallback = w
 		if currentSum -= load; currentSum <= 0 {
-			return w, nil
+			return w
 		}
 	}
-	return workers[0], nil
+	return fallback
 }
 
 var _ agent.WorkerSignalHandler = (*agentHandlerWorker)(nil)

--- a/pkg/service/agentservice_worker_select_test.go
+++ b/pkg/service/agentservice_worker_select_test.go
@@ -1,0 +1,50 @@
+// Copyright 2024 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/livekit-server/pkg/agent"
+)
+
+func TestPickWorkerWeightedByLoadNeverReturnsIneligible(t *testing.T) {
+	unavailable := &agent.Worker{}
+	eligibleA := &agent.Worker{}
+	eligibleB := &agent.Worker{}
+
+	// Use loads that are not dyadic fractions so float32 residuals are likely when r == 1.
+	normalizedLoads := map[*agent.Worker]float32{
+		eligibleA: 0.1,
+		eligibleB: 0.2,
+	}
+	availableSum := float32(0.3)
+
+	for _, r := range []float32{0, 0.5, 0.999999, 1.0} {
+		for i := 0; i < 200; i++ {
+			picked := pickWorkerWeightedByLoad(normalizedLoads, availableSum, r)
+			require.NotNil(t, picked)
+			require.NotEqual(t, unavailable, picked, "fallback must not return an ineligible worker")
+			require.Contains(t, []*agent.Worker{eligibleA, eligibleB}, picked)
+		}
+	}
+}
+
+func TestPickWorkerWeightedByLoadEmpty(t *testing.T) {
+	require.Nil(t, pickWorkerWeightedByLoad(nil, 1, 0.5))
+	require.Nil(t, pickWorkerWeightedByLoad(map[*agent.Worker]float32{}, 1, 0.5))
+}


### PR DESCRIPTION
## Summary
- After weighted selection, float residual could fall through to `return workers[0]`.
- `workers[0]` may be ignored/full/`WS_FULL`, so job assignment could pick an ineligible worker.
- Fall back to an eligible worker from `normalizedLoads` instead.

## Test plan
- [x] Unit coverage for `pickWorkerWeightedByLoad` residual / ineligible fallback (`TestPickWorkerWeightedByLoad*`)
- [ ] Assign jobs with mixed available/ignored workers and confirm only eligible workers are selected