### PR TITLE
Fix the egress store test updating the wrong record

### DIFF
--- a/pkg/service/redisstore_test.go
+++ b/pkg/service/redisstore_test.go
@@ -216,12 +216,12 @@ func TestEgressStore(t *testing.T) {
 	// list
 	list, err := rs.ListEgress(ctx, "", false)
 	require.NoError(t, err)
-	require.Len(t, list, 2)
+	require.Subset(t, egressIDs(list), []string{info.EgressId, info2.EgressId})
 
 	// list by room
 	list, err = rs.ListEgress(ctx, livekit.RoomName(roomName), false)
 	require.NoError(t, err)
-	require.Len(t, list, 1)
+	require.Equal(t, []string{info.EgressId}, egressIDs(list))
 
 	// update
 	info.Status = livekit.EgressStatus_EGRESS_COMPLETE
@@ -231,11 +231,23 @@ func TestEgressStore(t *testing.T) {
 	// clean
 	require.NoError(t, rs.CleanEndedEgress())
 
-	// list -- every room, since a record left behind in any of them outlives
-	// the test in a redis the next run will share
-	list, err = rs.ListEgress(ctx, "", false)
-	require.NoError(t, err)
-	require.Len(t, list, 0)
+	// gone -- both of them, since the one in the other room is swept by the
+	// same call and would otherwise be left behind
+	for _, id := range []string{info.EgressId, info2.EgressId} {
+		_, err = rs.LoadEgress(ctx, id)
+		require.ErrorIs(t, err, service.ErrEgressNotFound)
+	}
+}
+
+// egressIDs is what a listing can be asserted on: the store is a redis the
+// whole run shares, and on a development machine one that outlives the run, so
+// anything else on it is in the listing too.
+func egressIDs(list []*livekit.EgressInfo) []string {
+	ids := make([]string, 0, len(list))
+	for _, info := range list {
+		ids = append(ids, info.EgressId)
+	}
+	return ids
 }
 
 // cleanEgress ends an egress and sweeps it, so that a test which failed before

--- a/pkg/service/redisstore_test.go
+++ b/pkg/service/redisstore_test.go
@@ -185,6 +185,7 @@ func TestEgressStore(t *testing.T) {
 		},
 	}
 	require.NoError(t, rs.StoreEgress(ctx, info))
+	t.Cleanup(func() { cleanEgress(ctx, rs, info) })
 
 	// load
 	res, err := rs.LoadEgress(ctx, info.EgressId)
@@ -205,11 +206,12 @@ func TestEgressStore(t *testing.T) {
 		},
 	}
 	require.NoError(t, rs.StoreEgress(ctx, info2))
+	t.Cleanup(func() { cleanEgress(ctx, rs, info2) })
 
 	// update
 	info2.Status = livekit.EgressStatus_EGRESS_COMPLETE
 	info2.EndedAt = time.Now().Add(-24 * time.Hour).UnixNano()
-	require.NoError(t, rs.UpdateEgress(ctx, info))
+	require.NoError(t, rs.UpdateEgress(ctx, info2))
 
 	// list
 	list, err := rs.ListEgress(ctx, "", false)
@@ -229,10 +231,27 @@ func TestEgressStore(t *testing.T) {
 	// clean
 	require.NoError(t, rs.CleanEndedEgress())
 
-	// list
-	list, err = rs.ListEgress(ctx, livekit.RoomName(roomName), false)
+	// list -- every room, since a record left behind in any of them outlives
+	// the test in a redis the next run will share
+	list, err = rs.ListEgress(ctx, "", false)
 	require.NoError(t, err)
 	require.Len(t, list, 0)
+}
+
+// cleanEgress ends an egress and sweeps it, so that a test which failed before
+// it got that far does not leave a record behind for the next run to trip over.
+func cleanEgress(ctx context.Context, rs *service.RedisStore, info *livekit.EgressInfo) {
+	if _, err := rs.LoadEgress(ctx, info.EgressId); err != nil {
+		// already swept, and UpdateEgress would write it back
+		return
+	}
+
+	info.Status = livekit.EgressStatus_EGRESS_COMPLETE
+	info.EndedAt = time.Now().Add(-24 * time.Hour).UnixNano()
+	if err := rs.UpdateEgress(ctx, info); err != nil {
+		return
+	}
+	_ = rs.CleanEndedEgress()
 }
 
 func TestIngressStore(t *testing.T) {


### PR DESCRIPTION
### Problem

`TestEgressStore/CleanEndedEgress` leaves records behind in redis, and the next run against the same redis fails on them rather than on anything it did itself:

```
Error:  "[...]" should have 2 item(s), but has 5
```

The update step sets the second record's status and end time and then stores the *first* one, so the record the sweep is supposed to collect is never marked as ended. It survives the test. The final assertion does not notice because it lists one room rather than looking for that record.

### Fix

Store the record the test means to store, and sweep both records on the way out, so a run that fails before it gets that far does not leave the next one to trip over the leftovers.

The assertions no longer count what is on the instance either. `redisStore` is whichever redis answers on localhost:6379, which on a development machine outlives the run and serves whatever else is pointed at it, so the listings are checked for this test's own two records and the sweep is checked by loading them by id.

### Testing

`go test ./pkg/service/ -run TestEgressStore` twice in a row against the same redis — which is what fails on `master` today — and once more with an unrelated egress left on the instance, which the assertions this PR replaces also fail on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)