### PR TITLE
Fix two flaky assertions in the subscription manager tests

### DIFF
--- a/pkg/rtc/subscriptionmanager_test.go
+++ b/pkg/rtc/subscriptionmanager_test.go
@@ -113,7 +113,10 @@ func TestSubscribe(t *testing.T) {
 		require.Eventually(t, func() bool {
 			return numParticipantSubscribed.Load() == 2
 		}, subSettleTimeout, subCheckInterval, "participant subscribe status was not updated twice")
-		require.Equal(t, int32(1), numParticipantUnsubscribed.Load())
+		// the unsubscribed callback is delivered on a goroutine of its own
+		require.Eventually(t, func() bool {
+			return numParticipantUnsubscribed.Load() == 1
+		}, subSettleTimeout, subCheckInterval, "participant unsubscribe status was not updated")
 	})
 
 	t.Run("no track permission", func(t *testing.T) {
@@ -248,7 +251,10 @@ func TestUnsubscribe(t *testing.T) {
 
 	// no traces should be left
 	require.Len(t, sm.GetSubscribedTracks(), 0)
-	require.False(t, res.TrackChangedNotifier.HasObservers())
+	// the observer is dropped on a goroutine of its own
+	require.Eventually(t, func() bool {
+		return !res.TrackChangedNotifier.HasObservers()
+	}, subSettleTimeout, subCheckInterval, "observer was not removed")
 
 	tl := sm.params.Participant.GetTelemetryListener().(*typesfakes.FakeParticipantTelemetryListener)
 	require.Equal(t, 1, tl.OnTrackUnsubscribedCallCount())


### PR DESCRIPTION
### Problem

`TestUnsubscribe` fails intermittently in CI at `pkg/rtc/subscriptionmanager_test.go:251`:

```
❌ TestUnsubscribe (0s)
    Error Trace: pkg/rtc/subscriptionmanager_test.go:251
    Error:       Should be false
    Test:        TestUnsubscribe
```

`UnsubscribeFromTrack` → `setDesired(trackID, false)` clears the notifiers under `s.lock`, and `setChangedNotifierLocked` hands the removal to a goroutine of its own:

```go
if existing != nil {
	go existing.RemoveObserver(string(s.subscriberID))
}
```

The `require.Eventually` above the assertion waits for `needsUnsubscribe`, `pendingUnsubscribes` and the subscription map — none of which order against that goroutine — so `HasObservers()` can be read before it runs.

`TestSubscribe/happy path subscribe` has the same defect at line 116: it waits for `numParticipantSubscribed` to reach 2 and then reads `numParticipantUnsubscribed` directly, while `unmarkSubscribedTo` delivers that callback with a bare `go changedCB(publisherID, false)`. The subscribed one, in `markSubscribedTo`, is called inline.

### Fix

Wait for each of them, each with a message of its own rather than folded into an existing condition, so that a leak which is real still reports which invariant broke.

The `go` in `setChangedNotifierLocked` is left alone: it arrived in #1429 along with the `*Locked` refactor, to avoid holding `trackSubscription.lock` across the notifier's lock. Quieting a test is not a reason to reopen that.

### Testing

Both windows are microseconds wide and do not reproduce by repetition — 200 runs of `TestUnsubscribe` with `-race`, 8 concurrent runs of 50, and 300 runs at `-cpu=1` all pass either way. Forcing them with `go test -overlay` (a 50ms sleep before each of the two calls, leaving the tree untouched) reproduces both exactly as CI reports them — line 251 `Should be false`, and line 116 `expected: 1 / actual: 0` — and both pass 30/30 with this change under the same delays. `go test -race ./pkg/rtc/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
