### PR TITLE
Fix nil pointer dereference in IOInfoService.UpdateIngressState on concurrent DeleteIngress

### DIFF
--- a/pkg/service/ioservice_ingress.go
+++ b/pkg/service/ioservice_ingress.go
@@ -73,6 +73,13 @@ func (s *IOInfoService) UpdateIngressState(ctx context.Context, req *rpc.UpdateI
 	if err != nil {
 		return nil, err
 	}
+	if info.State == nil {
+		// LoadIngress reads the ingress info and its state non-atomically: a concurrent
+		// DeleteIngress can remove the state key between the two reads, in which case
+		// LoadIngress returns the info with a nil State and no error. Treat it as an
+		// empty state instead of panicking on the status comparison below.
+		info.State = &livekit.IngressState{}
+	}
 
 	if err = s.is.UpdateIngressState(ctx, req.IngressId, req.State); err != nil {
 		logger.Errorw("could not update ingress", err)

--- a/pkg/service/ioservice_ingress_test.go
+++ b/pkg/service/ioservice_ingress_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/rpc"
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/livekit-server/pkg/service"
+	"github.com/livekit/livekit-server/pkg/service/servicefakes"
+	"github.com/livekit/livekit-server/pkg/telemetry/telemetryfakes"
+)
+
+// A concurrent DeleteIngress can remove the ingress state key between the two
+// non-atomic reads LoadIngress performs, making it return an IngressInfo with a
+// nil State and no error. UpdateIngressState used to panic dereferencing it,
+// bringing down the whole node.
+func TestUpdateIngressStateWithNilState(t *testing.T) {
+	is := &servicefakes.FakeIngressStore{}
+	is.LoadIngressReturns(&livekit.IngressInfo{IngressId: "IN_test"}, nil)
+
+	io, err := service.NewIOInfoService(nil, nil, is, nil, &telemetryfakes.FakeTelemetryService{})
+	require.NoError(t, err)
+
+	_, err = io.UpdateIngressState(context.Background(), &rpc.UpdateIngressStateRequest{
+		IngressId: "IN_test",
+		State:     &livekit.IngressState{Status: livekit.IngressState_ENDPOINT_INACTIVE},
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
`LoadIngress` reads the ingress info and its state from two separate Redis keys non-atomically, while `DeleteIngress` removes both keys in one transaction. If the delete lands between the two reads, `LoadIngress` returns an `IngressInfo` with a nil `State` and no error, and `UpdateIngressState` panics at the `info.State.Status` comparison — killing the server and every room it hosts:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x19425f5]

goroutine 33745 [running]:
github.com/livekit/livekit-server/pkg/service.(*IOInfoService).UpdateIngressState(...)
	/workspace/pkg/service/ioservice_ingress.go:82 +0xf5
github.com/livekit/psrpc/pkg/server.newRPCHandler[...].func1.1(...)
	/go/pkg/mod/github.com/livekit/psrpc@v0.7.3/pkg/server/rpc.go:107 +0x2e
```

In practice the race fires when an ingress session is torn down by `DeleteIngress` while the ingress service reports that session's state change. With short-lived per-room WHIP ingresses (created when a call is enqueued, deleted when it is answered or hung up) we crashed servers within minutes: two independent crashes on v1.13.6, both within 30ms of a `DeleteIngress` call, one of them landing inside the delete's 16ms execution window on another node. The vulnerable code is identical on v1.13.5 and current master.

The fix treats the missing state as an empty state, matching how the store's own `UpdateIngressState` already tolerates a missing state key (it recreates it). Includes a regression test that reproduces the exact panic (`SIGSEGV addr=0x8`) without the fix and passes with it; the full `pkg/service` suite stays green.
