### PR TITLE
fix(auth): stop echoing bearer tokens and API keys into logs and responses

### DIFF
--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -88,13 +88,18 @@ func (m *APIKeyAuthMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request,
 
 		secret := m.provider.GetSecret(v.APIKey())
 		if secret == "" {
-			HandleError(w, r, http.StatusUnauthorized, errors.New("invalid API key: "+v.APIKey()))
+			// Do not echo the API key: HandleError writes the error to the WARN log
+			// and the response body, so embedding the key would persist a credential
+			// to logs and reflect it to any intermediary.
+			HandleError(w, r, http.StatusUnauthorized, errors.New("invalid API key"))
 			return
 		}
 
 		claims, grants, err := v.Verify(secret)
 		if err != nil {
-			HandleError(w, r, http.StatusUnauthorized, errors.New("invalid token: "+authToken+", error: "+err.Error()))
+			// Do not echo authToken: it is a live bearer credential and HandleError
+			// sends the message to the WARN log and the response body.
+			HandleError(w, r, http.StatusUnauthorized, errors.New("invalid token: "+err.Error()))
 			return
 		}
 


### PR DESCRIPTION
## Summary

When token or API-key verification fails, the middleware embedded the **presented credential** in the error message:

- `invalid token: <full bearer token>, error: ...`
- `invalid API key: <key>`

That message goes to `HandleError`, which (a) logs it at WARN via `handleError` (`pkg/service/utils.go:78`) and (b) writes it verbatim into the HTTP response body. Net effect: every rejected request persists a live credential to server logs (and whatever log pipeline sits behind them), and reflects it back through any intermediary.

## Fix

Drop the credential from both messages. The token path keeps the underlying verification error detail, which carries the actually-useful debugging signal (expired, bad signature, wrong issuer, ...).

## Testing

- `go build ./pkg/service/` passes.
- `go test ./pkg/service/ -run TestAuth` fails identically on master and on this branch in this environment (testcontainers needs a local Docker daemon); no test asserts on the old credential-echoing strings.

Made with Cursor

Made with [Cursor](https://cursor.com)