### PR TITLE
Allow deleting a room whose node has left the cluster

### DIFF
--- a/pkg/service/roomservice.go
+++ b/pkg/service/roomservice.go
@@ -157,7 +157,7 @@ func (s *RoomService) DeleteRoom(ctx context.Context, req *livekit.DeleteRoomReq
 		// left the cluster. There is no RTC room left to close, so delete the persisted
 		// state directly rather than failing every future attempt.
 		if errors.Is(err, routing.ErrNotFound) {
-			return s.deleteOrphanedRoom(ctx, livekit.RoomName(req.Room))
+			return s.deleteOrphanedRoom(ctx, livekit.RoomName(req.Room), err)
 		}
 		return nil, err
 	}
@@ -182,7 +182,19 @@ func (s *RoomService) DeleteRoom(ctx context.Context, req *livekit.DeleteRoomReq
 // crash, scale-in) while the room record itself lives on in the store with no TTL. Routing
 // then resolves the room to a node that is gone, and the regular delete path fails at that
 // lookup before it ever reaches the store, so the room can never be removed through the API.
-func (s *RoomService) deleteOrphanedRoom(ctx context.Context, roomName livekit.RoomName) (*livekit.DeleteRoomResponse, error) {
+func (s *RoomService) deleteOrphanedRoom(
+	ctx context.Context,
+	roomName livekit.RoomName,
+	routingErr error,
+) (*livekit.DeleteRoomResponse, error) {
+	// On the regular path the room is deleted by the node handling the request. Here there
+	// is no such node, so this store is the only thing that can remove the room. If it
+	// cannot, report the original routing failure rather than a delete that did not happen.
+	os, ok := s.roomStore.(OSSServiceStore)
+	if !ok {
+		return nil, routingErr
+	}
+
 	logger.Infow("deleting orphaned room, no live node hosts it", "room", roomName)
 
 	// best effort: drop the stale room -> node mapping so it does not leak
@@ -192,10 +204,8 @@ func (s *RoomService) deleteOrphanedRoom(ctx context.Context, roomName livekit.R
 		}
 	}
 
-	if os, ok := s.roomStore.(OSSServiceStore); ok {
-		if err := os.DeleteRoom(ctx, roomName); err != nil {
-			return nil, err
-		}
+	if err := os.DeleteRoom(ctx, roomName); err != nil {
+		return nil, err
 	}
 
 	res := &livekit.DeleteRoomResponse{}

--- a/pkg/service/roomservice.go
+++ b/pkg/service/roomservice.go
@@ -16,6 +16,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -151,6 +152,13 @@ func (s *RoomService) DeleteRoom(ctx context.Context, req *livekit.DeleteRoomReq
 	// ensure at least one node is available to handle the request
 	room, err := s.router.CreateRoom(ctx, &livekit.CreateRoomRequest{Name: req.Room})
 	if err != nil {
+		// The room is in the store, but routing cannot resolve a live node for it: either
+		// there is no room -> node mapping, or the mapping points at a node that has since
+		// left the cluster. There is no RTC room left to close, so delete the persisted
+		// state directly rather than failing every future attempt.
+		if errors.Is(err, routing.ErrNotFound) {
+			return s.deleteOrphanedRoom(ctx, livekit.RoomName(req.Room))
+		}
 		return nil, err
 	}
 
@@ -165,6 +173,34 @@ func (s *RoomService) DeleteRoom(ctx context.Context, req *livekit.DeleteRoomReq
 	res := &livekit.DeleteRoomResponse{}
 	RecordResponse(ctx, room)
 	return res, err
+}
+
+// deleteOrphanedRoom removes the persisted state of a room that is no longer hosted by any
+// live node, so that it stops being returned by ListRooms.
+//
+// A room becomes orphaned when the node it was mapped to leaves the cluster (pod rotation,
+// crash, scale-in) while the room record itself lives on in the store with no TTL. Routing
+// then resolves the room to a node that is gone, and the regular delete path fails at that
+// lookup before it ever reaches the store, so the room can never be removed through the API.
+func (s *RoomService) deleteOrphanedRoom(ctx context.Context, roomName livekit.RoomName) (*livekit.DeleteRoomResponse, error) {
+	logger.Infow("deleting orphaned room, no live node hosts it", "room", roomName)
+
+	// best effort: drop the stale room -> node mapping so it does not leak
+	if router, ok := s.router.(routing.Router); ok {
+		if err := router.ClearRoomState(ctx, roomName); err != nil {
+			logger.Warnw("could not clear routing state for orphaned room", err, "room", roomName)
+		}
+	}
+
+	if os, ok := s.roomStore.(OSSServiceStore); ok {
+		if err := os.DeleteRoom(ctx, roomName); err != nil {
+			return nil, err
+		}
+	}
+
+	res := &livekit.DeleteRoomResponse{}
+	RecordResponse(ctx, res)
+	return res, nil
 }
 
 func (s *RoomService) ListParticipants(ctx context.Context, req *livekit.ListParticipantsRequest) (res *livekit.ListParticipantsResponse, err error) {

--- a/pkg/service/roomservice_test.go
+++ b/pkg/service/roomservice_test.go
@@ -104,6 +104,21 @@ func TestDeleteRoom(t *testing.T) {
 		require.Equal(t, 1, svc.store.DeleteRoomCallCount())
 	})
 
+	// RoomService is constructed with a ServiceStore, which has no DeleteRoom. On the
+	// regular path the node handling the request deletes the room, but an orphaned room has
+	// no such node, so a store that cannot delete must not report success.
+	t.Run("orphaned room reports failure when the store cannot delete", func(t *testing.T) {
+		store := &servicefakes.FakeServiceStore{}
+		store.RoomExistsReturns(true, nil)
+		svc, router := newTestRoomServiceWithStore(config.LimitConfig{}, store)
+		router.CreateRoomReturns(nil, routing.ErrNotFound)
+
+		_, err := svc.DeleteRoom(createCtx(), &livekit.DeleteRoomRequest{
+			Room: "testroom",
+		})
+		require.ErrorIs(t, err, routing.ErrNotFound)
+	})
+
 	t.Run("unknown room is not found", func(t *testing.T) {
 		svc := newTestRoomService(config.LimitConfig{})
 		svc.store.RoomExistsReturns(false, nil)
@@ -243,6 +258,28 @@ func newTestAgentDispatchService(limitConf config.LimitConfig) *service.AgentDis
 	allocator := &servicefakes.FakeRoomAllocator{}
 	allocator.AutoCreateEnabledReturns(false)
 	return service.NewAgentDispatchService(limitConf, nil, rpc.NewTopicFormatter(), allocator, &routingfakes.FakeRouter{})
+}
+
+func newTestRoomServiceWithStore(
+	limitConf config.LimitConfig,
+	store service.ServiceStore,
+) (*service.RoomService, *routingfakes.FakeRouter) {
+	router := &routingfakes.FakeRouter{}
+	svc, err := service.NewRoomService(
+		limitConf,
+		config.APIConfig{ExecutionTimeout: 2},
+		router,
+		&servicefakes.FakeRoomAllocator{},
+		store,
+		nil,
+		rpc.NewTopicFormatter(),
+		&rpcfakes.FakeTypedRoomClient{},
+		&rpcfakes.FakeTypedParticipantClient{},
+	)
+	if err != nil {
+		panic(err)
+	}
+	return svc, router
 }
 
 func newTestRoomService(limitConf config.LimitConfig) *TestRoomService {

--- a/pkg/service/roomservice_test.go
+++ b/pkg/service/roomservice_test.go
@@ -27,12 +27,21 @@ import (
 	"github.com/livekit/protocol/rpc/rpcfakes"
 
 	"github.com/livekit/livekit-server/pkg/config"
+	"github.com/livekit/livekit-server/pkg/routing"
 	"github.com/livekit/livekit-server/pkg/routing/routingfakes"
 	"github.com/livekit/livekit-server/pkg/service"
 	"github.com/livekit/livekit-server/pkg/service/servicefakes"
 )
 
 func TestDeleteRoom(t *testing.T) {
+	createCtx := func() context.Context {
+		return service.WithGrants(
+			context.Background(),
+			&auth.ClaimGrants{Video: &auth.VideoGrant{RoomCreate: true}},
+			"",
+		)
+	}
+
 	t.Run("missing permissions", func(t *testing.T) {
 		svc := newTestRoomService(config.LimitConfig{})
 		grant := &auth.ClaimGrants{
@@ -43,6 +52,67 @@ func TestDeleteRoom(t *testing.T) {
 			Room: "testroom",
 		})
 		require.Error(t, err)
+	})
+
+	// A room whose node has left the cluster still exists in the store, but routing can no
+	// longer resolve a live node for it. It must still be deletable, otherwise it is
+	// returned by ListRooms forever. See #3766.
+	t.Run("deletes room orphaned by a departed node", func(t *testing.T) {
+		svc := newTestRoomService(config.LimitConfig{})
+		svc.store.RoomExistsReturns(true, nil)
+		svc.router.CreateRoomReturns(nil, routing.ErrNotFound)
+
+		_, err := svc.DeleteRoom(createCtx(), &livekit.DeleteRoomRequest{
+			Room: "testroom",
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, 1, svc.store.DeleteRoomCallCount(),
+			"orphaned room should be removed from the store")
+		_, deleted := svc.store.DeleteRoomArgsForCall(0)
+		require.Equal(t, livekit.RoomName("testroom"), deleted)
+
+		require.Equal(t, 1, svc.router.ClearRoomStateCallCount(),
+			"stale room -> node mapping should be cleared")
+
+		require.Zero(t, svc.roomClient.DeleteRoomCallCount(),
+			"no node hosts the room, so it should not be asked to close it")
+	})
+
+	t.Run("other routing errors are not swallowed", func(t *testing.T) {
+		svc := newTestRoomService(config.LimitConfig{})
+		svc.store.RoomExistsReturns(true, nil)
+		svc.router.CreateRoomReturns(nil, routing.ErrNodeLimitReached)
+
+		_, err := svc.DeleteRoom(createCtx(), &livekit.DeleteRoomRequest{
+			Room: "testroom",
+		})
+		require.ErrorIs(t, err, routing.ErrNodeLimitReached)
+		require.Zero(t, svc.store.DeleteRoomCallCount())
+	})
+
+	t.Run("healthy room is deleted through its node", func(t *testing.T) {
+		svc := newTestRoomService(config.LimitConfig{})
+		svc.store.RoomExistsReturns(true, nil)
+		svc.router.CreateRoomReturns(&livekit.Room{Name: "testroom"}, nil)
+
+		_, err := svc.DeleteRoom(createCtx(), &livekit.DeleteRoomRequest{
+			Room: "testroom",
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, svc.roomClient.DeleteRoomCallCount())
+		require.Equal(t, 1, svc.store.DeleteRoomCallCount())
+	})
+
+	t.Run("unknown room is not found", func(t *testing.T) {
+		svc := newTestRoomService(config.LimitConfig{})
+		svc.store.RoomExistsReturns(false, nil)
+
+		_, err := svc.DeleteRoom(createCtx(), &livekit.DeleteRoomRequest{
+			Room: "testroom",
+		})
+		require.ErrorIs(t, err, service.ErrRoomNotFound)
+		require.Zero(t, svc.store.DeleteRoomCallCount())
 	})
 }
 
@@ -178,7 +248,8 @@ func newTestAgentDispatchService(limitConf config.LimitConfig) *service.AgentDis
 func newTestRoomService(limitConf config.LimitConfig) *TestRoomService {
 	router := &routingfakes.FakeRouter{}
 	allocator := &servicefakes.FakeRoomAllocator{}
-	store := &servicefakes.FakeServiceStore{}
+	store := &servicefakes.FakeObjectStore{}
+	roomClient := &rpcfakes.FakeTypedRoomClient{}
 	svc, err := service.NewRoomService(
 		limitConf,
 		config.APIConfig{ExecutionTimeout: 2},
@@ -187,7 +258,7 @@ func newTestRoomService(limitConf config.LimitConfig) *TestRoomService {
 		store,
 		nil,
 		rpc.NewTopicFormatter(),
-		&rpcfakes.FakeTypedRoomClient{},
+		roomClient,
 		&rpcfakes.FakeTypedParticipantClient{},
 	)
 	if err != nil {
@@ -198,12 +269,14 @@ func newTestRoomService(limitConf config.LimitConfig) *TestRoomService {
 		router:      router,
 		allocator:   allocator,
 		store:       store,
+		roomClient:  roomClient,
 	}
 }
 
 type TestRoomService struct {
 	service.RoomService
-	router    *routingfakes.FakeRouter
-	allocator *servicefakes.FakeRoomAllocator
-	store     *servicefakes.FakeServiceStore
+	router     *routingfakes.FakeRouter
+	allocator  *servicefakes.FakeRoomAllocator
+	store      *servicefakes.FakeObjectStore
+	roomClient *rpcfakes.FakeTypedRoomClient
 }


### PR DESCRIPTION
Fixes #3766

## Problem

`DeleteRoom` fails permanently, with `could not find object`, for any room whose node has left the cluster. The room stays in the store forever: returned by `ListRooms`, undeletable through the API, and only removable by editing Redis by hand.

`RoomService.DeleteRoom` calls `router.CreateRoom` to locate the node hosting the room before asking it to close:

```go
// ensure at least one node is available to handle the request
room, err := s.router.CreateRoom(ctx, &livekit.CreateRoomRequest{Name: req.Room})
if err != nil {
    return nil, err
}
```

`RedisRouter.CreateRoom` starts with `GetNodeForRoom`, which returns `routing.ErrNotFound` — literally `errors.New("could not find object")` — in two cases: `room_node_map` has no entry for the room, or it has one but `GetNode` finds that node ID gone from the `nodes` hash.

So `DeleteRoom` returns early and the store delete further down is never reached. Since `RedisStore` sets no TTL on the room record and `ListRooms` reads straight from the `rooms` hash, the room is stranded.

This matches the field reports in the issue exactly. One user's Redis audit found ~1600 of ~2100 rooms whose `room_node_map` node ID was absent from `nodes`, all accumulated after pod rotations, with `ListRooms` latency degrading from ~800ms to ~4400ms as the count grew.

It also explains why this could not be reproduced locally: a healthy single node always has a live mapping, and `LocalRouter.GetNodeForRoom` never returns `ErrNotFound` at all. The bug needs a node to actually disappear.

Worth noting the asymmetry with `CreateRoom`, which calls `roomAllocator.SelectRoomNode` first — and `SelectRoomNode` explicitly tolerates `routing.ErrNotFound` and re-homes the room to a live node. `DeleteRoom` never got equivalent treatment.

## Fix

Treat `routing.ErrNotFound` from the node lookup as "no live node hosts this room" rather than a hard failure. There is no RTC room left to close, so the new `deleteOrphanedRoom` helper drops the stale `room_node_map` entry (best effort, via a `routing.Router` type assertion — `RoomService` only holds a `routing.MessageRouter`, which has no `ClearRoomState`) and deletes the persisted room state directly.

Deliberately narrow:

- Only `routing.ErrNotFound` is handled. Every other routing error, including a wrapped Redis failure, still propagates unchanged.
- The `RoomExists` check above is untouched, so a genuinely unknown room still returns `ErrRoomNotFound` rather than silently succeeding.
- The healthy path is unchanged.

I considered mirroring `CreateRoom` by calling `SelectRoomNode` before the lookup, which would re-home the room and let the normal close path run. I did not, because `SelectRoomNode` returns `ErrNodeLimitReached` when the room's existing node is at capacity — that would newly break `DeleteRoom` on a full node, a regression on a path that works today.

## Tests

Added to `TestDeleteRoom` in `pkg/service/roomservice_test.go`. The orphaned-room test fails on master with the reported error and passes with the fix:

```
--- FAIL: TestDeleteRoom/deletes_room_orphaned_by_a_departed_node
    Error: Received unexpected error:
           could not find object
```

Also covers that other routing errors are not swallowed, that the healthy path still routes through the node, and that an unknown room still 404s.

One test-harness change: `newTestRoomService` used `servicefakes.FakeServiceStore`, which does not satisfy the `OSSServiceStore` assertion in `DeleteRoom`, so the store delete was invisible to tests. Swapped to `servicefakes.FakeObjectStore` and kept a handle on the fake room client so RPC calls can be asserted. No existing test changes behavior.

`go test -race ./pkg/service/...` passes.

## Not covered here

`RoomManager.DeleteRoom`'s non-RTC branch calls `roomStore.DeleteRoom` without `ClearRoomState`, so it leaves a `room_node_map` entry behind — one way rooms become orphaned in the first place. That is a separate change and I left it alone to keep this focused; happy to follow up if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
