### PR TITLE
Fix VP9 simulcast freezing on first layer switch

### DIFF
--- a/pkg/sfu/buffer/dependencydescriptorparser.go
+++ b/pkg/sfu/buffer/dependencydescriptorparser.go
@@ -63,6 +63,12 @@ type DependencyDescriptorParser struct {
 	seqWrapAround             *utils.WrapAround[uint16, uint64]
 	frameWrapAround           *utils.WrapAround[uint16, uint64]
 	structureExtFrameNum      uint64
+	// drop threshold for frames belonging to a previous dependency structure.
+	// advanced only when the structure id actually changes: structureExtFrameNum
+	// advances on every structure-bearing key frame, so with frequent key frames
+	// repeating the same structure (e. g. screen content), valid late/retransmitted
+	// frames would be dropped as "earlier than current structure".
+	structureChangeExtFrameNum uint64
 	activeDecodeTargetsExtSeq uint64
 	activeDecodeTargetsMask   uint32
 	frameChecker              *FrameIntegrityChecker
@@ -153,12 +159,12 @@ func (r *DependencyDescriptorParser) Parse(pkt *rtp.Packet) (*ExtDependencyDescr
 	unwrapped := r.frameWrapAround.UpdateWithOrderKnown(ddVal.FrameNumber, restart)
 	extFN := unwrapped.ExtendedVal
 
-	if extFN < r.structureExtFrameNum {
+	if extFN < r.structureChangeExtFrameNum {
 		r.logger.Debugw(
 			"drop frame which is earlier than current structure",
 			"fn", ddVal.FrameNumber,
 			"extFN", extFN,
-			"structureExtFrameNum", r.structureExtFrameNum,
+			"structureChangeExtFrameNum", r.structureChangeExtFrameNum,
 			"unwrappedFN", unwrapped,
 			"frameWrapAround", r.frameWrapAround,
 		)
@@ -189,6 +195,9 @@ func (r *DependencyDescriptorParser) Parse(pkt *rtp.Packet) (*ExtDependencyDescr
 		}
 
 		if r.structure == nil || ddVal.AttachedStructure.StructureId != r.structure.StructureId {
+			// structure actually changed (or first structure): advance the drop threshold
+			// so that only frames preceding this structure are dropped.
+			r.structureChangeExtFrameNum = extFN
 			r.logger.Debugw(
 				"structure updated",
 				"structureID", ddVal.AttachedStructure.StructureId,
@@ -252,6 +261,7 @@ func (r *DependencyDescriptorParser) restart() {
 	r.frameChecker = NewFrameIntegrityChecker(integrityCheckFrame, integrityCheckPkt)
 	r.structure = nil
 	r.structureExtFrameNum = 0
+	r.structureChangeExtFrameNum = 0
 	r.activeDecodeTargetsExtSeq = 0
 	r.activeDecodeTargetsMask = 0
 	r.decodeTargets = r.decodeTargets[:0]

--- a/pkg/sfu/forwarder.go
+++ b/pkg/sfu/forwarder.go
@@ -405,6 +405,13 @@ func (f *Forwarder) DetermineCodec(codec webrtc.RTPCodecCapability, extensions [
 	case mime.MimeTypeVP9:
 		f.codecMunger = codecmunger.NewNull(f.logger)
 		if sfuutils.IsSimulcastMode(videoLayerMode) {
+			// VP9 simulcast sends one RTP stream per spatial layer and the per-layer
+			// RTCP sender reports do not provide a usable cross-layer timestamp offset,
+			// so the reference-timestamp based switch point calculation never establishes
+			// (tsOffset stays 0) and every layer switch fails with "switch point too far
+			// behind". treat it like ONE_SPATIAL_LAYER_PER_STREAM_INCOMPLETE_RTCP_SR and
+			// fall back to the expected-timestamp based switch point.
+			f.skipReferenceTS = true
 			if f.vls != nil {
 				f.vls = videolayerselector.NewSimulcastFromOther(f.vls)
 			} else {

--- a/pkg/sfu/receiver_base.go
+++ b/pkg/sfu/receiver_base.go
@@ -942,8 +942,14 @@ func (r *ReceiverBase) forwardRTP(
 		}
 
 		spatialLayer := layer
-		if extPkt.Spatial >= 0 {
-			// svc packet, take spatial layer info from packet
+		if extPkt.Spatial >= 0 && layer == 0 {
+			// svc packet, take spatial layer info from packet.
+			// only apply the override for the base uptrack (layer == 0): with SVC there is a
+			// single uptrack and the spatial layer comes from the packet. with simulcast
+			// (e. g. VP9/AV1 ONE_SPATIAL_LAYER_PER_STREAM) each rid is single-spatial, so the
+			// in-packet spatial id is always 0 and would collapse every rid to spatial layer 0,
+			// making the forwarder unable to tell the rids apart. for simulcast, the uptrack
+			// index (layer) is authoritative.
 			spatialLayer = extPkt.Spatial
 		}
 		if int(spatialLayer) >= len(spatialTrackers) {


### PR DESCRIPTION
## Summary

Fixes #4594 — a VP9 simulcast (`ONE_SPATIAL_LAYER_PER_STREAM`) subscriber works on its initial layer, then **freezes the instant the allocator first switches layers** (e.g. a BWE-driven upgrade): the forwarder enters a constant `processSourceSwitch` loop (~60/s), output timestamps freeze (`extNextTS = extLastTS + 1`), and a NACK/PLI storm follows. H.264/VP8 simulcast is unaffected.

The issue reporter root-caused this on a v1.11.0 fork running in production ([write-up](https://github.com/SpeakNow06/livekit-server)). One of their four fixes (Simulcast selector for VP9 simulcast) has already landed upstream; this PR ports the remaining three to current master:

1. **`pkg/sfu/receiver_base.go` — all rids collapsed to spatial layer 0.** `if extPkt.Spatial >= 0` overrode the rid/uptrack index with the in-packet spatial id. Each VP9 simulcast rid is single-spatial, so the DD `SpatialId` is 0 for every rid → all map to spatial layer 0 and the forwarder alternates SSRCs on every packet. (H.264/VP8 are unaffected because `extPkt.Spatial == -1`.) Fix: apply the override only for the base uptrack (`layer == 0`, the SVC case); for simulcast the uptrack index is authoritative.

2. **`pkg/sfu/forwarder.go` — the cross-layer SR timestamp offset never establishes.** Per-layer RTCP sender reports for VP9 simulcast do not provide a usable cross-layer offset, so `tsOffset` stays 0 and every switch errors `switch point too far behind`. Fix: treat VP9 simulcast like `ONE_SPATIAL_LAYER_PER_STREAM_INCOMPLETE_RTCP_SR` (`skipReferenceTS = true`), falling back to the expected-timestamp based switch point.

3. **`pkg/sfu/buffer/dependencydescriptorparser.go` — frame drops with frequent key frames.** The drop threshold advanced on every structure-bearing key frame even when `StructureId` was unchanged, so reordered/retransmitted frames were dropped as "earlier than current structure" (severe with screen content). Fix: advance the drop threshold (`structureChangeExtFrameNum`) only on an actual `StructureId` change; `structureExtFrameNum`/`ExtKeyFrameNum` behavior is unchanged.

Note: the client SDK also needs to signal `SimulcastCodec.videoLayerMode = ONE_SPATIAL_LAYER_PER_STREAM` plus per-encoding `scalabilityMode` for VP9 — this is the server-side path only.

## Test plan

- `go build ./...` passes
- `go test ./pkg/sfu/ ./pkg/sfu/buffer/` passes
- The equivalent changes have been running in production on the reporter's v1.11.0 fork (stable layer switches, no NACK/PLI storm)

Credit for the root-cause analysis and original fixes: @SpeakNow06