### PR TITLE
Support file-backed username/credential for external TURN servers

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -109,6 +109,15 @@ rtc:
   #     # Insecure username/password authentication
   #     username: ""
   #     credential: ""
+  #     # Paths for files containing the static username/password, so credentials can
+  #     # be mounted separately (systemd LoadCredential, Kubernetes secrets, NixOS)
+  #     # instead of being inlined here. When both the inline value and its file are
+  #     # set, the inline value takes precedence. File contents are trimmed, and an
+  #     # empty/whitespace-only file fails startup. credential_file must not be
+  #     # readable by others; username_file has no permission requirement because the
+  #     # username is not a secret.
+  #     username_file: "/run/credentials/livekit/turn-username"
+  #     credential_file: "/run/credentials/livekit/turn-credential"
   # # allows LiveKit to monitor congestion when sending streams and automatically
   # # manage bandwidth utilization to avoid congestion/loss. Enabled by default
   # congestion_control:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,8 +72,16 @@ var (
 	ErrTURNSecretFileIncorrectPermission = errors.New("turn secret file others permissions must be set to 0")
 	ErrKeysNotSet                        = errors.New("one of key-file or keys must be provided")
 	ErrTURNSecretEmpty                   = errors.New("turn secret is empty")
-	ErrTURNServerNoCredentials           = errors.New("turn server has no usable credentials: set a non-empty secret/secret_file for dynamic auth, or username and credential for static auth")
+	ErrTURNServerNoCredentials           = errors.New("turn server has no usable credentials: set a non-empty secret/secret_file for dynamic auth, or username/username_file and credential/credential_file for static auth")
+
+	ErrTURNCredentialFileIncorrectPermission = errors.New("turn credential file others permissions must be set to 0")
+	ErrTURNCredentialFileEmpty               = errors.New("turn credential file is empty")
 )
+
+// turnSecretFileOtherPerms masks the "other" permission bits a file holding a TURN
+// secret must not have set, so a world-readable secret fails startup instead of
+// leaking silently.
+const turnSecretFileOtherPerms os.FileMode = 0o007
 
 type Config struct {
 	Port          uint32   `yaml:"port,omitempty"`
@@ -189,11 +197,19 @@ type RTCConfig struct {
 }
 
 type TURNServer struct {
-	Host       string `yaml:"host,omitempty"`
-	Port       int    `yaml:"port,omitempty"`
-	Protocol   string `yaml:"protocol,omitempty"`
-	Username   string `yaml:"username,omitempty"`
-	Credential string `yaml:"credential,omitempty"`
+	Host     string `yaml:"host,omitempty"`
+	Port     int    `yaml:"port,omitempty"`
+	Protocol string `yaml:"protocol,omitempty"`
+	Username string `yaml:"username,omitempty"`
+	// File containing the static-auth username. Lets deployments that mount
+	// credentials as files (systemd LoadCredential, Kubernetes secrets, NixOS)
+	// keep them out of the config. Username takes precedence when both are set.
+	// The username is not a secret, so no permission restriction is applied.
+	UsernameFile string `yaml:"username_file,omitempty"`
+	Credential   string `yaml:"credential,omitempty"`
+	// File containing the static-auth credential. Credential takes precedence when
+	// both are set. The file must not be readable by others.
+	CredentialFile string `yaml:"credential_file,omitempty"`
 	// Secret is used for TURN static auth secrets mechanism. When provided,
 	// dynamic credentials are generated using HMAC-SHA1 instead of static Username/Credential
 	Secret string `yaml:"secret,omitempty"`
@@ -785,40 +801,108 @@ func (conf *Config) ValidateKeys() error {
 	return nil
 }
 
-func (conf *Config) LoadTURNSecrets() error {
-	var otherFilter os.FileMode = 0o007
-	for i, s := range conf.RTC.TURNServers {
-		// trim first so a blank inline secret falls back to secret_file rather than being treated as set
-		inlineSecret := strings.TrimSpace(s.Secret)
-		switch {
-		case s.SecretFile != "" && inlineSecret != "":
-			logger.Warnw("both secret and secret_file are set for TURN server, the hardcoded secret will be used", nil,
-				"host", s.Host, "port", s.Port)
-			conf.RTC.TURNServers[i].Secret = inlineSecret
-		case s.SecretFile != "":
-			st, err := os.Stat(s.SecretFile)
-			if err != nil {
-				return err
-			}
-			if st.Mode().Perm()&otherFilter != 0o000 {
-				return ErrTURNSecretFileIncorrectPermission
-			}
-			data, err := os.ReadFile(s.SecretFile)
-			if err != nil {
-				return fmt.Errorf("reading turn secret file %q: %w", s.SecretFile, err)
-			}
-			secret := strings.TrimSpace(string(data))
-			if secret == "" {
-				return fmt.Errorf("turn server %q secret file %q: %w", s.Host, s.SecretFile, ErrTURNSecretEmpty)
-			}
-			conf.RTC.TURNServers[i].Secret = secret
-		default:
-			conf.RTC.TURNServers[i].Secret = inlineSecret
+// turnCredentialSource describes one TURN credential that may be supplied either
+// inline in the config or through a file, so secret, username, and credential all
+// resolve through a single code path.
+type turnCredentialSource struct {
+	// field is the inline YAML key; the file counterpart is always "<field>_file".
+	field  string
+	inline string
+	file   string
+	// permErr is returned when the file is readable by others. It is nil for values
+	// that are not secrets, which skips the permission check entirely.
+	permErr error
+	// emptyErr is returned when the file holds nothing but whitespace.
+	emptyErr error
+	// trimInline trims the inline value before deciding whether it is set. Only
+	// `secret` does this, preserving its pre-existing behaviour; a static
+	// username/credential is passed to the TURN server verbatim, so trimming one
+	// would silently change what an existing deployment authenticates with.
+	trimInline bool
+}
+
+// loadTURNCredential resolves one credential from its inline value and its optional
+// file counterpart. The inline value always wins, so an explicit config entry is
+// never silently overridden by a leftover credential file. File contents are always
+// trimmed so a mounted secret written with a trailing newline works as expected.
+func loadTURNCredential(host string, port int, src turnCredentialSource) (string, error) {
+	inline := src.inline
+	if src.trimInline {
+		inline = strings.TrimSpace(inline)
+	}
+	if src.file == "" {
+		return inline, nil
+	}
+	if inline != "" {
+		logger.Warnw("both inline and file TURN credential are set, the inline value will be used", nil,
+			"host", host, "port", port, "field", src.field)
+		return inline, nil
+	}
+
+	if src.permErr != nil {
+		st, err := os.Stat(src.file)
+		if err != nil {
+			return "", err
 		}
+		if st.Mode().Perm()&turnSecretFileOtherPerms != 0o000 {
+			return "", src.permErr
+		}
+	}
+
+	data, err := os.ReadFile(src.file)
+	if err != nil {
+		return "", fmt.Errorf("reading turn %s_file %q: %w", src.field, src.file, err)
+	}
+	value := strings.TrimSpace(string(data))
+	if value == "" {
+		return "", fmt.Errorf("turn server %q %s_file %q: %w", host, src.field, src.file, src.emptyErr)
+	}
+	return value, nil
+}
+
+func (conf *Config) LoadTURNSecrets() error {
+	for i := range conf.RTC.TURNServers {
+		s := &conf.RTC.TURNServers[i]
+
+		secret, err := loadTURNCredential(s.Host, s.Port, turnCredentialSource{
+			field:      "secret",
+			inline:     s.Secret,
+			file:       s.SecretFile,
+			permErr:    ErrTURNSecretFileIncorrectPermission,
+			emptyErr:   ErrTURNSecretEmpty,
+			trimInline: true,
+		})
+		if err != nil {
+			return err
+		}
+
+		// the username is not a secret, so permErr is left nil and its file may be
+		// world-readable
+		username, err := loadTURNCredential(s.Host, s.Port, turnCredentialSource{
+			field:    "username",
+			inline:   s.Username,
+			file:     s.UsernameFile,
+			emptyErr: ErrTURNCredentialFileEmpty,
+		})
+		if err != nil {
+			return err
+		}
+
+		credential, err := loadTURNCredential(s.Host, s.Port, turnCredentialSource{
+			field:    "credential",
+			inline:   s.Credential,
+			file:     s.CredentialFile,
+			permErr:  ErrTURNCredentialFileIncorrectPermission,
+			emptyErr: ErrTURNCredentialFileEmpty,
+		})
+		if err != nil {
+			return err
+		}
+
+		s.Secret, s.Username, s.Credential = secret, username, credential
 
 		// validate credential mode as an explicit union rather than inferring it from a
 		// post-load empty secret (which would silently fall back to static credentials)
-		s := conf.RTC.TURNServers[i]
 		hasDynamic := s.Secret != ""
 		hasStatic := s.Username != "" && s.Credential != ""
 		if !hasDynamic && !hasStatic {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -225,4 +226,146 @@ func TestLoadTURNSecrets(t *testing.T) {
 		require.NoError(t, conf.LoadTURNSecrets())
 		require.Equal(t, "fromfile", conf.RTC.TURNServers[0].Secret)
 	})
+
+	t.Run("static credentials are loaded from files and trimmed", func(t *testing.T) {
+		dir := t.TempDir()
+		conf := &Config{}
+		conf.RTC.TURNServers = []TURNServer{{
+			Host:           "h",
+			UsernameFile:   writeTURNFile(t, dir, "username", " turn-user\n", 0o644),
+			CredentialFile: writeTURNFile(t, dir, "credential", "  turn-pass \n", 0o600),
+		}}
+		require.NoError(t, conf.LoadTURNSecrets())
+		require.Equal(t, "turn-user", conf.RTC.TURNServers[0].Username)
+		require.Equal(t, "turn-pass", conf.RTC.TURNServers[0].Credential)
+	})
+
+	t.Run("world-readable credential file is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		conf := &Config{}
+		conf.RTC.TURNServers = []TURNServer{{
+			Host:           "h",
+			Username:       "u",
+			CredentialFile: writeTURNFile(t, dir, "credential", "turn-pass", 0o644),
+		}}
+		require.ErrorIs(t, conf.LoadTURNSecrets(), ErrTURNCredentialFileIncorrectPermission)
+	})
+
+	t.Run("world-readable username file is accepted", func(t *testing.T) {
+		dir := t.TempDir()
+		conf := &Config{}
+		conf.RTC.TURNServers = []TURNServer{{
+			Host:         "h",
+			UsernameFile: writeTURNFile(t, dir, "username", "turn-user", 0o644),
+			Credential:   "c",
+		}}
+		require.NoError(t, conf.LoadTURNSecrets())
+		require.Equal(t, "turn-user", conf.RTC.TURNServers[0].Username)
+	})
+
+	t.Run("whitespace-only credential file is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		conf := &Config{}
+		conf.RTC.TURNServers = []TURNServer{{
+			Host:           "h",
+			Username:       "u",
+			CredentialFile: writeTURNFile(t, dir, "credential", " \n\t ", 0o600),
+		}}
+		require.ErrorIs(t, conf.LoadTURNSecrets(), ErrTURNCredentialFileEmpty)
+	})
+
+	t.Run("empty username file is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		conf := &Config{}
+		conf.RTC.TURNServers = []TURNServer{{
+			Host:         "h",
+			UsernameFile: writeTURNFile(t, dir, "username", "", 0o644),
+			Credential:   "c",
+		}}
+		require.ErrorIs(t, conf.LoadTURNSecrets(), ErrTURNCredentialFileEmpty)
+	})
+
+	t.Run("missing credential file surfaces the stat error", func(t *testing.T) {
+		conf := &Config{}
+		conf.RTC.TURNServers = []TURNServer{{
+			Host:           "h",
+			Username:       "u",
+			CredentialFile: filepath.Join(t.TempDir(), "does-not-exist"),
+		}}
+		require.ErrorIs(t, conf.LoadTURNSecrets(), os.ErrNotExist)
+	})
+
+	t.Run("unreadable username file surfaces the read error", func(t *testing.T) {
+		conf := &Config{}
+		conf.RTC.TURNServers = []TURNServer{{
+			Host:         "h",
+			UsernameFile: filepath.Join(t.TempDir(), "does-not-exist"),
+			Credential:   "c",
+		}}
+		require.ErrorIs(t, conf.LoadTURNSecrets(), os.ErrNotExist)
+	})
+
+	t.Run("inline static credentials take precedence over their files", func(t *testing.T) {
+		dir := t.TempDir()
+		conf := &Config{}
+		conf.RTC.TURNServers = []TURNServer{{
+			Host:           "h",
+			Username:       "inline-user",
+			UsernameFile:   writeTURNFile(t, dir, "username", "file-user", 0o644),
+			Credential:     "inline-pass",
+			CredentialFile: writeTURNFile(t, dir, "credential", "file-pass", 0o600),
+		}}
+		require.NoError(t, conf.LoadTURNSecrets())
+		require.Equal(t, "inline-user", conf.RTC.TURNServers[0].Username)
+		require.Equal(t, "inline-pass", conf.RTC.TURNServers[0].Credential)
+	})
+
+	// unlike secret, a static username/credential is sent to the TURN server as-is,
+	// so surrounding whitespace must survive exactly as it was configured
+	t.Run("inline static credentials keep surrounding whitespace", func(t *testing.T) {
+		conf := &Config{}
+		conf.RTC.TURNServers = []TURNServer{{Host: "h", Username: " u ", Credential: " c "}}
+		require.NoError(t, conf.LoadTURNSecrets())
+		require.Equal(t, " u ", conf.RTC.TURNServers[0].Username)
+		require.Equal(t, " c ", conf.RTC.TURNServers[0].Credential)
+	})
+
+	t.Run("credential file without a username is rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		conf := &Config{}
+		conf.RTC.TURNServers = []TURNServer{{
+			Host:           "h",
+			CredentialFile: writeTURNFile(t, dir, "credential", "turn-pass", 0o600),
+		}}
+		require.ErrorIs(t, conf.LoadTURNSecrets(), ErrTURNServerNoCredentials)
+	})
+}
+
+func writeTURNFile(t *testing.T, dir, name, content string, perm os.FileMode) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), perm))
+	return path
+}
+
+// TestNewConfigParsesTURNCredentialFiles covers the end-to-end path an operator
+// actually uses: YAML keys straight from the config file through to the resolved
+// credentials.
+func TestNewConfigParsesTURNCredentialFiles(t *testing.T) {
+	dir := t.TempDir()
+	usernameFile := writeTURNFile(t, dir, "username", "turn-user\n", 0o644)
+	credentialFile := writeTURNFile(t, dir, "credential", "  turn-pass \n", 0o600)
+
+	content := fmt.Sprintf(`rtc:
+  turn_servers:
+    - host: turn.example.com
+      username_file: %s
+      credential_file: %s
+`, usernameFile, credentialFile)
+
+	conf, err := NewConfig(content, true, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, conf.LoadTURNSecrets())
+	require.Equal(t, "turn-user", conf.RTC.TURNServers[0].Username)
+	require.Equal(t, "turn-pass", conf.RTC.TURNServers[0].Credential)
 }


### PR DESCRIPTION
Fix #4230

`turn_servers` already lets the dynamic (static-auth-secret) credential come from a file
via `secret_file`, but the static `username`/`credential` pair could only be written
inline in the config. Deployments that mount secrets as files — systemd
`LoadCredential=`, Kubernetes secrets, the NixOS module the issue reporter uses — have to
inline the TURN password into the config file, or give up the packaged config options and
hand-write the whole thing.

This adds `username_file` and `credential_file` next to the existing `secret_file`.

## Behaviour

- All three file-backed credentials resolve through one helper. The inline value always
  wins when both it and its `*_file` counterpart are set (logged as a warning), so an
  explicit config entry is never silently overridden by a leftover file.
- File contents are trimmed, so a secret written with a trailing newline works. An
  empty/whitespace-only file fails startup rather than silently degrading to "no
  credentials".
- `credential_file` must not be readable by others, matching `secret_file`.
  `username_file` has no permission requirement — the username is not a secret, and
  requiring `chmod o-rwx` on it would be a pointless deployment footgun.
- The pre-existing `secret`/`secret_file` behaviour is unchanged: same error identities
  (`ErrTURNSecretEmpty`, `ErrTURNSecretFileIncorrectPermission`), same precedence, and
  the inline `secret` is still trimmed. Inline `username`/`credential` are deliberately
  **not** trimmed — they are passed to the TURN server verbatim, so trimming them would
  change what an existing deployment authenticates with.

`config-sample.yaml` documents both new keys, their precedence, and the permission rule.

## Test verification (RED → GREEN)

RED — the new end-to-end test applied on unmodified `master` with **no production
change**, only the test file present:

```
=== RUN   TestNewConfigParsesTURNCredentialFiles
    Error:      	Received unexpected error:
    	            	could not parse config: yaml: unmarshal errors:
    	            	  line 4: field username_file not found in type config.TURNServer
    	            	  line 5: field credential_file not found in type config.TURNServer
    Test:       	TestNewConfigParsesTURNCredentialFiles
--- FAIL: TestNewConfigParsesTURNCredentialFiles (0.03s)
FAIL	github.com/livekit/livekit-server/pkg/config	0.088s
```

GREEN — same test plus the new `TestLoadTURNSecrets` subtests on this branch:

```
--- PASS: TestLoadTURNSecrets (0.01s)
    --- PASS: TestLoadTURNSecrets/static_credentials_are_loaded_from_files_and_trimmed (0.00s)
    --- PASS: TestLoadTURNSecrets/world-readable_credential_file_is_rejected (0.00s)
    --- PASS: TestLoadTURNSecrets/world-readable_username_file_is_accepted (0.00s)
    --- PASS: TestLoadTURNSecrets/whitespace-only_credential_file_is_rejected (0.00s)
    --- PASS: TestLoadTURNSecrets/empty_username_file_is_rejected (0.00s)
    --- PASS: TestLoadTURNSecrets/missing_credential_file_surfaces_the_stat_error (0.00s)
    --- PASS: TestLoadTURNSecrets/unreadable_username_file_surfaces_the_read_error (0.00s)
    --- PASS: TestLoadTURNSecrets/inline_static_credentials_take_precedence_over_their_files (0.00s)
    --- PASS: TestLoadTURNSecrets/inline_static_credentials_keep_surrounding_whitespace (0.00s)
    --- PASS: TestLoadTURNSecrets/credential_file_without_a_username_is_rejected (0.00s)
=== RUN   TestNewConfigParsesTURNCredentialFiles
--- PASS: TestNewConfigParsesTURNCredentialFiles (0.02s)
PASS
ok  	github.com/livekit/livekit-server/pkg/config	1.080s
```

All nine pre-existing `TestLoadTURNSecrets` subtests still pass unchanged.
