### PR TITLE
rtc: wire OnSubscribeStatusChanged through the participant listener

### DIFF
--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -1213,10 +1213,13 @@ func (m *SubscriptionManager) unmarkSubscribedTo(publisherID livekit.Participant
 	}
 	m.lock.Unlock()
 
-	// notify the listener only once per publisher, on the last subscription to it going away
+	// notify the listener only once per publisher, on the last subscription to it going away.
+	// delivered synchronously (like the subscribe notification) so that on a quick track
+	// close + resubscribe the `false` cannot be reordered after the following `true` and
+	// leave the publisher's speaker/quality state stale.
 	if lastSubscription {
 		if l, ok := m.params.Participant.GetParticipantListener().(types.LocalParticipantListener); ok {
-			go l.OnSubscribeStatusChanged(m.params.Participant, publisherID, false)
+			l.OnSubscribeStatusChanged(m.params.Participant, publisherID, false)
 		}
 	}
 }

--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -80,8 +80,6 @@ type SubscriptionManager struct {
 	closeCh              chan struct{}
 	doneCh               chan struct{}
 
-	onSubscribeStatusChanged func(publisherID livekit.ParticipantID, subscribed bool)
-
 	dataTrackSubscriptions map[livekit.TrackID]*dataTrackSubscription
 }
 
@@ -394,15 +392,6 @@ func (m *SubscriptionManager) UpdateDataTrackSubscriptionOptions(trackID livekit
 	m.lock.Unlock()
 
 	sub.setSubscriptionOptions(subscriptionOptions)
-}
-
-// OnSubscribeStatusChanged callback will be notified when a participant subscribes or unsubscribes to another participant
-// it will only fire once per publisher. If current participant is subscribed to multiple tracks from another, this
-// callback will only fire once.
-func (m *SubscriptionManager) OnSubscribeStatusChanged(fn func(publisherID livekit.ParticipantID, subscribed bool)) {
-	m.lock.Lock()
-	m.onSubscribeStatusChanged = fn
-	m.lock.Unlock()
 }
 
 func (m *SubscriptionManager) WaitUntilSubscribed(timeout time.Duration) error {
@@ -1193,7 +1182,6 @@ func (m *SubscriptionManager) markSubscribedTo(publisherID livekit.ParticipantID
 	firstSubscribe := false
 	m.lock.Lock()
 	pTracks := m.subscribedTo[publisherID]
-	changedCB := m.onSubscribeStatusChanged
 	if pTracks == nil {
 		pTracks = make(map[livekit.TrackID]struct{})
 		m.subscribedTo[publisherID] = pTracks
@@ -1202,8 +1190,12 @@ func (m *SubscriptionManager) markSubscribedTo(publisherID livekit.ParticipantID
 	pTracks[trackID] = struct{}{}
 	m.lock.Unlock()
 
-	if changedCB != nil && firstSubscribe {
-		changedCB(publisherID, true)
+	// notify the listener only once per publisher, on the first subscription to it. If the
+	// participant is subscribed to multiple tracks from the same publisher, this fires once.
+	if firstSubscribe {
+		if l, ok := m.params.Participant.GetParticipantListener().(types.LocalParticipantListener); ok {
+			l.OnSubscribeStatusChanged(m.params.Participant, publisherID, true)
+		}
 	}
 }
 
@@ -1211,7 +1203,6 @@ func (m *SubscriptionManager) unmarkSubscribedTo(publisherID livekit.Participant
 	// remove from subscribedTo
 	lastSubscription := false
 	m.lock.Lock()
-	changedCB := m.onSubscribeStatusChanged
 	pTracks := m.subscribedTo[publisherID]
 	if pTracks != nil {
 		delete(pTracks, trackID)
@@ -1221,8 +1212,12 @@ func (m *SubscriptionManager) unmarkSubscribedTo(publisherID livekit.Participant
 		}
 	}
 	m.lock.Unlock()
-	if changedCB != nil && lastSubscription {
-		go changedCB(publisherID, false)
+
+	// notify the listener only once per publisher, on the last subscription to it going away
+	if lastSubscription {
+		if l, ok := m.params.Participant.GetParticipantListener().(types.LocalParticipantListener); ok {
+			go l.OnSubscribeStatusChanged(m.params.Participant, publisherID, false)
+		}
 	}
 }
 

--- a/pkg/rtc/subscriptionmanager_test.go
+++ b/pkg/rtc/subscriptionmanager_test.go
@@ -58,7 +58,8 @@ func TestSubscribe(t *testing.T) {
 		}
 		numParticipantSubscribed := atomic.Int32{}
 		numParticipantUnsubscribed := atomic.Int32{}
-		sm.OnSubscribeStatusChanged(func(pubID livekit.ParticipantID, subscribed bool) {
+		pl := sm.params.Participant.GetParticipantListener().(*typesfakes.FakeLocalParticipantListener)
+		pl.OnSubscribeStatusChangedCalls(func(_ types.LocalParticipant, pubID livekit.ParticipantID, subscribed bool) {
 			if subscribed {
 				numParticipantSubscribed.Add(1)
 			} else {
@@ -267,7 +268,8 @@ func TestSubscribeStatusChanged(t *testing.T) {
 	sm.params.TrackResolver = resolver.Resolve
 	numParticipantSubscribed := atomic.Int32{}
 	numParticipantUnsubscribed := atomic.Int32{}
-	sm.OnSubscribeStatusChanged(func(pubID livekit.ParticipantID, subscribed bool) {
+	pl := sm.params.Participant.GetParticipantListener().(*typesfakes.FakeLocalParticipantListener)
+	pl.OnSubscribeStatusChangedCalls(func(_ types.LocalParticipant, pubID livekit.ParticipantID, subscribed bool) {
 		if subscribed {
 			numParticipantSubscribed.Add(1)
 		} else {
@@ -372,7 +374,8 @@ func TestSubscriptionLimits(t *testing.T) {
 	}
 	numParticipantSubscribed := atomic.Int32{}
 	numParticipantUnsubscribed := atomic.Int32{}
-	sm.OnSubscribeStatusChanged(func(pubID livekit.ParticipantID, subscribed bool) {
+	pl := sm.params.Participant.GetParticipantListener().(*typesfakes.FakeLocalParticipantListener)
+	pl.OnSubscribeStatusChangedCalls(func(_ types.LocalParticipant, pubID livekit.ParticipantID, subscribed bool) {
 		if subscribed {
 			numParticipantSubscribed.Add(1)
 		} else {
@@ -547,6 +550,9 @@ func newTestSubscriptionManagerWithParams(params testSubscriptionParams) *Subscr
 
 	tl := &typesfakes.FakeParticipantTelemetryListener{}
 	p.GetTelemetryListenerReturns(tl)
+
+	pl := &typesfakes.FakeLocalParticipantListener{}
+	p.GetParticipantListenerReturns(pl)
 
 	return NewSubscriptionManager(SubscriptionManagerParams{
 		Participant:         p,

--- a/pkg/rtc/subscriptionmanager_test.go
+++ b/pkg/rtc/subscriptionmanager_test.go
@@ -114,7 +114,6 @@ func TestSubscribe(t *testing.T) {
 		require.Eventually(t, func() bool {
 			return numParticipantSubscribed.Load() == 2
 		}, subSettleTimeout, subCheckInterval, "participant subscribe status was not updated twice")
-		// the unsubscribed callback is delivered on a goroutine of its own
 		require.Eventually(t, func() bool {
 			return numParticipantUnsubscribed.Load() == 1
 		}, subSettleTimeout, subCheckInterval, "participant unsubscribe status was not updated")


### PR DESCRIPTION
`SubscriptionManager`'s `onSubscribeStatusChanged` callback field was only ever registered in tests, so in production `markSubscribedTo`/`unmarkSubscribedTo` found a nil callback and never fired — the subscribe-time speaker + connection-quality push (`room.onSubscribeStatusChanged`) has been dead since #4136.

This removes the field/setter and instead invokes the participant's `LocalParticipantListener.OnSubscribeStatusChanged` directly (once per publisher; subscribe sync, unsubscribe on a goroutine, as before). Tests updated to assert via the fake listener.