### PR TITLE
Support VP9/AV1 simulcast

### DIFF
--- a/pkg/sfu/buffer/dependencydescriptorparser.go
+++ b/pkg/sfu/buffer/dependencydescriptorparser.go
@@ -60,12 +60,18 @@ type DependencyDescriptorParser struct {
 	onMaxLayerChanged func(int32, int32)
 	decodeTargets     []DependencyDescriptorDecodeTarget
 
-	seqWrapAround             *utils.WrapAround[uint16, uint64]
-	frameWrapAround           *utils.WrapAround[uint16, uint64]
-	structureExtFrameNum      uint64
-	activeDecodeTargetsExtSeq uint64
-	activeDecodeTargetsMask   uint32
-	frameChecker              *FrameIntegrityChecker
+	seqWrapAround        *utils.WrapAround[uint16, uint64]
+	frameWrapAround      *utils.WrapAround[uint16, uint64]
+	structureExtFrameNum uint64
+	// drop threshold for frames belonging to a previous dependency structure.
+	// advanced only when the structure id actually changes: structureExtFrameNum
+	// advances on every structure-bearing key frame, so with frequent key frames
+	// repeating the same structure (e. g. screen content), valid late/retransmitted
+	// frames would be dropped as "earlier than current structure".
+	structureChangeExtFrameNum uint64
+	activeDecodeTargetsExtSeq  uint64
+	activeDecodeTargetsMask    uint32
+	frameChecker               *FrameIntegrityChecker
 
 	ddNotFoundCount atomic.Uint32
 
@@ -153,12 +159,12 @@ func (r *DependencyDescriptorParser) Parse(pkt *rtp.Packet) (*ExtDependencyDescr
 	unwrapped := r.frameWrapAround.UpdateWithOrderKnown(ddVal.FrameNumber, restart)
 	extFN := unwrapped.ExtendedVal
 
-	if extFN < r.structureExtFrameNum {
+	if extFN < r.structureChangeExtFrameNum {
 		r.logger.Debugw(
 			"drop frame which is earlier than current structure",
 			"fn", ddVal.FrameNumber,
 			"extFN", extFN,
-			"structureExtFrameNum", r.structureExtFrameNum,
+			"structureChangeExtFrameNum", r.structureChangeExtFrameNum,
 			"unwrappedFN", unwrapped,
 			"frameWrapAround", r.frameWrapAround,
 		)
@@ -188,7 +194,24 @@ func (r *DependencyDescriptorParser) Parse(pkt *rtp.Packet) (*ExtDependencyDescr
 			return nil, videoLayer, ErrDDStructureAttachedToNonFirstPacket
 		}
 
+		if extFN < r.structureExtFrameNum {
+			// out-of-order key frame repeating the current structure: accepting it
+			// would regress structureExtFrameNum (ExtKeyFrameNum) and replay a stale
+			// structure update, confusing the downtrack's dependency descriptor
+			// selector.
+			r.logger.Debugw(
+				"drop out-of-order key frame",
+				"extFN", extFN,
+				"structureExtFrameNum", r.structureExtFrameNum,
+			)
+			ReleaseExtDependencyDescriptor(extDD)
+			return nil, videoLayer, ErrFrameEarlierThanKeyFrame
+		}
+
 		if r.structure == nil || ddVal.AttachedStructure.StructureId != r.structure.StructureId {
+			// structure actually changed (or first structure): advance the drop threshold
+			// so that only frames preceding this structure are dropped.
+			r.structureChangeExtFrameNum = extFN
 			r.logger.Debugw(
 				"structure updated",
 				"structureID", ddVal.AttachedStructure.StructureId,
@@ -252,6 +275,7 @@ func (r *DependencyDescriptorParser) restart() {
 	r.frameChecker = NewFrameIntegrityChecker(integrityCheckFrame, integrityCheckPkt)
 	r.structure = nil
 	r.structureExtFrameNum = 0
+	r.structureChangeExtFrameNum = 0
 	r.activeDecodeTargetsExtSeq = 0
 	r.activeDecodeTargetsMask = 0
 	r.decodeTargets = r.decodeTargets[:0]

--- a/pkg/sfu/buffer/dependencydescriptorparser_test.go
+++ b/pkg/sfu/buffer/dependencydescriptorparser_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buffer
+
+import (
+	"testing"
+
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/protocol/logger"
+
+	dd "github.com/livekit/livekit-server/pkg/sfu/rtpextension/dependencydescriptor"
+)
+
+const ddTestExtID = uint8(1)
+
+// single spatial layer, single temporal layer, one decode target, one chain
+func newL1T1Structure(structureID int) *dd.FrameDependencyStructure {
+	return &dd.FrameDependencyStructure{
+		StructureId:                  structureID,
+		NumDecodeTargets:             1,
+		NumChains:                    1,
+		DecodeTargetProtectedByChain: []int{0},
+		Templates: []*dd.FrameDependencyTemplate{
+			{ // key frame
+				DecodeTargetIndications: []dd.DecodeTargetIndication{dd.DecodeTargetSwitch},
+				ChainDiffs:              []int{0},
+			},
+			{ // delta frame
+				DecodeTargetIndications: []dd.DecodeTargetIndication{dd.DecodeTargetRequired},
+				FrameDiffs:              []int{1},
+				ChainDiffs:              []int{1},
+			},
+		},
+	}
+}
+
+type ddTestFeeder struct {
+	t      *testing.T
+	parser *DependencyDescriptorParser
+	// structure the writer marshals against, i. e. what the publisher last sent
+	structure *dd.FrameDependencyStructure
+	seq       uint16
+}
+
+func newDDTestFeeder(t *testing.T) *ddTestFeeder {
+	return &ddTestFeeder{
+		t:      t,
+		parser: NewDependencyDescriptorParser(ddTestExtID, logger.GetLogger(), func(int32, int32) {}, false),
+	}
+}
+
+// keyFrame sends a key frame carrying `structure`. Passing the same structure id as
+// the previous key frame models a publisher that repeats an unchanged structure,
+// which is what screen content with frequent key frames does.
+func (f *ddTestFeeder) keyFrame(frameNumber uint16, structure *dd.FrameDependencyStructure) (*ExtDependencyDescriptor, error) {
+	f.structure = structure
+	return f.feed(frameNumber, structure.Templates[0], structure)
+}
+
+func (f *ddTestFeeder) deltaFrame(frameNumber uint16) (*ExtDependencyDescriptor, error) {
+	return f.feed(frameNumber, f.structure.Templates[1], nil)
+}
+
+func (f *ddTestFeeder) feed(
+	frameNumber uint16,
+	template *dd.FrameDependencyTemplate,
+	attachedStructure *dd.FrameDependencyStructure,
+) (*ExtDependencyDescriptor, error) {
+	f.t.Helper()
+
+	ddVal := &dd.DependencyDescriptor{
+		FirstPacketInFrame: true,
+		LastPacketInFrame:  true,
+		FrameNumber:        frameNumber,
+		FrameDependencies:  template,
+		AttachedStructure:  attachedStructure,
+	}
+	buf, err := (&dd.DependencyDescriptorExtension{Descriptor: ddVal, Structure: f.structure}).Marshal()
+	require.NoError(f.t, err)
+
+	f.seq++
+	pkt := &rtp.Packet{Header: rtp.Header{SequenceNumber: f.seq}}
+	require.NoError(f.t, pkt.SetExtension(ddTestExtID, buf))
+
+	extDD, _, err := f.parser.Parse(pkt)
+	return extDD, err
+}
+
+// A key frame that repeats the current structure must not start dropping frames that
+// precede it. Upstream advanced the drop threshold on every structure bearing key
+// frame, so with frequent key frames (screen content) a late or retransmitted frame
+// arriving after one was discarded as "earlier than current structure".
+func TestDependencyDescriptorParserLateFrameAfterRepeatedStructure(t *testing.T) {
+	f := newDDTestFeeder(t)
+	structure := newL1T1Structure(0)
+
+	_, err := f.keyFrame(0, structure)
+	require.NoError(t, err)
+	_, err = f.deltaFrame(1)
+	require.NoError(t, err)
+	_, err = f.deltaFrame(3)
+	require.NoError(t, err)
+
+	// key frame repeating the same structure id
+	_, err = f.keyFrame(4, structure)
+	require.NoError(t, err)
+
+	// frame 2 finally shows up (reordered or retransmitted). The structure has not
+	// changed, so it is still decodable and must be forwarded.
+	extDD, err := f.deltaFrame(2)
+	require.NoError(t, err)
+	require.NotNil(t, extDD)
+	require.EqualValues(t, 2, extDD.ExtFrameNum)
+}
+
+// A key frame carrying a *different* structure does invalidate everything before it:
+// earlier frames reference templates that no longer exist.
+func TestDependencyDescriptorParserLateFrameAfterStructureChange(t *testing.T) {
+	f := newDDTestFeeder(t)
+
+	_, err := f.keyFrame(0, newL1T1Structure(0))
+	require.NoError(t, err)
+	_, err = f.deltaFrame(1)
+	require.NoError(t, err)
+	_, err = f.deltaFrame(3)
+	require.NoError(t, err)
+
+	_, err = f.keyFrame(4, newL1T1Structure(1))
+	require.NoError(t, err)
+
+	_, err = f.deltaFrame(2)
+	require.ErrorIs(t, err, ErrFrameEarlierThanKeyFrame)
+}
+
+// An out-of-order key frame must still be dropped: accepting it would regress
+// structureExtFrameNum (ExtKeyFrameNum) and replay a stale structure update.
+func TestDependencyDescriptorParserOutOfOrderKeyFrame(t *testing.T) {
+	f := newDDTestFeeder(t)
+	structure := newL1T1Structure(0)
+
+	_, err := f.keyFrame(0, structure)
+	require.NoError(t, err)
+	_, err = f.deltaFrame(1)
+	require.NoError(t, err)
+	_, err = f.keyFrame(4, structure)
+	require.NoError(t, err)
+
+	_, err = f.keyFrame(2, structure)
+	require.ErrorIs(t, err, ErrFrameEarlierThanKeyFrame)
+}
+
+// ExtKeyFrameNum keeps tracking every structure bearing key frame, unchanged by the
+// split of the drop threshold into its own field.
+func TestDependencyDescriptorParserExtKeyFrameNum(t *testing.T) {
+	f := newDDTestFeeder(t)
+	structure := newL1T1Structure(0)
+
+	extDD, err := f.keyFrame(0, structure)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, extDD.ExtKeyFrameNum)
+
+	extDD, err = f.deltaFrame(1)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, extDD.ExtKeyFrameNum)
+
+	// repeated structure still advances ExtKeyFrameNum
+	extDD, err = f.keyFrame(4, structure)
+	require.NoError(t, err)
+	require.EqualValues(t, 4, extDD.ExtKeyFrameNum)
+
+	extDD, err = f.deltaFrame(5)
+	require.NoError(t, err)
+	require.EqualValues(t, 4, extDD.ExtKeyFrameNum)
+}

--- a/pkg/sfu/receiver_base.go
+++ b/pkg/sfu/receiver_base.go
@@ -948,7 +948,7 @@ func (r *ReceiverBase) forwardRTP(
 		}
 
 		spatialLayer := layer
-		if extPkt.Spatial >= 0 {
+		if extPkt.Spatial >= 0 && !sfuutils.IsSimulcastMode(r.videoLayerMode) {
 			// svc packet, take spatial layer info from packet
 			spatialLayer = extPkt.Spatial
 		}


### PR DESCRIPTION
Comes from @iamadityaanjana #4718. Remove `2: pkg/sfu/forwarder.go` change  from the original PR as the simulcast SR looks good to me.