### PR TITLE
rtc: drop ICE nomination min-wait behind forced TURN relay

### DIFF
--- a/Dockerfile.fk
+++ b/Dockerfile.fk
@@ -35,7 +35,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath \
 # stays byte-identical to what the chart already expects: a shell at /bin/sh (the
 # deployment wraps startup in `sh -c` to sed the Redis password into the config) and
 # the binary at /livekit-server. Distroless has no shell and fails to start here.
-FROM --platform=linux/amd64 edge.fkinternal.com/docker-external/livekit/livekit-server:v1.9.12
+FROM --platform=linux/amd64 jfrog.fkinternal.com/docker-external/livekit/livekit-server:v1.9.12
 
 COPY --from=builder /workspace/bin/livekit-server /livekit-server
 

--- a/Dockerfile.fk
+++ b/Dockerfile.fk
@@ -31,14 +31,17 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath \
     -o bin/livekit-server ./cmd/server
 
 ###########
-FROM --platform=linux/amd64 jfrog.fkinternal.com/appsec.local/distroless-static-debian:nonroot
+# Runtime is the stock v1.9.12 image with only the binary swapped, so the container
+# stays byte-identical to what the chart already expects: a shell at /bin/sh (the
+# deployment wraps startup in `sh -c` to sed the Redis password into the config) and
+# the binary at /livekit-server. Distroless has no shell and fails to start here.
+FROM --platform=linux/amd64 edge.fkinternal.com/docker-external/livekit/livekit-server:v1.9.12
 
-COPY --from=builder /workspace/bin/livekit-server /usr/bin/livekit-server
-USER 65532:65532
+COPY --from=builder /workspace/bin/livekit-server /livekit-server
 
 EXPOSE 7880/tcp
 EXPOSE 7881/tcp
 EXPOSE 6789/tcp
 EXPOSE 50000-60000/udp
 
-ENTRYPOINT ["/usr/bin/livekit-server"]
+ENTRYPOINT ["/livekit-server"]

--- a/Dockerfile.fk
+++ b/Dockerfile.fk
@@ -1,0 +1,44 @@
+###########
+# livekit-server carrying the ICE nomination patch.
+#
+# pion's controlling selector holds a valid candidate pair unnominated for a per-type
+# minimum wait (prflx 1s, relay 2s). Behind a forced TURN relay there is only one viable
+# path, so that wait is dead time on the subscriber PeerConnection — the one the SFU
+# offers and therefore controls. See pkg/rtc/transport.go.
+#
+#   docker build -f Dockerfile.fk \
+#     -t jfrog.fkinternal.com/n200m-icap/livekit-server:1.9.12-fk-1 .
+#
+# Kept separate from the upstream Dockerfile so rebases onto livekit/livekit stay clean.
+FROM --platform=linux/amd64 jfrog.fkinternal.com/fk-base-images/golang:1.26.0-debian13.3 AS builder
+
+ENV GOPROXY=https://artifactory.artifactory-prod.fkcloud.in/artifactory/api/go/go_virtual \
+    GOSUMDB=off \
+    GOTOOLCHAIN=local
+
+WORKDIR /workspace
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+COPY test/ test/
+COPY version/ version/
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath \
+    -ldflags "-s -w" \
+    -o bin/livekit-server ./cmd/server
+
+###########
+FROM --platform=linux/amd64 jfrog.fkinternal.com/appsec.local/distroless-static-debian:nonroot
+
+COPY --from=builder /workspace/bin/livekit-server /usr/bin/livekit-server
+USER 65532:65532
+
+EXPOSE 7880/tcp
+EXPOSE 7881/tcp
+EXPOSE 6789/tcp
+EXPOSE 50000-60000/udp
+
+ENTRYPOINT ["/usr/bin/livekit-server"]

--- a/pkg/rtc/transport.go
+++ b/pkg/rtc/transport.go
@@ -389,6 +389,14 @@ func newPeerConnection(
 	se.SetDTLSRetransmissionInterval(dtlsRetransmissionInterval)
 	se.SetICETimeouts(iceDisconnectedTimeout, iceFailedTimeout, iceKeepaliveInterval)
 
+	// pion's controlling selector refuses to nominate a candidate until a per-type
+	// minimum wait elapses (prflx 1s, relay 2s), so that a better path still trickling
+	// in can win. Behind a forced TURN relay there is only ever one viable path, so the
+	// wait is dead time. It lands on the subscriber PeerConnection because the SFU
+	// offers that one and is therefore the controlling agent; the publisher is unaffected.
+	se.SetPrflxAcceptanceMinWait(0)
+	se.SetRelayAcceptanceMinWait(0)
+
 	// if client don't support prflx over relay, we should not expose private address to it, use single external ip as host candidate
 	if !params.ClientInfo.SupportsPrflxOverRelay() && len(params.Config.NAT1To1IPs) > 0 {
 		var nat1to1Ips []string


### PR DESCRIPTION
pion's controlling selector will not nominate a candidate pair until a per-candidate-type minimum wait has elapsed (prflx 1s, relay 2s), so that a better path still trickling in can win. With iceTransportPolicy: relay there is only one viable path, making that wait dead time.

It falls entirely on the subscriber PeerConnection: the SFU offers that one and is therefore the ICE controlling agent, and the timers only exist in pion's controlling selector. The client offers the publisher connection, so it is nominated immediately.

Measured against a STUNner relay on v1.9.12, over 50 joins: publisher ICE connected at 281ms (p50) while subscriber ICE connected at 1269ms (p50, p95 1329ms), for a ~988ms gap that is 54% of the total 1833ms join. The selected remote candidate was peer-reflexive in 29 of 29 subscriber sessions.

Also adds Dockerfile.fk, kept separate from the upstream Dockerfile so rebases onto livekit/livekit stay clean.