### PR TITLE
Group livekit dependency updates in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,11 +36,12 @@
       "groupName": "pion deps"
     },
     {
-      "description": "First-party deps, no need to quarantine new releases",
+      "description": "First-party deps, no need to quarantine new releases; they are co-released and depend on each other, so they are grouped into a single PR",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
         "github.com/livekit{/,}**"
       ],
+      "groupName": "livekit deps",
       "minimumReleaseAge": null
     },
     {


### PR DESCRIPTION
First-party `github.com/livekit/**` modules are co-released and depend on each other, so bumping them one at a time produces a stream of separate PRs (and can produce PRs that don't build on their own). Group them into a single `livekit deps` PR instead.

The rule sits after the `gomod` / `groupName: null` never-group default, so it overrides it for first-party modules only. `minimumReleaseAge: null` is preserved, and major bumps still split off on their own via Renovate's default `separateMajorMinor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)