### PR TITLE
fix(auth): reject join tokens carrying credentials instead of warn-only

### DIFF
--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -88,13 +88,18 @@ func (m *APIKeyAuthMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request,
 
 		secret := m.provider.GetSecret(v.APIKey())
 		if secret == "" {
-			HandleError(w, r, http.StatusUnauthorized, errors.New("invalid API key: "+v.APIKey()))
+			// Do not echo the API key: HandleError writes the error to the WARN log
+			// and the response body, so embedding the key would persist a credential
+			// to logs and reflect it to any intermediary.
+			HandleError(w, r, http.StatusUnauthorized, errors.New("invalid API key"))
 			return
 		}
 
 		claims, grants, err := v.Verify(secret)
 		if err != nil {
-			HandleError(w, r, http.StatusUnauthorized, errors.New("invalid token: "+authToken+", error: "+err.Error()))
+			// Do not echo authToken: it is a live bearer credential and HandleError
+			// sends the message to the WARN log and the response body.
+			HandleError(w, r, http.StatusUnauthorized, errors.New("invalid token: "+err.Error()))
 			return
 		}
 

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -325,8 +325,11 @@ func ValidateConnectRequest(
 
 	if claims.RoomConfig != nil {
 		if err := claims.RoomConfig.CheckCredentials(); err != nil {
-			lgr.Warnw("credentials found in token", nil)
-			// TODO(dz): in a future version, we'll reject these connections
+			// Credentials in a join token are base64-visible to the participant
+			// holding it and were already rejected at mint time in ToJWT; accept
+			// here would split the contract (join accepts, refresh hard-fails).
+			lgr.Warnw("rejecting connection: credentials found in token", nil)
+			return res, http.StatusBadRequest, errors.New("credentials are not allowed in token room configuration")
 		}
 	}
 


### PR DESCRIPTION
## Summary

Implements the documented TODO in `validateJoin` (`pkg/service/utils.go:328`).

Today the join path accepts a token whose `RoomConfig` carries embedded credentials (e.g. egress storage keys), logging only a warning:

- The credentials sit in the JWT claims, base64-readable by the participant holding the token.
- The mint path already rejects the same shape: `AccessToken.ToJWT()` refuses credential-bearing room configs unless explicitly allowed, so the **server's own refresh** (`RoomManager.refreshToken` re-mints via `ToJWT`) hard-fails on this data and the participant's session dies at first refresh.

Join accepts what mint rejects: a credential-exposure foot-gun plus a guaranteed session failure later.

## Fix

Reject the connection at join when `RoomConfig.CheckCredentials()` fails, per the TODO. Join and mint now share one contract.

Compatibility note: this is the behavioral break the TODO anticipates. If a staged rollout is preferred (e.g. behind a config flag for a release), happy to adjust.

## Testing

- `go build ./pkg/service/` passes.

Made with Cursor

Made with [Cursor](https://cursor.com)