### PR TITLE
Use cluster ID for Egress and SIP PSRPC topics

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -50,6 +50,11 @@ redis:
   # And it will use the password key above as cluster password
   # And the db key will not be used due to cluster mode not support it.
 
+# optional namespace for internal PSRPC topics used by external services such as
+# Egress and SIP. The value must match their cluster_id configuration. Leave
+# empty for the legacy global topics.
+# cluster_id: my-cluster
+
 # WebRTC configuration
 rtc:
   # UDP ports to use for client traffic.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -84,6 +84,7 @@ type Config struct {
 	DebugHandler   DebugHandlerConfig       `yaml:"debug_handler,omitempty"`
 	RTC            RTCConfig                `yaml:"rtc,omitempty"`
 	Redis          redisLiveKit.RedisConfig `yaml:"redis,omitempty"`
+	ClusterID      string                   `yaml:"cluster_id,omitempty"`
 	Audio          sfu.AudioConfig          `yaml:"audio,omitempty"`
 	Video          VideoConfig              `yaml:"video,omitempty"`
 	Room           RoomConfig               `yaml:"room,omitempty"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -42,6 +42,12 @@ func TestConfig_DefaultsKept(t *testing.T) {
 	require.Equal(t, uint32(10), conf.Room.EmptyTimeout)
 }
 
+func TestConfig_ClusterID(t *testing.T) {
+	conf, err := NewConfig("cluster_id: staging", true, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, "staging", conf.ClusterID)
+}
+
 func TestConfig_SignalMessageSizeLimitDefaults(t *testing.T) {
 	conf, err := NewConfig("", true, nil, nil)
 	require.NoError(t, err)

--- a/pkg/service/egress.go
+++ b/pkg/service/egress.go
@@ -42,9 +42,10 @@ type EgressService struct {
 }
 
 type egressLauncher struct {
-	client rpc.EgressClient
-	io     IOClient
-	store  ServiceStore
+	client    rpc.EgressClient
+	io        IOClient
+	store     ServiceStore
+	clusterID string
 }
 
 func NewEgressService(
@@ -61,14 +62,15 @@ func NewEgressService(
 	}
 }
 
-func NewEgressLauncher(client rpc.EgressClient, io IOClient, store ServiceStore) rtc.EgressLauncher {
+func NewEgressLauncher(client rpc.EgressClient, io IOClient, store ServiceStore, clusterID string) rtc.EgressLauncher {
 	if client == nil {
 		return nil
 	}
 	return &egressLauncher{
-		client: client,
-		io:     io,
-		store:  store,
+		client:    client,
+		io:        io,
+		store:     store,
+		clusterID: clusterID,
 	}
 }
 
@@ -270,7 +272,7 @@ func (s *egressLauncher) StartEgress(ctx context.Context, req *rpc.StartEgressRe
 		}
 	}
 
-	info, err := s.client.StartEgress(ctx, "", req)
+	info, err := s.client.StartEgress(ctx, s.clusterID, req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/psrpc_topic_test.go
+++ b/pkg/service/psrpc_topic_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/livekit/protocol/auth"
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/rpc"
+	"github.com/livekit/psrpc"
+
+	"github.com/livekit/livekit-server/pkg/config"
+	"github.com/livekit/livekit-server/pkg/service"
+	"github.com/livekit/livekit-server/pkg/service/servicefakes"
+)
+
+type recordingEgressServer struct {
+	rpc.UnimplementedEgressInternalServer
+	egressID string
+}
+
+func (s *recordingEgressServer) StartEgress(context.Context, *rpc.StartEgressRequest) (*livekit.EgressInfo, error) {
+	return &livekit.EgressInfo{EgressId: s.egressID}, nil
+}
+
+func (*recordingEgressServer) StartEgressAffinity(context.Context, *rpc.StartEgressRequest) float32 {
+	return 1
+}
+
+type recordingSIPServer struct {
+	rpc.UnimplementedSIPInternalServer
+	participantID string
+}
+
+func (s *recordingSIPServer) CreateSIPParticipant(context.Context, *rpc.InternalCreateSIPParticipantRequest) (*rpc.InternalCreateSIPParticipantResponse, error) {
+	return &rpc.InternalCreateSIPParticipantResponse{
+		ParticipantId:       s.participantID,
+		ParticipantIdentity: "sip_test",
+	}, nil
+}
+
+type recordingIOClient struct {
+	service.IOClient
+}
+
+func (recordingIOClient) CreateEgress(context.Context, *livekit.EgressInfo) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func TestEgressLauncherUsesConfiguredClusterIDForStartTopic(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		clusterID string
+		egressID  string
+	}{
+		{name: "legacy global topic", egressID: "EG_global"},
+		{name: "configured cluster topic", clusterID: "staging", egressID: "EG_staging"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			bus := psrpc.NewLocalMessageBus()
+			egressServer, err := rpc.NewEgressInternalServer(
+				&recordingEgressServer{egressID: test.egressID},
+				bus,
+			)
+			require.NoError(t, err)
+			require.NoError(t, egressServer.RegisterStartEgressTopic(test.clusterID))
+			t.Cleanup(egressServer.Shutdown)
+
+			egressClient, err := rpc.NewEgressClient(rpc.ClientParams{Bus: bus})
+			require.NoError(t, err)
+			t.Cleanup(egressClient.Close)
+
+			launcher := service.NewEgressLauncher(egressClient, recordingIOClient{}, nil, test.clusterID)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			info, err := launcher.StartEgress(ctx, &rpc.StartEgressRequest{
+				RoomId: "RM_test",
+				Request: &rpc.StartEgressRequest_Egress{
+					Egress: &livekit.StartEgressRequest{RoomName: "room"},
+				},
+			})
+			require.NoError(t, err)
+			require.Equal(t, test.egressID, info.EgressId)
+		})
+	}
+}
+
+func TestSIPServiceUsesConfiguredClusterIDForCreateTopic(t *testing.T) {
+	bus := psrpc.NewLocalMessageBus()
+	sipServer, err := rpc.NewSIPInternalServer(
+		&recordingSIPServer{participantID: "PA_staging"},
+		bus,
+	)
+	require.NoError(t, err)
+	require.NoError(t, sipServer.RegisterCreateSIPParticipantTopic("staging"))
+	t.Cleanup(sipServer.Shutdown)
+
+	sipClient, err := rpc.NewSIPClient(bus)
+	require.NoError(t, err)
+	t.Cleanup(sipClient.Close)
+
+	svc := service.NewSIPService(
+		&config.SIPConfig{},
+		"NE_test",
+		"staging",
+		nil,
+		sipClient,
+		&servicefakes.FakeSIPStore{},
+		nil,
+		nil,
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	ctx = service.WithGrants(ctx, &auth.ClaimGrants{
+		SIP: &auth.SIPGrant{Call: true},
+	}, "")
+
+	info, err := svc.CreateSIPParticipant(ctx, &livekit.CreateSIPParticipantRequest{
+		Trunk:     &livekit.SIPOutboundConfig{Hostname: "sip.example.com"},
+		SipNumber: "15551234567",
+		SipCallTo: "+15557654321",
+		RoomName:  "room",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "PA_staging", info.ParticipantId)
+}

--- a/pkg/service/sip.go
+++ b/pkg/service/sip.go
@@ -39,6 +39,7 @@ import (
 type SIPService struct {
 	conf        *config.SIPConfig
 	nodeID      livekit.NodeID
+	clusterID   string
 	bus         psrpc.MessageBus
 	psrpcClient rpc.SIPClient
 	store       SIPStore
@@ -48,6 +49,7 @@ type SIPService struct {
 func NewSIPService(
 	conf *config.SIPConfig,
 	nodeID livekit.NodeID,
+	clusterID string,
 	bus psrpc.MessageBus,
 	psrpcClient rpc.SIPClient,
 	store SIPStore,
@@ -57,6 +59,7 @@ func NewSIPService(
 	return &SIPService{
 		conf:        conf,
 		nodeID:      nodeID,
+		clusterID:   clusterID,
 		bus:         bus,
 		psrpcClient: psrpcClient,
 		store:       store,
@@ -624,7 +627,7 @@ func (s *SIPService) CreateSIPParticipant(ctx context.Context, req *livekit.Crea
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
-	resp, err := s.psrpcClient.CreateSIPParticipant(ctx, "", ireq, psrpc.WithRequestTimeout(timeout))
+	resp, err := s.psrpcClient.CreateSIPParticipant(ctx, s.clusterID, ireq, psrpc.WithRequestTimeout(timeout))
 	if err != nil {
 		unlikelyLogger.Errorw("cannot create sip participant", err)
 		return nil, wrapSIPContextError(err)

--- a/pkg/service/wire.go
+++ b/pkg/service/wire.go
@@ -67,6 +67,7 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 		rpc.NewEgressClient,
 		rpc.NewIngressClient,
 		getEgressStore,
+		getClusterID,
 		NewEgressLauncher,
 		NewEgressService,
 		getIngressStore,
@@ -257,6 +258,10 @@ func getSIPStore(s ObjectStore) SIPStore {
 
 func getSIPConfig(conf *config.Config) *config.SIPConfig {
 	return &conf.SIP
+}
+
+func getClusterID(conf *config.Config) string {
+	return conf.ClusterID
 }
 
 func getLimitConf(config *config.Config) config.LimitConfig {

--- a/pkg/service/wire_gen.go
+++ b/pkg/service/wire_gen.go
@@ -84,7 +84,8 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	if err != nil {
 		return nil, err
 	}
-	rtcEgressLauncher := NewEgressLauncher(egressClient, ioInfoService, objectStore)
+	clusterID := getClusterID(conf)
+	rtcEgressLauncher := NewEgressLauncher(egressClient, ioInfoService, objectStore, clusterID)
 	topicFormatter := rpc.NewTopicFormatter()
 	roomClient, err := rpc.NewTypedRoomClient(clientParams)
 	if err != nil {
@@ -115,7 +116,7 @@ func InitializeServer(conf *config.Config, currentNode routing.LocalNode) (*Live
 	if err != nil {
 		return nil, err
 	}
-	sipService := NewSIPService(sipConfig, nodeID, messageBus, sipClient, sipStore, roomService, telemetryService)
+	sipService := NewSIPService(sipConfig, nodeID, clusterID, messageBus, sipClient, sipStore, roomService, telemetryService)
 	rtcService := NewRTCService(conf, roomAllocator, router, telemetryService)
 	whipParticipantClient, err := rpc.NewTypedWHIPParticipantClient(clientParams)
 	if err != nil {
@@ -313,6 +314,10 @@ func getSIPStore(s ObjectStore) SIPStore {
 
 func getSIPConfig(conf *config.Config) *config.SIPConfig {
 	return &conf.SIP
+}
+
+func getClusterID(conf *config.Config) string {
+	return conf.ClusterID
 }
 
 func getLimitConf(config2 *config.Config) config.LimitConfig {


### PR DESCRIPTION
## Rationale

LiveKit Server currently sends Egress start and SIP participant creation RPCs on the global PSRPC topic (`""`). The Egress and SIP services already register these handlers using their configured `cluster_id`.

When multiple environments share a Redis instance, requests from LiveKit Server can therefore miss the intended worker and time out.

This change:

- Adds an optional top-level `cluster_id` to LiveKit Server configuration.
- Uses it for Egress `StartEgress` requests.
- Uses it for SIP `CreateSIPParticipant` requests.
- Preserves the existing global-topic behavior when unset.
- Updates the generated Wire setup and sample configuration.

## Configuration

Set the same value on the LiveKit Server, Egress, and SIP services for each environment:

```yaml
cluster_id: staging
```

Leaving `cluster_id` unset everywhere preserves the existing behavior.

The external workers should be configured before switching the server to a non-empty value. A mismatch temporarily causes requests to have no matching PSRPC handler.

## Scope

This change only affects environment-scoped start/create operations:

- Egress start requests use `cluster_id`.
- SIP participant creation requests use `cluster_id`.
- Egress stop/update requests continue using their existing per-egress topics.
- SIP transfer requests continue using their existing per-call topics.