### PR TITLE
fix: hold signal messages until the ReconnectResponse goes out

### DIFF
--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -261,6 +261,10 @@ type ParticipantImpl struct {
 	state        atomic.Value // livekit.ParticipantInfo_State
 	disconnected chan struct{}
 
+	// a migrating in participant resumes on a reconnect response, the client takes it
+	// only as the first message on the resumed signal connection
+	reconnectResponseSent atomic.Bool
+
 	grants      atomic.Pointer[auth.ClaimGrants]
 	isPublisher atomic.Bool
 
@@ -612,9 +616,10 @@ func (p *ParticipantImpl) IsReady() bool {
 	state := p.State()
 
 	// when migrating, there is no JoinResponse, state transitions from JOINING -> ACTIVE -> DISCONNECTED
-	// so JOINING is considered ready.
+	// so JOINING is considered ready. The ReconnectResponse takes the place of the JoinResponse
+	// as the message the resumed signal connection opens with, so readiness waits for it.
 	if p.params.Migration {
-		return state != livekit.ParticipantInfo_DISCONNECTED
+		return state != livekit.ParticipantInfo_DISCONNECTED && p.reconnectResponseSent.Load()
 	}
 
 	// when not migrating, there is a JoinResponse, state transitions from JOINING -> JOINED -> ACTIVE -> DISCONNECTED

--- a/pkg/rtc/participant.go
+++ b/pkg/rtc/participant.go
@@ -2076,8 +2076,9 @@ func (p *ParticipantImpl) setupSignalling() {
 		Participant: p,
 	})
 	p.signaller = signalling.NewSignallerAsync(signalling.SignallerAsyncParams{
-		Logger:      p.params.Logger,
-		Participant: p,
+		Logger:            p.params.Logger,
+		Participant:       p,
+		OnHandshakeOpened: p.flushQueuedUpdates,
 	})
 }
 

--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -783,6 +783,7 @@ type participantOpts struct {
 	publisher       bool
 	clientConf      *livekit.ClientConfiguration
 	clientInfo      *livekit.ClientInfo
+	migration       bool
 }
 
 func newParticipantForTestWithOpts(identity livekit.ParticipantIdentity, opts *participantOpts) *ParticipantImpl {
@@ -837,6 +838,7 @@ func newParticipantForTestWithOpts(identity livekit.ParticipantIdentity, opts *p
 		VersionGenerator:       utils.NewDefaultTimedVersionGenerator(),
 		ParticipantListener:    &typesfakes.FakeLocalParticipantListener{},
 		ParticipantHelper:      &typesfakes.FakeLocalParticipantHelper{},
+		Migration:              opts.migration,
 	})
 	p.isPublisher.Store(opts.publisher)
 	p.updateState(livekit.ParticipantInfo_ACTIVE)
@@ -893,5 +895,138 @@ func TestUnsequencedReliableDataBufferedWhileJoining(t *testing.T) {
 
 		require.Error(t, p.SendDataMessage(livekit.DataPacket_LOSSY, []byte("one"), "", 0))
 		require.Empty(t, p.reliableDataInfo.joiningUnsequencedMessages)
+	})
+}
+
+func TestMigratingInParticipantWaitsForReconnectResponse(t *testing.T) {
+	// a migrating in participant resumes on a ReconnectResponse, the client takes it only
+	// as the first message on the resumed signal connection, so everything else waits
+	newMigratingParticipant := func() (*ParticipantImpl, *routingfakes.FakeMessageSink) {
+		p := newParticipantForTestWithOpts("test", &participantOpts{
+			migration:       true,
+			protocolVersion: 17,
+			clientInfo:      &livekit.ClientInfo{Sdk: livekit.ClientInfo_JS, Version: "2.15.2"},
+		})
+		return p, p.params.Sink.(*routingfakes.FakeMessageSink)
+	}
+
+	t.Run("not ready until the response is sent", func(t *testing.T) {
+		p, sink := newMigratingParticipant()
+		require.False(t, p.IsReady())
+
+		require.NoError(t, p.HandleReconnectAndSendResponse(
+			livekit.ReconnectReason_RR_UNKNOWN,
+			&livekit.ReconnectResponse{LastMessageSeq: 21},
+		))
+		require.True(t, p.IsReady())
+
+		require.Equal(t, 1, sink.WriteMessageCallCount())
+		res := sink.WriteMessageArgsForCall(0).(*livekit.SignalResponse)
+		require.NotNil(t, res.GetReconnect())
+		require.EqualValues(t, 21, res.GetReconnect().LastMessageSeq)
+	})
+
+	t.Run("the response goes out first", func(t *testing.T) {
+		p, sink := newMigratingParticipant()
+
+		// a room update while waiting is dropped, it is re-sent after the migration
+		require.NoError(t, p.SendRoomUpdate(&livekit.Room{Name: "test"}))
+		// participant updates while waiting are queued
+		require.NoError(t, p.SendParticipantUpdate([]*livekit.ParticipantInfo{{
+			Sid:      "PA_other",
+			Identity: "other",
+			Version:  1,
+		}}))
+		require.Zero(t, sink.WriteMessageCallCount())
+
+		require.NoError(t, p.HandleReconnectAndSendResponse(
+			livekit.ReconnectReason_RR_UNKNOWN,
+			&livekit.ReconnectResponse{},
+		))
+
+		require.Equal(t, 2, sink.WriteMessageCallCount())
+		first := sink.WriteMessageArgsForCall(0).(*livekit.SignalResponse)
+		require.NotNil(t, first.GetReconnect())
+		second := sink.WriteMessageArgsForCall(1).(*livekit.SignalResponse)
+		require.NotNil(t, second.GetUpdate())
+		require.Len(t, second.GetUpdate().Participants, 1)
+		require.EqualValues(t, "PA_other", second.GetUpdate().Participants[0].Sid)
+	})
+
+	t.Run("a client that cannot handle the response is ready right away", func(t *testing.T) {
+		p := newParticipantForTestWithOpts("test", &participantOpts{
+			migration:       true,
+			protocolVersion: 17,
+			clientInfo:      &livekit.ClientInfo{Sdk: livekit.ClientInfo_JS, Version: "1.6.2"},
+		})
+		sink := p.params.Sink.(*routingfakes.FakeMessageSink)
+
+		require.NoError(t, p.HandleReconnectAndSendResponse(
+			livekit.ReconnectReason_RR_UNKNOWN,
+			&livekit.ReconnectResponse{},
+		))
+		require.True(t, p.IsReady())
+		require.Zero(t, sink.WriteMessageCallCount())
+
+		require.NoError(t, p.SendRoomUpdate(&livekit.Room{Name: "test"}))
+		require.Equal(t, 1, sink.WriteMessageCallCount())
+	})
+}
+
+func TestResumedParticipantWaitsForReconnectResponse(t *testing.T) {
+	// a resumed connection has to open with the ReconnectResponse too, and the
+	// participant is ready throughout, so the signaller holds messages back
+	newResumedParticipant := func(version string) (*ParticipantImpl, *routingfakes.FakeMessageSink) {
+		p := newParticipantForTestWithOpts("test", &participantOpts{
+			protocolVersion: 17,
+			clientInfo:      &livekit.ClientInfo{Sdk: livekit.ClientInfo_JS, Version: version},
+		})
+		require.True(t, p.IsReady())
+
+		sink := &routingfakes.FakeMessageSink{}
+		p.SwapResponseSink(sink, types.SignallingCloseReasonResume)
+		return p, sink
+	}
+
+	t.Run("the response goes out first", func(t *testing.T) {
+		p, sink := newResumedParticipant("2.15.2")
+
+		require.NoError(t, p.SendRoomUpdate(&livekit.Room{Name: "test"}))
+		require.NoError(t, p.SendParticipantUpdate([]*livekit.ParticipantInfo{{
+			Sid:      "PA_other",
+			Identity: "other",
+			Version:  1,
+		}}))
+		require.Zero(t, sink.WriteMessageCallCount())
+
+		require.NoError(t, p.HandleReconnectAndSendResponse(
+			livekit.ReconnectReason_RR_SIGNAL_DISCONNECTED,
+			&livekit.ReconnectResponse{LastMessageSeq: 7},
+		))
+
+		require.Equal(t, 2, sink.WriteMessageCallCount())
+		first := sink.WriteMessageArgsForCall(0).(*livekit.SignalResponse)
+		require.NotNil(t, first.GetReconnect())
+		require.EqualValues(t, 7, first.GetReconnect().LastMessageSeq)
+		second := sink.WriteMessageArgsForCall(1).(*livekit.SignalResponse)
+		require.NotNil(t, second.GetUpdate())
+		require.EqualValues(t, "PA_other", second.GetUpdate().Participants[0].Sid)
+
+		// and the connection is open from here on
+		require.NoError(t, p.SendRoomUpdate(&livekit.Room{Name: "test"}))
+		require.Equal(t, 3, sink.WriteMessageCallCount())
+	})
+
+	t.Run("a client that cannot handle the response is not held back", func(t *testing.T) {
+		p, sink := newResumedParticipant("1.6.2")
+
+		require.NoError(t, p.HandleReconnectAndSendResponse(
+			livekit.ReconnectReason_RR_SIGNAL_DISCONNECTED,
+			&livekit.ReconnectResponse{},
+		))
+		require.Zero(t, sink.WriteMessageCallCount())
+
+		require.NoError(t, p.SendRoomUpdate(&livekit.Room{Name: "test"}))
+		require.Equal(t, 1, sink.WriteMessageCallCount())
 	})
 }

--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -991,6 +991,8 @@ func TestResumedParticipantWaitsForReconnectResponse(t *testing.T) {
 	t.Run("the response goes out first", func(t *testing.T) {
 		p, sink := newResumedParticipant("2.15.2")
 
+		// the resume path re-sends room and participant state right after the response,
+		// so what is written in this window is dropped
 		require.NoError(t, p.SendRoomUpdate(&livekit.Room{Name: "test"}))
 		require.NoError(t, p.SendParticipantUpdate([]*livekit.ParticipantInfo{{
 			Sid:      "PA_other",
@@ -1004,17 +1006,21 @@ func TestResumedParticipantWaitsForReconnectResponse(t *testing.T) {
 			&livekit.ReconnectResponse{LastMessageSeq: 7},
 		))
 
-		require.Equal(t, 2, sink.WriteMessageCallCount())
+		require.Equal(t, 1, sink.WriteMessageCallCount())
 		first := sink.WriteMessageArgsForCall(0).(*livekit.SignalResponse)
 		require.NotNil(t, first.GetReconnect())
 		require.EqualValues(t, 7, first.GetReconnect().LastMessageSeq)
+
+		// and the connection is open from here on
+		require.NoError(t, p.SendParticipantUpdate([]*livekit.ParticipantInfo{{
+			Sid:      "PA_other",
+			Identity: "other",
+			Version:  2,
+		}}))
+		require.Equal(t, 2, sink.WriteMessageCallCount())
 		second := sink.WriteMessageArgsForCall(1).(*livekit.SignalResponse)
 		require.NotNil(t, second.GetUpdate())
 		require.EqualValues(t, "PA_other", second.GetUpdate().Participants[0].Sid)
-
-		// and the connection is open from here on
-		require.NoError(t, p.SendRoomUpdate(&livekit.Room{Name: "test"}))
-		require.Equal(t, 3, sink.WriteMessageCallCount())
 	})
 
 	t.Run("a client that cannot handle the response is not held back", func(t *testing.T) {

--- a/pkg/rtc/participant_internal_test.go
+++ b/pkg/rtc/participant_internal_test.go
@@ -991,9 +991,9 @@ func TestResumedParticipantWaitsForReconnectResponse(t *testing.T) {
 	t.Run("the response goes out first", func(t *testing.T) {
 		p, sink := newResumedParticipant("2.15.2")
 
-		// the resume path re-sends room and participant state right after the response,
-		// so what is written in this window is dropped
+		// a room update in this window is dropped, the resume path re-sends room state
 		require.NoError(t, p.SendRoomUpdate(&livekit.Room{Name: "test"}))
+		// participant updates are queued
 		require.NoError(t, p.SendParticipantUpdate([]*livekit.ParticipantInfo{{
 			Sid:      "PA_other",
 			Identity: "other",
@@ -1006,21 +1006,32 @@ func TestResumedParticipantWaitsForReconnectResponse(t *testing.T) {
 			&livekit.ReconnectResponse{LastMessageSeq: 7},
 		))
 
-		require.Equal(t, 1, sink.WriteMessageCallCount())
+		require.Equal(t, 2, sink.WriteMessageCallCount())
 		first := sink.WriteMessageArgsForCall(0).(*livekit.SignalResponse)
 		require.NotNil(t, first.GetReconnect())
 		require.EqualValues(t, 7, first.GetReconnect().LastMessageSeq)
-
-		// and the connection is open from here on
-		require.NoError(t, p.SendParticipantUpdate([]*livekit.ParticipantInfo{{
-			Sid:      "PA_other",
-			Identity: "other",
-			Version:  2,
-		}}))
-		require.Equal(t, 2, sink.WriteMessageCallCount())
 		second := sink.WriteMessageArgsForCall(1).(*livekit.SignalResponse)
 		require.NotNil(t, second.GetUpdate())
 		require.EqualValues(t, "PA_other", second.GetUpdate().Participants[0].Sid)
+	})
+
+	t.Run("a connection that opens without a response still delivers the queue", func(t *testing.T) {
+		p, sink := newResumedParticipant("2.15.2")
+
+		require.NoError(t, p.SendParticipantUpdate([]*livekit.ParticipantInfo{{
+			Sid:      "PA_other",
+			Identity: "other",
+			Version:  1,
+		}}))
+		require.Zero(t, sink.WriteMessageCallCount())
+
+		// no ReconnectResponse written, this is what the handshake window does on expiry
+		p.signaller.OpenHandshake()
+
+		require.Equal(t, 1, sink.WriteMessageCallCount())
+		res := sink.WriteMessageArgsForCall(0).(*livekit.SignalResponse)
+		require.NotNil(t, res.GetUpdate())
+		require.EqualValues(t, "PA_other", res.GetUpdate().Participants[0].Sid)
 	})
 
 	t.Run("a client that cannot handle the response is not held back", func(t *testing.T) {

--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -75,13 +75,16 @@ func (p *ParticipantImpl) SendJoinResponse(joinResponse *livekit.JoinResponse) e
 }
 
 func (p *ParticipantImpl) SendParticipantUpdate(participantsToUpdate []*livekit.ParticipantInfo) error {
+	// checked before taking the lock, opening the connection flushes the queue from here
+	handshakePending := p.signaller.HandshakePending()
+
 	p.updateLock.Lock()
 	if p.IsDisconnected() {
 		p.updateLock.Unlock()
 		return nil
 	}
 
-	if !p.IsReady() {
+	if !p.IsReady() || handshakePending {
 		// queue up updates
 		p.queuedUpdates = append(p.queuedUpdates, participantsToUpdate...)
 		p.updateLock.Unlock()
@@ -203,7 +206,7 @@ func (p *ParticipantImpl) HandleReconnectAndSendResponse(reconnectReason livekit
 }
 
 // reconnectResponseSentAndFlush makes a migrating in participant ready and sends what was
-// queued up while it was waiting for its ReconnectResponse.
+// queued up while the connection was waiting for its ReconnectResponse.
 func (p *ParticipantImpl) reconnectResponseSentAndFlush() error {
 	// a successful write opens the connection by itself, this covers the paths that do
 	// not write one, i. e. a client that cannot handle it and a failed write
@@ -220,6 +223,24 @@ func (p *ParticipantImpl) reconnectResponseSentAndFlush() error {
 	}
 
 	return nil
+}
+
+// flushQueuedUpdates sends the updates queued while the connection was closed for the
+// handshake. Called when the connection opens, including when it opens without a
+// ReconnectResponse having been written.
+func (p *ParticipantImpl) flushQueuedUpdates() {
+	p.updateLock.Lock()
+	queuedUpdates := p.queuedUpdates
+	p.queuedUpdates = nil
+	p.updateLock.Unlock()
+
+	if len(queuedUpdates) == 0 {
+		return
+	}
+
+	if err := p.SendParticipantUpdate(queuedUpdates); err != nil {
+		p.params.Logger.Warnw("could not send queued participant updates", err)
+	}
 }
 
 func (p *ParticipantImpl) sendDisconnectUpdatesForReconnect() error {

--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -81,7 +81,7 @@ func (p *ParticipantImpl) SendParticipantUpdate(participantsToUpdate []*livekit.
 		return nil
 	}
 
-	if !p.IsReady() || p.signaller.HandshakePending() {
+	if !p.IsReady() {
 		// queue up updates
 		p.queuedUpdates = append(p.queuedUpdates, participantsToUpdate...)
 		p.updateLock.Unlock()

--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -81,7 +81,7 @@ func (p *ParticipantImpl) SendParticipantUpdate(participantsToUpdate []*livekit.
 		return nil
 	}
 
-	if !p.IsReady() {
+	if !p.IsReady() || p.signaller.HandshakePending() {
 		// queue up updates
 		p.queuedUpdates = append(p.queuedUpdates, participantsToUpdate...)
 		p.updateLock.Unlock()
@@ -177,14 +177,46 @@ func (p *ParticipantImpl) HandleReconnectAndSendResponse(reconnectReason livekit
 	p.TransportManager.HandleClientReconnect(reconnectReason)
 
 	if !p.params.ClientInfo.CanHandleReconnectResponse() {
-		return nil
+		// no ReconnectResponse opens this connection, so nothing to hold back
+		return p.reconnectResponseSentAndFlush()
 	}
-	if err := p.signaller.WriteMessage(p.signalling.SignalReconnectResponse(reconnectResponse)); err != nil {
+
+	// send reconnect response
+	err := p.signaller.WriteMessage(p.signalling.SignalReconnectResponse(reconnectResponse))
+
+	// mark sent after sending the message, so that nothing could slip through before
+	// ReconnectResponse is sent. Marked on a failed write too: the sink is gone in that
+	// case, and leaving it unmarked would hold back every message after it.
+	flushErr := p.reconnectResponseSentAndFlush()
+	if err != nil {
 		return err
+	}
+	if flushErr != nil {
+		return flushErr
 	}
 
 	if p.params.ProtocolVersion.SupportsDisconnectedUpdate() {
 		return p.sendDisconnectUpdatesForReconnect()
+	}
+
+	return nil
+}
+
+// reconnectResponseSentAndFlush makes a migrating in participant ready and sends what was
+// queued up while it was waiting for its ReconnectResponse.
+func (p *ParticipantImpl) reconnectResponseSentAndFlush() error {
+	// a successful write opens the connection by itself, this covers the paths that do
+	// not write one, i. e. a client that cannot handle it and a failed write
+	p.signaller.OpenHandshake()
+
+	p.updateLock.Lock()
+	p.reconnectResponseSent.Store(true)
+	queuedUpdates := p.queuedUpdates
+	p.queuedUpdates = nil
+	p.updateLock.Unlock()
+
+	if len(queuedUpdates) > 0 {
+		return p.SendParticipantUpdate(queuedUpdates)
 	}
 
 	return nil

--- a/pkg/rtc/participant_signal.go
+++ b/pkg/rtc/participant_signal.go
@@ -75,16 +75,15 @@ func (p *ParticipantImpl) SendJoinResponse(joinResponse *livekit.JoinResponse) e
 }
 
 func (p *ParticipantImpl) SendParticipantUpdate(participantsToUpdate []*livekit.ParticipantInfo) error {
-	// checked before taking the lock, opening the connection flushes the queue from here
-	handshakePending := p.signaller.HandshakePending()
-
 	p.updateLock.Lock()
 	if p.IsDisconnected() {
 		p.updateLock.Unlock()
 		return nil
 	}
 
-	if !p.IsReady() || handshakePending {
+	// read under the lock the flush takes, so an update either queues before the flush
+	// or goes out after the connection has opened
+	if !p.IsReady() || p.signaller.HandshakePending() {
 		// queue up updates
 		p.queuedUpdates = append(p.queuedUpdates, participantsToUpdate...)
 		p.updateLock.Unlock()

--- a/pkg/rtc/signalling/interfaces.go
+++ b/pkg/rtc/signalling/interfaces.go
@@ -32,6 +32,13 @@ type ParticipantSignaller interface {
 	GetResponseSink() routing.MessageSink
 	CloseSignalConnection(reason types.SignallingCloseReason)
 
+	// HandshakePending reports whether a resumed connection is still waiting for the
+	// ReconnectResponse it has to open with
+	HandshakePending() bool
+	// OpenHandshake lets messages flow on a resumed connection that does not open with
+	// a ReconnectResponse
+	OpenHandshake()
+
 	WriteMessage(msg proto.Message) error
 }
 

--- a/pkg/rtc/signalling/signallerasync.go
+++ b/pkg/rtc/signalling/signallerasync.go
@@ -69,17 +69,25 @@ func (s *signallerAsync) WriteMessage(msg proto.Message) error {
 		return nil
 	}
 
-	if !s.params.Participant.IsReady() {
-		if typed, ok := msg.(*livekit.SignalResponse); !ok {
-			s.params.Logger.Warnw(
-				"unknown message type", nil,
-				"messageType", fmt.Sprintf("%T", msg),
-			)
-		} else {
-			if typed.GetJoin() == nil {
-				return nil
-			}
-		}
+	// a signal connection opens with a join response, or with a reconnect response when
+	// it is resumed or migrated in. The client reads that first message as the handshake,
+	// so nothing may go out ahead of it.
+	isHandshake := false
+	if typed, ok := msg.(*livekit.SignalResponse); !ok {
+		s.params.Logger.Warnw(
+			"unknown message type", nil,
+			"messageType", fmt.Sprintf("%T", msg),
+		)
+	} else {
+		isHandshake = typed.GetJoin() != nil || typed.GetReconnect() != nil
+	}
+
+	if !isHandshake && (!s.params.Participant.IsReady() || s.HandshakePending()) {
+		s.params.Logger.Debugw(
+			"dropping message, connection has not opened yet",
+			"messageType", getMessageType(msg),
+		)
+		return nil
 	}
 
 	sink := s.GetResponseSink()
@@ -108,6 +116,10 @@ func (s *signallerAsync) WriteMessage(msg proto.Message) error {
 			return err
 		}
 	} else {
+		if isHandshake {
+			// the connection is open, hold nothing back any more
+			s.OpenHandshake()
+		}
 		s.params.Logger.Debugw("sent signal response", "response", logger.Proto(msg))
 	}
 	return nil

--- a/pkg/rtc/signalling/signallerasync.go
+++ b/pkg/rtc/signalling/signallerasync.go
@@ -73,6 +73,7 @@ func (s *signallerAsync) WriteMessage(msg proto.Message) error {
 	// it is resumed or migrated in. The client reads that first message as the handshake,
 	// so nothing may go out ahead of it.
 	isHandshake := false
+	isSdp := false
 	if typed, ok := msg.(*livekit.SignalResponse); !ok {
 		s.params.Logger.Warnw(
 			"unknown message type", nil,
@@ -80,10 +81,19 @@ func (s *signallerAsync) WriteMessage(msg proto.Message) error {
 		)
 	} else {
 		isHandshake = typed.GetJoin() != nil || typed.GetReconnect() != nil
+		isSdp = typed.GetOffer() != nil || typed.GetAnswer() != nil
 	}
 
 	if !isHandshake && (!s.params.Participant.IsReady() || s.HandshakePending()) {
-		s.params.Logger.Debugw(
+		logFunc := s.params.Logger.Debugw
+		if isSdp {
+			// a dropped SDP leaves the negotiation waiting for the peer until the
+			// negotiation state machine recovers it, so make it visible
+			logFunc = func(msg string, keysAndValues ...any) {
+				s.params.Logger.Infow(msg, keysAndValues...)
+			}
+		}
+		logFunc(
 			"dropping message, connection has not opened yet",
 			"messageType", getMessageType(msg),
 		)

--- a/pkg/rtc/signalling/signallerasync.go
+++ b/pkg/rtc/signalling/signallerasync.go
@@ -31,8 +31,9 @@ import (
 var _ ParticipantSignaller = (*signallerAsync)(nil)
 
 type SignallerAsyncParams struct {
-	Logger      logger.Logger
-	Participant types.LocalParticipant
+	Logger            logger.Logger
+	Participant       types.LocalParticipant
+	OnHandshakeOpened func()
 }
 
 type signallerAsync struct {
@@ -43,8 +44,11 @@ type signallerAsync struct {
 
 func NewSignallerAsync(params SignallerAsyncParams) ParticipantSignaller {
 	return &signallerAsync{
-		params:             params,
-		signallerAsyncBase: newSignallerAsyncBase(signallerAsyncBaseParams{Logger: params.Logger}),
+		params: params,
+		signallerAsyncBase: newSignallerAsyncBase(signallerAsyncBaseParams{
+			Logger:            params.Logger,
+			OnHandshakeOpened: params.OnHandshakeOpened,
+		}),
 	}
 }
 

--- a/pkg/rtc/signalling/signallerasyncbase.go
+++ b/pkg/rtc/signalling/signallerasyncbase.go
@@ -26,6 +26,9 @@ import (
 
 type signallerAsyncBaseParams struct {
 	Logger logger.Logger
+	// called when the connection opens, i. e. when messages held back for the
+	// handshake may be sent
+	OnHandshakeOpened func()
 }
 
 // how long a resumed connection holds messages back waiting for its ReconnectResponse.
@@ -84,27 +87,42 @@ func (s *signallerAsyncBase) SwapResponseSink(sink routing.MessageSink, reason t
 
 func (s *signallerAsyncBase) HandshakePending() bool {
 	s.resSinkMu.Lock()
-	defer s.resSinkMu.Unlock()
-
-	if s.handshakeArmedAt.IsZero() {
+	armedAt := s.handshakeArmedAt
+	if armedAt.IsZero() {
+		s.resSinkMu.Unlock()
 		return false
 	}
-	if time.Since(s.handshakeArmedAt) > handshakeWindow {
-		s.params.Logger.Warnw(
-			"resumed connection did not open with a ReconnectResponse", nil,
-			"armedAt", s.handshakeArmedAt,
-		)
-		s.handshakeArmedAt = time.Time{}
-		return false
+	if time.Since(armedAt) <= handshakeWindow {
+		s.resSinkMu.Unlock()
+		return true
 	}
+	s.handshakeArmedAt = time.Time{}
+	s.resSinkMu.Unlock()
 
-	return true
+	s.params.Logger.Warnw(
+		"resumed connection did not open with a ReconnectResponse", nil,
+		"armedAt", armedAt,
+	)
+	s.notifyHandshakeOpened()
+	return false
 }
 
 func (s *signallerAsyncBase) OpenHandshake() {
 	s.resSinkMu.Lock()
+	wasPending := !s.handshakeArmedAt.IsZero()
 	s.handshakeArmedAt = time.Time{}
 	s.resSinkMu.Unlock()
+
+	if wasPending {
+		s.notifyHandshakeOpened()
+	}
+}
+
+// notifyHandshakeOpened runs without resSinkMu held, the callback sends messages
+func (s *signallerAsyncBase) notifyHandshakeOpened() {
+	if s.params.OnHandshakeOpened != nil {
+		s.params.OnHandshakeOpened()
+	}
 }
 
 func (s *signallerAsyncBase) GetResponseSink() routing.MessageSink {

--- a/pkg/rtc/signalling/signallerasyncbase.go
+++ b/pkg/rtc/signalling/signallerasyncbase.go
@@ -44,9 +44,12 @@ type signallerAsyncBase struct {
 	resSinkMu sync.Mutex
 	resSink   routing.MessageSink
 	// set while a resumed connection holds messages back waiting for its
-	// ReconnectResponse, the timer opens the connection if none is written
-	handshakePending bool
-	handshakeTimer   *time.Timer
+	// ReconnectResponse, the timer opens the connection if none is written.
+	// handshakeGeneration tells a timeout whether it belongs to the current wait, a
+	// Stop cannot cancel a callback that has already started running.
+	handshakePending    bool
+	handshakeGeneration uint32
+	handshakeTimer      *time.Timer
 }
 
 func newSignallerAsyncBase(params signallerAsyncBaseParams) *signallerAsyncBase {
@@ -116,30 +119,42 @@ func (s *signallerAsyncBase) OpenHandshake() {
 }
 
 func (s *signallerAsyncBase) armHandshakeLocked() {
+	s.stopHandshakeTimerLocked()
+
 	s.handshakePending = true
-	if s.handshakeTimer != nil {
-		s.handshakeTimer.Stop()
-	}
+	s.handshakeGeneration++
+	generation := s.handshakeGeneration
 	// the connection opens on its own if nothing writes a ReconnectResponse, a path
 	// that resumes without one should not hold messages back for the whole session
-	s.handshakeTimer = time.AfterFunc(handshakeWindow, s.onHandshakeTimeout)
+	s.handshakeTimer = time.AfterFunc(handshakeWindow, func() { s.onHandshakeTimeout(generation) })
 }
 
 // disarmHandshakeLocked reports whether it opened a connection that was holding
 // messages back
 func (s *signallerAsyncBase) disarmHandshakeLocked() bool {
+	s.stopHandshakeTimerLocked()
+
+	wasPending := s.handshakePending
+	s.handshakePending = false
+	// a timeout of the wait that just ended is stale
+	s.handshakeGeneration++
+	return wasPending
+}
+
+func (s *signallerAsyncBase) stopHandshakeTimerLocked() {
 	if s.handshakeTimer != nil {
 		s.handshakeTimer.Stop()
 		s.handshakeTimer = nil
 	}
-
-	wasPending := s.handshakePending
-	s.handshakePending = false
-	return wasPending
 }
 
-func (s *signallerAsyncBase) onHandshakeTimeout() {
+func (s *signallerAsyncBase) onHandshakeTimeout(generation uint32) {
 	s.resSinkMu.Lock()
+	if generation != s.handshakeGeneration {
+		// the wait this timeout was armed for has ended, a later one may be in progress
+		s.resSinkMu.Unlock()
+		return
+	}
 	opened := s.disarmHandshakeLocked()
 	s.resSinkMu.Unlock()
 

--- a/pkg/rtc/signalling/signallerasyncbase.go
+++ b/pkg/rtc/signalling/signallerasyncbase.go
@@ -16,6 +16,7 @@ package signalling
 
 import (
 	"sync"
+	"time"
 
 	"github.com/livekit/protocol/logger"
 
@@ -27,6 +28,11 @@ type signallerAsyncBaseParams struct {
 	Logger logger.Logger
 }
 
+// how long a resumed connection holds messages back waiting for its ReconnectResponse.
+// A path that resumes without sending one lets messages flow after this instead of
+// holding them back for the rest of the session.
+const handshakeWindow = 5 * time.Second
+
 type signallerAsyncBase struct {
 	signallerUnimplemented
 
@@ -34,6 +40,8 @@ type signallerAsyncBase struct {
 
 	resSinkMu sync.Mutex
 	resSink   routing.MessageSink
+	// when the wait for a ReconnectResponse started, zero once the connection is open
+	handshakeArmedAt time.Time
 }
 
 func newSignallerAsyncBase(params signallerAsyncBaseParams) *signallerAsyncBase {
@@ -46,6 +54,13 @@ func (s *signallerAsyncBase) SwapResponseSink(sink routing.MessageSink, reason t
 	s.resSinkMu.Lock()
 	oldSink := s.resSink
 	s.resSink = sink
+	// a resumed connection has to open with the ReconnectResponse, the client takes it
+	// only as the first message it reads
+	if sink != nil && reason == types.SignallingCloseReasonResume {
+		s.handshakeArmedAt = time.Now()
+	} else {
+		s.handshakeArmedAt = time.Time{}
+	}
 	s.resSinkMu.Unlock()
 
 	if oldSink != nil {
@@ -65,6 +80,31 @@ func (s *signallerAsyncBase) SwapResponseSink(sink routing.MessageSink, reason t
 		}
 		oldSink.Close()
 	}
+}
+
+func (s *signallerAsyncBase) HandshakePending() bool {
+	s.resSinkMu.Lock()
+	defer s.resSinkMu.Unlock()
+
+	if s.handshakeArmedAt.IsZero() {
+		return false
+	}
+	if time.Since(s.handshakeArmedAt) > handshakeWindow {
+		s.params.Logger.Warnw(
+			"resumed connection did not open with a ReconnectResponse", nil,
+			"armedAt", s.handshakeArmedAt,
+		)
+		s.handshakeArmedAt = time.Time{}
+		return false
+	}
+
+	return true
+}
+
+func (s *signallerAsyncBase) OpenHandshake() {
+	s.resSinkMu.Lock()
+	s.handshakeArmedAt = time.Time{}
+	s.resSinkMu.Unlock()
 }
 
 func (s *signallerAsyncBase) GetResponseSink() routing.MessageSink {

--- a/pkg/rtc/signalling/signallerasyncbase.go
+++ b/pkg/rtc/signalling/signallerasyncbase.go
@@ -43,8 +43,10 @@ type signallerAsyncBase struct {
 
 	resSinkMu sync.Mutex
 	resSink   routing.MessageSink
-	// when the wait for a ReconnectResponse started, zero once the connection is open
-	handshakeArmedAt time.Time
+	// set while a resumed connection holds messages back waiting for its
+	// ReconnectResponse, the timer opens the connection if none is written
+	handshakePending bool
+	handshakeTimer   *time.Timer
 }
 
 func newSignallerAsyncBase(params signallerAsyncBaseParams) *signallerAsyncBase {
@@ -59,12 +61,21 @@ func (s *signallerAsyncBase) SwapResponseSink(sink routing.MessageSink, reason t
 	s.resSink = sink
 	// a resumed connection has to open with the ReconnectResponse, the client takes it
 	// only as the first message it reads
-	if sink != nil && reason == types.SignallingCloseReasonResume {
-		s.handshakeArmedAt = time.Now()
-	} else {
-		s.handshakeArmedAt = time.Time{}
+	opened := false
+	switch {
+	case sink == nil:
+		// the connection is gone, keep anything queued for the next one
+		s.disarmHandshakeLocked()
+	case reason == types.SignallingCloseReasonResume:
+		s.armHandshakeLocked()
+	default:
+		opened = s.disarmHandshakeLocked()
 	}
 	s.resSinkMu.Unlock()
+
+	if opened {
+		s.notifyHandshakeOpened()
+	}
 
 	if oldSink != nil {
 		if sink != nil {
@@ -85,37 +96,59 @@ func (s *signallerAsyncBase) SwapResponseSink(sink routing.MessageSink, reason t
 	}
 }
 
+// HandshakePending is a plain read, so a caller can decide to hold a message back
+// while holding its own lock
 func (s *signallerAsyncBase) HandshakePending() bool {
 	s.resSinkMu.Lock()
-	armedAt := s.handshakeArmedAt
-	if armedAt.IsZero() {
-		s.resSinkMu.Unlock()
-		return false
-	}
-	if time.Since(armedAt) <= handshakeWindow {
-		s.resSinkMu.Unlock()
-		return true
-	}
-	s.handshakeArmedAt = time.Time{}
-	s.resSinkMu.Unlock()
+	defer s.resSinkMu.Unlock()
 
-	s.params.Logger.Warnw(
-		"resumed connection did not open with a ReconnectResponse", nil,
-		"armedAt", armedAt,
-	)
-	s.notifyHandshakeOpened()
-	return false
+	return s.handshakePending
 }
 
 func (s *signallerAsyncBase) OpenHandshake() {
 	s.resSinkMu.Lock()
-	wasPending := !s.handshakeArmedAt.IsZero()
-	s.handshakeArmedAt = time.Time{}
+	opened := s.disarmHandshakeLocked()
 	s.resSinkMu.Unlock()
 
-	if wasPending {
+	if opened {
 		s.notifyHandshakeOpened()
 	}
+}
+
+func (s *signallerAsyncBase) armHandshakeLocked() {
+	s.handshakePending = true
+	if s.handshakeTimer != nil {
+		s.handshakeTimer.Stop()
+	}
+	// the connection opens on its own if nothing writes a ReconnectResponse, a path
+	// that resumes without one should not hold messages back for the whole session
+	s.handshakeTimer = time.AfterFunc(handshakeWindow, s.onHandshakeTimeout)
+}
+
+// disarmHandshakeLocked reports whether it opened a connection that was holding
+// messages back
+func (s *signallerAsyncBase) disarmHandshakeLocked() bool {
+	if s.handshakeTimer != nil {
+		s.handshakeTimer.Stop()
+		s.handshakeTimer = nil
+	}
+
+	wasPending := s.handshakePending
+	s.handshakePending = false
+	return wasPending
+}
+
+func (s *signallerAsyncBase) onHandshakeTimeout() {
+	s.resSinkMu.Lock()
+	opened := s.disarmHandshakeLocked()
+	s.resSinkMu.Unlock()
+
+	if !opened {
+		return
+	}
+
+	s.params.Logger.Warnw("resumed connection did not open with a ReconnectResponse", nil)
+	s.notifyHandshakeOpened()
 }
 
 // notifyHandshakeOpened runs without resSinkMu held, the callback sends messages

--- a/pkg/rtc/signalling/signallerasyncbase_test.go
+++ b/pkg/rtc/signalling/signallerasyncbase_test.go
@@ -1,0 +1,62 @@
+package signalling
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/protocol/logger"
+
+	"github.com/livekit/livekit-server/pkg/routing/routingfakes"
+	"github.com/livekit/livekit-server/pkg/rtc/types"
+)
+
+func TestHandshakeGate(t *testing.T) {
+	newBase := func() *signallerAsyncBase {
+		return newSignallerAsyncBase(signallerAsyncBaseParams{Logger: logger.GetLogger()})
+	}
+
+	t.Run("a resumed connection holds messages back", func(t *testing.T) {
+		s := newBase()
+		require.False(t, s.HandshakePending())
+
+		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
+		require.True(t, s.HandshakePending())
+
+		s.OpenHandshake()
+		require.False(t, s.HandshakePending())
+	})
+
+	t.Run("other sink swaps do not hold messages back", func(t *testing.T) {
+		s := newBase()
+
+		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonUnknown)
+		require.False(t, s.HandshakePending())
+	})
+
+	t.Run("closing the connection opens the gate", func(t *testing.T) {
+		s := newBase()
+
+		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
+		require.True(t, s.HandshakePending())
+
+		s.CloseSignalConnection(types.SignallingCloseReasonParticipantClose)
+		require.False(t, s.HandshakePending())
+	})
+
+	t.Run("the gate opens on its own after the handshake window", func(t *testing.T) {
+		s := newBase()
+
+		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
+		require.True(t, s.HandshakePending())
+
+		s.resSinkMu.Lock()
+		s.handshakeArmedAt = time.Now().Add(-handshakeWindow - time.Second)
+		s.resSinkMu.Unlock()
+
+		require.False(t, s.HandshakePending())
+		// and stays open
+		require.False(t, s.HandshakePending())
+	})
+}

--- a/pkg/rtc/signalling/signallerasyncbase_test.go
+++ b/pkg/rtc/signalling/signallerasyncbase_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/livekit/protocol/logger"
 
@@ -12,13 +13,24 @@ import (
 	"github.com/livekit/livekit-server/pkg/rtc/types"
 )
 
-func TestHandshakeGate(t *testing.T) {
-	newBase := func() *signallerAsyncBase {
-		return newSignallerAsyncBase(signallerAsyncBaseParams{Logger: logger.GetLogger()})
-	}
+func newTestSignallerBase(onHandshakeOpened func()) *signallerAsyncBase {
+	return newSignallerAsyncBase(signallerAsyncBaseParams{
+		Logger:            logger.GetLogger(),
+		OnHandshakeOpened: onHandshakeOpened,
+	})
+}
 
+// currentHandshakeGeneration is what a timeout armed right now would be tagged with
+func currentHandshakeGeneration(s *signallerAsyncBase) uint32 {
+	s.resSinkMu.Lock()
+	defer s.resSinkMu.Unlock()
+
+	return s.handshakeGeneration
+}
+
+func TestHandshakeGate(t *testing.T) {
 	t.Run("a resumed connection holds messages back", func(t *testing.T) {
-		s := newBase()
+		s := newTestSignallerBase(nil)
 		require.False(t, s.HandshakePending())
 
 		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
@@ -29,14 +41,14 @@ func TestHandshakeGate(t *testing.T) {
 	})
 
 	t.Run("other sink swaps do not hold messages back", func(t *testing.T) {
-		s := newBase()
+		s := newTestSignallerBase(nil)
 
 		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonUnknown)
 		require.False(t, s.HandshakePending())
 	})
 
 	t.Run("closing the connection clears the gate", func(t *testing.T) {
-		s := newBase()
+		s := newTestSignallerBase(nil)
 
 		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
 		require.True(t, s.HandshakePending())
@@ -46,17 +58,17 @@ func TestHandshakeGate(t *testing.T) {
 	})
 
 	t.Run("the handshake window opens the gate", func(t *testing.T) {
-		s := newBase()
+		s := newTestSignallerBase(nil)
 
 		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
 		require.True(t, s.HandshakePending())
 
-		s.onHandshakeTimeout()
+		s.onHandshakeTimeout(currentHandshakeGeneration(s))
 		require.False(t, s.HandshakePending())
 	})
 
 	t.Run("a swap to a fresh connection opens the gate", func(t *testing.T) {
-		s := newBase()
+		s := newTestSignallerBase(nil)
 
 		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
 		require.True(t, s.HandshakePending())
@@ -64,77 +76,82 @@ func TestHandshakeGate(t *testing.T) {
 		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonUnknown)
 		require.False(t, s.HandshakePending())
 	})
+
+	t.Run("a timeout of a wait that has ended does nothing", func(t *testing.T) {
+		var opened atomic.Int32
+		s := newTestSignallerBase(func() { opened.Inc() })
+
+		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
+		stale := currentHandshakeGeneration(s)
+
+		// the client resumes again while the first timeout is running, Stop cannot
+		// cancel a callback that has already started
+		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
+		s.onHandshakeTimeout(stale)
+
+		require.True(t, s.HandshakePending())
+		require.Zero(t, opened.Load())
+
+		// and the wait in progress still opens on its own timeout
+		s.onHandshakeTimeout(currentHandshakeGeneration(s))
+		require.False(t, s.HandshakePending())
+		require.EqualValues(t, 1, opened.Load())
+	})
 }
 
 func TestHandshakeGateNotifiesOnOpen(t *testing.T) {
-	var opened int
-	newBase := func() *signallerAsyncBase {
-		return newSignallerAsyncBase(signallerAsyncBaseParams{
-			Logger:            logger.GetLogger(),
-			OnHandshakeOpened: func() { opened++ },
-		})
-	}
-
 	t.Run("on an explicit open", func(t *testing.T) {
-		opened = 0
-		s := newBase()
+		var opened atomic.Int32
+		s := newTestSignallerBase(func() { opened.Inc() })
 
 		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
-		require.Zero(t, opened)
+		require.Zero(t, opened.Load())
 
 		s.OpenHandshake()
-		require.Equal(t, 1, opened)
+		require.EqualValues(t, 1, opened.Load())
 
 		// only the transition notifies
 		s.OpenHandshake()
-		require.Equal(t, 1, opened)
+		require.EqualValues(t, 1, opened.Load())
 	})
 
 	t.Run("on the handshake window expiring", func(t *testing.T) {
-		opened = 0
-		s := newBase()
+		var opened atomic.Int32
+		s := newTestSignallerBase(func() { opened.Inc() })
 
 		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
-		require.Zero(t, opened)
+		s.onHandshakeTimeout(currentHandshakeGeneration(s))
 
-		s.onHandshakeTimeout()
 		require.False(t, s.HandshakePending())
-		require.Equal(t, 1, opened)
-
-		// only the transition notifies
-		s.onHandshakeTimeout()
-		require.Equal(t, 1, opened)
+		require.EqualValues(t, 1, opened.Load())
 	})
 
 	t.Run("the window fires without anything else touching the gate", func(t *testing.T) {
-		opened = 0
-		s := newSignallerAsyncBase(signallerAsyncBaseParams{
-			Logger:            logger.GetLogger(),
-			OnHandshakeOpened: func() { opened++ },
-		})
+		var opened atomic.Int32
+		s := newTestSignallerBase(func() { opened.Inc() })
 
 		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
 		require.Eventually(t, func() bool {
-			return !s.HandshakePending() && opened == 1
+			return !s.HandshakePending() && opened.Load() == 1
 		}, 2*handshakeWindow, 100*time.Millisecond)
 	})
 
 	t.Run("not on a connection close", func(t *testing.T) {
-		opened = 0
-		s := newBase()
+		var opened atomic.Int32
+		s := newTestSignallerBase(func() { opened.Inc() })
 
 		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
 		s.CloseSignalConnection(types.SignallingCloseReasonParticipantClose)
 
 		require.False(t, s.HandshakePending())
-		require.Zero(t, opened)
+		require.Zero(t, opened.Load())
 	})
 
 	t.Run("not when the gate was never armed", func(t *testing.T) {
-		opened = 0
-		s := newBase()
+		var opened atomic.Int32
+		s := newTestSignallerBase(func() { opened.Inc() })
 
 		s.OpenHandshake()
-		require.Zero(t, opened)
+		require.Zero(t, opened.Load())
 	})
 }

--- a/pkg/rtc/signalling/signallerasyncbase_test.go
+++ b/pkg/rtc/signalling/signallerasyncbase_test.go
@@ -60,3 +60,52 @@ func TestHandshakeGate(t *testing.T) {
 		require.False(t, s.HandshakePending())
 	})
 }
+
+func TestHandshakeGateNotifiesOnOpen(t *testing.T) {
+	var opened int
+	newBase := func() *signallerAsyncBase {
+		return newSignallerAsyncBase(signallerAsyncBaseParams{
+			Logger:            logger.GetLogger(),
+			OnHandshakeOpened: func() { opened++ },
+		})
+	}
+
+	t.Run("on an explicit open", func(t *testing.T) {
+		opened = 0
+		s := newBase()
+
+		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
+		require.Zero(t, opened)
+
+		s.OpenHandshake()
+		require.Equal(t, 1, opened)
+
+		// only the transition notifies
+		s.OpenHandshake()
+		require.Equal(t, 1, opened)
+	})
+
+	t.Run("on the handshake window expiring", func(t *testing.T) {
+		opened = 0
+		s := newBase()
+
+		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
+		s.resSinkMu.Lock()
+		s.handshakeArmedAt = time.Now().Add(-handshakeWindow - time.Second)
+		s.resSinkMu.Unlock()
+
+		require.False(t, s.HandshakePending())
+		require.Equal(t, 1, opened)
+
+		require.False(t, s.HandshakePending())
+		require.Equal(t, 1, opened)
+	})
+
+	t.Run("not when the gate was never armed", func(t *testing.T) {
+		opened = 0
+		s := newBase()
+
+		s.OpenHandshake()
+		require.Zero(t, opened)
+	})
+}

--- a/pkg/rtc/signalling/signallerasyncbase_test.go
+++ b/pkg/rtc/signalling/signallerasyncbase_test.go
@@ -35,7 +35,7 @@ func TestHandshakeGate(t *testing.T) {
 		require.False(t, s.HandshakePending())
 	})
 
-	t.Run("closing the connection opens the gate", func(t *testing.T) {
+	t.Run("closing the connection clears the gate", func(t *testing.T) {
 		s := newBase()
 
 		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
@@ -45,18 +45,23 @@ func TestHandshakeGate(t *testing.T) {
 		require.False(t, s.HandshakePending())
 	})
 
-	t.Run("the gate opens on its own after the handshake window", func(t *testing.T) {
+	t.Run("the handshake window opens the gate", func(t *testing.T) {
 		s := newBase()
 
 		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
 		require.True(t, s.HandshakePending())
 
-		s.resSinkMu.Lock()
-		s.handshakeArmedAt = time.Now().Add(-handshakeWindow - time.Second)
-		s.resSinkMu.Unlock()
-
+		s.onHandshakeTimeout()
 		require.False(t, s.HandshakePending())
-		// and stays open
+	})
+
+	t.Run("a swap to a fresh connection opens the gate", func(t *testing.T) {
+		s := newBase()
+
+		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
+		require.True(t, s.HandshakePending())
+
+		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonUnknown)
 		require.False(t, s.HandshakePending())
 	})
 }
@@ -90,15 +95,39 @@ func TestHandshakeGateNotifiesOnOpen(t *testing.T) {
 		s := newBase()
 
 		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
-		s.resSinkMu.Lock()
-		s.handshakeArmedAt = time.Now().Add(-handshakeWindow - time.Second)
-		s.resSinkMu.Unlock()
+		require.Zero(t, opened)
 
+		s.onHandshakeTimeout()
 		require.False(t, s.HandshakePending())
 		require.Equal(t, 1, opened)
 
-		require.False(t, s.HandshakePending())
+		// only the transition notifies
+		s.onHandshakeTimeout()
 		require.Equal(t, 1, opened)
+	})
+
+	t.Run("the window fires without anything else touching the gate", func(t *testing.T) {
+		opened = 0
+		s := newSignallerAsyncBase(signallerAsyncBaseParams{
+			Logger:            logger.GetLogger(),
+			OnHandshakeOpened: func() { opened++ },
+		})
+
+		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
+		require.Eventually(t, func() bool {
+			return !s.HandshakePending() && opened == 1
+		}, 2*handshakeWindow, 100*time.Millisecond)
+	})
+
+	t.Run("not on a connection close", func(t *testing.T) {
+		opened = 0
+		s := newBase()
+
+		s.SwapResponseSink(&routingfakes.FakeMessageSink{}, types.SignallingCloseReasonResume)
+		s.CloseSignalConnection(types.SignallingCloseReasonParticipantClose)
+
+		require.False(t, s.HandshakePending())
+		require.Zero(t, opened)
 	})
 
 	t.Run("not when the gate was never armed", func(t *testing.T) {

--- a/pkg/rtc/signalling/signallerunimplemented.go
+++ b/pkg/rtc/signalling/signallerunimplemented.go
@@ -34,6 +34,12 @@ func (u *signallerUnimplemented) GetResponseSink() routing.MessageSink {
 
 func (u *signallerUnimplemented) CloseSignalConnection(reason types.SignallingCloseReason) {}
 
+func (u *signallerUnimplemented) HandshakePending() bool {
+	return false
+}
+
+func (u *signallerUnimplemented) OpenHandshake() {}
+
 func (u *signallerUnimplemented) WriteMessage(msg proto.Message) error {
 	return nil
 }


### PR DESCRIPTION
Clients take the ReconnectResponse as the first message on a resumed or migrated in signal connection and drop anything that arrives ahead of it, losing the ICE servers, server info and the reliable message sequence it carries.

A migrating in participant is now not ready until the response has been written, and a resumed connection holds messages back until then, opening on its own after 5s if a path sends no response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
