### PR TITLE
Sweep dead node registrations while the cluster runs

### DIFF
--- a/pkg/routing/redisrouter.go
+++ b/pkg/routing/redisrouter.go
@@ -83,18 +83,41 @@ func (r *RedisRouter) UnregisterNode() error {
 }
 
 func (r *RedisRouter) RemoveDeadNodes() error {
+	// a node that cannot hear its own keepalive is looking at a bus that has
+	// stopped carrying registrations, not at a fleet that has died
+	if !r.hearsItself() {
+		return nil
+	}
+
 	nodes, err := r.ListNodes()
 	if err != nil {
 		return err
 	}
+
+	dead := make([]string, 0, len(nodes))
 	for _, n := range nodes {
-		if !selector.IsAvailable(n) {
-			if err := r.rc.HDel(context.Background(), NodesKey, n.Id).Err(); err != nil {
-				return err
-			}
+		// this node's own entry is the one it is least able to judge: its
+		// registration goes stale while its local stats do not
+		if n.Id != string(r.currentNode.NodeID()) && selector.IsDead(n) {
+			dead = append(dead, n.Id)
 		}
 	}
-	return nil
+	if len(dead) == 0 {
+		return nil
+	}
+
+	return r.rc.HDel(r.ctx, NodesKey, dead...).Err()
+}
+
+// hearsItself reports whether this node's own keepalive has come back to it
+// recently enough for what it reads about the others to mean anything.
+// StatsMaxDelay is what the stats worker already takes for this path being
+// wedged; half the timeout is the ceiling over that, so that a peer always has
+// to be at least the other half further behind than this node before it can be
+// buried, whatever the delay is set to.
+func (r *RedisRouter) hearsItself() bool {
+	fresh := min(r.nodeStatsConfig.StatsMaxDelay, selector.DeadNodeTimeout/2)
+	return r.currentNode.SecondsSinceNodeStatsUpdate() <= fresh.Seconds()
 }
 
 // GetNodeForRoom finds the node where the room is hosted at
@@ -176,6 +199,7 @@ func (r *RedisRouter) Start() error {
 
 	workerStarted := make(chan error)
 	go r.statsWorker()
+	go r.deadNodeWorker()
 	go r.keepaliveWorker(workerStarted)
 
 	// wait until worker is running
@@ -222,6 +246,55 @@ func (r *RedisRouter) statsWorker() {
 			}
 		case <-r.ctx.Done():
 			return
+		}
+	}
+}
+
+// sweepDue reports whether a sweep may run, which takes a whole timeout since
+// this node last could not hear itself, and another since the last sweep, that
+// second one being what holds this to the pace of what it watches for rather
+// than to the pace of the ticker.
+func sweepDue(now, unheard, lastSweep time.Time) bool {
+	return now.Sub(unheard) >= selector.DeadNodeTimeout &&
+		now.Sub(lastSweep) >= selector.DeadNodeTimeout
+}
+
+// deadNodeWorker sweeps the registrations of nodes that are gone. A node killed
+// outright never unregisters itself and nothing else deletes what it leaves
+// behind, so this runs while the cluster does rather than only when a node
+// happens to start.
+func (r *RedisRouter) deadNodeWorker() {
+	// sampled on the stats interval rather than on the timeout it guards: a
+	// tick as coarse as that timeout cannot see an outage shorter than one,
+	// which is the length that makes a peer look dead in the first place
+	ticker := time.NewTicker(r.nodeStatsConfig.StatsUpdateInterval)
+	defer ticker.Stop()
+
+	// starting up counts as not having heard itself, so the first sweep comes a
+	// whole timeout in -- as does the first after an outage, which gives the
+	// peers coming back from it the time to re-register that this node took
+	unheard := time.Now()
+	var lastSweep time.Time
+	for {
+		select {
+		case <-r.ctx.Done():
+			return
+		case <-ticker.C:
+			now := time.Now()
+			// the sweep asks this too, for whoever reaches it through the
+			// Router interface; here it is asked to date the outage
+			if !r.hearsItself() {
+				unheard = now
+				continue
+			}
+			if !sweepDue(now, unheard, lastSweep) {
+				continue
+			}
+
+			lastSweep = now
+			if err := r.RemoveDeadNodes(); err != nil {
+				logger.Errorw("could not remove dead nodes", err)
+			}
 		}
 	}
 }

--- a/pkg/routing/redisrouter_test.go
+++ b/pkg/routing/redisrouter_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/protocol/livekit"
+
+	"github.com/livekit/livekit-server/pkg/config"
+	"github.com/livekit/livekit-server/pkg/routing/selector"
+)
+
+func TestSweepDue(t *testing.T) {
+	now := time.Now()
+	timeout := selector.DeadNodeTimeout
+	// started a moment ago, and the worker counts that as not having heard
+	// itself, which is what holds the first sweep off
+	started := now.Add(-time.Second)
+	long := now.Add(-2 * timeout)
+
+	t.Run("not while this node is new", func(t *testing.T) {
+		require.False(t, sweepDue(now, started, time.Time{}))
+	})
+
+	t.Run("not while the outage is recent", func(t *testing.T) {
+		// the bus came back a moment ago, and the peers that were on it are
+		// still registering as stale as this node was
+		require.False(t, sweepDue(now, now.Add(-timeout+time.Second), long))
+	})
+
+	t.Run("a whole timeout after the outage", func(t *testing.T) {
+		require.True(t, sweepDue(now, now.Add(-timeout), long))
+	})
+
+	t.Run("not twice in a timeout", func(t *testing.T) {
+		require.False(t, sweepDue(now, long, now.Add(-timeout+time.Second)))
+		require.True(t, sweepDue(now, long, now.Add(-timeout)))
+	})
+
+	t.Run("first sweep is not held up by a zero last sweep", func(t *testing.T) {
+		require.True(t, sweepDue(now, long, time.Time{}))
+	})
+}
+
+// a node that cannot hear its own keepalive is in no position to decide that
+// anybody else is dead
+func TestRemoveDeadNodesNeedsThisNodeToBeHeard(t *testing.T) {
+	node, err := NewLocalNode(nil)
+	require.NoError(t, err)
+	node.SetStats(&livekit.NodeStats{
+		UpdatedAt: time.Now().Add(-time.Hour).Unix(),
+	})
+
+	// nothing is listening there, so a router that gets as far as reading the
+	// registry fails here rather than reaping against whatever redis is up
+	rc := redis.NewClient(&redis.Options{Addr: "127.0.0.1:1"})
+	defer rc.Close()
+
+	r := NewRedisRouter(
+		NewLocalRouter(node, nil, nil, config.DefaultNodeStatsConfig),
+		rc,
+		nil,
+	)
+
+	require.NoError(t, r.RemoveDeadNodes(), "a node this far behind on its own stats should not have read the registry at all")
+}

--- a/pkg/routing/selector/utils.go
+++ b/pkg/routing/selector/utils.go
@@ -29,6 +29,23 @@ import (
 
 const AvailableSeconds = 5
 
+// how long a registration has to stand still before it is deleted rather than
+// merely passed over, which is a much longer wait: a node refreshes its own
+// entry when its keepalive comes back to it, so a stale one is as much a report
+// on the message bus as on the node behind it. It takes stats_update_interval
+// to be well under this, a healthy entry being that old between keepalives.
+const DeadNodeTimeout = time.Minute
+
+// checks if a node's registration is worth keeping at all
+func IsDead(node *livekit.Node) bool {
+	if node.Stats == nil {
+		// nothing to have gone stale, so nothing to go on
+		return false
+	}
+
+	return time.Since(time.Unix(node.Stats.UpdatedAt, 0)) > DeadNodeTimeout
+}
+
 // checks if a node has been updated recently to be considered for selection
 func IsAvailable(node *livekit.Node) bool {
 	if node.Stats == nil {

--- a/pkg/routing/selector/utils_test.go
+++ b/pkg/routing/selector/utils_test.go
@@ -44,3 +44,40 @@ func TestIsAvailable(t *testing.T) {
 		require.False(t, selector.IsAvailable(n))
 	})
 }
+
+func TestIsDead(t *testing.T) {
+	t.Run("never reported", func(t *testing.T) {
+		// no stats is nothing to go on, in either direction
+		require.False(t, selector.IsDead(&livekit.Node{}))
+	})
+
+	t.Run("current", func(t *testing.T) {
+		n := &livekit.Node{
+			Stats: &livekit.NodeStats{
+				UpdatedAt: time.Now().Unix() - 3,
+			},
+		}
+		require.False(t, selector.IsDead(n))
+	})
+
+	t.Run("stale is not dead", func(t *testing.T) {
+		// far enough behind to be passed over for new rooms, nowhere near far
+		// enough for its registration to be thrown away
+		n := &livekit.Node{
+			Stats: &livekit.NodeStats{
+				UpdatedAt: time.Now().Unix() - 20,
+			},
+		}
+		require.False(t, selector.IsAvailable(n))
+		require.False(t, selector.IsDead(n))
+	})
+
+	t.Run("dead", func(t *testing.T) {
+		n := &livekit.Node{
+			Stats: &livekit.NodeStats{
+				UpdatedAt: time.Now().Unix() - 61,
+			},
+		}
+		require.True(t, selector.IsDead(n))
+	})
+}

--- a/pkg/service/server.go
+++ b/pkg/service/server.go
@@ -192,10 +192,6 @@ func NewLivekitServer(conf *config.Config,
 		}
 	}
 
-	if err = router.RemoveDeadNodes(); err != nil {
-		return
-	}
-
 	return
 }
 


### PR DESCRIPTION
### Problem

`RemoveDeadNodes` has exactly one caller — `NewLivekitServer`, at construction — and deletes every node whose stats are older than `AvailableSeconds` (5s). Two consequences:

**Nothing reaps while a cluster runs.** A node that dies uncleanly never reaches `UnregisterNode`, so its entry stays in the `nodes` hash until some other node is constructed. A clean `SIGTERM` unregisters itself, so the leak is exactly unclean death — OOM, host failure, `SIGKILL` after `terminationGracePeriodSeconds`. `ListNodes` does an `HVals` and unmarshals the whole hash on every allocation that needs a new node, so that cost grows with the number of nodes that have ever died badly, not with the size of the cluster.

**Five seconds cannot tell death from a slow bus.** A node refreshes its registration when its own keepalive comes back (`keepaliveWorker` → `RegisterNode`), so `Stats.UpdatedAt` measures the message bus. A node constructed during a redis hiccup deleted every healthy peer.

### Fix

`selector.IsDead` is a separate, much longer question from `IsAvailable`: `DeadNodeTimeout` is a minute, against the five seconds that keep a node out of selection. Deleting late costs nothing, since `GetAvailableNodes` already filters on the short threshold — the sweep's only job is to stop the hash growing.

`RemoveDeadNodes` refuses to act when this node cannot hear its own keepalive, skips its own entry, and deletes in one variadic `HDel`. A new `deadNodeWorker` runs it on its own goroutine, sampling every `stats_update_interval` and sweeping at most once per timeout, never within a timeout of an outage — so a node whose subscription recovers first gives its peers the same chance to re-register that it just took.

The construction-time call is removed rather than kept: `NewLocalNode` stamps `Stats.UpdatedAt` at construction, so a node reaping there looks healthy to itself while every peer looks dead, which is the mass deletion above.

### Behaviour worth reviewing

- Construction no longer makes a redis round trip, so an unreachable redis is reported by `Start()` rather than by `NewLivekitServer`.
- `hearsItself` uses `min(stats_max_delay, DeadNodeTimeout/2)`, so a peer must always be at least 30s further behind than this node before it can be deleted, whatever `stats_max_delay` is set to. `DeadNodeTimeout` itself assumes `stats_update_interval` is well under a minute.
- There is a TOCTOU between `ListNodes` and `HDel`: a node that re-registers in the gap loses its entry for one `stats_update_interval`. Consistent with how the rest of the file treats the registry.
- `room_node_map` grows for the same reason and is untouched here.
- Found while working on #4663, but independent of it.

### Testing

Unit tests for `IsDead` (stale is deliberately *not* dead), for the sweep schedule, and for the guard — the last points the router at a dead address, so a regression that reads the registry fails on the connection rather than passing quietly. Verified by stubbing the guard out: the test goes red.

The deletion itself is not covered — that needs a real redis, and `pkg/routing` has no helper. Once #4797 lands, `pkg/testutils/redis.go` is the natural home for that test rather than a third copy of the same helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
