### PR TITLE
Exclude Ingress participants from max_participants count

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -568,7 +568,7 @@ func (p *ParticipantImpl) IsAgent() bool {
 func (p *ParticipantImpl) IsDependent() bool {
 	grants := p.grants.Load()
 	switch grants.GetParticipantKind() {
-	case livekit.ParticipantInfo_AGENT, livekit.ParticipantInfo_EGRESS:
+	case livekit.ParticipantInfo_AGENT, livekit.ParticipantInfo_EGRESS, livekit.ParticipantInfo_INGRESS:
 		return true
 	default:
 		return grants.Video.Agent || grants.Video.Recorder

--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -78,6 +78,40 @@ func TestIsReady(t *testing.T) {
 	}
 }
 
+func TestIsDependent(t *testing.T) {
+	tests := []struct {
+		kind      livekit.ParticipantInfo_Kind
+		dependent bool
+	}{
+		{
+			kind:      livekit.ParticipantInfo_STANDARD,
+			dependent: false,
+		},
+		{
+			kind:      livekit.ParticipantInfo_INGRESS,
+			dependent: true,
+		},
+		{
+			kind:      livekit.ParticipantInfo_EGRESS,
+			dependent: true,
+		},
+		{
+			kind:      livekit.ParticipantInfo_AGENT,
+			dependent: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.kind.String(), func(t *testing.T) {
+			grants := &auth.ClaimGrants{Video: &auth.VideoGrant{}}
+			grants.SetParticipantKind(test.kind)
+			p := &ParticipantImpl{}
+			p.grants.Store(grants)
+			require.Equal(t, test.dependent, p.IsDependent())
+		})
+	}
+}
+
 func TestSupportsMoving(t *testing.T) {
 	t.Run("current protocol version", func(t *testing.T) {
 		p := newParticipantForTestWithOpts("test", &participantOpts{protocolVersion: types.CurrentProtocol})


### PR DESCRIPTION
## Summary

`ParticipantImpl.IsDependent()` only excluded `AGENT` and `EGRESS` kind
participants from a room's `max_participants` occupancy check
(`Room.Join`). Both `CreateRoomRequest` and `RoomConfiguration` in the
protocol docs describe `max_participants` as excluding Egress **and**
Ingress participants, but Ingress was never added to the switch, so an
Ingress participant currently still consumes a regular occupancy slot.

This adds `livekit.ParticipantInfo_INGRESS` to the dependent-kind
switch so the actual behavior matches the documented one.

## Test plan

- Added `TestIsDependent` in `pkg/rtc/participant_internal_test.go`,
  covering `STANDARD` (not dependent) vs `INGRESS`/`EGRESS`/`AGENT`
  (dependent).