### PR TITLE
Fix pacer activity tracking without RTP header extensions

### DIFF
--- a/pkg/sfu/pacer/base.go
+++ b/pkg/sfu/pacer/base.go
@@ -85,6 +85,7 @@ func (b *Base) SendPacket(p *Packet) (int, error) {
 		return 0, err
 	}
 
+	b.lastPacketSentAt.Store(mono.UnixNano())
 	return written, nil
 }
 
@@ -103,8 +104,6 @@ func (b *Base) patchRTPHeaderExtensions(p *Packet) error {
 		if err = p.Header.SetExtension(p.AbsSendTimeExtID, absSendTimeBytes); err != nil {
 			return err
 		}
-
-		b.lastPacketSentAt.Store(sendingAt.UnixNano())
 	}
 
 	packetSize := p.HeaderSize + len(p.Payload)
@@ -127,8 +126,6 @@ func (b *Base) patchRTPHeaderExtensions(p *Packet) error {
 		if err = p.Header.SetExtension(p.TransportWideExtID, twccExtBytes); err != nil {
 			return err
 		}
-
-		b.lastPacketSentAt.Store(sendingAt.UnixNano())
 	}
 
 	b.ProbeObserver.RecordPacket(packetSize, p.IsRTX, p.ProbeClusterId, p.IsProbe)

--- a/pkg/sfu/pacer/base_test.go
+++ b/pkg/sfu/pacer/base_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pacer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/livekit/protocol/logger"
+	"github.com/livekit/protocol/utils/mono"
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+)
+
+type testTrackLocalWriter struct{}
+
+func (testTrackLocalWriter) WriteRTP(header *rtp.Header, payload []byte) (int, error) {
+	return header.MarshalSize() + len(payload), nil
+}
+
+func (testTrackLocalWriter) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+
+func TestBaseSendPacketTracksActivityWithoutHeaderExtensions(t *testing.T) {
+	b := NewBase(logger.GetLogger(), nil)
+	b.lastPacketSentAt.Store(mono.UnixNano() - int64(time.Second))
+
+	p := &Packet{
+		Header:      &rtp.Header{Version: 2},
+		HeaderSize: 12,
+		Payload:     []byte{1, 2, 3, 4},
+		WriteStream: testTrackLocalWriter{},
+	}
+
+	_, err := b.SendPacket(p)
+	require.NoError(t, err)
+	require.Less(t, b.TimeSinceLastSentPacket(), 100*time.Millisecond)
+}


### PR DESCRIPTION
### What this fixes

`pacer.Base.TimeSinceLastSentPacket()` is used by the stream allocator to decide whether a deficient connection has been idle long enough to reset BWE and resume probing.

Today `lastPacketSentAt` is only updated while patching either the abs-send-time or transport-wide-cc RTP header extension. If a subscriber negotiates neither extension, successful RTP writes never update the timestamp, so an actively forwarding connection can look permanently idle to the stream allocator.

That can trigger unnecessary BWE resets/probing while media is still flowing, which can destabilize bitrate selection and add avoidable latency/jitter during congestion recovery.

### Change

Update `lastPacketSentAt` after every successful RTP write, independent of negotiated RTP header extensions. Remove the extension-specific timestamp updates.

This also makes the timestamp reflect an actual successful write rather than merely successful header patching.

### Test

Adds a regression test that sends RTP with neither abs-send-time nor TWCC configured and verifies pacer activity is refreshed.

I found this while reviewing the SFU packet/latency path; I could not find an existing issue or PR covering this behavior.