### PR TITLE
Do not escape the ICE server URI in the WHIP Link header

### DIFF
--- a/pkg/service/whipservice.go
+++ b/pkg/service/whipservice.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/pion/webrtc/v4"
@@ -269,7 +268,7 @@ func (s *WHIPService) handleCreate(w http.ResponseWriter, r *http.Request) {
 	for _, iceServer := range res.IceServers {
 		for _, iceURL := range iceServer.Urls {
 			iceServerLink := &linkheader.Link{
-				URL:    url.PathEscape(iceURL),
+				URL:    iceURL,
 				Rel:    "ice-server",
 				Params: map[string]string{},
 			}


### PR DESCRIPTION
The link target was passed through url.PathEscape, which turns the '?' of turn:host:3478?transport=udp into %3F. The target of a Link header field is a URI reference and "?transport=" is part of TURN URI syntax , not a query string, so a publisher that percent-decodes the target ends up with an unparsable host.