### PR TITLE
Update README to include snippet about Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ LiveKit's server is written in Go, using the awesome [Pion WebRTC](https://githu
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/livekit/livekit/buildtest.yaml?branch=master)](https://github.com/livekit/livekit/actions/workflows/buildtest.yaml)
 [![License](https://img.shields.io/github/license/livekit/livekit)](https://github.com/livekit/livekit/blob/master/LICENSE)
 
+<!--BEGIN_AGENTS_INFO-->
 > [!IMPORTANT]
 > If you're building Voice AI, [LiveKit Agents](https://github.com/livekit/agents) is the SDK for code-first realtime voice agents. STT, LLM, TTS, turn detection, [expressive speech](https://docs.livekit.io/agents/models/tts/expressive/), [keyterm accuracy](https://docs.livekit.io/agents/models/stt/keyterms/), tool usage, and telephony all come bundled in the framework. It's available in both [Python](https://github.com/livekit/agents) and [Node.js](https://github.com/livekit/agents-js).
 >
@@ -53,6 +54,7 @@ LiveKit's server is written in Go, using the awesome [Pion WebRTC](https://githu
 >```
 >
 >Models come from [LiveKit Inference](https://docs.livekit.io/agents/models/) with no per-provider API keys, and LiveKit Cloud handles [deployment](https://docs.livekit.io/deploy/agents/) and [observability](https://docs.livekit.io/deploy/observability/). Visit the docs for more info at [docs.livekit.io/agents](https://docs.livekit.io/agents/).
+<!--END_AGENTS_INFO-->
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,37 @@ LiveKit's server is written in Go, using the awesome [Pion WebRTC](https://githu
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/livekit/livekit/buildtest.yaml?branch=master)](https://github.com/livekit/livekit/actions/workflows/buildtest.yaml)
 [![License](https://img.shields.io/github/license/livekit/livekit)](https://github.com/livekit/livekit/blob/master/LICENSE)
 
+> [!IMPORTANT]
+> If you're building Voice AI, [LiveKit Agents](https://github.com/livekit/agents) is the SDK for code-first realtime voice agents. STT, LLM, TTS, turn detection, [expressive speech](https://docs.livekit.io/agents/models/tts/expressive/), [keyterm accuracy](https://docs.livekit.io/agents/models/stt/keyterms/), tool usage, and telephony all come bundled in the framework. It's available in both [Python](https://github.com/livekit/agents) and [Node.js](https://github.com/livekit/agents-js).
+>
+>```python
+># agent.py
+>from livekit import agents
+>from livekit.agents import Agent, AgentServer, AgentSession, STTContextOptions, TurnHandlingOptions, inference
+>
+>server = AgentServer()
+>
+>
+>@server.rtc_session(agent_name="my-agent")
+>async def my_agent(ctx: agents.JobContext):
+>    session = AgentSession(
+>        stt=inference.STT(model="deepgram/nova-3", language="multi"),
+>        llm=inference.LLM(model="google/gemma-4-31b-it"),
+>        tts=inference.TTS(model="inworld/inworld-tts-2", voice="Ashley"),
+>        turn_handling=TurnHandlingOptions(turn_detection=inference.TurnDetector()),
+>        stt_context_options=STTContextOptions(keyterms=["LiveKit", "Acme Corp"]),
+>        expressive=True,
+>    )
+>    await session.start(room=ctx.room, agent=Agent(instructions="You are a helpful voice AI assistant."))
+>    await session.generate_reply(instructions="Greet the user and offer your assistance.")
+>
+>
+>if __name__ == "__main__":
+>    agents.cli.run_app(server)
+>```
+>
+>Models come from [LiveKit Inference](https://docs.livekit.io/agents/models/) with no per-provider API keys, and LiveKit Cloud handles [deployment](https://docs.livekit.io/deploy/agents/) and [observability](https://docs.livekit.io/deploy/observability/). Visit the docs for more info at [docs.livekit.io/agents](https://docs.livekit.io/agents/).
+
 ## Features
 
 -   Scalable, distributed WebRTC SFU (Selective Forwarding Unit)


### PR DESCRIPTION
Rather than having information about Agents buried as a small entry in `## Ecosystem`, it makes sense to have a block talking about them sooner. Added as a reusable block so that we don't need to update each repo individually if we want to change the snippet or the copy.