### PR TITLE
support configurable advertised TURN endpoints

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -295,8 +295,12 @@ keys:
 #   # defaults to 3478 - recommended to 443 if not running HTTP3/QUIC server
 #   # only 53/80/443 are allowed if less than 1024
 #   udp_port: 3478
+#   # advertise domain instead of node IP for UDP TURN candidates, defaults to false
+#   udp_use_domain: false
 #   # defaults to 5349 - if not using a load balancer, this must be set to 443
 #   tls_port: 5349
+#   # advertise tls_port instead of 443 for TURN/TLS candidates, defaults to false
+#   advertise_tls_port: false
 #   # set UDP port range for TURN relay to connect to LiveKit SFU, by default it uses a any available port
 #   relay_range_start: 1024
 #   relay_range_end: 30000
@@ -305,7 +309,7 @@ keys:
 #   # defaults to 12; a value <= 0 disables the quota.
 #   per_user_relay_allocation_limit: 12
 #   # set external_tls to true if using a L4 load balancer to terminate TLS. when enabled,
-#   # LiveKit expects unencrypted traffic on tls_port, and still advertise tls_port as a TURN/TLS candidate.
+#   # LiveKit expects unencrypted traffic on tls_port and advertises 443 unless advertise_tls_port is true.
 #   external_tls: true
 #   # needs to match tls cert domain
 #   domain: turn.myhost.com

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -278,6 +278,8 @@ type TURNConfig struct {
 	RelayPortRangeStart uint16   `yaml:"relay_range_start,omitempty"`
 	RelayPortRangeEnd   uint16   `yaml:"relay_range_end,omitempty"`
 	ExternalTLS         bool     `yaml:"external_tls,omitempty"`
+	AdvertiseTLSPort    bool     `yaml:"advertise_tls_port,omitempty"`
+	UDPUseDomain        bool     `yaml:"udp_use_domain,omitempty"`
 	BindAddresses       []string `yaml:"bind_addresses,omitempty"`
 	// PerUserRelayAllocationLimit caps the number of concurrent relay allocations
 	// a single participant credential may hold, keyed by the participant ID. This

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -42,6 +42,21 @@ func TestConfig_DefaultsKept(t *testing.T) {
 	require.Equal(t, uint32(10), conf.Room.EmptyTimeout)
 }
 
+func TestConfig_TURNURLOptions(t *testing.T) {
+	conf, err := NewConfig("", true, nil, nil)
+	require.NoError(t, err)
+	require.False(t, conf.TURN.AdvertiseTLSPort)
+	require.False(t, conf.TURN.UDPUseDomain)
+
+	const content = `turn:
+  advertise_tls_port: true
+  udp_use_domain: true`
+	conf, err = NewConfig(content, true, nil, nil)
+	require.NoError(t, err)
+	require.True(t, conf.TURN.AdvertiseTLSPort)
+	require.True(t, conf.TURN.UDPUseDomain)
+}
+
 func TestConfig_SignalMessageSizeLimitDefaults(t *testing.T) {
 	conf, err := NewConfig("", true, nil, nil)
 	require.NoError(t, err)

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -1061,12 +1061,20 @@ func (r *RoomManager) iceServersForParticipant(apiKey string, participant types.
 		if r.config.TURN.UDPPort > 0 && !tlsOnly {
 			// UDP TURN is used as STUN
 			hasSTUN = true
-			for _, ip := range r.config.RTC.NodeIP.ToStringSlice() {
-				urls = append(urls, fmt.Sprintf("turn:%s?transport=udp", net.JoinHostPort(ip, strconv.Itoa(int(r.config.TURN.UDPPort)))))
+			if r.config.TURN.UDPUseDomain {
+				urls = append(urls, fmt.Sprintf("turn:%s?transport=udp", net.JoinHostPort(r.config.TURN.Domain, strconv.Itoa(int(r.config.TURN.UDPPort)))))
+			} else {
+				for _, ip := range r.config.RTC.NodeIP.ToStringSlice() {
+					urls = append(urls, fmt.Sprintf("turn:%s?transport=udp", net.JoinHostPort(ip, strconv.Itoa(int(r.config.TURN.UDPPort)))))
+				}
 			}
 		}
 		if r.config.TURN.TLSPort > 0 {
-			urls = append(urls, fmt.Sprintf("turns:%s:443?transport=tcp", r.config.TURN.Domain))
+			turnTLSPort := 443
+			if r.config.TURN.AdvertiseTLSPort {
+				turnTLSPort = r.config.TURN.TLSPort
+			}
+			urls = append(urls, fmt.Sprintf("turns:%s:%d?transport=tcp", r.config.TURN.Domain, turnTLSPort))
 		}
 		if len(urls) > 0 {
 			username, expiry := r.turnAuthHandler.CreateUsername(apiKey, participant.ID(), r.config.TURN.TTLSeconds)

--- a/pkg/service/roommanager_service_test.go
+++ b/pkg/service/roommanager_service_test.go
@@ -9,12 +9,88 @@ import (
 	"go.uber.org/atomic"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/livekit/protocol/auth"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/rpc"
 	"github.com/livekit/psrpc"
 
+	"github.com/livekit/livekit-server/pkg/config"
 	"github.com/livekit/livekit-server/pkg/rtc/types/typesfakes"
 )
+
+func TestRoomManagerICEServersForParticipant_TURNURLOptions(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		advertiseTLSPort bool
+		udpUseDomain     bool
+		tlsOnly          bool
+		urls             []string
+	}{
+		{
+			name: "defaults",
+			urls: []string{
+				"turn:203.0.113.1:3478?transport=udp",
+				"turns:turn.example.com:443?transport=tcp",
+			},
+		},
+		{
+			name:             "advertise tls port",
+			advertiseTLSPort: true,
+			urls: []string{
+				"turn:203.0.113.1:3478?transport=udp",
+				"turns:turn.example.com:8443?transport=tcp",
+			},
+		},
+		{
+			name:         "use domain for udp",
+			udpUseDomain: true,
+			urls: []string{
+				"turn:turn.example.com:3478?transport=udp",
+				"turns:turn.example.com:443?transport=tcp",
+			},
+		},
+		{
+			name:             "both options",
+			advertiseTLSPort: true,
+			udpUseDomain:     true,
+			urls: []string{
+				"turn:turn.example.com:3478?transport=udp",
+				"turns:turn.example.com:8443?transport=tcp",
+			},
+		},
+		{
+			name:    "tls only omits udp",
+			tlsOnly: true,
+			urls:    []string{"turns:turn.example.com:443?transport=tcp"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := &config.Config{}
+			conf.RTC.NodeIP.UnmarshalString("203.0.113.1")
+			conf.TURN = config.TURNConfig{
+				Enabled:          true,
+				Domain:           "turn.example.com",
+				TLSPort:          8443,
+				UDPPort:          3478,
+				AdvertiseTLSPort: tc.advertiseTLSPort,
+				UDPUseDomain:     tc.udpUseDomain,
+			}
+			participant := &typesfakes.FakeLocalParticipant{}
+			participant.IDReturns(livekit.ParticipantID("PA_test"))
+			manager := &RoomManager{
+				config: conf,
+				turnAuthHandler: NewTURNAuthHandler(auth.NewSimpleKeyProvider(
+					turnTestAPIKey,
+					turnTestAPISecret,
+				)),
+			}
+
+			iceServers := manager.iceServersForParticipant(turnTestAPIKey, participant, tc.tlsOnly)
+			require.Len(t, iceServers, 1)
+			require.Equal(t, tc.urls, iceServers[0].Urls)
+		})
+	}
+}
 
 // fakeIngressHandlerClient records WHIPRTCConnectionNotify calls. It embeds the
 // interface so only the method under test needs to be implemented; any other

--- a/pkg/service/turn.go
+++ b/pkg/service/turn.go
@@ -68,7 +68,7 @@ func NewTurnServer(conf *config.Config, authHandler turn.AuthHandler, standalone
 
 	if turnConf.TLSPort <= 0 && turnConf.UDPPort <= 0 {
 		return nil, errors.New("invalid TURN ports")
-	} else if turnConf.TLSPort > 0 {
+	} else if turnConf.TLSPort > 0 || (turnConf.UDPUseDomain && turnConf.UDPPort > 0) {
 		if turnConf.Domain == "" {
 			return nil, errors.New("TURN domain required")
 		}

--- a/pkg/service/turn_test.go
+++ b/pkg/service/turn_test.go
@@ -265,6 +265,27 @@ func TestNewTurnServer_InvalidPeerCIDRFailsStartup(t *testing.T) {
 	}
 }
 
+func TestNewTurnServer_UDPUseDomainRequiresValidDomain(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		domain string
+	}{
+		{name: "missing domain"},
+		{name: "invalid domain", domain: "not a domain"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := &config.Config{}
+			conf.TURN.Enabled = true
+			conf.TURN.UDPPort = 3478
+			conf.TURN.UDPUseDomain = true
+			conf.TURN.Domain = tc.domain
+
+			_, err := NewTurnServer(conf, nil, false)
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestTURNAuthHandler_CreateUsername_TTLClamped(t *testing.T) {
 	h := newTestTurnAuthHandler()
 	pID := livekit.ParticipantID("PA_ttl_clamp")


### PR DESCRIPTION
  ## Summary

  This PR adds configurable advertised TURN endpoints for embedded TURN.

  - Adds `turn.advertise_tls_port` to advertise the configured `tls_port` in TURN/TLS URLs.
  The default remains port `443`.
  - Adds `turn.udp_use_domain` to advertise `turn.domain` for UDP TURN URLs. The default
  remains `RTC.NodeIP`.
  - Validates that `turn.domain` is present and valid when `udp_use_domain` is enabled with a
  UDP TURN port.
  - Updates the sample configuration and adds coverage for defaults, option combinations,
  `tlsOnly`, and validation.

  ## Backward Compatibility

  Both options default to `false`, preserving existing behavior:

  - UDP: `turn:<NodeIP>:<udp_port>?transport=udp`
  - TLS: `turns:<domain>:443?transport=tcp`

  ## Issue

  Resolves https://github.com/livekit/livekit/issues/2344 by allowing deployments behind
  custom port mappings or load balancers to advertise the intended TURN/TLS port and use a
  domain name for UDP TURN candidates.

  Closes #2344