### PR TITLE
rtc: send connection quality to participants that subscribe after their first update

### DIFF
--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -1681,6 +1681,8 @@ func (r *Room) connectionQualityWorker() {
 	defer ticker.Stop()
 
 	prevConnectionInfos := make(map[livekit.ParticipantID]*livekit.ConnectionQualityInfo)
+	// per participant, the participants whose quality it was told about in its last update
+	toldQualityOf := make(map[livekit.ParticipantID]map[livekit.ParticipantID]struct{})
 	// send updates to only users that are subscribed to each other
 	for !r.IsClosed() {
 		<-ticker.C
@@ -1718,6 +1720,32 @@ func (r *Room) connectionQualityWorker() {
 			}
 		}
 
+		// also send if a participant is subscribed to someone whose quality it has never been told about:
+		// its subscriptions may have been established after the tick that announced it as a new entrant,
+		// and without a later quality change it would never receive their quality
+		for pID := range toldQualityOf {
+			if _, nowOk := nowConnectionInfos[pID]; !nowOk {
+				delete(toldQualityOf, pID)
+			}
+		}
+		for _, op := range participants {
+			if sendUpdate {
+				break
+			}
+			if !op.ProtocolVersion().SupportsConnectionQuality() || op.State() != livekit.ParticipantInfo_ACTIVE {
+				continue
+			}
+			for _, sid := range op.GetSubscribedParticipants() {
+				if _, nowOk := nowConnectionInfos[sid]; !nowOk {
+					continue
+				}
+				if _, told := toldQualityOf[op.ID()][sid]; !told {
+					sendUpdate = true
+					break
+				}
+			}
+		}
+
 		if !sendUpdate {
 			prevConnectionInfos = nowConnectionInfos
 			continue
@@ -1746,6 +1774,14 @@ func (r *Room) connectionQualityWorker() {
 				// no change
 				continue
 			}
+
+			// remember which participants' quality this participant is being told about in this update
+			told := make(map[livekit.ParticipantID]struct{}, len(update.Updates))
+			for _, info := range update.Updates {
+				told[livekit.ParticipantID(info.ParticipantSid)] = struct{}{}
+			}
+			toldQualityOf[op.ID()] = told
+			
 			if err := op.SendConnectionQualityUpdate(update); err != nil {
 				r.logger.Warnw("could not send connection quality update", err,
 					"participant", op.Identity())

--- a/pkg/rtc/room.go
+++ b/pkg/rtc/room.go
@@ -1725,25 +1725,25 @@ func (r *Room) connectionQualityWorker() {
 		// and without a later quality change it would never receive their quality
 		for pID := range toldQualityOf {
 			if _, nowOk := nowConnectionInfos[pID]; !nowOk {
+				// participant is not ACTIVE any more
 				delete(toldQualityOf, pID)
 			}
 		}
-		for _, op := range participants {
-			if sendUpdate {
-				break
-			}
-			if !op.ProtocolVersion().SupportsConnectionQuality() || op.State() != livekit.ParticipantInfo_ACTIVE {
-				continue
-			}
-			for _, sid := range op.GetSubscribedParticipants() {
-				if _, nowOk := nowConnectionInfos[sid]; !nowOk {
-					continue
+		if !sendUpdate {
+			sendUpdate = slices.ContainsFunc(participants, func(op types.LocalParticipant) bool {
+				if !op.ProtocolVersion().SupportsConnectionQuality() || op.State() != livekit.ParticipantInfo_ACTIVE {
+					return false
 				}
-				if _, told := toldQualityOf[op.ID()][sid]; !told {
-					sendUpdate = true
-					break
+				for _, sid := range op.GetSubscribedParticipants() {
+					if _, nowOk := nowConnectionInfos[sid]; !nowOk {
+						continue
+					}
+					if _, told := toldQualityOf[op.ID()][sid]; !told {
+						return true
+					}
 				}
-			}
+				return false
+			})
 		}
 
 		if !sendUpdate {
@@ -1775,17 +1775,19 @@ func (r *Room) connectionQualityWorker() {
 				continue
 			}
 
-			// remember which participants' quality this participant is being told about in this update
+			if err := op.SendConnectionQualityUpdate(update); err != nil {
+				r.logger.Warnw("could not send connection quality update", err,
+					"participant", op.Identity())
+				continue
+			}
+
+			// remember which participants' quality this participant has been sent,
+			// only after a successful send so that a failed one is retried on next tick
 			told := make(map[livekit.ParticipantID]struct{}, len(update.Updates))
 			for _, info := range update.Updates {
 				told[livekit.ParticipantID(info.ParticipantSid)] = struct{}{}
 			}
 			toldQualityOf[op.ID()] = told
-			
-			if err := op.SendConnectionQualityUpdate(update); err != nil {
-				r.logger.Warnw("could not send connection quality update", err,
-					"participant", op.Identity())
-			}
 		}
 
 		prevConnectionInfos = nowConnectionInfos


### PR DESCRIPTION
### Bug description
`connectionQualityWorker` only sends `ConnectionQualityUpdate` when:
1. A participant is new.
2. Some participant's quality level changed (#767).

Each update contains a participant's own quality plus the quality of the participants it is subscribed to ***at that tick*** of the `connectionQualityWorker`.

If a participant's subscriptions are established after the tick that announce it as a new entrant, the worker never sends it the quality of the participants it subscribed to until one of them changes level. On a stable network that can be never, and the client keeps reporting those remote participants as `ConnectionQuality.UNKNOWN`.

### Fix
Remember, per participant, which participants' quality it was last sent, and also trigger an update when a participant is subscribed to someone it has not been told about yet. The existing send path is reused, so the cost is just one full update per late subscription. Entries of participants that left are dropped every tick.

### Proof of the bug
Below is a simple Go file that uses the LiveKit Go SDK to join a publisher and a subscriber participant to the same Room and using `autoSubscribe: false` forces the wrong behavior.

Run livekit-server:

```bash
livekit-server --dev 
```

Create a temporal folder, initialize a go project and install the LiveKit Go SDK:

```bash
mkdir cqproof && cd cqproof 
go mod init cqproof
go get github.com/livekit/server-sdk-go/v2@latest github.com/go-logr/logr@latest
```

Now store this `main.go` file in that same folder `cqproof`:

```go
// Proves that a participant subscribing to another one AFTER its first
// ConnectionQualityUpdate never receives that participant's connection quality
// (the remote participant stays at ConnectionQuality UNKNOWN on the client).

package main
import (
	"fmt"
	"os"
	"time"

	"github.com/go-logr/logr"
	"github.com/pion/webrtc/v4"

	"github.com/livekit/protocol/livekit"
	protoLogger "github.com/livekit/protocol/logger"
	lksdk "github.com/livekit/server-sdk-go/v2"
)

func main() {
	lksdk.SetLogger(protoLogger.LogRLogger(logr.Discard())) // hide SDK/pion logs
	url := "ws://localhost:7880"
	if len(os.Args) > 1 {
		url = os.Args[1]
	}
	info := func(identity string) lksdk.ConnectInfo {
		return lksdk.ConnectInfo{APIKey: "devkey", APISecret: "secret", RoomName: "cq-proof", ParticipantIdentity: identity}
	}

	// 1) "publisher" joins and publishes an audio track (silence at 32 kbps).
	publisher, err := lksdk.ConnectToRoom(url, info("publisher"), &lksdk.RoomCallback{})
	must(err)
	defer publisher.Disconnect()
	track, err := lksdk.NewLocalSampleTrack(webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeOpus, ClockRate: 48000, Channels: 2})
	must(err)
	_, err = publisher.LocalParticipant.PublishTrack(track, &lksdk.TrackPublicationOptions{Name: "audio"})
	must(err)
	must(track.StartWrite(lksdk.NewNullSampleProvider(32000), nil))
	fmt.Println("publisher connected and publishing")

	// 2) "subscriber" joins WITHOUT auto-subscribe and waits for its first
	//    ConnectionQualityUpdate (which can only contain itself).
	ownQuality := make(chan struct{}, 1)
	publisherQuality := make(chan struct{}, 1)
	subscribed := make(chan struct{}, 1)
	cb := &lksdk.RoomCallback{ParticipantCallback: lksdk.ParticipantCallback{
		OnConnectionQualityChanged: func(update *livekit.ConnectionQualityInfo, p lksdk.Participant) {
			fmt.Printf("%s subscriber got connection quality of %q: %s\n", time.Now().Format("15:04:05.000"), p.Identity(), update.Quality)
			switch p.Identity() {
			case "subscriber":
				select {
				case ownQuality <- struct{}{}:
				default:
				}
			case "publisher":
				select {
				case publisherQuality <- struct{}{}:
				default:
				}
			}
		},
		OnTrackSubscribed: func(_ *webrtc.TrackRemote, _ *lksdk.RemoteTrackPublication, rp *lksdk.RemoteParticipant) {
			fmt.Printf("%s subscriber is now subscribed to %q's track\n", time.Now().Format("15:04:05.000"), rp.Identity())
			select {
			case subscribed <- struct{}{}:
			default:
			}
		},
	}}
	subscriber, err := lksdk.ConnectToRoom(url, info("subscriber"), cb, lksdk.WithAutoSubscribe(false))
	must(err)
	defer subscriber.Disconnect()
	fmt.Println("subscriber connected (autoSubscribe=false), waiting for its first connection quality update")
	waitFor(ownQuality, 15*time.Second, "subscriber never received its own connection quality")

	// 3) Only now subscribe to the publisher's track.
	for _, rp := range subscriber.GetRemoteParticipants() {
		for _, pub := range rp.TrackPublications() {
			must(pub.(*lksdk.RemoteTrackPublication).SetSubscribed(true))
		}
	}
	waitFor(subscribed, 15*time.Second, "subscriber never got subscribed to the publisher's track")

	// 4) The server sends ConnectionQualityUpdate only on a new participant or a
	//    quality LEVEL change. Nothing changes here, so on an unfixed server the
	//    subscriber never learns the publisher's quality (the client-side remote
	//    participant stays UNKNOWN). A fixed server sends it on the next 5 s tick.
	start := time.Now()
	select {
	case <-publisherQuality:
		fmt.Printf("OK: publisher's connection quality reached the subscriber %.1fs after subscribing\n", time.Since(start).Seconds())
	case <-time.After(30 * time.Second):
		fmt.Println("BUG: 30s after subscribing, the subscriber still has no connection quality for the publisher")
		os.Exit(1)
	}
}

func waitFor(ch chan struct{}, timeout time.Duration, errMsg string) {
	select {
	case <-ch:
	case <-time.After(timeout):
		fmt.Println("ERROR:", errMsg)
		os.Exit(2)
	}
}

func must(err error) {
	if err != nil {
		fmt.Println("ERROR:", err)
		os.Exit(2)
	}
}
```

Then just run the go file and wait for the output:

```bash
go mod tidy && go run .
```

The livekit-server in `main` will output something like:

```log
user@ubuntu:~/Documents/cqproof$ go mod tidy && go run .
publisher connected and publishing
subscriber connected (autoSubscribe=false), waiting for its first connection quality update
19:43:53.086 subscriber got connection quality of "subscriber": EXCELLENT
19:43:53.113 subscriber is now subscribed to "publisher"'s track
BUG: 30s after subscribing, the subscriber still has no connection quality for the publisher
exit status 1
```

A livekit-server with this PR merged outputs:

```log
19:40:14.138 subscriber got connection quality of "subscriber": EXCELLENT
19:40:14.173 subscriber is now subscribed to "publisher"'s track
19:40:19.137 subscriber got connection quality of "subscriber": EXCELLENT
19:40:19.137 subscriber got connection quality of "publisher": EXCELLENT
OK: publisher's connection quality reached the subscriber 5.0s after subscribing
```