### PR TITLE
ci: add Buildkite CI/CD (build/vet/test + graceful-drain deploy on master)

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -1,0 +1,132 @@
+# Buildkite CI/CD
+
+CI/CD runs on Buildkite (org `gusto`), pipeline slug **`tax-credits-livekit-server`**.
+`pipeline.yml` defines the steps; the CI step runs hermetically via the `docker`
+plugin on the shared `default_stable` queue, matching
+`ardiustech/watercooler`'s own pipeline conventions.
+
+Before this pipeline existed, this repo had **no CI/CD at all**: the inherited
+upstream `.github/workflows/buildtest.yaml` isn't wired in as a required
+status check (see "Also fix: make buildtest.yaml a required check" below),
+and deploy was a fully manual SSM runbook (see
+`ardiustech/watercooler`'s `infrastructure/livekit/README.md`, pre-this-pipeline
+version of "Rolling the LiveKit version").
+
+## What runs
+
+| Step | Image | Does |
+|---|---|---|
+| build · vet · test | `golang:1.26` | `gofmt -l` (fails on any diff), `go build ./...`, `go vet ./...`, `go test ./...` |
+| deploy (graceful drain) | agent Docker | **master only**, after the above pass: build+push amd64 image, trigger on-box graceful-drain deploy via SSM |
+
+The verify step needs no credentials. The deploy step (`.buildkite/steps/deploy.sh`)
+needs the CI AWS keys as **`LK_AWS_*`** secrets (below); without them it
+**soft-skips** (green, no deploy) — same pattern as watercooler's own `WC_AWS_*`.
+Named `LK_AWS_*` (not `WC_AWS_*` or bare `AWS_*`) because this is a **different
+IAM user**, scoped to only the `livekit-server` ECR repo and the LiveKit
+instance — it has no access to anything watercooler's own CD user can touch,
+and vice versa.
+
+## CD / auto-deploy
+
+On merge to `master`, the deploy step builds the amd64 image (tagged by commit
+SHA + `latest` — amd64 only, since the LiveKit box is a c6i x86_64 instance,
+not arm64 like the watercooler app box), pushes to ECR, and runs
+`/opt/livekit/deploy.sh <sha>` on the instance via SSM.
+
+**This is NOT a blue/green swap like watercooler's own app deploy.** LiveKit
+runs `network_mode: host` bound to fixed ports (7880 signaling, 7881/7882
+media) — two copies can't bind those simultaneously on one box, so there's no
+second color to flip to. Instead, the on-box script leans on **LiveKit's own
+built-in graceful shutdown**: `cmd/server/main.go`'s SIGTERM handler calls
+`router.Drain()` (stop accepting new joins) then waits for every active
+participant to leave before actually exiting — this is not something this
+pipeline invented, it's already how the upstream binary behaves. A deploy
+therefore:
+- does **not** forcibly drop any call already in progress (the old process
+  waits for it to end naturally, up to a generous bound — see `DRAIN_TIMEOUT`
+  in the on-box `deploy.sh`);
+- **does** pause new joins for the drain window, since there's nowhere else
+  for them to go on a single-node SFU.
+
+True zero-downtime (new joins routed to an already-warm second node while the
+old one drains) needs a second EC2 node + Redis-backed multi-node LiveKit + a
+router in front — a separate, materially bigger infra project, not something
+this pipeline does. See `ardiustech/watercooler`'s
+`infrastructure/livekit/README.md` for the full tradeoff writeup.
+
+### Activate (one-time)
+
+1. `cd infrastructure/livekit && terraform apply` (in `ardiustech/watercooler`)
+   — creates the `watercooler-livekit-ci-<env>` IAM user (ECR push to the
+   `livekit-server` repo + SSM `SendCommand` to the livekit instance only; no
+   EC2/Terraform access) and the `livekit-server` ECR repository itself.
+2. Read its key:
+   ```bash
+   terraform -chdir=infrastructure/livekit output -raw livekit_ci_access_key_id
+   terraform -chdir=infrastructure/livekit output -raw livekit_ci_secret_access_key
+   ```
+3. Add them as pipeline env vars in AWS Secrets Manager (same mechanism
+   watercooler's own pipeline uses — see its `.buildkite/README.md` for the
+   exact account/region/secret-name convention): secret
+   `buildkite/tax-credits-livekit-server/environment`, plaintext `KEY=value`
+   lines: `LK_AWS_ACCESS_KEY_ID`, `LK_AWS_SECRET_ACCESS_KEY` (optional:
+   `LK_AWS_REGION` default `us-west-2`, `ECR_REPO`, `INSTANCE_NAME_TAG`,
+   `DEPLOY_ACCOUNT_ID`).
+
+Until step 3 is done the deploy step soft-skips, so merges stay green.
+
+**Separately, and just as important:** even once this deploys, the fork is
+still a no-op in production until:
+- `infrastructure/livekit/terraform.tfvars`'s `livekit_image` is switched from
+  the stock `livekit/livekit-server:vX.Y.Z` image to this repo's ECR
+  repository — a deliberate go-live decision, not a side effect of this
+  pipeline existing (matches the project's existing philosophy — see that
+  repo's `ARDIUSTECH_FORK.md`);
+- `rtc.reconnect_on_publication_error: true` is set — this pipeline's
+  companion change bakes it into the LiveKit config template by default, but
+  it only takes effect once the box actually boots that config (a fresh
+  instance, or an intentional `user_data` roll).
+
+### Rollback
+
+Images are tagged by commit SHA. To roll back, run the previous SHA on the box:
+```bash
+aws ssm send-command --document-name AWS-RunShellScript \
+  --targets "Key=tag:Name,Values=watercooler-livekit-prod" \
+  --parameters 'commands=["/opt/livekit/deploy.sh <previous-sha>"]' \
+  --profile ardius-admin-ardius-dev --region us-west-2
+```
+
+### Also fix: make `buildtest.yaml` a required check
+
+Separate from this Buildkite pipeline: the inherited upstream
+`.github/workflows/buildtest.yaml` (Go tests + a Redis service container) runs
+on every push/PR to `master` today but isn't a **required** status check, so
+a PR can merge without it having passed (flagged in PR #1's third
+adversarial-review round). Once this pipeline's own PR merges, add both
+`test` (from `buildtest.yaml`) and this pipeline's checks as required status
+checks on `master` via branch protection — needs a GitHub admin on the
+`ardiustech` org (not something a repo-scoped token can set).
+
+## One-time setup (requires Buildkite admin / `write_pipelines`)
+
+1. **Buildkite → Add pipeline.**
+   - Name / slug: `tax-credits-livekit-server`
+   - Repository: `git@github.com:ardiustech/livekit-server.git`
+   - Cluster/queue: the one that provides `default_stable` agents (matches
+     mithrin / watercooler).
+2. **Initial step** (the only step configured in the UI):
+   ```
+   buildkite-agent pipeline upload
+   ```
+   Everything else is read from `.buildkite/pipeline.yml` in the repo.
+3. **Builds on PRs:** enable "Build pull requests" so PRs get checked.
+
+## Inspecting builds (bk CLI)
+
+```bash
+bk build list -p tax-credits-livekit-server
+bk build view  -p tax-credits-livekit-server <number>
+bk job log <job-id> -p tax-credits-livekit-server -b <number>
+```

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,58 @@
+# Buildkite CI/CD for the ardiustech/livekit-server fork (pipeline slug:
+# tax-credits-livekit-server). Mirrors ardiustech/watercooler's own
+# .buildkite/pipeline.yml structure (CI -> wait -> gated CD via SSM) — see that
+# repo's .buildkite/README.md for the shared conventions (secret storage,
+# soft-skip-until-activated pattern, etc.).
+#
+# This repo had NO CI/CD at all before this: the inherited upstream
+# .github/workflows/buildtest.yaml exists but isn't wired in as a required
+# check (flagged in PR #1's third adversarial-review round), and deploy was a
+# fully manual SSM runbook (see ardiustech/watercooler's
+# infrastructure/livekit/README.md, "Rolling the LiveKit version" section,
+# pre-this-pipeline).
+#
+# To wire this up, the Buildkite pipeline's initial step should be
+# `buildkite-agent pipeline upload`, which reads this file. See .buildkite/README.md.
+
+agents:
+  queue: default_stable
+
+steps:
+  - label: ":golang: build · vet · test"
+    if: build.source != "schedule"
+    command:
+      - "gofmt -l $(find . -name '*.go' -not -path './vendor/*') | tee /tmp/fmt.out"
+      - "test ! -s /tmp/fmt.out"
+      - go build ./...
+      - go vet ./...
+      - go test ./...
+    plugins:
+      - docker#v5.13.0:
+          image: "golang:1.26"
+          environment:
+            - "CI=true"
+            - "GOFLAGS=-mod=mod"
+
+  # Gate the deploy on the checks above passing.
+  - wait
+
+  # CD: only on master (this repo's default branch — NOT "main", unlike
+  # watercooler). Builds + pushes an amd64 image (the LiveKit box is a c6i
+  # x86_64 instance, unlike the app's arm64 t4g — see
+  # ardiustech/watercooler's infrastructure/livekit/README.md "Notes / decisions")
+  # and triggers the on-box graceful deploy via SSM. Runs on the agent's Docker
+  # (needs buildx), not the docker plugin. Requires
+  # LK_AWS_ACCESS_KEY_ID / LK_AWS_SECRET_ACCESS_KEY secrets (the
+  # watercooler-livekit-ci IAM user) — named LK_* to avoid clashing with the
+  # agent's existing AWS_* creds or watercooler's own WC_* creds (this is a
+  # DIFFERENT IAM user, scoped to the livekit-server ECR repo + the livekit
+  # instance only). See .buildkite/README.md.
+  - label: ":rocket: deploy (graceful drain)"
+    if: build.branch == "master" && build.source != "schedule"
+    command: .buildkite/steps/deploy.sh
+    # Idempotent (always deploys the given tag fresh), so a single retry covers
+    # transient build/push/network flakiness safely.
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 1

--- a/.buildkite/steps/deploy.sh
+++ b/.buildkite/steps/deploy.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# CD: build + push the amd64 image (tagged by commit SHA + latest), then trigger
+# the on-box graceful-drain deploy via SSM and wait for it. Runs on the agent's
+# Docker (needs buildx). Mirrors ardiustech/watercooler's own
+# .buildkite/steps/deploy.sh structure closely — see that file's comments for
+# the AWS-profile-isolation rationale, which is identical here.
+#
+# Credentials come from LK_AWS_* Buildkite secrets (the watercooler-livekit-ci
+# IAM user — see ardiustech/watercooler's infrastructure/livekit/ci_user.tf).
+# NOT the same user/creds as watercooler's own WC_AWS_* (different repo,
+# different scope: this user can only push to the livekit-server ECR repo and
+# SendCommand to the livekit instance, nothing else).
+set -euo pipefail
+
+# Soft-skip until CD is activated (LK_AWS_* secrets set), so a merge before
+# activation is green rather than red. See .buildkite/README.md.
+if [ -z "${LK_AWS_ACCESS_KEY_ID:-}" ] || [ -z "${LK_AWS_SECRET_ACCESS_KEY:-}" ]; then
+  echo "CD not activated: LK_AWS_ACCESS_KEY_ID / LK_AWS_SECRET_ACCESS_KEY not set."
+  echo "Skipping deploy. See .buildkite/README.md to activate."
+  exit 0
+fi
+
+ACCOUNT="${DEPLOY_ACCOUNT_ID:-396735084811}"
+REGION="${LK_AWS_REGION:-${LK_AWS_DEFAULT_REGION:-us-west-2}}"
+REPO="${ECR_REPO:-livekit-server}"
+INSTANCE_TAG="${INSTANCE_NAME_TAG:-watercooler-livekit-prod}"
+REGISTRY="$ACCOUNT.dkr.ecr.$REGION.amazonaws.com"
+IMAGE="$REGISTRY/$REPO"
+TAG="${BUILDKITE_COMMIT:-latest}"
+# How long to let LiveKit finish draining active calls on the box before the
+# SSM command itself gives up waiting (the on-box deploy.sh has its own,
+# separate DRAIN_TIMEOUT bound on the docker-level stop — this is just how
+# long THIS step polls for that to finish). Generous by design; see
+# infrastructure/livekit/README.md in ardiustech/watercooler for the full
+# graceful-drain rationale (LiveKit's own SIGTERM handling, not a new
+# mechanism this pipeline invents).
+POLL_ATTEMPTS="${DEPLOY_POLL_ATTEMPTS:-200}" # 200 * 5s = ~16.5 min ceiling
+
+# Isolated AWS profile dir (never the agent's ~/.aws), cleaned up on exit.
+AWS_DIR="$(mktemp -d)"
+trap 'rm -rf "$AWS_DIR"' EXIT
+cat >"$AWS_DIR/credentials" <<CREDS
+[lk]
+aws_access_key_id=$LK_AWS_ACCESS_KEY_ID
+aws_secret_access_key=$LK_AWS_SECRET_ACCESS_KEY
+CREDS
+cat >"$AWS_DIR/config" <<CONF
+[profile lk]
+region=$REGION
+CONF
+
+# Run aws-cli in a container with the "lk" profile mounted, so the agent needn't
+# have the CLI and its own AWS env stays untouched.
+awscli() {
+  docker run --rm \
+    -v "$AWS_DIR":/root/.aws:ro \
+    -e AWS_PROFILE=lk -e AWS_DEFAULT_REGION="$REGION" \
+    amazon/aws-cli:latest "$@"
+}
+
+echo "--- :docker: buildx builder"
+docker buildx inspect lkbuilder >/dev/null 2>&1 \
+  || docker buildx create --name lkbuilder --driver docker-container
+docker buildx use lkbuilder
+
+echo "--- :ecr: login (lk profile)"
+awscli ecr get-login-password | docker login --username AWS --password-stdin "$REGISTRY"
+
+echo "--- :hammer: build + push ($TAG)"
+# amd64 only — the LiveKit box is a c6i (Intel) instance, not arm64 like the
+# app's t4g box (see ardiustech/watercooler's infrastructure/livekit/README.md
+# "Notes / decisions": LiveKit is CPU-bound on media forwarding, x86_64 is the
+# well-trodden path). No emulation/binfmt needed since the agent is already
+# amd64.
+docker buildx build --platform linux/amd64 \
+  -t "$IMAGE:$TAG" -t "$IMAGE:latest" --push .
+
+echo "--- :rocket: trigger graceful-drain deploy via SSM"
+CMD_ID="$(awscli ssm send-command \
+  --document-name AWS-RunShellScript \
+  --targets "Key=tag:Name,Values=$INSTANCE_TAG" \
+  --comment "livekit-server CD $TAG" \
+  --parameters "commands=[\"/opt/livekit/deploy.sh $TAG\"]" \
+  --query 'Command.CommandId' --output text)"
+echo "command id: $CMD_ID"
+
+for _ in $(seq 1 "$POLL_ATTEMPTS"); do
+  sleep 5
+  STATUS="$(awscli ssm list-command-invocations --command-id "$CMD_ID" \
+    --query 'CommandInvocations[0].Status' --output text 2>/dev/null || echo Pending)"
+  echo "  deploy status: $STATUS"
+  case "$STATUS" in
+    Success) echo "+++ :white_check_mark: deploy succeeded"; exit 0 ;;
+    Failed | Cancelled | TimedOut)
+      echo "+++ :x: deploy $STATUS — on-box output:" >&2
+      awscli ssm list-command-invocations --command-id "$CMD_ID" --details \
+        --query 'CommandInvocations[0].CommandPlugins[0].Output' --output text >&2 || true
+      exit 1
+      ;;
+  esac
+done
+echo "timed out waiting for the on-box deploy (it may still complete — the box's own DRAIN_TIMEOUT can legitimately run longer than this poll; check SSM directly: aws ssm list-command-invocations --command-id $CMD_ID)" >&2
+exit 1

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @livekit/cs-devs
+* @ardiustech/watercooler-maintainers

--- a/ARDIUSTECH_FORK.md
+++ b/ARDIUSTECH_FORK.md
@@ -1,0 +1,303 @@
+# Ardius Tech fork of `livekit/livekit`
+
+Forked so we can patch SFU-side issues we hit in production without waiting on
+upstream review/release cadence. Kept as a **separate file, not an edit to
+README.md**, deliberately — editing the upstream README would conflict on
+every future `git merge upstream/master`; this file never will.
+
+- `origin` = this fork (`ardiustech/livekit-server`)
+- `upstream` = `https://github.com/livekit/livekit.git`
+- Base: `upstream/master` @ `v1.13.5` (the latest tag as of 2026-07-31).
+  **Currently deployed production** (watercooler's LiveKit box) is one patch
+  behind, at `v1.13.4` — see the patch list below for what changes when this
+  fork is actually adopted.
+
+## Patches on top of upstream
+
+### 1. Proactive republish nudge for stuck publisher tracks (`feat/publish-mid-stuck-nudge`)
+
+**Problem:** `pkg/rtc/participant.go`'s `mediaTrackReceived` can receive RTP
+for a just-published track before the SDP negotiation assigning it a `mid`
+has resolved (logged as `WARN "could not get mid for track"`). Upstream
+queues the track (`pendingRemoteTracks`) and waits for the SAME participant
+to renegotiate again for some UNRELATED reason
+(`handlePendingRemoteTracks`'s three call sites are all client-initiated: a
+fresh offer, an AddTrack request, or an unpublish) — there's no code path
+where the server proactively asks the stuck publisher to renegotiate. An app
+whose usage pattern doesn't naturally trigger another renegotiation (publish
+once, then nothing) can have this track sit broken indefinitely — invisible
+to every OTHER peer in the room, with the publisher's own client reporting
+itself as perfectly healthy.
+
+Full incident writeup + evidence from watercooler's production LiveKit box:
+`docs/sfu-multiparty-triage-2026-07-31.md` in the `ardiustech/watercooler`
+repo (a 2-minute-long stuck-track incident during a live meeting, 215 failed
+mid-resolution attempts on one participant, only cleared when that
+participant's client happened to reconnect on its own).
+
+**Fix:** `pkg/rtc/participant.go` — when a track lands in
+`pendingRemoteTracks` because `mid == ""`, schedule a check 750ms later
+(`scheduleStuckPublishNudge`). If the SAME track is still stuck, proactively
+push a small marker payload down that SAME participant's own data channel
+(`sendRepublishNudge`, via the existing, unmodified `DataPacket_User` wire
+type — `p.TransportManager.SendDataMessage`). No new protobuf message type,
+no `livekit-protocol` changes, no `client-sdk-js` changes: `RoomEvent.DataReceived`
+already exists in the stock JS SDK and already surfaces this payload
+unmodified to app code. **This fork touches exactly one repo.**
+
+The app-side handler (`ardiustech/watercooler`, `feat/sfu-republish-signal-handler`,
+PR #162) listens for `RoomEvent.DataReceived` with topic
+`_ardiustech_republish_nudge` and republishes ONLY the one named stuck track
+(`republishOneTrack`, unpublish+publish of that single track) — NOT
+`republishAllTracks()`. That app's OWN client-side blind timer (which DID
+call `republishAllTracks()` on a fixed schedule) has since been deleted
+entirely: live A/B/C instrumentation (`INVESTIGATION_LOG.md` facts #20-22 on
+this repo's [`experiment/mid-resolution-timing`](https://github.com/ardiustech/livekit-server/tree/experiment/mid-resolution-timing)
+branch — a diagnostic-only branch, not merged to `master` or this PR's
+branch, so that file won't appear in a plain checkout of `feat/publish-mid-stuck-nudge`;
+follow the link) proved that blind timer was the DOMINANT source of the
+exact "could not get mid for track" collateral damage this whole effort
+exists to fix, not a mitigation for it. This reactive, server-signaled
+nudge is now the ONLY republish-nudge mechanism on the client — which is
+why the dedup/cap/escalation fix below matters: there's no other backstop
+left if this one runs away.
+
+**Fixed since first opened (review round, 2026-08-01 — see PR #1 comments):**
+- **No de-dup/cap on the nudge timer (was a must-fix).** Every retry of a
+  still-stuck track (215, in the production incident) called
+  `scheduleStuckPublishNudge` again, arming an independent duplicate
+  `time.AfterFunc` with no coordination — under sustained failure this could
+  compound into a self-sustaining nudge/renegotiate loop with the app-side
+  handler. Added `stuckPublishNudgeState` (per-trackID, guarded by the
+  existing `pendingTracksLock`): a duplicate call while a timer is already
+  in flight is now a no-op, actual send attempts are capped at
+  `stuckPublishNudgeMaxAttempts` (3) per stuck episode, and exhausting that
+  cap escalates to `p.IssueFullReconnect(...)` — self-contained recovery
+  that doesn't depend on the same (possibly impaired) client renegotiating
+  correctly again — instead of nudging indefinitely.
+- **No Close()-time cleanup.** Unlike this file's existing
+  `migrationTimer`/`disconnectTimer` pattern, a participant disconnecting
+  within the 750ms grace period could leave a nudge timer firing after
+  teardown. `clearAllStuckPublishNudges()` is now called from `Close()`;
+  `onStuckPublishNudgeFired` also checks `IsClosed()`/`IsDisconnected()` as
+  a second guard.
+- **Reserved topic wasn't blocked on the inbound relay path.** Any
+  participant could send a `DataPacket_User` naming the
+  `_ardiustech_republish_nudge` topic to another participant, and
+  `handleReceivedDataMessage` would relay it like any other user payload.
+  The app-side client already rejects this (a relayed message always
+  resolves to a real, non-`undefined` `RemoteParticipant`, which its
+  `handleDataReceived` guard ignores), so this was never end-to-end
+  exploitable — but defense shouldn't depend on only one side of a
+  two-repo boundary staying correct forever. Now hard-dropped at the source.
+- **Hand-built JSON payload could be invalid for a control-byte trackID.**
+  `fmt.Sprintf("%q", trackID)` escapes some control bytes as `\xNN`, not
+  valid JSON's `\u00NN` — and `trackID` originates from client-controlled
+  SDP/`MediaStreamTrack` id. Switched to `encoding/json.Marshal` on a typed
+  `republishNudgePayload` struct.
+
+**Round 2 fixes (full-panel re-review after round 1's fixes landed —
+verdict came back "Reconsider," not "ship-with-changes"; all 5 must-fixes
+addressed):**
+- **MUST-FIX, most severe: a guaranteed self-deadlock on the NORMAL
+  (non-stuck) publish path.** `mediaTrackReceived` acquires
+  `pendingTracksLock` at entry and only unlocks it inside the `mid==""`
+  branch — so the mid-RESOLVED success path (added in round 1) that called
+  the LOCKING `clearStuckPublishNudge` was calling `Lock()` on an
+  already-held, non-reentrant `utils.RWMutex`. Every track whose `mid`
+  resolved on the first try (the overwhelmingly common case) would hang the
+  calling goroutine forever, wedging every other operation on that
+  participant needing the same lock. Missed in round 1 because a real
+  `*webrtc.TrackRemote` can't be constructed in this test suite, so
+  `mediaTrackReceived`'s actual runtime path was never unit-exercised. Fixed
+  by splitting into `clearStuckPublishNudge` (locking, for external callers)
+  and `clearStuckPublishNudgeLocked` (for callers already holding the lock);
+  regression test uses a goroutine + timeout to detect a re-introduced
+  deadlock without hanging the test suite itself if it recurs.
+- **MUST-FIX: escalation was unreachable in the exact scenario this patch
+  targets.** `scheduleStuckPublishNudge` is only called from
+  `mediaTrackReceived`'s `mid==""` branch, which only fires again on an
+  UNRELATED renegotiation. In a "publish once, then nothing" app (this
+  fork's own stated target case), one nudge fired at t=750ms and `attempts`
+  froze at 1 forever — no further nudges, no escalation, regardless of
+  whether the client ever acted on it. `onStuckPublishNudgeFired` now
+  re-arms itself (`p.scheduleStuckPublishNudge(trackID)`) after every
+  still-stuck firing, making the check self-sustaining until the track
+  resolves or the cap trips.
+- **MUST-FIX: escalation bypassed an existing operator control on an
+  untuned timeline.** `IssueFullReconnect` fired unconditionally once the
+  cap tripped (~3s), for a strictly larger set of cases than the one
+  incident this targets (a merely-slow client, not just a pathologically
+  stuck one) — and the incident this cites ran 2 MINUTES with ordinary
+  renegotiations already failing to help, so ~3s is unvalidated against the
+  fork's own evidence. Now gated behind `p.params.ReconnectOnPublicationError`,
+  the same flag `onPublicationError` already uses elsewhere in this file;
+  logs clearly either way.
+- **MUST-FIX: a failed nudge SEND still counted toward the escalation
+  cap.** `attempts` incremented unconditionally before `sendRepublishNudge`
+  even ran — a transport-level failure (data channel not yet open, e.g.
+  right after a fresh join) is not evidence the track is actually stuck,
+  but could still burn through the cap and trigger an unwarranted full
+  reconnect. `sendRepublishNudge` now returns whether the transport
+  actually accepted the message; only a confirmed-sent attempt counts.
+  Still re-arms on failure either way, so a transient hiccup gets retried
+  next tick instead of going quiet.
+- **Should-consider, applied: the escalation cap's trackID-stability
+  assumption is real but not independently re-verified in this round.**
+  The cap only engages if the SAME `track.ID()` keeps reappearing across
+  republish cycles — if `republishOneTrack`'s unpublish+publish somehow
+  produced a fresh id each time, the cap would silently never trip. Per
+  earlier investigation (`ardiustech/watercooler`'s `findLocalTrackById` doc
+  comment, cross-checked against this fork's own `getPublishedTrackBySdpCid`
+  lookup and the client SDK's `AddTrackRequest{cid: track.mediaStreamTrack.id}`
+  construction), the id IS the client's own `cid`, which stays stable across
+  a republish because `republishOneTrack` reuses the SAME `LocalTrack`
+  instance rather than constructing a new one — so this should already hold.
+  Flagged here rather than silently assumed: this specific claim has NOT
+  been independently re-verified end-to-end in this round (the same
+  `*webrtc.TrackRemote`-construction limitation applies), so treat it as
+  well-evidenced, not proven, until a live multi-nudge repro confirms it.
+- Also applied two nice-to-haves: `stuckPublishNudges` entries are now
+  explicitly deleted (not just timer-nulled) on the resolved-early path, and
+  the `INVESTIGATION_LOG.md` citation above now names the actual branch it
+  lives on (it's diagnostic-only, never merged to `master` or this PR).
+
+**Round 3 fixes (full-panel re-review after round 2's fixes landed — verdict
+came back "Reconsider" again; 1 of 2 must-fixes addressed, see "Not yet
+done" below for the other):**
+- **MUST-FIX: a persistently-failing send could loop forever without ever
+  escalating.** Round 2's fix made `attempts` count only CONFIRMED-sent
+  nudges (correctly, to stop a transient failure from burning cap budget) —
+  but combined with the same round's unconditional re-arm, a participant
+  whose data channel NEVER opens (a persistent, not transient, failure)
+  would never advance `attempts`, and `onStuckPublishNudgeFired` would keep
+  firing every `stuckPublishNudgeGracePeriod` indefinitely, never reaching
+  `IssueFullReconnect`. Fixed with a second, independent counter — `checks`
+  — that increments on every still-stuck firing regardless of send outcome;
+  escalation now trips on `attempts >= stuckPublishNudgeMaxAttempts OR
+  checks >= stuckPublishNudgeMaxChecks` (8, deliberately looser than
+  `attempts`' 3, since this is the "give up on sending at all" backstop, not
+  the normal case). Explicitly did NOT revert to counting a failed send as
+  an attempt — that's the round-2 bug again. The decision itself is now a
+  pure function (`shouldEscalateStuckPublish`), directly unit-tested, since
+  the surrounding "still stuck" branch can't be driven end-to-end here (see
+  "Files changed" below).
+
+**Files changed:** `pkg/rtc/participant.go` (~280 lines net across both
+rounds — the pure functions `isTrackStillPending`/`buildRepublishNudgePacket`,
+the scheduling/send/dedup/cap/escalate/re-arm glue, the locked/unlocked
+clear split, and the relay-path hard-drop),
+`pkg/rtc/participant_republish_nudge_test.go` (covers the pure functions
+directly, `onStuckPublishNudgeFired`'s resolved-without-sending/re-arming
+cases, dedup/re-arm/clear/clear-all behavior via direct state manipulation
+— no real timer waits — a goroutine+timeout deadlock regression test, and a
+JSON-validity regression test for the control-byte fix; a real
+`*webrtc.TrackRemote` still can't be constructed in a unit test at all,
+since every field is private with no exported constructor, so the "still
+stuck, N attempts, then escalates" full integration path remains covered
+only by the pure `isTrackStillPending` decision plus manual/live
+verification — this is the SAME limitation that let round 1's deadlock
+ship in the first place, not a newly-accepted gap).
+
+**Verified:**
+- `go build ./pkg/rtc/...`, `go vet ./pkg/rtc/...`, `gofmt -l` all clean.
+- New/updated tests: 11/11 pass, repeatably, no `time.Sleep`-based waits.
+- Full `pkg/rtc` suite: passes clean on multiple runs. **Caveat:** this
+  package has pre-existing flaky tests unrelated to this patch —
+  `TestNegotiationFailed`, `TestFilteringCandidates`, and
+  `TestFirstAnswerMissedDuringICERestart` in `transport_test.go` do real
+  ICE/network-candidate work and fail intermittently (~1 in 3-4 runs)
+  **on completely unmodified upstream code too** (confirmed by stashing this
+  patch and re-running). Don't be alarmed if CI flakes on one of those three
+  specifically; re-run before assuming a regression.
+
+**Not yet done (tracked as follow-ups, not blocking this patch):**
+- **Deploy prerequisite, not just a nice-to-have: `ReconnectOnPublicationError`
+  defaults to `false` upstream** (`pkg/service/roommanager.go`: "default do
+  not force full reconnect on a publication error"). Every round of this
+  patch's escalation work (round 2's gating, round 3's `checks` counter) is
+  reachable code that is a NO-OP in production unless an operator explicitly
+  sets this flag in config. Without it, a persistently-stuck track still
+  gets nudged on a bounded schedule but never actually recovers via
+  `IssueFullReconnect` — the same "stuck until an unrelated renegotiation or
+  the participant leaves" outcome the original incident had, just with more
+  logging. This must be set (`rtc.reconnect_on_publication_error: true`, or
+  the equivalent env var) as part of deploying this fork, not left at its
+  upstream default.
+- **Stale `pendingRemoteTracks` entries are a pre-existing upstream
+  bookkeeping gap, not something this patch introduced or fixes.** Round 3's
+  review flagged that an entry for a given `trackID` can in principle
+  outlive the specific `*webrtc.TrackRemote` it was created for (e.g. across
+  a republish that produces a fresh `TrackRemote` for the same `trackID`)
+  and only gets purged in bulk when `handlePendingRemoteTracks` next runs,
+  not by trackID as each one individually resolves. This predates every line
+  this patch added — `isTrackStillPending`/`onStuckPublishNudgeFired` only
+  READ `pendingRemoteTracks`, they don't own its lifecycle — so fixing it
+  means touching `mediaTrackReceived`'s/`handlePendingRemoteTracks`'s core
+  track-management logic well outside this patch's scope, with real risk of
+  destabilizing paths this patch doesn't otherwise touch. Scoped out
+  deliberately; flagging for whoever owns that code next.
+- **"Escalation sawtooth" follow-up:** `onStuckPublishNudgeFired` calls
+  `clearStuckPublishNudge` (which deletes the map entry) on cap-trip. If a
+  LATER, unrelated renegotiation re-stuck the same trackID, it would start a
+  brand-new episode at `attempts=0, checks=0` — i.e. a track that already
+  escalated once could earn a full fresh budget rather than staying
+  escalated. Suggested fix for whoever picks this up: add a terminal
+  `escalated bool` to `stuckPublishNudgeState` that's checked (and skips
+  re-arming/re-nudging) once set, rather than deleting the entry on
+  cap-trip — do not implement this as a generation/episode counter with a
+  fresh budget per renegotiation, which reintroduces the exact sawtooth this
+  is meant to close.
+- Production deploy — `infrastructure/livekit/terraform.tfvars`'s
+  `livekit_image` still points at the stock `livekit/livekit-server` image.
+  This fork is not live anywhere yet; deploying it is a deliberate follow-up
+  decision, not a side effect of creating this fork. **This now matters
+  more than it did at first open**: the app-side blind timer that used to
+  provide SOME (confirmed net-negative, but non-zero) recovery coverage on
+  its own has been deleted, so until this fork deploys, the original
+  incident class has NO republish-nudge coverage at all.
+- The equivalent nudge for the *other* branch that appends to
+  `pendingRemoteTracks` (`ti == nil`, a related but distinct AddTrack-timing
+  race) — scoped out of this first patch to stay narrowly targeted at the
+  exact, confirmed, reproduced production incident.
+- A live, multi-nudge, real-negotiation repro to independently re-confirm
+  the trackID-stability assumption the escalation cap depends on (see
+  above) — real evidence exists (client-side investigation, cited), but a
+  fresh, this-mechanism-specific confirmation would close the gap fully.
+- The recovery signal still rides the same WebRTC DataChannel/negotiation
+  path this patch works around, rather than the always-up WS signaling
+  channel LiveKit's own server-push messages (RoomUpdate,
+  ConnectionQualityUpdate) already use. A stronger delivery-ack pattern
+  (`PerformRpc`'s ack/timeout, elsewhere in this file) is also still a
+  fire-and-forget-vs-confirmed-delivery gap. Both are real, scoped-out
+  hardening opportunities, not correctness bugs in what shipped.
+- Whether renegotiation-based recovery is even the right general mechanism
+  is a real open question the review round raised: the incident's own 215
+  failed attempts happened WHILE ordinary renegotiations were occurring, and
+  the incident only actually cleared via a full client reconnect. The
+  escalate-to-`IssueFullReconnect` behavior above is the concrete answer for
+  the bounded-attempts case; whether to skip straight to it sooner is a
+  tuning question for after this has real production data, not decided
+  here.
+- A delivery-confirmation/retry pattern for the nudge itself (it's currently
+  fire-and-forget over `SendDataMessage(RELIABLE, ...)` — "reliable" bounds
+  in-order delivery if the channel is up, not that it arrives at all) —
+  `PerformRpc`'s ack/timeout pattern elsewhere in this file could be adapted
+  if this needs to be more than best-effort.
+
+## Upstream sync process
+
+No automation yet. Manual process until this needs more rigor:
+
+```bash
+git fetch upstream
+git checkout master
+git merge upstream/master   # resolve conflicts (ARDIUSTECH_FORK.md never will)
+git checkout feat/publish-mid-stuck-nudge
+git rebase master
+go test ./pkg/rtc/...
+```
+
+Re-run `go test ./pkg/rtc/... -count=1` a couple of times after any sync
+given the flaky-test caveat above — don't rebase-and-ship on a single red run
+without checking whether it's one of the three known-flaky tests.

--- a/magefile.go
+++ b/magefile.go
@@ -92,7 +92,7 @@ func BuildLinux() error {
 	if len(buildArch) == 0 {
 		buildArch = "amd64"
 	}
-	cmd := mageutil.CommandDir(context.Background(), "cmd/server", "go build -buildvcs=false -o ../../bin/livekit-server-" + buildArch)
+	cmd := mageutil.CommandDir(context.Background(), "cmd/server", "go build -buildvcs=false -o ../../bin/livekit-server-"+buildArch)
 	cmd.Env = []string{
 		"GOOS=linux",
 		"GOARCH=" + buildArch,

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -62,9 +62,9 @@ type JobRequest struct {
 	// only set for participant jobs
 	Participant *livekit.ParticipantInfo
 	Metadata    string
-	AgentName  string
-	Deployment string
-	Attributes map[string]string
+	AgentName   string
+	Deployment  string
+	Attributes  map[string]string
 }
 
 type agentClient struct {

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -15,6 +15,7 @@
 package rtc
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"maps"
@@ -271,6 +272,15 @@ type ParticipantImpl struct {
 	pendingTracks           map[string]*pendingTrackInfo
 	pendingPublishingTracks map[livekit.TrackID]*pendingTrackInfo
 	pendingRemoteTracks     []*pendingRemoteTrack
+	// ardiustech fork: in-flight/attempt state for scheduleStuckPublishNudge,
+	// keyed by trackID, guarded by pendingTracksLock (same lock already
+	// guarding the pendingRemoteTracks this state tracks nudges for). See
+	// that function's doc comment — review finding, 2026-08-01: without
+	// this, every retry of a still-stuck track armed an independent
+	// duplicate timer with no cap, which could self-sustain a nudge/
+	// renegotiate loop under exactly the sustained-failure conditions the
+	// nudge exists to recover from.
+	stuckPublishNudges map[string]*stuckPublishNudgeState
 
 	// supported codecs
 	enabledPublishCodecs   []*livekit.Codec
@@ -362,6 +372,7 @@ func NewParticipant(params ParticipantParams) (*ParticipantImpl, error) {
 		}),
 		pendingTracks:           make(map[string]*pendingTrackInfo),
 		pendingPublishingTracks: make(map[livekit.TrackID]*pendingTrackInfo),
+		stuckPublishNudges:      make(map[string]*stuckPublishNudgeState),
 		connectedAt:             time.Now().Truncate(time.Millisecond),
 		rttUpdatedAt:            time.Now(),
 		cachedDownTracks:        make(map[livekit.TrackID]*downTrackState),
@@ -1485,6 +1496,7 @@ func (p *ParticipantImpl) Close(sendLeave bool, reason types.ParticipantCloseRea
 	p.closeReason.Store(reason)
 	p.clearDisconnectTimer()
 	p.clearMigrationTimer()
+	p.clearAllStuckPublishNudges()
 
 	if sendLeave {
 		p.sendLeaveRequest(
@@ -2390,6 +2402,363 @@ func (p *ParticipantImpl) handlePendingRemoteTracks() {
 	}
 }
 
+// ardiustech fork: republishNudgeTopic is a private data-channel topic this
+// fork uses to tell a publisher's OWN client "one of your tracks got stuck
+// unresolved — please renegotiate." Deliberately NOT a new DataPacket oneof
+// variant (that would require forking livekit-protocol AND client-sdk-js too,
+// to add and consume a new wire type) — DataPacket_User already exists
+// upstream for exactly this kind of arbitrary, app-defined payload, and
+// RoomEvent.DataReceived on the STOCK client SDK already surfaces it
+// unmodified. This keeps the fork to a single repo.
+const republishNudgeTopic = "_ardiustech_republish_nudge"
+
+// scheduleStuckPublishNudge checks back on one specific just-received track
+// after a short grace period and, if it's STILL sitting in
+// pendingRemoteTracks unresolved, proactively tells the publishing
+// participant to renegotiate — instead of silently relying on that
+// participant's app happening to trigger an unrelated renegotiation later
+// (see handlePendingRemoteTracks' three call sites, all client-initiated).
+//
+// gracePeriod is short (750ms) and deliberately shorter than any client-side
+// timer-based mitigation might use (e.g. a settle-nudge scheduled at
+// multi-second delays) — the goal is for the SERVER, which already has full
+// knowledge of the exact failure the instant it happens, to react faster and
+// more reliably than a client polling/guessing on a fixed schedule ever
+// could.
+const stuckPublishNudgeGracePeriod = 750 * time.Millisecond
+
+// stuckPublishNudgeMaxAttempts bounds how many times this fork will nudge
+// the SAME stuck track before giving up on renegotiation-based recovery and
+// escalating to a full reconnect instead (review finding, 2026-08-01: the
+// production incident this nudge targets logged 215 failed mid-resolution
+// attempts on one track, with ordinary renegotiations ALREADY occurring
+// during that window without resolving it — nudging the same participant to
+// renegotiate again can hit the identical failure mode indefinitely if
+// something about that connection's negotiation is itself impaired, not
+// just unlucky timing). `IssueFullReconnect` is self-contained recovery —
+// it doesn't depend on the same client cooperating correctly again.
+const stuckPublishNudgeMaxAttempts = 3
+
+// stuckPublishNudgeMaxChecks bounds a DIFFERENT failure mode than
+// stuckPublishNudgeMaxAttempts (review finding, 2026-08-01 — must-fix):
+// attempts only counts CONFIRMED-SENT nudges, so a participant whose data
+// channel never opens (a persistent, not transient, send failure) never
+// advances attempts and — combined with onStuckPublishNudgeFired's
+// unconditional re-arm — would otherwise loop at stuckPublishNudgeGracePeriod
+// forever, never escalating. checks counts every firing regardless of send
+// outcome, so this path still terminates even when sendRepublishNudge never
+// once succeeds. Deliberately larger than stuckPublishNudgeMaxAttempts (this
+// is the "give up on sending entirely" backstop, not the normal case) — do
+// not collapse the two counters back into one; that was the prior bug this
+// replaces (a failed send counting toward the same budget as a confirmed
+// one).
+const stuckPublishNudgeMaxChecks = 8
+
+// stuckPublishNudgeState is the per-trackID bookkeeping scheduleStuckPublishNudge
+// needs to dedup and cap nudges — guarded by pendingTracksLock (see that
+// field's doc comment on the ParticipantImpl struct).
+type stuckPublishNudgeState struct {
+	// timer is non-nil exactly while a nudge check is in flight for this
+	// track (armed, not yet fired) — used to skip arming a DUPLICATE timer
+	// when mediaTrackReceived sees the same track still stuck on a later
+	// retry, before the first check has even run.
+	timer *time.Timer
+	// attempts counts CONFIRMED-SENT sendRepublishNudge calls (i.e. it
+	// returned true) for this track's current stuck episode — NOT schedule
+	// calls (deduped above, costs nothing) and NOT a send that failed at the
+	// transport level (e.g. data channel not yet open — see
+	// onStuckPublishNudgeFired). Escalation trips once this reaches
+	// stuckPublishNudgeMaxAttempts (i.e. on the (max+1)th still-stuck
+	// check-in, since the check happens BEFORE incrementing for that
+	// attempt) — with max=3, that's 3 nudges sent, then reconnect on the 4th
+	// still-stuck firing, not literally "after 3 seconds."
+	attempts int
+	// checks counts every still-pending firing of onStuckPublishNudgeFired,
+	// regardless of whether sendRepublishNudge succeeded — see
+	// stuckPublishNudgeMaxChecks for why this exists alongside attempts.
+	checks int
+}
+
+// scheduleStuckPublishNudge is safe to call repeatedly for the SAME trackID
+// while it's stuck — see stuckPublishNudgeState's doc comment for why a
+// duplicate call while a check is already in flight is a no-op rather than
+// arming a second, independent timer (review finding, 2026-08-01: this
+// dedup was missing entirely, so every retry of a still-stuck track armed
+// its own timer with no cap — see stuckPublishNudgeMaxAttempts for the other
+// half of that fix).
+//
+// Guarded by the same IsClosed()/IsDisconnected() check onStuckPublishNudgeFired
+// uses at its own entry (review finding, 2026-08-02): onStuckPublishNudgeFired's
+// tail re-arms via this method without rechecking those flags, so without a
+// guard here too, a Close() racing in between that firing's initial check and
+// its re-arm could re-populate stuckPublishNudges with a fresh timer AFTER
+// clearAllStuckPublishNudges() already ran for this participant — defeating
+// the Close()-time cleanup guarantee clearAllStuckPublishNudges was added for.
+func (p *ParticipantImpl) scheduleStuckPublishNudge(trackID string) {
+	if p.IsClosed() || p.IsDisconnected() {
+		return
+	}
+	p.pendingTracksLock.Lock()
+	defer p.pendingTracksLock.Unlock()
+	state, ok := p.stuckPublishNudges[trackID]
+	if ok && state.timer != nil {
+		return
+	}
+	if !ok {
+		state = &stuckPublishNudgeState{}
+		p.stuckPublishNudges[trackID] = state
+	}
+	state.timer = time.AfterFunc(stuckPublishNudgeGracePeriod, func() {
+		p.onStuckPublishNudgeFired(trackID)
+	})
+}
+
+// shouldEscalateStuckPublish is the escalation decision pulled into its own
+// pure function (review finding, 2026-08-01) so a test can drive it directly
+// — the "still stuck" branch of onStuckPublishNudgeFired itself can't be
+// exercised end-to-end in this test binary (isTrackStillPending needs a real
+// *webrtc.TrackRemote in pendingRemoteTracks, which isn't fabricable here;
+// see participant_republish_nudge_test.go). Escalates on EITHER counter
+// reaching its cap: attempts bounds genuine confirmed-sent retries, checks
+// independently bounds the case where sendRepublishNudge never once
+// succeeds (a persistent, not transient, send failure) — see
+// stuckPublishNudgeMaxChecks's doc comment for why a failed send must still
+// count toward SOME cap even though it doesn't count toward attempts.
+func shouldEscalateStuckPublish(attemptsSoFar, checksSoFar int) bool {
+	return attemptsSoFar >= stuckPublishNudgeMaxAttempts || checksSoFar >= stuckPublishNudgeMaxChecks
+}
+
+// onStuckPublishNudgeFired is scheduleStuckPublishNudge's timer callback,
+// pulled into its own method (rather than an inline closure, as before) so
+// the still-pending / attempts-exhausted / send-nudge decision is one place
+// a test can drive without waiting out a real timer.
+func (p *ParticipantImpl) onStuckPublishNudgeFired(trackID string) {
+	if p.IsClosed() || p.IsDisconnected() {
+		// Participant torn down while this was waiting out its grace period
+		// — nothing left to nudge or reconnect (review finding, 2026-08-01:
+		// this class had no such guard, unlike migrationTimer/disconnectTimer's
+		// established pattern elsewhere in this file).
+		return
+	}
+	p.pendingTracksLock.Lock()
+	pendingTrackIDs := make([]string, len(p.pendingRemoteTracks))
+	for i, rt := range p.pendingRemoteTracks {
+		pendingTrackIDs[i] = rt.track.ID()
+	}
+	stillPending := isTrackStillPending(pendingTrackIDs, trackID)
+	// Peek at the CURRENT attempt count without incrementing yet (review
+	// finding, 2026-08-01): incrementing here, before sendRepublishNudge
+	// even runs, meant a nudge that failed to SEND (e.g. the data channel
+	// isn't open yet, right after a fresh join — an expected, transient
+	// condition, not evidence the track is actually stuck) still burned a
+	// slot toward the escalation cap. Only a CONFIRMED-sent attempt should
+	// count; see below.
+	var attemptsSoFar, checksSoFar int
+	if state, ok := p.stuckPublishNudges[trackID]; ok {
+		if stillPending {
+			state.timer = nil // this firing is done; a later schedule call may arm a fresh one
+			state.checks++
+			attemptsSoFar = state.attempts
+			checksSoFar = state.checks
+		} else {
+			// Belt-and-suspenders (review finding, 2026-08-01): the NORMAL
+			// path here is that mediaTrackReceived's success path already
+			// called clearStuckPublishNudgeLocked and removed this entry
+			// before this timer ever got a chance to fire — but explicitly
+			// deleting here too means a state entry can never outlive the
+			// episode it was tracking, regardless of ordering.
+			delete(p.stuckPublishNudges, trackID)
+		}
+	}
+	p.pendingTracksLock.Unlock()
+
+	if !stillPending {
+		// Resolved on its own (some other renegotiation flushed the queue)
+		// in the interim — nothing to do.
+		return
+	}
+	if shouldEscalateStuckPublish(attemptsSoFar, checksSoFar) {
+		p.clearStuckPublishNudge(trackID)
+		// Gated behind the SAME operator control onPublicationError already
+		// uses (review finding, 2026-08-01) — escalating unconditionally
+		// would let this new mechanism silently bypass an existing,
+		// off-by-default reconnect-on-error control an operator may have
+		// deliberately disabled, and would do so on an UNTUNED timeline
+		// (~3s here vs. the 2-minute incident window this patch's own
+		// evidence is drawn from) that hasn't been validated against real
+		// production data yet.
+		if p.params.ReconnectOnPublicationError {
+			p.pubLogger.Warnw(
+				"stuck-track republish nudge exhausted retries, issuing full reconnect", nil,
+				"trackID", trackID, "attempts", attemptsSoFar, "checks", checksSoFar,
+			)
+			p.IssueFullReconnect(types.ParticipantCloseReasonPublicationError)
+		} else {
+			p.pubLogger.Warnw(
+				"stuck-track republish nudge exhausted retries; NOT issuing a full reconnect "+
+					"(ReconnectOnPublicationError is disabled) — track will remain stuck until an "+
+					"unrelated renegotiation or the participant leaves", nil,
+				"trackID", trackID, "attempts", attemptsSoFar, "checks", checksSoFar,
+			)
+		}
+		return
+	}
+	if p.sendRepublishNudge(trackID) {
+		// Only count a CONFIRMED-sent attempt toward the cap (review finding,
+		// 2026-08-01) — a transport-level failure (e.g. data channel not yet
+		// open) is not evidence the track is actually stuck, and shouldn't
+		// spend budget that's meant to bound GENUINE retries.
+		p.pendingTracksLock.Lock()
+		if state, ok := p.stuckPublishNudges[trackID]; ok {
+			state.attempts++
+		}
+		p.pendingTracksLock.Unlock()
+	}
+	// Re-arm the next check regardless of send success (review finding,
+	// 2026-08-01 — must-fix): without this, the cap/escalation logic above
+	// was UNREACHABLE in exactly the scenario this whole patch targets.
+	// scheduleStuckPublishNudge is only ever called from mediaTrackReceived's
+	// mid=="" branch, which only fires again on an UNRELATED renegotiation —
+	// in the fork's own stated target case ("publish once, then typically no
+	// further track changes"), the timer fired exactly ONCE, sent one nudge,
+	// and then attempts froze forever: no further nudges, no escalation,
+	// regardless of whether the client ever acted on that first nudge.
+	// Re-scheduling here makes this method self-sustaining — it keeps
+	// checking back every stuckPublishNudgeGracePeriod until the track
+	// resolves (mediaTrackReceived clears state) or the cap trips (escalates
+	// above) — rather than depending on an external, unrelated event to give
+	// it another chance. A send FAILURE also re-arms (not just success) so a
+	// transient transport hiccup gets retried on the next tick instead of
+	// silently going quiet.
+	p.scheduleStuckPublishNudge(trackID)
+}
+
+// clearStuckPublishNudge removes any in-flight timer/attempt-count state for
+// trackID — called once a track's mid actually resolves (mediaTrackReceived's
+// success path) or when this specific track's episode ends via full
+// reconnect, so neither a stale timer nor a stale attempt count can outlive
+// what they were tracking. Acquires pendingTracksLock itself — callers that
+// ALREADY hold it (mediaTrackReceived's mid-resolved path) MUST call
+// clearStuckPublishNudgeLocked instead (review finding, 2026-08-01: this was
+// a real, guaranteed self-deadlock — utils.RWMutex is not reentrant, and
+// mediaTrackReceived holds this exact lock across its entire mid-resolved
+// path, including its original call to this function).
+func (p *ParticipantImpl) clearStuckPublishNudge(trackID string) {
+	p.pendingTracksLock.Lock()
+	defer p.pendingTracksLock.Unlock()
+	p.clearStuckPublishNudgeLocked(trackID)
+}
+
+// clearStuckPublishNudgeLocked is clearStuckPublishNudge's body, callable by
+// a caller that already holds pendingTracksLock.
+func (p *ParticipantImpl) clearStuckPublishNudgeLocked(trackID string) {
+	if state, ok := p.stuckPublishNudges[trackID]; ok {
+		if state.timer != nil {
+			state.timer.Stop()
+		}
+		delete(p.stuckPublishNudges, trackID)
+	}
+}
+
+// clearAllStuckPublishNudges stops every in-flight nudge timer for this
+// participant — called from Close() (review finding, 2026-08-01: this class
+// of timer had no Close()-time cleanup at all, unlike migrationTimer/
+// disconnectTimer's established pattern, so a participant disconnecting
+// within the 750ms grace period could leave a timer firing after teardown,
+// racing TransportManager.Close()).
+func (p *ParticipantImpl) clearAllStuckPublishNudges() {
+	p.pendingTracksLock.Lock()
+	defer p.pendingTracksLock.Unlock()
+	for _, state := range p.stuckPublishNudges {
+		if state.timer != nil {
+			state.timer.Stop()
+		}
+	}
+	p.stuckPublishNudges = make(map[string]*stuckPublishNudgeState)
+}
+
+// isTrackStillPending is the pure decision onStuckPublishNudgeFired acts
+// on — pulled out (and taking already-extracted IDs, not
+// []*pendingRemoteTrack) so it's testable with a plain string slice, no
+// live TransportManager/WebRTC stack required. *webrtc.TrackRemote has no
+// exported constructor (every field is private), so a real one can't be
+// built in a unit test at all — extracting IDs before this call is what
+// makes the actual decision logic testable.
+func isTrackStillPending(pendingTrackIDs []string, trackID string) bool {
+	return slices.Contains(pendingTrackIDs, trackID)
+}
+
+// republishNudgePayload is buildRepublishNudgePacket's payload shape,
+// marshaled via encoding/json rather than hand-built with fmt.Sprintf("%q",
+// ...) (review finding, 2026-08-01: %q escapes some control bytes as
+// `\xNN`, which is not valid JSON — `\u00NN` is required — and trackID
+// originates from client-controlled SDP/MediaStreamTrack id, not a purely
+// server-controlled value, so a client using an off-spec id could silently
+// break its own recovery signal with no error on either end).
+type republishNudgePayload struct {
+	Reason  string `json:"reason"`
+	TrackID string `json:"trackId"`
+}
+
+// buildRepublishNudgePacket is the pure packet-construction half of
+// sendRepublishNudge — pulled out so the wire shape (identity, topic,
+// payload) is directly assertable in a test without needing a live
+// TransportManager to actually send anything.
+func buildRepublishNudgePacket(identity livekit.ParticipantIdentity, trackID string) *livekit.DataPacket {
+	// Marshal errors here would mean republishNudgePayload itself is
+	// malformed (a programmer error, not a runtime/input one — TrackID is a
+	// string, which always marshals) — but ignore-and-fall-back-to-empty
+	// rather than panicking keeps a delivery bug in a best-effort nudge from
+	// ever taking down the caller.
+	payload, err := json.Marshal(republishNudgePayload{Reason: "stuck_mid", TrackID: trackID})
+	if err != nil {
+		payload = []byte(`{"reason":"stuck_mid"}`)
+	}
+	return &livekit.DataPacket{
+		ParticipantIdentity: string(identity),
+		Value: &livekit.DataPacket_User{
+			User: &livekit.UserPacket{
+				Payload: payload,
+				Topic:   pointer.To(republishNudgeTopic),
+			},
+		},
+	}
+}
+
+// sendRepublishNudge pushes a small marker payload down this SAME
+// participant's own data channel (server -> the participant who's stuck,
+// not a relay to anyone else) via the existing, unmodified DataPacket_User
+// wire type. The app's client-side code (LiveKitRoomManager.ts, in the app
+// repo — no SDK changes needed) listens for RoomEvent.DataReceived with this
+// topic and reacts by calling its own existing republishAllTracks(), the
+// exact same recovery action the app's blind settle-nudge already uses, just
+// triggered by a real signal instead of a timer.
+// sendRepublishNudge returns whether the nudge was actually handed to the
+// transport — the caller (onStuckPublishNudgeFired) uses this to decide
+// whether this firing counts toward stuckPublishNudgeMaxAttempts (review
+// finding, 2026-08-01: attempts previously incremented unconditionally
+// BEFORE this call, so e.g. a data channel not yet open right after a fresh
+// join — expected, transient, logged as a Warnw elsewhere, not a real
+// nudge failure — could burn through the cap and trigger an unwarranted
+// full reconnect for a participant that was never actually stuck, just
+// still connecting). "Sent" here means the transport accepted it, not that
+// the client received/processed it — RELIABLE bounds in-order delivery IF
+// the channel is up, not that it arrives at all; a stronger delivery-ack
+// guarantee is a separate, not-yet-built follow-up (see ARDIUSTECH_FORK.md).
+func (p *ParticipantImpl) sendRepublishNudge(trackID string) bool {
+	dpData, err := proto.Marshal(buildRepublishNudgePacket(p.Identity(), trackID))
+	if err != nil {
+		p.pubLogger.Errorw("failed to marshal republish-nudge data packet", err, "trackID", trackID)
+		return false
+	}
+	if err := p.TransportManager.SendDataMessage(livekit.DataPacket_RELIABLE, dpData); err != nil {
+		p.pubLogger.Warnw("failed to send republish nudge", err, "trackID", trackID)
+		return false
+	}
+	p.pubLogger.Infow("sent republish nudge for stuck track", "trackID", trackID)
+	return true
+}
+
 func (p *ParticipantImpl) onReceivedDataMessage(kind livekit.DataPacket_Kind, data []byte) {
 	if p.IsDisconnected() || !p.CanPublishData() {
 		return
@@ -2474,6 +2843,25 @@ func (p *ParticipantImpl) handleReceivedDataMessage(kind livekit.DataPacket_Kind
 			return
 		}
 		u := payload.User
+		// ardiustech fork: hard-drop the reserved republish-nudge topic here
+		// rather than relying solely on the client-side participant===undefined
+		// check (review finding, 2026-08-01: without this, any participant
+		// could send a DataPacket_User on this topic naming another
+		// participant as the destination, and this function would relay it
+		// like any other user payload — reaching that OTHER participant's
+		// client with a real, non-empty ParticipantIdentity below, which the
+		// client-side guard already rejects, but defense should not depend
+		// on only one side of a two-repo boundary staying correct forever).
+		// sendRepublishNudge bypasses this whole function via
+		// TransportManager.SendDataMessage directly, so genuine nudges never
+		// reach this check at all — only a forged/relayed one would.
+		if u.Topic != nil && *u.Topic == republishNudgeTopic {
+			p.pubLogger.Warnw(
+				"dropped a client-sent data packet on the reserved republish-nudge topic", nil,
+				"senderIdentity", p.params.Identity,
+			)
+			return
+		}
 		if p.Hidden() {
 			u.ParticipantSid = ""
 			u.ParticipantIdentity = ""
@@ -3224,8 +3612,29 @@ func (p *ParticipantImpl) mediaTrackReceived(
 		)
 		p.pendingTracksLock.Unlock()
 		p.pubLogger.Warnw("could not get mid for track", nil, "trackID", track.ID())
+		// ardiustech fork: this track is now stuck in pendingRemoteTracks with
+		// nothing to flush it except the SAME participant renegotiating again
+		// for an unrelated reason (see handlePendingRemoteTracks' call sites —
+		// all client-initiated: a fresh offer, an AddTrack request, or an
+		// unpublish). Upstream has no mechanism to proactively ask the
+		// publisher to do that, so a track can sit unrecoverable indefinitely
+		// if the app's usage pattern never naturally triggers one. Give the
+		// publisher a real, immediate reason to renegotiate instead of relying
+		// on an app-side blind timer guessing when (or whether) this happened.
+		p.scheduleStuckPublishNudge(track.ID())
 		return nil, false, false, buffer.VideoLayersRid{}
 	}
+	// mid resolved — clear any in-flight nudge/attempt-count state for this
+	// track so a LATER, unrelated stuck episode for the same trackID (e.g.
+	// after a full unpublish/republish cycle reuses the id) starts its
+	// attempt count fresh, and so a still-pending timer from an earlier
+	// episode can't fire against a track that's no longer stuck. Uses the
+	// ALREADY-LOCKED variant — pendingTracksLock is held from function entry
+	// and only unlocked in the mid=="" branch above, which already returned;
+	// calling the locking clearStuckPublishNudge here deadlocked on every
+	// single successful (non-stuck) track publish (review finding,
+	// 2026-08-01 — caught before this ever reached production).
+	p.clearStuckPublishNudgeLocked(track.ID())
 
 	// use existing media track to handle simulcast
 	var pubTime time.Duration

--- a/pkg/rtc/participant_republish_nudge_test.go
+++ b/pkg/rtc/participant_republish_nudge_test.go
@@ -1,0 +1,319 @@
+// Copyright 2026 Ardius Tech, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rtc
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/livekit/protocol/livekit"
+)
+
+// ardiustech fork: tests for the stuck-publish republish-nudge added in
+// pkg/rtc/participant.go — see that file's doc comments for the full
+// rationale (watercooler's docs/sfu-multiparty-triage-2026-07-31.md has the
+// production incident this fixes).
+
+func TestIsTrackStillPending(t *testing.T) {
+	tests := []struct {
+		name    string
+		pending []string
+		trackID string
+		want    bool
+	}{
+		{"empty list", nil, "track-1", false},
+		{"present, only entry", []string{"track-1"}, "track-1", true},
+		{"present, among several", []string{"track-0", "track-1", "track-2"}, "track-1", true},
+		{"absent, non-empty list", []string{"track-0", "track-2"}, "track-1", false},
+		{"resolved and removed", []string{}, "track-1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isTrackStillPending(tt.pending, tt.trackID))
+		})
+	}
+}
+
+func TestBuildRepublishNudgePacket(t *testing.T) {
+	identity := livekit.ParticipantIdentity("scott-identity")
+	trackID := `TR_weird"quote`
+
+	dp := buildRepublishNudgePacket(identity, trackID)
+
+	require.Equal(t, string(identity), dp.ParticipantIdentity)
+	user, ok := dp.Value.(*livekit.DataPacket_User)
+	require.True(t, ok, "expected DataPacket_User variant, not a new oneof member")
+	require.NotNil(t, user.User.Topic)
+	require.Equal(t, republishNudgeTopic, *user.User.Topic)
+	require.JSONEq(t, `{"reason":"stuck_mid","trackId":"TR_weird\"quote"}`, string(user.User.Payload))
+
+	// Round-trips through actual protobuf marshal/unmarshal, matching what
+	// sendRepublishNudge really does — catches anything the struct-literal
+	// assertions above wouldn't (e.g. a field with no wire tag).
+	raw, err := proto.Marshal(dp)
+	require.NoError(t, err)
+	roundTripped := &livekit.DataPacket{}
+	require.NoError(t, proto.Unmarshal(raw, roundTripped))
+	rtUser, ok := roundTripped.Value.(*livekit.DataPacket_User)
+	require.True(t, ok)
+	require.Equal(t, republishNudgeTopic, *rtUser.User.Topic)
+}
+
+// TestBuildRepublishNudgePacket_ValidJSONForControlByteTrackID pins the
+// review finding (2026-08-01) that the ORIGINAL fmt.Sprintf(`{"reason":
+// "stuck_mid","trackId":%q}`, trackID) implementation could emit invalid
+// JSON: Go's %q escapes some control bytes as `\xNN`, which is not valid
+// JSON (`\u00NN` is required), and trackID originates from client-controlled
+// SDP/MediaStreamTrack id, not a purely server-controlled value. The
+// existing TestBuildRepublishNudgePacket above only covers an embedded `"`,
+// which %q happens to escape identically to JSON — masking this class of
+// bug. Switching to encoding/json.Marshal (this commit) fixes it; this test
+// would have failed against the old %q-based implementation.
+func TestBuildRepublishNudgePacket_ValidJSONForControlByteTrackID(t *testing.T) {
+	trackID := "TR_weird\x01control\x1fbytes"
+
+	dp := buildRepublishNudgePacket(livekit.ParticipantIdentity("scott-identity"), trackID)
+
+	user, ok := dp.Value.(*livekit.DataPacket_User)
+	require.True(t, ok)
+	require.True(t, json.Valid(user.User.Payload), "payload must be valid JSON even for a trackID with raw control bytes: %s", user.User.Payload)
+
+	var decoded republishNudgePayload
+	require.NoError(t, json.Unmarshal(user.User.Payload, &decoded))
+	require.Equal(t, trackID, decoded.TrackID)
+}
+
+// TestOnStuckPublishNudgeFired_ResolvedClearsStateWithoutSending exercises
+// onStuckPublishNudgeFired directly (review finding, 2026-08-01: the
+// PREVIOUS version of this test — TestScheduleStuckPublishNudge_ResolvedDoesNotPanic
+// — went through the real timer via a 1s+ time.Sleep and only asserted
+// NotPanics, which would still pass even if the resolved case incorrectly
+// sent a nudge or left stale state behind). newParticipantForTest's
+// pendingRemoteTracks starts empty, matching a track that was never stuck
+// (or already flushed by an unrelated renegotiation) — isTrackStillPending
+// returns false, so this must be a pure no-op: no nudge sent, no state left
+// behind. Asserts the entry is REMOVED entirely (round-2 fix, 2026-08-01),
+// not just left with attempts==0 — a leaked zero-value entry is still a
+// leak, and this is also belt-and-suspenders against
+// mediaTrackReceived's own clearStuckPublishNudgeLocked call not having run
+// for some reason.
+func TestOnStuckPublishNudgeFired_ResolvedClearsStateWithoutSending(t *testing.T) {
+	p := newParticipantForTest("scott-identity")
+	const trackID = "TR_will_resolve"
+	p.stuckPublishNudges[trackID] = &stuckPublishNudgeState{}
+
+	require.NotPanics(t, func() {
+		p.onStuckPublishNudgeFired(trackID)
+	})
+	_, exists := p.stuckPublishNudges[trackID]
+	require.False(t, exists, "must remove the entry entirely for a track that already resolved, not just zero its attempts")
+}
+
+// TestScheduleStuckPublishNudge_DedupsWhileATimerIsAlreadyInFlight pins the
+// review finding (2026-08-01) that scheduleStuckPublishNudge previously
+// armed a BRAND NEW time.AfterFunc on every call with no dedup — since
+// mediaTrackReceived calls this on EVERY retry of a still-stuck track, a
+// track retried many times (215, in the production incident this fixes)
+// could accumulate many independent, uncoordinated timers. A second call
+// while the first's timer is still pending must be a no-op.
+func TestScheduleStuckPublishNudge_DedupsWhileATimerIsAlreadyInFlight(t *testing.T) {
+	p := newParticipantForTest("scott-identity")
+	const trackID = "TR_stuck"
+
+	p.scheduleStuckPublishNudge(trackID)
+	require.Len(t, p.stuckPublishNudges, 1)
+	firstTimer := p.stuckPublishNudges[trackID].timer
+	require.NotNil(t, firstTimer)
+
+	p.scheduleStuckPublishNudge(trackID)
+
+	require.Len(t, p.stuckPublishNudges, 1, "must not create a second entry")
+	require.Same(t, firstTimer, p.stuckPublishNudges[trackID].timer, "must not replace the already-in-flight timer with a new one")
+
+	p.clearStuckPublishNudge(trackID) // don't leak a real timer past the test
+}
+
+// TestScheduleStuckPublishNudge_ReArmsOnceThePreviousTimerHasFired confirms
+// the dedup above is scoped to "already in flight," not "ever scheduled
+// before" — once a timer fires (state.timer reset to nil), a later call for
+// the SAME still-stuck track must be able to arm a fresh one.
+func TestScheduleStuckPublishNudge_ReArmsOnceThePreviousTimerHasFired(t *testing.T) {
+	p := newParticipantForTest("scott-identity")
+	const trackID = "TR_stuck"
+
+	p.scheduleStuckPublishNudge(trackID)
+	p.stuckPublishNudges[trackID].timer = nil // simulate the timer having already fired
+
+	p.scheduleStuckPublishNudge(trackID)
+
+	require.NotNil(t, p.stuckPublishNudges[trackID].timer, "must arm a fresh timer once the previous one is no longer in flight")
+	p.clearStuckPublishNudge(trackID)
+}
+
+// TestClearStuckPublishNudge_RemovesStateAndStopsTheTimer covers both the
+// mediaTrackReceived success-path caller (a track resolving mid-episode)
+// and general cleanup — a cleared track must accept a completely fresh
+// schedule/attempts cycle later (e.g. a NEW stuck episode reusing the same
+// trackID after a full unpublish/republish).
+func TestClearStuckPublishNudge_RemovesStateAndStopsTheTimer(t *testing.T) {
+	p := newParticipantForTest("scott-identity")
+	const trackID = "TR_stuck"
+	p.scheduleStuckPublishNudge(trackID)
+	require.Len(t, p.stuckPublishNudges, 1)
+
+	p.clearStuckPublishNudge(trackID)
+
+	require.Empty(t, p.stuckPublishNudges)
+	// A fresh schedule after clearing must behave like a first-ever call —
+	// not blocked by stale dedup state.
+	p.scheduleStuckPublishNudge(trackID)
+	require.Len(t, p.stuckPublishNudges, 1)
+	require.Equal(t, 0, p.stuckPublishNudges[trackID].attempts)
+	p.clearStuckPublishNudge(trackID)
+}
+
+// TestClearStuckPublishNudgeLocked_DoesNotReacquireTheLock is a regression
+// test for a real, guaranteed self-deadlock (review finding, 2026-08-01,
+// caught before this ever reached production): mediaTrackReceived's
+// mid-resolved path called the LOCKING clearStuckPublishNudge while it
+// ALREADY held pendingTracksLock (acquired at function entry, only unlocked
+// in the mid=="" branch) — utils.RWMutex is not reentrant, so this hung
+// EVERY successful (non-stuck) track publish, wedging every other operation
+// on that participant needing the same lock (AddTrack, handlePendingRemoteTracks,
+// Close). The fix splits it into a locking wrapper (clearStuckPublishNudge,
+// for callers that don't hold the lock) and clearStuckPublishNudgeLocked
+// (for callers already inside the critical section). This test simulates
+// mediaTrackReceived's exact pattern — Lock(), then clear — and would hang
+// (caught via a timeout, not an actual indefinite block) if
+// clearStuckPublishNudgeLocked ever regressed to re-acquiring the lock.
+func TestClearStuckPublishNudgeLocked_DoesNotReacquireTheLock(t *testing.T) {
+	p := newParticipantForTest("scott-identity")
+	const trackID = "TR_stuck"
+	p.scheduleStuckPublishNudge(trackID)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.pendingTracksLock.Lock() // exactly mediaTrackReceived's own entry lock
+		defer p.pendingTracksLock.Unlock()
+		p.clearStuckPublishNudgeLocked(trackID)
+	}()
+
+	select {
+	case <-done:
+		require.Empty(t, p.stuckPublishNudges)
+	case <-time.After(2 * time.Second):
+		t.Fatal(
+			"clearStuckPublishNudgeLocked deadlocked while pendingTracksLock was already held — " +
+				"this is the exact self-deadlock bug the locked/unlocked split exists to prevent",
+		)
+	}
+}
+
+// TestOnStuckPublishNudgeFired_ReArmsAfterSendingWithoutARealPendingTrack
+// covers as much of the re-arm fix (review finding, 2026-08-01 — must-fix:
+// escalation was UNREACHABLE because nothing re-scheduled after a nudge) as
+// is constructible without a real *webrtc.TrackRemote (see
+// isTrackStillPending's doc comment — pendingRemoteTracks entries can't be
+// fabricated in this test binary, so the "still stuck" branch itself can't
+// be driven end-to-end here). What IS directly testable: calling
+// scheduleStuckPublishNudge → firing it manually via onStuckPublishNudgeFired
+// with an EMPTY pendingRemoteTracks (the "resolved" branch) must NOT re-arm —
+// re-arming is conditional on stillPending, and this pins that it stays
+// conditional rather than firing unconditionally.
+func TestOnStuckPublishNudgeFired_ResolvedDoesNotReArm(t *testing.T) {
+	p := newParticipantForTest("scott-identity")
+	const trackID = "TR_will_resolve"
+	p.stuckPublishNudges[trackID] = &stuckPublishNudgeState{}
+
+	p.onStuckPublishNudgeFired(trackID)
+
+	// The entry is removed entirely on resolve (see
+	// TestOnStuckPublishNudgeFired_ResolvedClearsStateWithoutSending) — which
+	// itself is what prevents a re-arm: scheduleStuckPublishNudge's dedup
+	// check only reads state that no longer exists here.
+	state, exists := p.stuckPublishNudges[trackID]
+	require.False(t, exists, "must not re-arm for a track that already resolved")
+	require.Nil(t, state)
+}
+
+// TestClearAllStuckPublishNudges_StopsEveryTimerAcrossMultipleTracks covers
+// the Close()-time cleanup (review finding, 2026-08-01: this class of timer
+// previously had NO Close()-time cleanup at all, unlike this file's existing
+// migrationTimer/disconnectTimer pattern) — a participant with SEVERAL
+// simultaneously-stuck tracks (e.g. camera+mic+screen, per the PR's own
+// self-feeding-loop discussion) must have every one of them cleared, not
+// just the first.
+func TestClearAllStuckPublishNudges_StopsEveryTimerAcrossMultipleTracks(t *testing.T) {
+	p := newParticipantForTest("scott-identity")
+	p.scheduleStuckPublishNudge("TR_cam")
+	p.scheduleStuckPublishNudge("TR_mic")
+	p.scheduleStuckPublishNudge("TR_screen")
+	require.Len(t, p.stuckPublishNudges, 3)
+
+	p.clearAllStuckPublishNudges()
+
+	require.Empty(t, p.stuckPublishNudges)
+}
+
+// TestShouldEscalateStuckPublish pins the review finding (2026-08-01 —
+// must-fix, round 3): attempts alone can never trip for a participant whose
+// sendRepublishNudge call NEVER succeeds (e.g. a data channel that never
+// opens) — attempts only increments on a CONFIRMED send (see
+// onStuckPublishNudgeFired's "peek before incrementing" fix from round 2),
+// so a persistently-failing send combined with the unconditional re-arm
+// would otherwise loop forever, never reaching IssueFullReconnect. checks
+// increments on every firing regardless of send outcome and independently
+// bounds this case. Explicitly does NOT revert to counting a failed send as
+// an attempt — that was the round-2 bug (a transient failure right after
+// join burning real retry budget).
+func TestShouldEscalateStuckPublish(t *testing.T) {
+	tests := []struct {
+		name     string
+		attempts int
+		checks   int
+		want     bool
+	}{
+		{"neither counter near its cap", 0, 0, false},
+		{"attempts reaches its cap, checks still low", stuckPublishNudgeMaxAttempts, 1, true},
+		{"attempts below cap, checks reaches its cap (persistent send failure)", 0, stuckPublishNudgeMaxChecks, true},
+		{"checks below cap and attempts below cap", stuckPublishNudgeMaxAttempts - 1, stuckPublishNudgeMaxChecks - 1, false},
+		{"checks always outpaces attempts on a persistent failure, so checks alone must trip it", 0, stuckPublishNudgeMaxChecks + 10, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, shouldEscalateStuckPublish(tt.attempts, tt.checks))
+		})
+	}
+}
+
+// TestSendRepublishNudge_DoesNotPanicWithoutLiveTransport covers the "still
+// stuck, nudge actually attempted" path directly (rather than through
+// scheduleStuckPublishNudge's timer, which would need a real, populated
+// pendingRemoteTracks entry — not constructible in a unit test; see above).
+// newParticipantForTest builds a real TransportManager with no live
+// PeerConnection/ICE, so the actual SendDataMessage call is expected to
+// error here — sendRepublishNudge already handles that by logging and
+// returning, not panicking, which is exactly what this asserts.
+func TestSendRepublishNudge_DoesNotPanicWithoutLiveTransport(t *testing.T) {
+	p := newParticipantForTest("scott-identity")
+	require.NotPanics(t, func() {
+		p.sendRepublishNudge("TR_stuck")
+	})
+}

--- a/pkg/service/basic_auth.go
+++ b/pkg/service/basic_auth.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 )
 
-func GenBasicAuthMiddleware(username string, password string) (func(http.ResponseWriter, *http.Request, http.HandlerFunc) ) {
+func GenBasicAuthMiddleware(username string, password string) func(http.ResponseWriter, *http.Request, http.HandlerFunc) {
 	return func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 		given_username, given_password, ok := r.BasicAuth()
 		unauthorized := func() {
@@ -14,18 +14,18 @@ func GenBasicAuthMiddleware(username string, password string) (func(http.Respons
 		if !ok {
 			unauthorized()
 			return
-		} 
-	
+		}
+
 		if given_username != username {
 			unauthorized()
 			return
 		}
-	
+
 		if given_password != password {
 			unauthorized()
 			return
 		}
-	
+
 		next(rw, r)
-	  }
+	}
 }

--- a/pkg/sfu/packettrailer/packet_trailer_test.go
+++ b/pkg/sfu/packettrailer/packet_trailer_test.go
@@ -78,7 +78,7 @@ func makeTimestampOnlyTrailer(timestampUs int64) []byte {
 }
 
 func TestStripTrailer(t *testing.T) {
-	fullTrailerSize := 21 // (1+1+8) + (1+1+4) + 5
+	fullTrailerSize := 21   // (1+1+8) + (1+1+4) + 5
 	tsOnlyTrailerSize := 15 // (1+1+8) + 5
 
 	tests := []struct {


### PR DESCRIPTION
## Problem

This repo had no CI/CD at all. The inherited upstream `.github/workflows/buildtest.yaml` runs but isn't a required status check (flagged in PR #1's third adversarial-review round), and deploy was a fully manual SSM runbook (SSM in, `sed` the image tag, `docker compose pull && up -d` — see `ardiustech/watercooler`'s `infrastructure/livekit/README.md`).

## What this adds

`.buildkite/pipeline.yml`:
- **CI**: `gofmt -l` (fails on any diff), `go build ./...`, `go vet ./...`, `go test ./...`, via `golang:1.26`.
- **CD** (master only, gated on CI passing): builds + pushes an **amd64** image (the LiveKit box is a c6i x86_64 instance, unlike the watercooler app's arm64 box) to this fork's own ECR repo, then triggers an on-box deploy via SSM.

## Deploy mechanism — not blue/green

LiveKit runs `network_mode: host` bound to fixed ports (7880/7881/7882) — two copies can't bind simultaneously on one box, so there's no second color to flip to like the watercooler app's own CD.

Instead, the on-box script (companion PR: `ardiustech/watercooler`'s `infrastructure/livekit/`) leans on **LiveKit's own built-in graceful shutdown** — `cmd/server/main.go`'s SIGTERM handler already calls `router.Drain()` (stop accepting new joins) and waits for every active participant to leave before exiting. `docker compose stop -t <bounded timeout>` triggers exactly that. Net effect: a deploy does not forcibly drop calls already in progress; new joins pause for the drain window instead. True zero-downtime (new joins routed to an already-warm second node while the old one drains) needs a second node + Redis-backed multi-node LiveKit — a separate, materially bigger effort. Full writeup in `.buildkite/README.md`.

## Also

Gofmt-fixed 4 pre-existing files (`magefile.go`, `pkg/agent/client.go`, `pkg/service/basic_auth.go`, `pkg/sfu/packettrailer/packet_trailer_test.go`) so the new gofmt CI gate starts clean instead of red on day one — whitespace only, no functional change.

## Activation

Soft-skips (green, no deploy) until `LK_AWS_ACCESS_KEY_ID`/`LK_AWS_SECRET_ACCESS_KEY` are set — see `.buildkite/README.md` for the full one-time setup (Buildkite pipeline creation, IAM user via the companion watercooler PR, secrets). This PR does not switch any production traffic.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean (repo-wide)
- [x] Full test suite passes (`go test ./...`)
- [ ] Buildkite pipeline itself needs to be created by someone with `write_pipelines` — see `.buildkite/README.md` "One-time setup"

---
*Note: This PR was created with AI assistance.*