### PR TITLE
Fix/reconcile data track subscription deadlock

### DIFF
--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -599,7 +599,7 @@ func (m *SubscriptionManager) reconcileDataTrackSubscriptions() {
 	var needsToReconcile []*dataTrackSubscription
 	m.lock.RLock()
 	for _, sub := range m.dataTrackSubscriptions {
-		if sub.needsSubscribe() || sub.needsUnsubscribe() {
+		if sub.needsSubscribe() || sub.needsUnsubscribe() || sub.needsCleanup() {
 			needsToReconcile = append(needsToReconcile, sub)
 		}
 	}
@@ -630,7 +630,7 @@ func (m *SubscriptionManager) reconcileDataTrackSubscription(s *dataTrackSubscri
 				if s.durationSinceStart() > notFoundTimeout {
 					s.logger.Infow("unsubscribing from data track after notFoundTimeout", "error", err)
 					s.setDesired(false)
-					m.queueReconcile(s.trackID)
+					m.queueReconcileDataTrack(s.trackID)
 				}
 			default:
 				// all other errors
@@ -668,12 +668,16 @@ func (m *SubscriptionManager) reconcileDataTrackSubscription(s *dataTrackSubscri
 	}
 
 	m.lock.Lock()
-	if s.needsCleanup() {
+	cleanedUp := s.needsCleanup()
+	if cleanedUp {
 		s.logger.Debugw("cleanup removing data track subscription")
 		delete(m.dataTrackSubscriptions, s.trackID)
-		m.notifyDataTrackSubscriberHandles()
 	}
 	m.lock.Unlock()
+
+	if cleanedUp {
+		m.notifyDataTrackSubscriberHandles()
+	}
 }
 
 // trigger an immediate reconciliation, when trackID is empty, will reconcile all subscriptions

--- a/pkg/rtc/subscriptionmanager_test.go
+++ b/pkg/rtc/subscriptionmanager_test.go
@@ -526,6 +526,35 @@ func TestSubscribeDataTrack(t *testing.T) {
 		}, subSettleTimeout, subCheckInterval, "should be resubscribed")
 		require.Equal(t, 2, resolver.dataTrack.AddSubscriberCallCount())
 	})
+
+	t.Run("unsubscribe before track resolves", func(t *testing.T) {
+		sm := newTestSubscriptionManager()
+		defer sm.Close(false)
+		// no track available, subscribe attempts fail with ErrTrackNotFound
+		resolver := newTestDataTrackResolver(true, false, "pub", "pubID")
+		sm.params.DataTrackResolver = resolver.Resolve
+
+		sm.SubscribeToDataTrack("track")
+		sm.lock.RLock()
+		s := sm.dataTrackSubscriptions["track"]
+		sm.lock.RUnlock()
+		require.NotNil(t, s)
+
+		// let the worker attempt (and fail) the subscribe
+		require.Eventually(t, func() bool {
+			return s.getNumAttempts() > 0
+		}, subSettleTimeout, subCheckInterval, "no subscribe attempt was made")
+
+		// unsubscribing while no down track exists must clean up the
+		// subscription without deadlocking the reconcile worker
+		sm.UnsubscribeFromDataTrack("track")
+		require.Eventually(t, func() bool {
+			sm.lock.RLock()
+			_, ok := sm.dataTrackSubscriptions["track"]
+			sm.lock.RUnlock()
+			return !ok
+		}, subSettleTimeout, subCheckInterval, "data track subscription was not cleaned up")
+	})
 }
 
 type testSubscriptionParams struct {

--- a/pkg/rtc/subscriptionmanager_test.go
+++ b/pkg/rtc/subscriptionmanager_test.go
@@ -527,7 +527,7 @@ func TestSubscribeDataTrack(t *testing.T) {
 		require.Equal(t, 2, resolver.dataTrack.AddSubscriberCallCount())
 	})
 
-	t.Run("unsubscribe before track resolves", func(t *testing.T) {
+	t.Run("unsubscribe before data track resolves", func(t *testing.T) {
 		sm := newTestSubscriptionManager()
 		defer sm.Close(false)
 		// no track available, subscribe attempts fail with ErrTrackNotFound
@@ -545,8 +545,6 @@ func TestSubscribeDataTrack(t *testing.T) {
 			return s.getNumAttempts() > 0
 		}, subSettleTimeout, subCheckInterval, "no subscribe attempt was made")
 
-		// unsubscribing while no down track exists must clean up the
-		// subscription without deadlocking the reconcile worker
 		sm.UnsubscribeFromDataTrack("track")
 		require.Eventually(t, func() bool {
 			sm.lock.RLock()


### PR DESCRIPTION
Fixes #4842 

`reconcileDataTrackSubscription` called `notifyDataTrackSubscriberHandles()`
while holding `m.lock`; that function takes `m.lock` itself, so the reconcile
worker deadlocked whenever the cleanup branch ran (e.g. unsubscribing from a
data track that never resolved). Since one worker services all of a
participant's subscriptions, this froze media and data reconciliation for the
participant and made `SubscriptionManager.Close()` block forever on `doneCh`.

Changes in `pkg/rtc/subscriptionmanager.go`:

- **Notify outside the lock**: the cleanup branch now records the decision
  under `m.lock`, unlocks, and only then calls
  `notifyDataTrackSubscriberHandles()` — the same pattern the
  `needsUnsubscribe` branch above it already uses.
- **Queue not-found cleanup on the right channel**: after `notFoundTimeout`,
  the data track ID was queued via `queueReconcile` (media channel), where the
  lookup in `m.subscriptions` misses and the cleanup never runs. Now uses
  `queueReconcileDataTrack`.
- **Reap abandoned subscriptions periodically**: `reconcileDataTrackSubscriptions()`
  now also selects subscriptions with `needsCleanup()`, matching the media
  path in `reconcileSubscriptions()`. Previously an abandoned subscription
  (`!desired`, no down track) leaked in `dataTrackSubscriptions` forever.

All three issues came in with data track subscriptions (#4089).

Added a regression test, `TestSubscribeDataTrack/unsubscribe_before_track_resolves`:
subscribe to an unresolvable data track, unsubscribe, and assert the
subscription is removed. Before the fix it deadlocks (test times out with the
worker stuck in `notifyDataTrackSubscriberHandles` and `Close` blocked behind
it); with the fix it passes.

Verified with `go test -race ./pkg/rtc/...` and `go vet ./pkg/rtc/...`.