### PR TITLE
config: clarify AdvertiseInternalIP applies to explicit node_ip too

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -67,7 +67,9 @@ rtc:
   use_external_ip: true
   # # when set to true, advertises both mapped external and internal IPs to clients as server candidates.
   # # useful when clients connect from both private and public networks.
-  # # works only when `use_external_ip` is set to true.
+  # # applies when `use_external_ip` is set to true, and also when `node_ip` is set explicitly below
+  # # (with `use_external_ip: false`) — in both cases the node's original local candidate is kept
+  # # alongside the mapped one, instead of being replaced by it.
   # # when both this and `external_ip_only` are set, SFU advertises all private IPs with their mapped external IPs and skips
   # # private IPs that do not have a mapped external IP.
   # advertise_internal_ip: true

--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -67,9 +67,8 @@ rtc:
   use_external_ip: true
   # # when set to true, advertises both mapped external and internal IPs to clients as server candidates.
   # # useful when clients connect from both private and public networks.
-  # # applies when `use_external_ip` is set to true, and also when `node_ip` is set explicitly below
-  # # (with `use_external_ip: false`) — in both cases the node's original local candidate is kept
-  # # alongside the mapped one, instead of being replaced by it.
+  # # works when `use_external_ip` is set to true, and also when `node_ip` is set explicitly below.
+  # # in both cases the node's local candidate is kept alongside the mapped one instead of being replaced by it.
   # # when both this and `external_ip_only` are set, SFU advertises all private IPs with their mapped external IPs and skips
   # # private IPs that do not have a mapped external IP.
   # advertise_internal_ip: true


### PR DESCRIPTION
The advertise_internal_ip comment in config-sample.yaml said it works only when use_external_ip is true. That was accurate until livekit/mediatransportutil#94, which extended AdvertiseInternalIP to also be respected on the explicit node_ip path (use_external_ip: false with rtc.node_ip set) — previously that branch always replaced the host candidate with node_ip, dropping the original local candidate, regardless of AdvertiseInternalIP.

Update the comment so it reflects both cases: advertise_internal_ip keeps the original local candidate alongside the mapped one whether the mapped IP comes from external-IP discovery or from an explicitly configured node_ip.