### PR TITLE
Skip the docker-backed service tests when there is no docker

### DIFF
--- a/pkg/service/docker_test.go
+++ b/pkg/service/docker_test.go
@@ -16,7 +16,9 @@ package service_test
 
 import (
 	"context"
+	"flag"
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"testing"
@@ -28,23 +30,30 @@ import (
 	"github.com/ory/dockertest/v4"
 )
 
-var (
-	Docker dockertest.ClosablePool
-	// why Docker is not available, if it is not. the tests that need it skip on
-	// this locally, and fail on it under CI, rather than the whole package
-	// failing to run without a daemon
-	dockerErr error
-)
+var Docker dockertest.ClosablePool
+
+// go test -docker=false ./pkg/service skips the tests that need a docker
+// daemon, for a checkout without one. Running them is the default: a run that
+// quietly covers less than the last one is worse than a run that stops, so a
+// daemon that should be there and is not still fails the whole package.
+var useDocker = flag.Bool("docker", true, "run the tests that need a docker daemon")
 
 func TestMain(m *testing.M) {
-	ctx := context.Background()
-	pool, err := dockertest.NewPool(ctx, "")
-	if err != nil {
-		dockerErr = fmt.Errorf("could not construct pool: %w", err)
-	} else if _, err = pool.Client().Ping(ctx, mobyclient.PingOptions{}); err != nil {
+	// m.Run would parse them, but the flag is read before that
+	flag.Parse()
+
+	if *useDocker {
+		ctx := context.Background()
+		pool, err := dockertest.NewPool(ctx, "")
+		if err != nil {
+			log.Fatalf("Could not construct pool: %s", err)
+		}
+
 		// uses pool to try to connect to Docker
-		dockerErr = fmt.Errorf("could not connect to Docker: %w", err)
-	} else {
+		_, err = pool.Client().Ping(ctx, mobyclient.PingOptions{})
+		if err != nil {
+			log.Fatalf("Could not connect to Docker: %s", err)
+		}
 		Docker = pool
 	}
 
@@ -55,15 +64,9 @@ func TestMain(m *testing.M) {
 func requireDocker(t testing.TB) {
 	t.Helper()
 
-	if dockerErr == nil {
-		return
+	if !*useDocker {
+		t.Skip("this test needs a docker daemon, and -docker=false says there is none")
 	}
-	if os.Getenv("CI") != "" {
-		// a runner that cannot reach docker is a broken build, not a reason to
-		// quietly cover less than the last one did
-		t.Fatal(dockerErr)
-	}
-	t.Skip(dockerErr)
 }
 
 func waitTCPPort(t testing.TB, addr string) {

--- a/pkg/service/docker_test.go
+++ b/pkg/service/docker_test.go
@@ -17,7 +17,6 @@ package service_test
 import (
 	"context"
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"testing"
@@ -29,24 +28,42 @@ import (
 	"github.com/ory/dockertest/v4"
 )
 
-var Docker dockertest.ClosablePool
+var (
+	Docker dockertest.ClosablePool
+	// why Docker is not available, if it is not. the tests that need it skip on
+	// this locally, and fail on it under CI, rather than the whole package
+	// failing to run without a daemon
+	dockerErr error
+)
 
 func TestMain(m *testing.M) {
 	ctx := context.Background()
 	pool, err := dockertest.NewPool(ctx, "")
 	if err != nil {
-		log.Fatalf("Could not construct pool: %s", err)
+		dockerErr = fmt.Errorf("could not construct pool: %w", err)
+	} else if _, err = pool.Client().Ping(ctx, mobyclient.PingOptions{}); err != nil {
+		// uses pool to try to connect to Docker
+		dockerErr = fmt.Errorf("could not connect to Docker: %w", err)
+	} else {
+		Docker = pool
 	}
-
-	// uses pool to try to connect to Docker
-	_, err = pool.Client().Ping(ctx, mobyclient.PingOptions{})
-	if err != nil {
-		log.Fatalf("Could not connect to Docker: %s", err)
-	}
-	Docker = pool
 
 	code := m.Run()
 	os.Exit(code)
+}
+
+func requireDocker(t testing.TB) {
+	t.Helper()
+
+	if dockerErr == nil {
+		return
+	}
+	if os.Getenv("CI") != "" {
+		// a runner that cannot reach docker is a broken build, not a reason to
+		// quietly cover less than the last one did
+		t.Fatal(dockerErr)
+	}
+	t.Skip(dockerErr)
 }
 
 func waitTCPPort(t testing.TB, addr string) {
@@ -66,6 +83,8 @@ func waitTCPPort(t testing.TB, addr string) {
 var redisLast atomic.Uint32
 
 func runRedis(t testing.TB) string {
+	requireDocker(t)
+
 	c, err := Docker.Run(t.Context(),
 		"redis",
 		dockertest.WithName(fmt.Sprintf("lktest-redis-%d", redisLast.Inc())),


### PR DESCRIPTION
### Problem

`TestMain` in `pkg/service` calls `log.Fatalf` when it cannot reach a docker daemon, so the whole package refuses to run without one — including every test in it that needs no container at all. On a machine without docker, `go test ./pkg/service/` covers nothing and says so only in passing.

### Fix

`go test -docker=false ./pkg/service/` skips the tests that need a container and runs the rest.

Running them is the default: a daemon that should be there and is not still fails the package, with the same two messages, since a run that quietly covers less than the last one did is worse than a run that stops.

### Testing

`go test -docker=false ./pkg/service/` with no docker on the machine — the container-backed tests skip, the rest run — and `go test ./pkg/service/` there, which fails exactly as it does on `master`. The daemon-present path is unchanged and is what CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)