### PR TITLE
fix(egress): bind record permission to the token's room; stop in-place grant widening

### DIFF
--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -209,10 +209,23 @@ func EnsureListPermission(ctx context.Context) error {
 	return nil
 }
 
-func EnsureRecordPermission(ctx context.Context) error {
+// EnsureRecordPermission requires the RoomRecord grant. When the caller's
+// token is scoped to a room (Video.Room is set, as with tokens minted for a
+// single room's recording client), the targeted room must match it: without
+// this binding a room-scoped recording token can start, update, list and stop
+// egress jobs in every other room on the server. Unscoped tokens (Video.Room
+// empty, e.g. server-side recording services) retain server-wide access.
+func EnsureRecordPermission(ctx context.Context, rooms ...livekit.RoomName) error {
 	claims := GetGrants(ctx)
 	if claims == nil || claims.Video == nil || !claims.Video.RoomRecord {
 		return ErrPermissionDenied
+	}
+	if claims.Video.Room != "" {
+		for _, room := range rooms {
+			if room != "" && room != livekit.RoomName(claims.Video.Room) {
+				return ErrPermissionDenied
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/service/auth_test.go
+++ b/pkg/service/auth_test.go
@@ -15,6 +15,7 @@
 package service_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -71,4 +72,35 @@ func TestAuthMiddleware(t *testing.T) {
 	m.ServeHTTP(w, r, handler)
 	require.Nil(t, grants)
 	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestEnsureRecordPermissionRoomBinding(t *testing.T) {
+	t.Run("unscoped record token keeps server-wide access", func(t *testing.T) {
+		ctx := service.WithGrants(context.Background(), &auth.ClaimGrants{
+			Video: &auth.VideoGrant{RoomRecord: true},
+		}, "")
+		require.NoError(t, service.EnsureRecordPermission(ctx))
+		require.NoError(t, service.EnsureRecordPermission(ctx, "any-room"))
+	})
+
+	t.Run("room-scoped record token passes for its own room", func(t *testing.T) {
+		ctx := service.WithGrants(context.Background(), &auth.ClaimGrants{
+			Video: &auth.VideoGrant{Room: "room-a", RoomRecord: true},
+		}, "")
+		require.NoError(t, service.EnsureRecordPermission(ctx, "room-a"))
+	})
+
+	t.Run("room-scoped record token is denied for other rooms", func(t *testing.T) {
+		ctx := service.WithGrants(context.Background(), &auth.ClaimGrants{
+			Video: &auth.VideoGrant{Room: "room-a", RoomRecord: true},
+		}, "")
+		require.Error(t, service.EnsureRecordPermission(ctx, "room-b"))
+	})
+
+	t.Run("room-scoped record token without the record grant is denied", func(t *testing.T) {
+		ctx := service.WithGrants(context.Background(), &auth.ClaimGrants{
+			Video: &auth.VideoGrant{Room: "room-a"},
+		}, "")
+		require.Error(t, service.EnsureRecordPermission(ctx, "room-a"))
+	})
 }

--- a/pkg/service/egress.go
+++ b/pkg/service/egress.go
@@ -229,10 +229,14 @@ func (s *EgressService) startEgress(ctx context.Context, req *rpc.StartEgressReq
 	switch v := req.Request.(type) {
 	case *rpc.StartEgressRequest_RoomComposite:
 		roomName = livekit.RoomName(v.RoomComposite.RoomName)
+	case *rpc.StartEgressRequest_Participant:
+		roomName = livekit.RoomName(v.Participant.RoomName)
 	case *rpc.StartEgressRequest_TrackComposite:
 		roomName = livekit.RoomName(v.TrackComposite.RoomName)
 	case *rpc.StartEgressRequest_Track:
 		roomName = livekit.RoomName(v.Track.RoomName)
+	case *rpc.StartEgressRequest_Egress:
+		roomName = livekit.RoomName(v.Egress.RoomName)
 	}
 	if err := EnsureRecordPermission(ctx, roomName); err != nil {
 		return nil, twirpAuthError(err)
@@ -346,12 +350,18 @@ func (s *EgressService) UpdateStream(ctx context.Context, req *livekit.UpdateStr
 		return nil, ErrEgressNotConnected
 	}
 
-	bindInfo, bindErr := s.io.GetEgress(ctx, &rpc.GetEgressRequest{EgressId: req.EgressId})
-	if bindErr != nil {
-		return nil, bindErr
-	}
-	if err := EnsureRecordPermission(ctx, livekit.RoomName(bindInfo.RoomName)); err != nil {
-		return nil, twirpAuthError(err)
+	if grants := GetGrants(ctx); grants != nil && grants.Video != nil && grants.Video.Room != "" {
+		// Room-scoped token: bind to the egress job's room before delegating.
+		// Fail closed on lookup error - skipping the check would reopen the
+		// cross-room bypass this binding exists to close. Unscoped tokens keep
+		// the previous flow with no extra store read.
+		bindInfo, bindErr := s.io.GetEgress(ctx, &rpc.GetEgressRequest{EgressId: req.EgressId})
+		if bindErr != nil {
+			return nil, twirp.NewError(twirp.Internal, fmt.Sprintf("could not load egress for room binding: %s", bindErr.Error()))
+		}
+		if err := EnsureRecordPermission(ctx, livekit.RoomName(bindInfo.RoomName)); err != nil {
+			return nil, twirpAuthError(err)
+		}
 	}
 
 	info, err := s.client.UpdateStream(ctx, req.EgressId, req)
@@ -382,10 +392,23 @@ func (s *EgressService) ListEgress(ctx context.Context, req *livekit.ListEgressR
 	if err := EnsureRecordPermission(ctx, livekit.RoomName(req.RoomName)); err != nil {
 		return nil, twirpAuthError(err)
 	}
-	if grants := GetGrants(ctx); grants != nil && grants.Video != nil && grants.Video.Room != "" && req.RoomName == "" {
-		// Room-scoped recording tokens list their own room only; an unfiltered
-		// listing would disclose every egress job on the server.
-		req.RoomName = grants.Video.Room
+	if grants := GetGrants(ctx); grants != nil && grants.Video != nil && grants.Video.Room != "" {
+		if req.EgressId != "" {
+			// IOInfoService short-circuits the room filter when a specific
+			// egress ID is requested, so bind it explicitly here: a room-scoped
+			// token must not read other rooms' recordings by ID.
+			info, err := s.io.GetEgress(ctx, &rpc.GetEgressRequest{EgressId: req.EgressId})
+			if err != nil {
+				return nil, err
+			}
+			if err := EnsureRecordPermission(ctx, livekit.RoomName(info.RoomName)); err != nil {
+				return nil, twirpAuthError(err)
+			}
+		} else if req.RoomName == "" {
+			// Room-scoped recording tokens list their own room only; an
+			// unfiltered listing would disclose every egress job on the server.
+			req.RoomName = grants.Video.Room
+		}
 	}
 	return s.io.ListEgress(ctx, req)
 }
@@ -403,12 +426,16 @@ func (s *EgressService) StopEgress(ctx context.Context, req *livekit.StopEgressR
 		return nil, twirpAuthError(err)
 	}
 
-	bindInfo, bindErr := s.io.GetEgress(ctx, &rpc.GetEgressRequest{EgressId: req.EgressId})
-	if bindErr != nil {
-		return nil, bindErr
-	}
-	if err := EnsureRecordPermission(ctx, livekit.RoomName(bindInfo.RoomName)); err != nil {
-		return nil, twirpAuthError(err)
+	if grants := GetGrants(ctx); grants != nil && grants.Video != nil && grants.Video.Room != "" {
+		// Room-scoped token: bind to the egress job's room before stopping.
+		// Fail closed on lookup error; unscoped tokens keep the previous flow.
+		bindInfo, bindErr := s.io.GetEgress(ctx, &rpc.GetEgressRequest{EgressId: req.EgressId})
+		if bindErr != nil {
+			return nil, twirp.NewError(twirp.Internal, fmt.Sprintf("could not load egress for room binding: %s", bindErr.Error()))
+		}
+		if err := EnsureRecordPermission(ctx, livekit.RoomName(bindInfo.RoomName)); err != nil {
+			return nil, twirpAuthError(err)
+		}
 	}
 
 	info, err = s.launcher.StopEgress(ctx, req)

--- a/pkg/service/egress.go
+++ b/pkg/service/egress.go
@@ -225,7 +225,16 @@ func (s *EgressService) StartTrackEgress(ctx context.Context, req *livekit.Track
 }
 
 func (s *EgressService) startEgress(ctx context.Context, req *rpc.StartEgressRequest) (*livekit.EgressInfo, error) {
-	if err := EnsureRecordPermission(ctx); err != nil {
+	var roomName livekit.RoomName
+	switch v := req.Request.(type) {
+	case *rpc.StartEgressRequest_RoomComposite:
+		roomName = livekit.RoomName(v.RoomComposite.RoomName)
+	case *rpc.StartEgressRequest_TrackComposite:
+		roomName = livekit.RoomName(v.TrackComposite.RoomName)
+	case *rpc.StartEgressRequest_Track:
+		roomName = livekit.RoomName(v.Track.RoomName)
+	}
+	if err := EnsureRecordPermission(ctx, roomName); err != nil {
 		return nil, twirpAuthError(err)
 	} else if s.launcher == nil {
 		return nil, ErrEgressNotConnected
@@ -297,15 +306,23 @@ func (s *EgressService) UpdateLayout(ctx context.Context, req *livekit.UpdateLay
 	if err != nil {
 		return nil, err
 	}
+	if err := EnsureRecordPermission(ctx, livekit.RoomName(info.RoomName)); err != nil {
+		return nil, twirpAuthError(err)
+	}
 
 	metadata, err := json.Marshal(&LayoutMetadata{Layout: req.Layout})
 	if err != nil {
 		return nil, err
 	}
 
-	grants := GetGrants(ctx)
+	// The internal UpdateParticipant call needs room-admin on the egress job's
+	// room. Grant it on a COPY of the caller's claims: the context grants are
+	// shared request state, and rewriting them in place would silently widen
+	// the caller's privileges for any later check in this request.
+	grants := GetGrants(ctx).Clone()
 	grants.Video.Room = info.RoomName
 	grants.Video.RoomAdmin = true
+	ctx = WithGrants(ctx, grants, GetAPIKey(ctx))
 
 	_, err = s.roomService.UpdateParticipant(ctx, &livekit.UpdateParticipantRequest{
 		Room:     info.RoomName,
@@ -327,6 +344,14 @@ func (s *EgressService) UpdateStream(ctx context.Context, req *livekit.UpdateStr
 
 	if s.client == nil {
 		return nil, ErrEgressNotConnected
+	}
+
+	bindInfo, bindErr := s.io.GetEgress(ctx, &rpc.GetEgressRequest{EgressId: req.EgressId})
+	if bindErr != nil {
+		return nil, bindErr
+	}
+	if err := EnsureRecordPermission(ctx, livekit.RoomName(bindInfo.RoomName)); err != nil {
+		return nil, twirpAuthError(err)
 	}
 
 	info, err := s.client.UpdateStream(ctx, req.EgressId, req)
@@ -354,8 +379,13 @@ func (s *EgressService) ListEgress(ctx context.Context, req *livekit.ListEgressR
 	if req.RoomName != "" {
 		AppendLogFields(ctx, "room", req.RoomName)
 	}
-	if err := EnsureRecordPermission(ctx); err != nil {
+	if err := EnsureRecordPermission(ctx, livekit.RoomName(req.RoomName)); err != nil {
 		return nil, twirpAuthError(err)
+	}
+	if grants := GetGrants(ctx); grants != nil && grants.Video != nil && grants.Video.Room != "" && req.RoomName == "" {
+		// Room-scoped recording tokens list their own room only; an unfiltered
+		// listing would disclose every egress job on the server.
+		req.RoomName = grants.Video.Room
 	}
 	return s.io.ListEgress(ctx, req)
 }
@@ -370,6 +400,14 @@ func (s *EgressService) StopEgress(ctx context.Context, req *livekit.StopEgressR
 
 	AppendLogFields(ctx, "egressID", req.EgressId)
 	if err := EnsureRecordPermission(ctx); err != nil {
+		return nil, twirpAuthError(err)
+	}
+
+	bindInfo, bindErr := s.io.GetEgress(ctx, &rpc.GetEgressRequest{EgressId: req.EgressId})
+	if bindErr != nil {
+		return nil, bindErr
+	}
+	if err := EnsureRecordPermission(ctx, livekit.RoomName(bindInfo.RoomName)); err != nil {
 		return nil, twirpAuthError(err)
 	}
 


### PR DESCRIPTION
## Problem

Every Egress API operation gates on the boolean `RoomRecord` grant alone (`EnsureRecordPermission`, `pkg/service/auth.go`). A recording token that is **scoped to a single room** (`Video.Room` set — the common pattern for per-room recording clients) can therefore operate on egress jobs in **every other room** on the server:

- `StartRoomCompositeEgress` / `TrackComposite` / `Track` — start a recording of someone else's room to an attacker-chosen output (S3 etc.): cross-room eavesdropping.
- `UpdateStream` / `StopEgress` — mutate or kill other rooms' recordings, addressed by egress ID.
- `ListEgress` — enumerate egress jobs server-wide, disclosing other rooms' activity.
- `UpdateLayout` — worse: it rewrites the caller's **shared context grants in place** (`grants.Video.Room = info.RoomName; grants.Video.RoomAdmin = true`) to pass the internal `UpdateParticipant` admin check, silently widening the caller's privileges for the rest of the request.

## Fix

- `EnsureRecordPermission(ctx, rooms...)` now takes the targeted room(s): a **room-scoped** token must match them. Unscoped tokens (`Video.Room` empty — server-side recording services) keep server-wide access, so existing server clients are unaffected.
- `startEgress` binds the room from the request union; `UpdateLayout`/`UpdateStream`/`StopEgress` bind the room of the loaded egress job; `ListEgress` binds the filter and forces it to the token's room when unset.
- `UpdateLayout` clones the grants and re-injects them via `WithGrants` for the internal call instead of mutating shared request state.

## Tests

- New `TestEnsureRecordPermissionRoomBinding`: unscoped token keeps access, scoped token passes its own room, denied for other rooms, denied without the record grant.
- The package suite requires Docker (unavailable locally); the four cases were verified against a standalone build: `unscoped/any-room → nil`, `scoped/own-room → nil`, `scoped/other-room → permissions denied`, `no-grant → permissions denied`. Relying on CI for the full suite.

Made with [Cursor](https://cursor.com)