### PR TITLE
config: reject unknown send_side_bwe_pacer, warn on unwired fallback

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -117,6 +117,16 @@ rtc:
   #   # in the unlikely event of highly congested networks, SFU may choose to pause some tracks
   #   # in order to allow others to stream smoothly. You can disable this behavior here
   #   allow_pause: true
+  #   # use send-side bandwidth estimation instead of relying on receiver reports, default false
+  #   use_send_side_bwe: false
+  #   # how egress is paced when use_send_side_bwe is enabled. one of:
+  #   #   no-queue     - hand packets to a send worker that drains them without rate
+  #   #                  limiting, so the sender never blocks on a write (default)
+  #   #   pass-through - send each packet inline on the calling goroutine
+  #   #   leaky-bucket - accepted, but not currently wired to the bandwidth estimate; it
+  #   #                  logs a warning and falls back to no-queue. see livekit/livekit#4724
+  #   # an unrecognized value is rejected at startup.
+  #   send_side_bwe_pacer: no-queue
   # # allows automatic connection fallback to TCP and TURN/TLS (if configured) when UDP has been unstable, default true
   # allow_tcp_fallback: true
   # # signaling RTT (in milliseconds) below which ICE/TCP is attempted on a UDP failure; at or above it,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -220,6 +220,22 @@ type CongestionControlConfig struct {
 	SendSideBWE      sendsidebwe.SendSideBWEConfig `yaml:"send_side_bwe,omitempty"`
 }
 
+// Validate reports configuration that would otherwise be ignored at runtime.
+func (c CongestionControlConfig) Validate() error {
+	switch pacer.PacerBehavior(c.SendSideBWEPacer) {
+	case "", pacer.PacerBehaviorPassThrough, pacer.PacerBehaviorNoQueue, pacer.PacerBehaviorLeakybucket:
+		return nil
+	default:
+		return fmt.Errorf(
+			"invalid send_side_bwe_pacer %q, must be one of %q, %q, %q",
+			c.SendSideBWEPacer,
+			pacer.PacerBehaviorPassThrough,
+			pacer.PacerBehaviorNoQueue,
+			pacer.PacerBehaviorLeakybucket,
+		)
+	}
+}
+
 type PlayoutDelayConfig struct {
 	Enabled bool `yaml:"enabled,omitempty"`
 	Min     int  `yaml:"min,omitempty"`
@@ -630,6 +646,10 @@ func NewConfig(confString string, strictMode bool, c *cli.Command, baseFlags []c
 
 	if err := conf.RTC.Validate(conf.Development); err != nil {
 		return nil, fmt.Errorf("could not validate RTC config: %v", err)
+	}
+
+	if err := conf.RTC.CongestionControl.Validate(); err != nil {
+		return nil, fmt.Errorf("could not validate congestion control config: %v", err)
 	}
 
 	conf.NormalizeTURNTTLs()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/livekit/livekit-server/pkg/config/configtest"
+	"github.com/livekit/livekit-server/pkg/sfu/pacer"
 )
 
 func TestConfig_UnmarshalKeys(t *testing.T) {
@@ -159,6 +160,40 @@ func TestNewConfigNormalizesTURNTTL(t *testing.T) {
 	conf, err := NewConfig(content, true, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, DefaultTURNTTLSeconds, conf.TURN.TTLSeconds)
+}
+
+func TestNewConfigValidatesSendSideBWEPacer(t *testing.T) {
+	cases := []struct {
+		name    string
+		pacer   string
+		wantErr bool
+	}{
+		{name: "unset keeps the default", pacer: "", wantErr: false},
+		{name: "pass-through", pacer: string(pacer.PacerBehaviorPassThrough), wantErr: false},
+		{name: "no-queue", pacer: string(pacer.PacerBehaviorNoQueue), wantErr: false},
+		{name: "leaky-bucket", pacer: string(pacer.PacerBehaviorLeakybucket), wantErr: false},
+		{name: "typo is rejected", pacer: "leakybucket", wantErr: true},
+		{name: "unknown value is rejected", pacer: "not-a-pacer", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			content := "rtc:\n  congestion_control:\n    send_side_bwe_pacer: " + tc.pacer
+			conf, err := NewConfig(content, true, nil, nil)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.pacer)
+				return
+			}
+
+			require.NoError(t, err)
+			if tc.pacer == "" {
+				require.Equal(t, string(pacer.PacerBehaviorNoQueue), conf.RTC.CongestionControl.SendSideBWEPacer)
+				return
+			}
+			require.Equal(t, tc.pacer, conf.RTC.CongestionControl.SendSideBWEPacer)
+		})
+	}
 }
 
 func writeSecretFile(t *testing.T, content string) string {

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -578,12 +578,25 @@ func NewPCTransport(params TransportParams) (*PCTransport, error) {
 				Config: params.CongestionControlConfig.SendSideBWE,
 				Logger: params.Logger,
 			})
-			switch pacer.PacerBehavior(params.CongestionControlConfig.SendSideBWEPacer) {
+			switch behavior := pacer.PacerBehavior(params.CongestionControlConfig.SendSideBWEPacer); behavior {
 			case pacer.PacerBehaviorPassThrough:
 				t.pacer = pacer.NewPassThrough(params.Logger, t.bwe)
 			case pacer.PacerBehaviorNoQueue:
 				t.pacer = pacer.NewNoQueue(params.Logger, t.bwe)
 			default:
+				// leaky-bucket lands here: it is a recognized value, but LeakyBucket paces
+				// to a bitrate set through Pacer.SetBitrate and nothing drives that from
+				// the bandwidth estimate, so it would pace at a fixed rate and ignore
+				// congestion. Unknown values are rejected by CongestionControlConfig.
+				// Validate, so they only reach here from callers building TransportParams
+				// directly.
+				if behavior != "" {
+					params.Logger.Warnw(
+						"send side BWE pacer unavailable, falling back", nil,
+						"pacerBehavior", behavior,
+						"fallback", pacer.PacerBehaviorNoQueue,
+					)
+				}
 				t.pacer = pacer.NewNoQueue(params.Logger, t.bwe)
 			}
 		} else {


### PR DESCRIPTION
Refs #4724. Deliberately not `Fixes` — this addresses the silent-degrade half of
that issue, not the request for rate-based pacing, so I have left it open for you
to decide.

`send_side_bwe_pacer: leaky-bucket` is accepted by the config loader and then
silently ignored: `PacerBehaviorLeakybucket` is defined in `pkg/sfu/pacer` and
`LeakyBucket` is fully implemented, but the selection switch in
`NewPCTransport` only handles `pass-through` and `no-queue`, so `leaky-bucket`
falls through to `default:` and gets `NewNoQueue`. A typo like `leakybucket`
behaves identically. Either way the server starts, reports nothing, and runs a
pacer the operator did not ask for.

This PR does not wire `leaky-bucket` up, because doing so naively would be a
regression rather than a fix — see the note below. It makes the current
behaviour observable instead:

- `CongestionControlConfig.Validate()` rejects an unrecognised
  `send_side_bwe_pacer` at startup, naming the bad value and the accepted ones.
  Called from `NewConfig` next to the existing `RTC.Validate`. A typo now fails
  fast instead of silently degrading.
- The `default:` branch in `NewPCTransport` logs a warning naming the requested
  pacer and the fallback, so a `leaky-bucket` request is visible in the log.
- `send_side_bwe_pacer` (and `use_send_side_bwe`) are documented in
  `config-sample.yaml`, where neither appeared before.
- Table-driven test over the three valid names, the unset case, and two
  rejected ones. `pkg/sfu/pacer` has no test file, so it lives in
  `pkg/config/config_test.go` alongside the existing `NewConfig` tests.

### Why `leaky-bucket` is not simply added as a `case`

`LeakyBucket` paces to a bitrate supplied through `Pacer.SetBitrate`.
`SetBitrate` and `SetInterval` are on the `Pacer` interface, `Base` no-ops both,
and `LeakyBucket` is the only real implementation — but **no production code
calls either one**. The sole caller in the tree is `capturingPacer` in
`pkg/sfu/downtrack_downstream_integration_test.go`, which is test-only.

So a wired `LeakyBucket` would pace at its static constructor bitrate forever
and ignore the send-side bandwidth estimate. That is worse than the current
fallback, and it looks like the reason the case was left out in the first place.

Making that reachable needs the stream allocator's estimate plumbed through to
`Pacer.SetBitrate`, which is a behavioural change to congestion control rather
than a config fix, so I have kept it out of this PR.

That also answers @eilon-decart's third question in #4724 ("any known caveats
that led to it being left unwired?") as far as I can tell from the code: the
rate input has no producer. I would be glad to do the allocator plumbing in a
follow-up if that is the direction you want and if `LeakyBucket` is considered
production-ready — happy to drop this in favour of a different approach if you
would rather handle it another way.

---

Disclosure: I work at DIDWW, a SIP trunking / DID provider; we are building on
LiveKit and LiveKit SIP. This particular fix has no telephony angle — I hit it
while reading the congestion control config.
