### PR TITLE
telemetry: drop unused getCPUStats, unblocking darwin builds without cgo

### DIFF
--- a/pkg/telemetry/prometheus/node_nonwindows.go
+++ b/pkg/telemetry/prometheus/node_nonwindows.go
@@ -18,39 +18,8 @@
 
 package prometheus
 
-import (
-	"runtime"
-	"sync"
-
-	"github.com/mackerelio/go-osstat/cpu"
-	"github.com/mackerelio/go-osstat/loadavg"
-)
-
-var (
-	cpuStatsLock              sync.RWMutex
-	lastCPUTotal, lastCPUIdle uint64
-)
+import "github.com/mackerelio/go-osstat/loadavg"
 
 func getLoadAvg() (*loadavg.Stats, error) {
 	return loadavg.Get()
-}
-
-func getCPUStats() (cpuLoad float32, numCPUs uint32, err error) {
-	cpuInfo, err := cpu.Get()
-	if err != nil {
-		return
-	}
-
-	cpuStatsLock.Lock()
-	if lastCPUTotal > 0 && lastCPUTotal < cpuInfo.Total {
-		cpuLoad = 1 - float32(cpuInfo.Idle-lastCPUIdle)/float32(cpuInfo.Total-lastCPUTotal)
-	}
-
-	lastCPUTotal = cpuInfo.Total
-	lastCPUIdle = cpuInfo.Idle
-	cpuStatsLock.Unlock()
-
-	numCPUs = uint32(runtime.NumCPU())
-
-	return
 }

--- a/pkg/telemetry/prometheus/node_windows.go
+++ b/pkg/telemetry/prometheus/node_windows.go
@@ -23,7 +23,3 @@ import "github.com/mackerelio/go-osstat/loadavg"
 func getLoadAvg() (*loadavg.Stats, error) {
 	return &loadavg.Stats{}, nil
 }
-
-func getCPUStats() (cpuLoad float32, numCPUs uint32, err error) {
-	return 1, 1, nil
-}


### PR DESCRIPTION
## Problem

`pkg/telemetry/prometheus` imports `github.com/mackerelio/go-osstat/cpu`, whose darwin implementation exists only behind cgo, so `CGO_ENABLED=0 GOOS=darwin go build ./...` fails:

```
# github.com/livekit/livekit-server/pkg/telemetry/prometheus
pkg/telemetry/prometheus/node_nonwindows.go:39:22: undefined: cpu.Get
```

That blocks cross-compiling a darwin build of the server from a linux host, where `CGO_ENABLED=0` is required.

## Change

`getCPUStats` has **no callers**: node CPU load comes from `hwstats.CPUStats` in `GetNodeStats`, and nothing in the tree reads `getCPUStats` (`git grep getCPUStats` finds only its two definitions). Only `getLoadAvg` is still used. It survives because golangci-lint enables `staticcheck` but not `unused`.

Keeping it is not free: it is the sole reason this package imports `go-osstat/cpu`. Removing the function from both the windows and non-windows variants, along with the state it kept, fixes the build as a net deletion (-36/+1) with no new build tags and no metrics impact. `getLoadAvg` is untouched (`go-osstat/loadavg` already has a pure-Go darwin path), and go-osstat stays a direct dependency through it.

If you would rather keep the function, the alternative is a `darwin && !cgo` stub returning zeros, mirroring `node_windows.go` — happy to switch.

## Depends on

livekit/protocol#1770 — `utils/hwstats` has the same go-osstat/cgo issue; without it the server still fails to cross-compile for darwin even with this change. Suggest landing that first.

## Verification

- `CGO_ENABLED=0 go build ./...` for `darwin/arm64`, `darwin/amd64`, `linux`, `windows` — pass (with a local `replace` onto the protocol fix, since protocol must land first)
- native `go build ./...`, `go vet ./pkg/telemetry/...`, `go test ./pkg/telemetry/...` — pass without the replace

🤖 Generated with [Claude Code](https://claude.com/claude-code)