### PR TITLE
Add redis_channel_prefix config to namespace psrpc pubsub channels

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -50,6 +50,12 @@ redis:
   # And it will use the password key above as cluster password
   # And the db key will not be used due to cluster mode not support it.
 
+# redis_channel_prefix namespaces pubsub channel names, letting multiple
+# LiveKit deployments share one redis instance without colliding on
+# channel names (the redis db above only scopes the keyspace, not
+# pubsub channels)
+# redis_channel_prefix: myproject:
+
 # WebRTC configuration
 rtc:
   # UDP ports to use for client traffic.

--- a/go.mod
+++ b/go.mod
@@ -168,3 +168,10 @@ replace github.com/pion/webrtc/v4 => github.com/livekit/webrtc-pion/v4 v4.2.18-w
 replace github.com/pion/dtls/v3 => github.com/livekit/dtls/v3 v3.1.5-warp.1
 
 replace github.com/pion/ice/v4 => github.com/livekit/ice/v4 v4.4.0-warp.1
+
+// TODO(karolyi): temporary fork adding psrpc.WithChannelPrefix (redis pubsub
+// channel namespacing), used by config.Config.RedisChannelPrefix. Upstream PR
+// open against livekit/psrpc (github.com/karolyi/psrpc, commit 83d4a74, rebased
+// on livekit/psrpc main). Once it merges, revert this replace back to
+// github.com/livekit/psrpc.
+replace github.com/livekit/psrpc => github.com/karolyi/psrpc v0.0.0-20260828131748-83d4a7488787

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/jsimonetti/rtnetlink v0.0.0-20211022192332-93da33804786 h1:N527AHMa79
 github.com/jsimonetti/rtnetlink v0.0.0-20211022192332-93da33804786/go.mod h1:v4hqbTdfQngbVSZJVWUhGE/lbTFf9jb+ygmNUDQMuOs=
 github.com/jxskiss/base62 v1.1.0 h1:A5zbF8v8WXx2xixnAKD2w+abC+sIzYJX+nxmhA6HWFw=
 github.com/jxskiss/base62 v1.1.0/go.mod h1:HhWAlUXvxKThfOlZbcuFzsqwtF5TcqS9ru3y5GfjWAc=
+github.com/karolyi/psrpc v0.0.0-20260828131748-83d4a7488787 h1:Iv+wLvG1IK0eNjvqxxl6BMDIY7E2nKqNUnbnh1S9YEA=
+github.com/karolyi/psrpc v0.0.0-20260828131748-83d4a7488787/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
 github.com/klauspost/compress v1.19.2 h1:hMRETovs/pu/dVWN7zIT1PGG8t509MwT6bO7XSi26R8=
 github.com/klauspost/compress v1.19.2/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.4.0 h1:S6Hrbc7+ywsr0r+RLapfGBHfyefhCTwEh3A0tV913Dw=
@@ -166,8 +168,6 @@ github.com/livekit/mediatransportutil v0.0.0-20260821083140-f234b534b095 h1:Bcli
 github.com/livekit/mediatransportutil v0.0.0-20260821083140-f234b534b095/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
 github.com/livekit/protocol v1.50.5-0.20260828115123-c6d0e234b41d h1:qqObuGUWqdu1LbuexhZrrx2J7I25ZliwKRn/4ITu348=
 github.com/livekit/protocol v1.50.5-0.20260828115123-c6d0e234b41d/go.mod h1:x7m1nX86XfvS0YoqXnVe0jixkCmAZglR4mcbRHURSro=
-github.com/livekit/psrpc v0.7.5 h1:WxfJIQ41X1b+48A1uzc8Gy9FhYEMxBJNCpCYqPdO/Ds=
-github.com/livekit/psrpc v0.7.5/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
 github.com/livekit/webrtc-pion/v4 v4.2.18-warp.1 h1:fH+v4W+NFp9FfPzON6FaUFNmazGcctaAhb2P+Ksf+1s=
 github.com/livekit/webrtc-pion/v4 v4.2.18-warp.1/go.mod h1:rbKGHo2OpNUImWTvRIV776/3xjjq/t47H3IZiTtwluc=
 github.com/mackerelio/go-osstat v0.2.8 h1:I2duicTaCGWoM53XwAwA9OIe1inu0xnVs8/pqOWWVr4=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -84,6 +84,12 @@ type Config struct {
 	DebugHandler   DebugHandlerConfig       `yaml:"debug_handler,omitempty"`
 	RTC            RTCConfig                `yaml:"rtc,omitempty"`
 	Redis          redisLiveKit.RedisConfig `yaml:"redis,omitempty"`
+	// RedisChannelPrefix namespaces psrpc pubsub channel names, letting multiple
+	// LiveKit deployments share one redis instance without colliding on channel
+	// names (the redis db index only scopes the keyspace, not pubsub channels).
+	// Requires the github.com/livekit/psrpc replace in go.mod (see the TODO
+	// there) until channel-prefix support lands upstream.
+	RedisChannelPrefix string `yaml:"redis_channel_prefix,omitempty"`
 	Audio          sfu.AudioConfig          `yaml:"audio,omitempty"`
 	Video          VideoConfig              `yaml:"video,omitempty"`
 	Room           RoomConfig               `yaml:"room,omitempty"`

--- a/pkg/service/wire.go
+++ b/pkg/service/wire.go
@@ -193,11 +193,14 @@ func createStore(rc redis.UniversalClient) ObjectStore {
 	return NewLocalStore()
 }
 
-func getMessageBus(rc redis.UniversalClient) psrpc.MessageBus {
+func getMessageBus(conf *config.Config, rc redis.UniversalClient) psrpc.MessageBus {
 	if rc == nil {
 		return psrpc.NewLocalMessageBus()
 	}
-	return psrpc.NewRedisMessageBus(rc)
+	if conf.RedisChannelPrefix == "" {
+		return psrpc.NewRedisMessageBus(rc)
+	}
+	return psrpc.NewRedisMessageBus(rc, psrpc.WithChannelPrefix(conf.RedisChannelPrefix))
 }
 
 func getEgressStore(s ObjectStore) EgressStore {

--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -39,7 +39,7 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 		return nil, err
 	}
 	nodeID := getNodeID(currentNode)
-	messageBus := getMessageBus(universalClient)
+	messageBus := getMessageBus(conf, universalClient)
 	signalRelayConfig := getSignalRelayConfig(conf)
 	signalClient, err := routing.NewSignalClient(nodeID, messageBus, signalRelayConfig)
 	if err != nil {
@@ -164,7 +164,7 @@ func InitializeRouter(conf *config.Config, currentNode routing.LocalNode) (routi
 		return nil, err
 	}
 	nodeID := getNodeID(currentNode)
-	messageBus := getMessageBus(universalClient)
+	messageBus := getMessageBus(conf, universalClient)
 	signalRelayConfig := getSignalRelayConfig(conf)
 	signalClient, err := routing.NewSignalClient(nodeID, messageBus, signalRelayConfig)
 	if err != nil {
@@ -254,11 +254,14 @@ func createStore(rc redis.UniversalClient) ObjectStore {
 	return NewLocalStore()
 }
 
-func getMessageBus(rc redis.UniversalClient) psrpc.MessageBus {
+func getMessageBus(conf *config.Config, rc redis.UniversalClient) psrpc.MessageBus {
 	if rc == nil {
 		return psrpc.NewLocalMessageBus()
 	}
-	return psrpc.NewRedisMessageBus(rc)
+	if conf.RedisChannelPrefix == "" {
+		return psrpc.NewRedisMessageBus(rc)
+	}
+	return psrpc.NewRedisMessageBus(rc, psrpc.WithChannelPrefix(conf.RedisChannelPrefix))
 }
 
 func getEgressStore(s ObjectStore) EgressStore {


### PR DESCRIPTION
Redis's db index only scopes the keyspace, not PUBLISH/SUBSCRIBE, so multiple LiveKit deployments sharing one redis instance previously collided on psrpc channel names (Signal, Room, Keepalive, etc). RedisChannelPrefix threads through to psrpc.WithChannelPrefix so each deployment can namespace its channels.

Requires github.com/karolyi/psrpc (fork of livekit/psrpc adding WithChannelPrefix), pinned via a go.mod replace.

Prerequisite is merging https://github.com/livekit/psrpc/pull/121 and reverting my referred fork for it to the original. Mentioned in the commit as well.