### PR TITLE
Process NACK retransmissions in a single worker per DownTrack

### DIFF
--- a/pkg/sfu/downtrack.go
+++ b/pkg/sfu/downtrack.go
@@ -65,6 +65,9 @@ const (
 	keyFrameIntervalMax = 1000
 	flushTimeout        = 1 * time.Second
 
+	// upper bound on NACKed sequence numbers buffered between retransmit worker runs
+	maxPendingNACKs = 5000
+
 	waitBeforeSendPaddingOnMute = 100 * time.Millisecond
 	maxPaddingOnMuteDuration    = 5 * time.Second
 	paddingOnMuteInterval       = 100 * time.Millisecond
@@ -336,6 +339,12 @@ type DownTrack struct {
 	keyFrameRequesterCh       chan struct{}
 	keyFrameRequesterChClosed bool
 
+	retransmitChMu     sync.RWMutex
+	retransmitCh       chan struct{}
+	retransmitChClosed bool
+	pendingNACKsMu     sync.Mutex
+	pendingNACKs       []uint16
+
 	createdAt     int64
 	lastUnmutedAt atomic.Time
 }
@@ -363,6 +372,7 @@ func NewDownTrack(params DownTrackParams) (*DownTrack, error) {
 		pacer:               params.Pacer,
 		maxLayerNotifierCh:  make(chan string, 1),
 		keyFrameRequesterCh: make(chan struct{}, 1),
+		retransmitCh:        make(chan struct{}, 1),
 		createdAt:           time.Now().UnixNano(),
 		receiver:            params.Receiver,
 	}
@@ -421,6 +431,8 @@ func NewDownTrack(params DownTrackParams) (*DownTrack, error) {
 		go d.maxLayerNotifierWorker()
 		go d.keyFrameRequester()
 	}
+
+	go d.retransmitWorker()
 
 	d.params.Receiver.AddOnReady(d.handleReceiverReady)
 	d.rtxSequenceNumber.Store(uint64(rand.Intn(1<<14)) + uint64(1<<15)) // a random number in third quartile of sequence number space
@@ -1461,6 +1473,11 @@ func (d *DownTrack) CloseWithFlush(flush bool, isEnding bool) {
 	close(d.keyFrameRequesterCh)
 	d.keyFrameRequesterChMu.Unlock()
 
+	d.retransmitChMu.Lock()
+	d.retransmitChClosed = true
+	close(d.retransmitCh)
+	d.retransmitChMu.Unlock()
+
 	d.params.Listener.OnDownTrackClose(!flush)
 }
 
@@ -2032,7 +2049,7 @@ func (d *DownTrack) handleRTCP(bytes []byte) {
 					numNACKs += uint32(len(packetList))
 					nacks = append(nacks, packetList...)
 				}
-				go d.retransmitPackets(nacks)
+				d.postRetransmitPackets(nacks)
 			}
 
 		case *rtcp.TransportLayerCC:
@@ -2251,6 +2268,49 @@ func (d *DownTrack) retransmitPacket(epm *extPacketMeta, sourcePkt []byte, isPro
 	}
 	d.pacer.Enqueue(pacerPacket)
 	return headerSize + len(payload), nil
+}
+
+// postRetransmitPackets buffers the NACKed sequence numbers, capped at
+// maxPendingNACKs, and signals the retransmit worker without blocking.
+func (d *DownTrack) postRetransmitPackets(nacks []uint16) {
+	if d.sequencer == nil || len(nacks) == 0 {
+		return
+	}
+
+	d.pendingNACKsMu.Lock()
+	d.pendingNACKs = append(d.pendingNACKs, nacks...)
+	if len(d.pendingNACKs) > maxPendingNACKs {
+		// drop the oldest NACKs under a NACK flood
+		d.pendingNACKs = d.pendingNACKs[len(d.pendingNACKs)-maxPendingNACKs:]
+	}
+	d.pendingNACKsMu.Unlock()
+
+	d.retransmitChMu.RLock()
+	if !d.retransmitChClosed {
+		select {
+		case d.retransmitCh <- struct{}{}:
+		default:
+		}
+	}
+	d.retransmitChMu.RUnlock()
+}
+
+func (d *DownTrack) retransmitWorker() {
+	for {
+		_, more := <-d.retransmitCh
+		if !more {
+			return
+		}
+
+		d.pendingNACKsMu.Lock()
+		nacks := d.pendingNACKs
+		d.pendingNACKs = nil
+		d.pendingNACKsMu.Unlock()
+
+		if len(nacks) > 0 {
+			d.retransmitPackets(nacks)
+		}
+	}
 }
 
 func (d *DownTrack) retransmitPackets(nacks []uint16) {


### PR DESCRIPTION
## Summary

`DownTrack.handleRTCP` spawned a new goroutine (`go d.retransmitPackets(nacks)`) for every inbound `TransportLayerNack` RTCP packet. Since NACK arrival rate is driven by the subscriber, this meant goroutine count and per-packet retransmit work scaled 1:1 with the incoming RTCP rate, with no server-side bound.

This replaces the per-packet goroutine with a single long-lived retransmit worker per `DownTrack`, following the same pattern as the existing `keyFrameRequester` / `maxLayerNotifier` workers:

- `postRetransmitPackets` runs on the (already single-threaded) RTCP read callback: it appends the NACKed sequence numbers to a bounded pending buffer and does a non-blocking signal — it never blocks or spawns a goroutine.
- `retransmitWorker` drains all pending NACKs at once and makes a single `retransmitPackets` call, coalescing bursts.
- Pending sequence numbers are capped at `maxPendingNACKs` (oldest dropped) so buffered work can't grow memory unboundedly.

The sequencer already throttles per-packet retransmission (`refTime - meta.lastNack`), so coalescing duplicate sequence numbers does not produce extra retransmits.

## Test plan

- `go build ./pkg/sfu/` and `go vet ./pkg/sfu/` pass
- `go test ./pkg/sfu/` (DownTrack / NACK tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)