### PR TITLE
Return created ingress info from io service

### DIFF
--- a/pkg/service/ingress.go
+++ b/pkg/service/ingress.go
@@ -140,13 +140,14 @@ func (s *IngressService) CreateIngressWithUrl(ctx context.Context, urlStr string
 		urlStr = urlObj.String()
 	}
 
+	reqID := RequestID(ctx)
 	var sk string
 	if req.InputType != livekit.IngressInput_URL_INPUT {
 		sk = guid.New("")
 	}
 
 	info := &livekit.IngressInfo{
-		IngressId:           guid.New(utils.IngressPrefix),
+		IngressId:           DeterministicID(utils.IngressPrefix, reqID),
 		Name:                req.Name,
 		StreamKey:           sk,
 		Url:                 urlStr,
@@ -192,11 +193,13 @@ func (s *IngressService) CreateIngressWithUrl(ctx context.Context, urlStr string
 		}
 		// The Ingress instance will create the ingress object when handling the URL pull ingress
 	} else {
-		// TODO-jie: ingress retry idempotency: generate ingress key by request-id, and return the ingress object from CreateIngress.
-		_, err = s.io.CreateIngress(ctx, info)
+		var resp *rpc.CreateIngressResponse
+		resp, err = s.io.CreateIngress(ctx, info)
 		switch err {
 		case nil:
-			break
+			if resp.GetInfo() != nil {
+				info = resp.GetInfo()
+			}
 		case ingress.ErrIngressOutOfDate:
 			// Error returned if the ingress was already created by the ingress service
 			err = nil


### PR DESCRIPTION
The stream key is randomly generated for each request. Return exsiting record if the `ingressID` already exists on retry.