### PR TITLE
config: document additional ICE host IPs

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -78,6 +78,11 @@ rtc:
   # # in such cases, use this setting to set the public IP of the node
   # # use_external_ip takes precedence, for this to take effect, set use_external_ip to false
   # node_ip: <external-ip-of-node>
+  # # additional static IPs to advertise as ICE host candidates
+  # # unlike node_ip, these addresses are not used as the node's identity
+  # # traffic sent to each address must be routed to this node
+  # additional_host_ips:
+  #   - <additional-external-ip>
   # # when set, LiveKit will attempt to use a UDP mux so all UDP traffic goes through
   # # listed port(s). To maximize system performance, we recommend using a range of ports
   # # greater or equal to the number of vCPUs on the machine.


### PR DESCRIPTION
Add a sample for the additional_host_ips RTC setting introduced by livekit/mediatransportutil#95. Clarify that these addresses are used for ICE candidate advertisement, do not change node identity, and must already be routed to the node.