### PR TITLE
Fix deadlock in regress codec check.

### DIFF
--- a/pkg/rtc/mediatrack.go
+++ b/pkg/rtc/mediatrack.go
@@ -348,8 +348,11 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track sfu.TrackRe
 	})
 
 	ti := t.MediaTrackReceiver.TrackInfoClone()
-	t.lock.Lock()
+
 	var regressCodec bool
+	enableRegression := t.enableRegression()
+
+	t.lock.Lock()
 	mimeType := mime.NormalizeMimeType(track.Codec().MimeType)
 	layer := buffer.GetSpatialLayerForRid(mimeType, track.RID(), ti)
 	if layer < 0 {
@@ -531,7 +534,7 @@ func (t *MediaTrack) AddReceiver(receiver *webrtc.RTPReceiver, track sfu.TrackRe
 		})
 	}
 
-	if newCodec && t.enableRegression() {
+	if newCodec && enableRegression {
 		if mimeType == t.regressionTargetCodec {
 			t.params.Logger.Infow("regression target codec received", "codec", mimeType)
 			t.regressionTargetCodecReceived = true

--- a/pkg/service/rtcservice.go
+++ b/pkg/service/rtcservice.go
@@ -381,7 +381,7 @@ func (s *RTCService) serve(w http.ResponseWriter, r *http.Request, needsJoinRequ
 	var cr connectionResult
 	var initialResponse *livekit.SignalResponse
 	for attempt := 0; attempt < s.config.SignalRelay.ConnectAttempts; attempt++ {
-		connectionTimeout := 3 * time.Second * time.Duration(attempt+1)
+		connectionTimeout := time.Duration(3+attempt) * time.Second
 		ctx := utils.ContextWithAttempt(r.Context(), attempt)
 		cr, initialResponse, err = s.startConnection(ctx, roomName, pi, connectionTimeout)
 		if err == nil || errors.Is(err, context.Canceled) {


### PR DESCRIPTION
Also, change the start signal timeout to linear increase so that three attempts timeout in 12s which is lesser than default client SDK timeout of 15s for initial connection establishment.