### PR TITLE
Remove duplication within cpuload and sysload

### DIFF
--- a/pkg/routing/selector/cpuload.go
+++ b/pkg/routing/selector/cpuload.go
@@ -27,21 +27,13 @@ type CPULoadSelector struct {
 }
 
 func (s *CPULoadSelector) filterNodes(nodes []*livekit.Node) ([]*livekit.Node, error) {
-	nodes = GetAvailableNodes(nodes)
-	if len(nodes) == 0 {
-		return nil, ErrNoAvailableNodes
+	nodes, err := FilterNodesByCriteria(nodes, s.CPULoadLimit, func(node *livekit.Node) float32 {
+		return node.Stats.CpuLoad
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	nodesLowLoad := make([]*livekit.Node, 0)
-	for _, node := range nodes {
-		stats := node.Stats
-		if stats.CpuLoad < s.CPULoadLimit {
-			nodesLowLoad = append(nodesLowLoad, node)
-		}
-	}
-	if len(nodesLowLoad) > 0 {
-		nodes = nodesLowLoad
-	}
 	return nodes, nil
 }
 

--- a/pkg/routing/selector/nodesfilter.go
+++ b/pkg/routing/selector/nodesfilter.go
@@ -2,7 +2,7 @@ package selector
 
 import "github.com/livekit/protocol/livekit"
 
-func FilterNodesByCriteria(nodes []*livekit.Node, criteriaThreashold float32, calculateCriteriaFunc func(*livekit.Node) float32) ([]*livekit.Node, error) {
+func FilterNodesByCriteria(nodes []*livekit.Node, criteriaThreshold float32, calculateCriteriaFunc func(*livekit.Node) float32) ([]*livekit.Node, error) {
 	nodes = GetAvailableNodes(nodes)
 	if len(nodes) == 0 {
 		return nil, ErrNoAvailableNodes
@@ -10,7 +10,7 @@ func FilterNodesByCriteria(nodes []*livekit.Node, criteriaThreashold float32, ca
 
 	filteredNodes := make([]*livekit.Node, 0)
 	for _, node := range nodes {
-		if calculateCriteriaFunc(node) < criteriaThreashold {
+		if calculateCriteriaFunc(node) < criteriaThreshold {
 			filteredNodes = append(filteredNodes, node)
 		}
 	}

--- a/pkg/routing/selector/nodesfilter.go
+++ b/pkg/routing/selector/nodesfilter.go
@@ -1,0 +1,21 @@
+package selector
+
+import "github.com/livekit/protocol/livekit"
+
+func FilterNodesByCriteria(nodes []*livekit.Node, criteriaThreashold float32, calculateCriteriaFunc func(*livekit.Node) float32) ([]*livekit.Node, error) {
+	nodes = GetAvailableNodes(nodes)
+	if len(nodes) == 0 {
+		return nil, ErrNoAvailableNodes
+	}
+
+	filteredNodes := make([]*livekit.Node, 0)
+	for _, node := range nodes {
+		if calculateCriteriaFunc(node) < criteriaThreashold {
+			filteredNodes = append(filteredNodes, node)
+		}
+	}
+	if len(filteredNodes) > 0 {
+		nodes = filteredNodes
+	}
+	return nodes, nil
+}

--- a/pkg/routing/selector/sysload.go
+++ b/pkg/routing/selector/sysload.go
@@ -27,20 +27,11 @@ type SystemLoadSelector struct {
 }
 
 func (s *SystemLoadSelector) filterNodes(nodes []*livekit.Node) ([]*livekit.Node, error) {
-	nodes = GetAvailableNodes(nodes)
-	if len(nodes) == 0 {
-		return nil, ErrNoAvailableNodes
+	nodes, err := FilterNodesByCriteria(nodes, s.SysloadLimit, GetNodeSysload)
+	if err != nil {
+		return nil, err
 	}
 
-	nodesLowLoad := make([]*livekit.Node, 0)
-	for _, node := range nodes {
-		if GetNodeSysload(node) < s.SysloadLimit {
-			nodesLowLoad = append(nodesLowLoad, node)
-		}
-	}
-	if len(nodesLowLoad) > 0 {
-		nodes = nodesLowLoad
-	}
 	return nodes, nil
 }
 


### PR DESCRIPTION
## Summary

`CPULoadSelector.filterNodes` and `SystemLoadSelector.filterNodes` contained the
same node-filtering logic, differing only in the per-node metric and the limit
they compared against. This extracts that shared logic into a single helper so
the two selectors no longer duplicate it.

## Changes

- Add `FilterNodesByCriteria(nodes, threshold, criteriaFunc)` in
  `pkg/routing/selector/nodesfilter.go`. It filters to available nodes, returns
  `ErrNoAvailableNodes` when none remain, and then keeps only nodes whose
  criteria value falls below the threshold — falling back to the full available
  set when nothing is under the threshold.
- `SystemLoadSelector` now delegates to the helper with `GetNodeSysload`.
- `CPULoadSelector` now delegates to the helper with `node.Stats.CpuLoad`.

## Notes

Pure refactor with no behavioural changes: the "keep all available nodes if none
are under the limit" fallback is preserved exactly as before, so selection
results are unchanged.
