### PR TITLE
Keep new rooms off draining nodes; clear routing only when it is ours

### DIFF
--- a/pkg/routing/interfaces.go
+++ b/pkg/routing/interfaces.go
@@ -134,7 +134,9 @@ type Router interface {
 
 	GetNodeForRoom(ctx context.Context, roomName livekit.RoomName) (*livekit.Node, error)
 	SetNodeForRoom(ctx context.Context, roomName livekit.RoomName, nodeId livekit.NodeID) error
-	ClearRoomState(ctx context.Context, roomName livekit.RoomName) error
+	// clears a room's routing, and reports whether it was this node's to clear:
+	// a room can be routed to another node before this one is done with it
+	ClearRoomState(ctx context.Context, roomName livekit.RoomName) (bool, error)
 
 	GetRegion() string
 

--- a/pkg/routing/localrouter.go
+++ b/pkg/routing/localrouter.go
@@ -64,8 +64,9 @@ func (r *LocalRouter) SetNodeForRoom(_ context.Context, _ livekit.RoomName, _ li
 	return nil
 }
 
-func (r *LocalRouter) ClearRoomState(_ context.Context, _ livekit.RoomName) error {
-	return nil
+func (r *LocalRouter) ClearRoomState(_ context.Context, _ livekit.RoomName) (bool, error) {
+	// the only node there is, so every room is its own
+	return true, nil
 }
 
 func (r *LocalRouter) RegisterNode() error {

--- a/pkg/routing/localrouter_test.go
+++ b/pkg/routing/localrouter_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/livekit-server/pkg/config"
+	"github.com/livekit/livekit-server/pkg/routing"
+)
+
+// There is nowhere for a room to have moved to on a single node, so clearing
+// one always did clear it. Saying so is what lets the room's own records be
+// deleted at all on a deployment that routes locally.
+func TestLocalRouterClearsRoomState(t *testing.T) {
+	r := routing.NewLocalRouter(testNode(t), nil, nil, config.DefaultNodeStatsConfig)
+
+	cleared, err := r.ClearRoomState(context.Background(), "test-room")
+	require.NoError(t, err)
+	require.True(t, cleared)
+}

--- a/pkg/routing/redisrouter.go
+++ b/pkg/routing/redisrouter.go
@@ -113,11 +113,29 @@ func (r *RedisRouter) SetNodeForRoom(_ context.Context, roomName livekit.RoomNam
 	return r.rc.HSet(r.ctx, NodeRoomKey, string(roomName), string(nodeID)).Err()
 }
 
-func (r *RedisRouter) ClearRoomState(_ context.Context, roomName livekit.RoomName) error {
-	if err := r.rc.HDel(context.Background(), NodeRoomKey, string(roomName)).Err(); err != nil {
-		return errors.Wrap(err, "could not clear room state")
+var clearRoomStateScript = redis.NewScript(`if redis.call("hget", KEYS[1], ARGV[1]) == ARGV[2] then
+												return redis.call("hdel", KEYS[1], ARGV[1])
+											 else return 0
+											 end`)
+
+// ClearRoomState clears a room's routing, but only while it still names this
+// node: a room can be routed to another node before the node it was on is done
+// with it, and clearing it then would unroute a room that is being hosted.
+func (r *RedisRouter) ClearRoomState(_ context.Context, roomName livekit.RoomName) (bool, error) {
+	// could be called after Stop(), so we'd want to use an unrelated context
+	res, err := clearRoomStateScript.Run(
+		context.Background(),
+		r.rc,
+		[]string{NodeRoomKey},
+		string(roomName),
+		string(r.currentNode.NodeID()),
+	).Result()
+	if err != nil {
+		return false, errors.Wrap(err, "could not clear room state")
 	}
-	return nil
+
+	cleared, _ := res.(int64)
+	return cleared == 1, nil
 }
 
 func (r *RedisRouter) GetNode(nodeID livekit.NodeID) (*livekit.Node, error) {

--- a/pkg/routing/redisrouter_test.go
+++ b/pkg/routing/redisrouter_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/rpc/rpcfakes"
+
+	"github.com/livekit/livekit-server/pkg/config"
+	"github.com/livekit/livekit-server/pkg/routing"
+	"github.com/livekit/livekit-server/pkg/testutils"
+)
+
+const testNodeID = livekit.NodeID("node-test")
+
+func testNode(t *testing.T) routing.LocalNode {
+	node, err := routing.NewLocalNodeFromNodeProto(&livekit.Node{Id: string(testNodeID)})
+	require.NoError(t, err)
+	return node
+}
+
+// liveRedis is a redis of this test's own, for the few things that cannot be
+// shown without one. The keys a router writes to are fixed ones, and the rest
+// of the suite flushes the redis it shares whenever a multi-node test ends, so
+// a redis this test is alone on is the only one it can rely on.
+func liveRedis(t *testing.T) *redis.Client {
+	rc := redis.NewClient(testutils.StartRedis(t).Options())
+	t.Cleanup(func() { _ = rc.Close() })
+	return rc
+}
+
+func testRedisRouter(t *testing.T, rc redis.UniversalClient) *routing.RedisRouter {
+	return routing.NewRedisRouter(
+		routing.NewLocalRouter(testNode(t), nil, nil, config.DefaultNodeStatsConfig),
+		rc,
+		&rpcfakes.FakeKeepalivePubSub{},
+	)
+}
+
+// A room can be moved off a draining node while that node still has it, and
+// then the node finishing its drain must not take the mapping with it: the room
+// it would clear is the one the live node is now hosting, and the next
+// participant to look for it would be sent somewhere else again.
+func TestRedisRouterClearsOnlyItsOwnRoomMapping(t *testing.T) {
+	rc := liveRedis(t)
+	ctx := context.Background()
+
+	const room = livekit.RoomName("clear-room-state-test")
+
+	r := testRedisRouter(t, rc)
+	t.Cleanup(r.Stop)
+
+	require.NoError(t, r.SetNodeForRoom(ctx, room, "node-other"))
+	cleared, err := r.ClearRoomState(ctx, room)
+	require.NoError(t, err)
+	require.False(t, cleared, "a room routed to another node was reported as cleared")
+	held, err := rc.HGet(ctx, routing.NodeRoomKey, string(room)).Result()
+	require.NoError(t, err, "the room was cleared off the node that had taken it over")
+	require.Equal(t, "node-other", held)
+
+	require.NoError(t, r.SetNodeForRoom(ctx, room, testNodeID))
+	cleared, err = r.ClearRoomState(ctx, room)
+	require.NoError(t, err)
+	require.True(t, cleared, "a room this node was on was not reported as cleared")
+	_, err = rc.HGet(ctx, routing.NodeRoomKey, string(room)).Result()
+	require.ErrorIs(t, err, redis.Nil, "the room was left routed to the node it was on")
+}
+
+// The rooms outlive the router on the way out: a node stops its router before
+// the room manager closes what is left on it, and each of those rooms clears
+// its own routing as it goes. A call made on the router's own context would
+// find it cancelled and clear nothing.
+func TestRedisRouterClearsRoomStateAfterStop(t *testing.T) {
+	rc := liveRedis(t)
+	ctx := context.Background()
+
+	const room = livekit.RoomName("clear-after-stop-test")
+
+	r := testRedisRouter(t, rc)
+
+	require.NoError(t, r.SetNodeForRoom(ctx, room, testNodeID))
+	r.Stop()
+
+	cleared, err := r.ClearRoomState(ctx, room)
+	require.NoError(t, err)
+	require.True(t, cleared, "a stopped router left the room it was closing routed to itself")
+}

--- a/pkg/routing/routingfakes/fake_router.go
+++ b/pkg/routing/routingfakes/fake_router.go
@@ -10,17 +10,19 @@ import (
 )
 
 type FakeRouter struct {
-	ClearRoomStateStub        func(context.Context, livekit.RoomName) error
+	ClearRoomStateStub        func(context.Context, livekit.RoomName) (bool, error)
 	clearRoomStateMutex       sync.RWMutex
 	clearRoomStateArgsForCall []struct {
 		arg1 context.Context
 		arg2 livekit.RoomName
 	}
 	clearRoomStateReturns struct {
-		result1 error
+		result1 bool
+		result2 error
 	}
 	clearRoomStateReturnsOnCall map[int]struct {
-		result1 error
+		result1 bool
+		result2 error
 	}
 	CreateRoomStub        func(context.Context, *livekit.CreateRoomRequest) (*livekit.Room, error)
 	createRoomMutex       sync.RWMutex
@@ -152,7 +154,7 @@ type FakeRouter struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeRouter) ClearRoomState(arg1 context.Context, arg2 livekit.RoomName) error {
+func (fake *FakeRouter) ClearRoomState(arg1 context.Context, arg2 livekit.RoomName) (bool, error) {
 	fake.clearRoomStateMutex.Lock()
 	ret, specificReturn := fake.clearRoomStateReturnsOnCall[len(fake.clearRoomStateArgsForCall)]
 	fake.clearRoomStateArgsForCall = append(fake.clearRoomStateArgsForCall, struct {
@@ -167,9 +169,9 @@ func (fake *FakeRouter) ClearRoomState(arg1 context.Context, arg2 livekit.RoomNa
 		return stub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeRouter) ClearRoomStateCallCount() int {
@@ -178,7 +180,7 @@ func (fake *FakeRouter) ClearRoomStateCallCount() int {
 	return len(fake.clearRoomStateArgsForCall)
 }
 
-func (fake *FakeRouter) ClearRoomStateCalls(stub func(context.Context, livekit.RoomName) error) {
+func (fake *FakeRouter) ClearRoomStateCalls(stub func(context.Context, livekit.RoomName) (bool, error)) {
 	fake.clearRoomStateMutex.Lock()
 	defer fake.clearRoomStateMutex.Unlock()
 	fake.ClearRoomStateStub = stub
@@ -191,27 +193,30 @@ func (fake *FakeRouter) ClearRoomStateArgsForCall(i int) (context.Context, livek
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeRouter) ClearRoomStateReturns(result1 error) {
+func (fake *FakeRouter) ClearRoomStateReturns(result1 bool, result2 error) {
 	fake.clearRoomStateMutex.Lock()
 	defer fake.clearRoomStateMutex.Unlock()
 	fake.ClearRoomStateStub = nil
 	fake.clearRoomStateReturns = struct {
-		result1 error
-	}{result1}
+		result1 bool
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeRouter) ClearRoomStateReturnsOnCall(i int, result1 error) {
+func (fake *FakeRouter) ClearRoomStateReturnsOnCall(i int, result1 bool, result2 error) {
 	fake.clearRoomStateMutex.Lock()
 	defer fake.clearRoomStateMutex.Unlock()
 	fake.ClearRoomStateStub = nil
 	if fake.clearRoomStateReturnsOnCall == nil {
 		fake.clearRoomStateReturnsOnCall = make(map[int]struct {
-			result1 error
+			result1 bool
+			result2 error
 		})
 	}
 	fake.clearRoomStateReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
+		result1 bool
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeRouter) CreateRoom(arg1 context.Context, arg2 *livekit.CreateRoomRequest) (*livekit.Room, error) {

--- a/pkg/routing/selector/utils.go
+++ b/pkg/routing/selector/utils.go
@@ -40,10 +40,16 @@ func IsAvailable(node *livekit.Node) bool {
 	return int(delta) < AvailableSeconds
 }
 
+// checks if a node can be given a room to host: updated recently enough to be
+// answering, and not on its way out. A node keeps registering itself while it
+// drains, so it stays as fresh as any other for as long as it takes, and
+// freshness alone would keep handing it participants it cannot see out.
+func CanHostRoom(node *livekit.Node) bool {
+	return IsAvailable(node) && node.State == livekit.NodeState_SERVING
+}
+
 func GetAvailableNodes(nodes []*livekit.Node) []*livekit.Node {
-	return funk.Filter(nodes, func(node *livekit.Node) bool {
-		return IsAvailable(node) && node.State == livekit.NodeState_SERVING
-	}).([]*livekit.Node)
+	return funk.Filter(nodes, CanHostRoom).([]*livekit.Node)
 }
 
 func GetNodeSysload(node *livekit.Node) float32 {

--- a/pkg/routing/selector/utils_test.go
+++ b/pkg/routing/selector/utils_test.go
@@ -44,3 +44,35 @@ func TestIsAvailable(t *testing.T) {
 		require.False(t, selector.IsAvailable(n))
 	})
 }
+
+// A node on its way out keeps registering itself for as long as it drains, so
+// its stats stay as fresh as a serving node's. Freshness alone cannot tell the
+// two apart, and only one of them can be given a room.
+func TestCanHostRoom(t *testing.T) {
+	fresh := func(state livekit.NodeState) *livekit.Node {
+		return &livekit.Node{
+			State: state,
+			Stats: &livekit.NodeStats{
+				UpdatedAt: time.Now().Unix(),
+			},
+		}
+	}
+
+	t.Run("serving", func(t *testing.T) {
+		require.True(t, selector.CanHostRoom(fresh(livekit.NodeState_SERVING)))
+	})
+
+	t.Run("draining", func(t *testing.T) {
+		require.False(t, selector.CanHostRoom(fresh(livekit.NodeState_SHUTTING_DOWN)))
+	})
+
+	t.Run("not yet serving", func(t *testing.T) {
+		require.False(t, selector.CanHostRoom(fresh(livekit.NodeState_STARTING_UP)))
+	})
+
+	t.Run("stale", func(t *testing.T) {
+		n := fresh(livekit.NodeState_SERVING)
+		n.Stats.UpdatedAt = time.Now().Unix() - 20
+		require.False(t, selector.CanHostRoom(n))
+	})
+}

--- a/pkg/service/roomallocator.go
+++ b/pkg/service/roomallocator.go
@@ -138,8 +138,19 @@ func (r *StandardRoomAllocator) SelectRoomNode(ctx context.Context, roomName liv
 		return err
 	}
 
-	// if already assigned and still available, keep it on that node
-	if err == nil && selector.IsAvailable(existing) {
+	// if already assigned and still available, keep it on that node.
+	//
+	// a node that has begun draining is not available, however fresh it looks:
+	// it keeps registering itself for as long as it drains, and everything left
+	// on it goes when it does. the room moves, and the participants still on the
+	// draining node follow it there as they reconnect.
+	//
+	// until they have, both nodes host a room of that name, and a room's records
+	// and its rpc topics are keyed by the name alone. so for that window the
+	// store holds whichever node wrote last, and a room rpc reaches whichever
+	// node answers first. moving the room when the drain begins, rather than
+	// leaving it to be found here, is what would close the window.
+	if err == nil && selector.CanHostRoom(existing) {
 		// if node hosting the room is full, deny entry
 		if selector.LimitsReached(r.config.Limit, existing.Stats) {
 			return routing.ErrNodeLimitReached

--- a/pkg/service/roomallocator_test.go
+++ b/pkg/service/roomallocator_test.go
@@ -17,6 +17,7 @@ package service_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -47,7 +48,7 @@ func TestCreateRoom(t *testing.T) {
 	})
 }
 
-func SelectRoomNode(t *testing.T) {
+func TestSelectRoomNode(t *testing.T) {
 	t.Run("reject new participants when track limit has been reached", func(t *testing.T) {
 		conf, err := config.NewConfig("", true, nil, nil)
 		require.NoError(t, err)
@@ -56,6 +57,7 @@ func SelectRoomNode(t *testing.T) {
 		node, err := routing.NewLocalNode(conf)
 		require.NoError(t, err)
 		node.SetStats(&livekit.NodeStats{
+			UpdatedAt:    time.Now().Unix(),
 			NumTracksIn:  100,
 			NumTracksOut: 100,
 		})
@@ -74,8 +76,13 @@ func SelectRoomNode(t *testing.T) {
 		node, err := routing.NewLocalNode(conf)
 		require.NoError(t, err)
 		node.SetStats(&livekit.NodeStats{
-			BytesInPerSec:  1000,
-			BytesOutPerSec: 1000,
+			UpdatedAt: time.Now().Unix(),
+			// the limit is read off the most recent rate sample, the per-second
+			// fields on the stats themselves having been left behind
+			Rates: []*livekit.NodeStatsRate{{
+				BytesIn:  1000,
+				BytesOut: 1000,
+			}},
 		})
 
 		ra, _ := newTestRoomAllocator(t, conf, node.Clone())

--- a/pkg/service/roomallocator_test.go
+++ b/pkg/service/roomallocator_test.go
@@ -38,7 +38,7 @@ func TestCreateRoom(t *testing.T) {
 		node, err := routing.NewLocalNode(conf)
 		require.NoError(t, err)
 
-		ra, conf := newTestRoomAllocator(t, conf, node.Clone())
+		ra, _ := newTestRoomAllocator(t, conf, node.Clone())
 
 		room, _, _, err := ra.CreateRoom(context.Background(), &livekit.CreateRoomRequest{Name: "myroom"}, true)
 		require.NoError(t, err)
@@ -90,9 +90,33 @@ func TestSelectRoomNode(t *testing.T) {
 		err = ra.SelectRoomNode(context.Background(), "low-limit-room", "")
 		require.ErrorIs(t, err, routing.ErrNodeLimitReached)
 	})
+
+	// A node that has begun draining is on its way out, and takes everything on
+	// it along. Leaving the room there hands the participants about to join a
+	// session that ends when the node does, while a node that is staying up is
+	// standing right there.
+	t.Run("move the room off a node that has begun draining", func(t *testing.T) {
+		conf, err := config.NewConfig("", true, nil, nil)
+		require.NoError(t, err)
+
+		draining := registeredNode(t, conf, livekit.NodeState_SHUTTING_DOWN)
+		serving := registeredNode(t, conf, livekit.NodeState_SERVING)
+
+		ra, router := newTestRoomAllocator(t, conf, draining)
+		router.ListNodesReturns([]*livekit.Node{draining, serving}, nil)
+
+		require.NoError(t, ra.SelectRoomNode(context.Background(), "draining-room", ""))
+
+		require.Equal(t, 1, router.SetNodeForRoomCallCount(), "the room was left on the draining node")
+		_, roomName, nodeID := router.SetNodeForRoomArgsForCall(0)
+		require.Equal(t, livekit.RoomName("draining-room"), roomName)
+		require.Equal(t, livekit.NodeID(serving.Id), nodeID)
+	})
 }
 
-func newTestRoomAllocator(t *testing.T, conf *config.Config, node *livekit.Node) (service.RoomAllocator, *config.Config) {
+func newTestRoomAllocator(t *testing.T, conf *config.Config, node *livekit.Node) (service.RoomAllocator, *routingfakes.FakeRouter) {
+	t.Helper()
+
 	store := &servicefakes.FakeObjectStore{}
 	store.LoadRoomReturns(nil, nil, service.ErrRoomNotFound)
 	router := &routingfakes.FakeRouter{}
@@ -101,5 +125,18 @@ func newTestRoomAllocator(t *testing.T, conf *config.Config, node *livekit.Node)
 
 	ra, err := service.NewRoomAllocator(conf, router, store)
 	require.NoError(t, err)
-	return ra, conf
+	return ra, router
+}
+
+// registeredNode is a node as the registry would have it: registered a moment
+// ago, and so as fresh as any node the router would hand back.
+func registeredNode(t *testing.T, conf *config.Config, state livekit.NodeState) *livekit.Node {
+	t.Helper()
+
+	node, err := routing.NewLocalNode(conf)
+	require.NoError(t, err)
+
+	n := node.Clone()
+	n.State = state
+	return n
 }

--- a/pkg/service/roommanager.go
+++ b/pkg/service/roommanager.go
@@ -189,32 +189,34 @@ func (r *RoomManager) GetRoom(_ context.Context, roomName livekit.RoomName) *rtc
 }
 
 // deleteRoom completely deletes all room information, including active sessions, room store, and routing info
-func (r *RoomManager) deleteRoom(ctx context.Context, roomName livekit.RoomName) error {
+func (r *RoomManager) deleteRoom(ctx context.Context, roomInfo *livekit.Room) error {
+	roomName := livekit.RoomName(roomInfo.Name)
 	logger.Infow("deleting room state", "room", roomName)
 	r.lock.Lock()
 	delete(r.rooms, roomName)
 	r.lock.Unlock()
 
-	var err, err2 error
-	wg := sync.WaitGroup{}
-	wg.Add(2)
-	// clear routing information
-	go func() {
-		defer wg.Done()
-		err = r.router.ClearRoomState(ctx, roomName)
-	}()
-	// also delete room from db
-	go func() {
-		defer wg.Done()
-		err2 = r.roomStore.DeleteRoom(ctx, roomName)
-	}()
-
-	wg.Wait()
-	if err2 != nil {
-		err = err2
+	// the routing goes first, and the room itself only if this node still had
+	// it: a room routed to another node while this one was closing its copy is
+	// being served there under the same name its records are keyed by
+	cleared, err := r.router.ClearRoomState(ctx, roomName)
+	if err != nil {
+		return err
+	}
+	if !cleared {
+		// either another node has taken the room over, or the routing is gone
+		// altogether -- a redis that came back empty has no record of either the
+		// room or the node it was on. leaving the records alone is right for both
+		logger.Infow("room routing was not this node's to clear, leaving its state alone", "room", roomName)
+		return nil
 	}
 
-	return err
+	// the room has ended, rather than moved, so this is where it is announced:
+	// the webhook says the room finished, and it finished only once
+	r.telemetry.RoomEnded(ctx, roomInfo)
+
+	// also delete room from db
+	return r.roomStore.DeleteRoom(ctx, roomName)
 }
 
 func (r *RoomManager) CloseIdleRooms() {
@@ -697,9 +699,10 @@ func (r *RoomManager) getOrCreateRoom(ctx context.Context, createRoom *livekit.C
 		killDispServer()
 
 		roomInfo := newRoom.ToProto()
-		r.telemetry.RoomEnded(ctx, roomInfo)
+		// the room is off this node either way, so the gauge comes down either
+		// way; whether the room ended at all is deleteRoom's to say
 		prometheus.RoomEnded(time.Unix(roomInfo.CreationTime, 0))
-		if err := r.deleteRoom(ctx, roomName); err != nil {
+		if err := r.deleteRoom(ctx, roomInfo); err != nil {
 			newRoom.Logger().Errorw("could not delete room", err)
 		}
 

--- a/pkg/service/roommanager_test.go
+++ b/pkg/service/roommanager_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
+	"github.com/livekit/protocol/livekit"
+
+	"github.com/livekit/livekit-server/pkg/routing/routingfakes"
+	"github.com/livekit/livekit-server/pkg/rtc"
+	"github.com/livekit/livekit-server/pkg/telemetry/telemetryfakes"
+)
+
+// fakeRoomStore counts the rooms deleted from it. It embeds the interface so
+// only the method under test needs to be implemented; any other call would
+// panic (and we assert none happen).
+type fakeRoomStore struct {
+	ObjectStore
+	deleteCount atomic.Int32
+}
+
+func (f *fakeRoomStore) DeleteRoom(_ context.Context, _ livekit.RoomName) error {
+	f.deleteCount.Inc()
+	return nil
+}
+
+// A room can be taken over by a node that is staying up before the node it was
+// on has finished closing its copy. What that node deletes on the way out has
+// to be its own: a room's records are keyed by its name and nothing else, so
+// the ones it would reach for are the ones being served on the other node.
+func TestDeleteRoomState(t *testing.T) {
+	room := &livekit.Room{Name: "test-room"}
+
+	newRoomManager := func(cleared bool, err error) (*RoomManager, *fakeRoomStore, *telemetryfakes.FakeTelemetryService) {
+		store := &fakeRoomStore{}
+		router := &routingfakes.FakeRouter{}
+		router.ClearRoomStateReturns(cleared, err)
+		fakeTelemetry := &telemetryfakes.FakeTelemetryService{}
+
+		return &RoomManager{
+			router:    router,
+			roomStore: store,
+			telemetry: fakeTelemetry,
+			rooms:     map[livekit.RoomName]*rtc.Room{"test-room": {}},
+		}, store, fakeTelemetry
+	}
+
+	t.Run("delete a room this node was hosting", func(t *testing.T) {
+		r, store, telemetry := newRoomManager(true, nil)
+
+		require.NoError(t, r.deleteRoom(context.Background(), room))
+		require.EqualValues(t, 1, store.deleteCount.Load(), "the room was left in the store")
+		require.NotContains(t, r.rooms, livekit.RoomName("test-room"), "the room is still being served")
+		require.Equal(t, 1, telemetry.RoomEndedCallCount(), "the room ended here and was not announced")
+	})
+
+	// The webhook goes with the records: a room that has moved has not ended,
+	// and the node now serving it is the one that will say when it has.
+	t.Run("leave a room that has moved to another node", func(t *testing.T) {
+		r, store, telemetry := newRoomManager(false, nil)
+
+		require.NoError(t, r.deleteRoom(context.Background(), room))
+		require.Zero(t, store.deleteCount.Load(), "a room being hosted elsewhere was deleted")
+		require.NotContains(t, r.rooms, livekit.RoomName("test-room"), "the room is still being served")
+		require.Zero(t, telemetry.RoomEndedCallCount(), "a room being hosted elsewhere was announced as ended")
+	})
+
+	// Not knowing whether the room is still this node's is a reason to leave it
+	// alone, not a reason to go ahead: the records are shared, and the node that
+	// may have taken the room over is serving participants out of them.
+	t.Run("leave a room whose routing could not be read", func(t *testing.T) {
+		outage := errors.New("redis is down")
+		r, store, telemetry := newRoomManager(false, outage)
+
+		require.ErrorIs(t, r.deleteRoom(context.Background(), room), outage)
+		require.Zero(t, store.deleteCount.Load(), "a room of unknown ownership was deleted")
+		require.NotContains(t, r.rooms, livekit.RoomName("test-room"), "the room is still being served")
+		require.Zero(t, telemetry.RoomEndedCallCount(), "a room of unknown ownership was announced as ended")
+	})
+}

--- a/pkg/testutils/redis.go
+++ b/pkg/testutils/redis.go
@@ -1,0 +1,130 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+// RedisServer is a redis a test runs for itself rather than sharing the one the
+// suite has, so that nothing else can write to it or flush it out from under
+// the test.
+type RedisServer struct {
+	bin  string
+	addr string
+	dir  string
+
+	cmd    *exec.Cmd
+	exited chan struct{}
+}
+
+// StartRedis starts a redis on a socket of its own, which nothing else can find
+// and which cannot lose a race for a port.
+func StartRedis(t *testing.T) *RedisServer {
+	// not t.TempDir(), whose name carries the test's own and would put the
+	// socket over the length a socket path is allowed to be
+	dir, err := os.MkdirTemp("", "lkredis")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	return startRedis(t, filepath.Join(dir, "redis.sock"), dir)
+}
+
+func startRedis(t *testing.T, addr, dir string) *RedisServer {
+	bin := os.Getenv("REDIS_SERVER")
+	if bin == "" {
+		bin = "redis-server"
+	}
+	bin, err := exec.LookPath(bin)
+	if err != nil {
+		// a test that quietly stops running is worse on CI than one that fails,
+		// since nothing there is watching for a run that covered less than the
+		// last one did
+		if os.Getenv("CI") != "" {
+			t.Fatalf("redis-server is not on PATH: %v", err)
+		}
+		t.Skip("redis-server is not on PATH; set REDIS_SERVER to run this test")
+	}
+
+	r := &RedisServer{bin: bin, addr: addr, dir: dir}
+	// before starting it, so that a start which fails once the server is running
+	// -- on a socket path too long for the OS, say -- does not leave it running
+	// for the rest of the suite
+	t.Cleanup(r.stop)
+	r.start(t)
+
+	return r
+}
+
+// Options are what a client needs to reach this redis.
+func (r *RedisServer) Options() *redis.Options {
+	return &redis.Options{Network: "unix", Addr: r.addr}
+}
+
+func (r *RedisServer) start(t *testing.T) {
+	// no persistence: nothing here outlives the test
+	cmd := exec.Command(r.bin,
+		"--port", "0", "--unixsocket", r.addr,
+		"--dir", r.dir, "--save", "", "--appendonly", "no")
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Start())
+
+	exited := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(exited)
+	}()
+
+	// held only once there is a process to hold: stop reads them to mean there
+	// is one to kill, and a start that never got that far leaves it nothing
+	r.cmd, r.exited = cmd, exited
+
+	r.waitUp(t)
+}
+
+func (r *RedisServer) stop() {
+	if r.cmd == nil {
+		return
+	}
+	_ = r.cmd.Process.Kill()
+	<-r.exited
+	r.cmd = nil
+}
+
+func (r *RedisServer) waitUp(t *testing.T) {
+	c := redis.NewClient(r.Options())
+	defer c.Close()
+
+	exited := r.exited
+	WithTimeout(t, func() string {
+		select {
+		case <-exited:
+			t.Fatalf("redis-server on %s exited", r.addr)
+		default:
+		}
+		if err := c.Ping(context.Background()).Err(); err != nil {
+			return fmt.Sprintf("redis at %s is not up: %v", r.addr, err)
+		}
+		return ""
+	})
+}


### PR DESCRIPTION
## Summary

A node advertises `SHUTTING_DOWN` for as long as it drains, but `SelectRoomNode`'s sticky check only asked whether the node's stats were fresh — and a draining node keeps registering itself, so its stats stay as fresh as anyone's. Rooms therefore stayed on a node that was going away, and participants who joined in the meantime got a session that ended when the node did.

Moving those rooms exposes a second problem, which is the larger half of this PR. A room can now be routed to another node before the node it was on has finished closing its copy, and `ClearRoomState` deleted the mapping unconditionally — unrouting a room that is being served, and deleting records that are keyed by room name and nothing else. That path already existed without anyone draining: a node whose stats go stale loses its rooms to the node picked in its place and goes on hosting the participants it has.

Related to #4663 — a draining node under an outage is where I hit this — but independent of #4796, which fixes that issue. Either can land first.

## Changes

- **`selector.CanHostRoom`**: fresh *and* `SERVING`. It is the predicate `GetAvailableNodes` already applied when choosing a node; the sticky check in `SelectRoomNode` now applies it too.
- **`Router.ClearRoomState` becomes a compare-and-delete** and reports whether it cleared. The redis implementation is a Lua script in the same shape as the existing `unlockScript` in `redisstore.go`: single key, so it is cluster-safe, and go-redis handles the `EVALSHA`/`NOSCRIPT` fallback.
- **`RoomManager.deleteRoom` leaves a room alone when it was not this node's** — its records, and the `room_finished` webhook, which previously fired from whichever node closed its copy last. The node that still owns the room is the one whose telling ends it.
- Unit tests for the predicate, both directions of the compare-and-delete against a real redis, the local router's answer, and each branch of the delete.

## Behavior / decisions to review

- **`Router.ClearRoomState` changes signature** from `error` to `(bool, error)`. It is an exported interface, so out-of-tree implementations need updating. A sentinel error or a second method would avoid the break if you would rather — say which you prefer and I will redo it that way.
- **There is an overlap window, and this PR narrows rather than closes it.** When a room moves, the participants still on the old node follow it as they reconnect; until they have, both nodes host a room of that name, and a room's records and its RPC topics are keyed by the name alone. So for that window the store holds whichever node wrote last, and a room RPC reaches whichever node answers first. The guard above stops the window from destroying state; what would close it is migrating rooms when the drain begins rather than waiting for the next `SelectRoomNode` to notice. That is a bigger change and I have kept it out of this one. If you would rather have that fix instead of this one, I am happy to write it.
- **`deleteRoom` now makes its two redis calls in sequence** rather than in parallel, because the routing has to be settled before the records can be touched. A node closing many rooms against a slow redis pays for that.
- **On a failed routing read, `deleteRoom` leaves the records alone** and returns the error. Not knowing whether the room is still ours is a reason to leave shared state alone, not a reason to delete it — but it does mean records can outlive a room when redis is unwell, where before they were always deleted.

## Testing

`go test ./pkg/routing/... ./pkg/service/...`, with the redis-backed tests running against a `redis-server` the test starts for itself so the shared suite redis cannot be flushed underneath them. Each new test was checked against a mutated build to confirm it fails when the behavior it pins is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
