### PR TITLE
turn: accept PROXY protocol on the TCP listener

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -317,6 +317,12 @@ keys:
 #   # set external_tls to true if using a L4 load balancer to terminate TLS. when enabled,
 #   # LiveKit expects unencrypted traffic on tls_port, and still advertise tls_port as a TURN/TLS candidate.
 #   external_tls: true
+#   # set proxy_protocol to true if the proxy or load balancer in front of tls_port does not preserve
+#   # the client address (it terminates TLS, or dials LiveKit from its own IP) and can send a
+#   # PROXY protocol v1/v2 header instead. Without it TURN reports the proxy's address to the
+#   # client as XOR-MAPPED-ADDRESS, which Firefox rejects when it is loopback or wildcard.
+#   # every connection on tls_port must then carry the header; connections without it are rejected.
+#   proxy_protocol: false
 #   # needs to match tls cert domain
 #   domain: turn.myhost.com
 #   # optional (set only if not using external TLS termination)

--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -322,7 +322,14 @@ keys:
 #   # PROXY protocol v1/v2 header instead. Without it TURN reports the proxy's address to the
 #   # client as XOR-MAPPED-ADDRESS, which Firefox rejects when it is loopback or wildcard.
 #   # every connection on tls_port must then carry the header; connections without it are rejected.
+#   # prefer PROXY protocol v2 on the proxy side: the v1 text header must arrive in a single read.
 #   proxy_protocol: false
+#   # proxies whose PROXY header is trusted. connections from any other address are closed, so a
+#   # client that reaches tls_port directly cannot claim an arbitrary source address.
+#   # defaults to loopback, for a proxy running on the same host.
+#   proxy_protocol_trusted_cidrs:
+#     - 127.0.0.0/8
+#     - ::1/128
 #   # needs to match tls cert domain
 #   domain: turn.myhost.com
 #   # optional (set only if not using external TLS termination)

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/pion/transport/v4 v4.1.0
 	github.com/pion/turn/v5 v5.0.13
 	github.com/pion/webrtc/v4 v4.2.18
+	github.com/pires/go-proxyproto v0.15.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.24.1
 	github.com/redis/go-redis/v9 v9.22.0

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/pion/transport/v4 v4.1.0 h1:8S+nF2reM2cJuqC6g78OVy2BBgmbdns+acx3jA97B
 github.com/pion/transport/v4 v4.1.0/go.mod h1:06hFI+jCFcok2X2MekVufNZ/uzNZXivGBPfviSVcjgM=
 github.com/pion/turn/v5 v5.0.13 h1:erHOsJyxuV6QK54+PjWJhe8u1O7BM3a/US0zYJJsnx4=
 github.com/pion/turn/v5 v5.0.13/go.mod h1:btdOovUYdYc8iBnvt87JHN4Pa1XV5UiLaCYe4ay3o9A=
+github.com/pires/go-proxyproto v0.15.0 h1:dTshmNbFm/D+0+sbrxUuddPOZ5Y0B7c5NhtsBkm6LqI=
+github.com/pires/go-proxyproto v0.15.0/go.mod h1:OXsCrKwrK2tXS9YrI5tkHx5xaQlO8FH3lFW76orFh24=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -279,6 +279,15 @@ type TURNConfig struct {
 	RelayPortRangeEnd   uint16   `yaml:"relay_range_end,omitempty"`
 	ExternalTLS         bool     `yaml:"external_tls,omitempty"`
 	BindAddresses       []string `yaml:"bind_addresses,omitempty"`
+	// ProxyProtocol makes the TURN TCP listener require a PROXY protocol (v1 or v2)
+	// header on every connection and use the client address it carries. Needed when
+	// a proxy in front of TURN dials from its own address (a TLS-terminating L4
+	// proxy, a TCP reverse proxy): TURN echoes the address it sees back to the
+	// client as XOR-MAPPED-ADDRESS, and browsers such as Firefox reject a loopback
+	// or wildcard address there and abandon the allocation. Connections without
+	// the header are rejected, so only enable it on a port that is reached
+	// exclusively through such a proxy.
+	ProxyProtocol bool `yaml:"proxy_protocol,omitempty"`
 	// PerUserRelayAllocationLimit caps the number of concurrent relay allocations
 	// a single participant credential may hold, keyed by the participant ID. This
 	// stops one authenticated participant from consuming the shared relay-port

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -285,9 +285,13 @@ type TURNConfig struct {
 	// proxy, a TCP reverse proxy): TURN echoes the address it sees back to the
 	// client as XOR-MAPPED-ADDRESS, and browsers such as Firefox reject a loopback
 	// or wildcard address there and abandon the allocation. Connections without
-	// the header are rejected, so only enable it on a port that is reached
-	// exclusively through such a proxy.
+	// the header are rejected.
 	ProxyProtocol bool `yaml:"proxy_protocol,omitempty"`
+	// ProxyProtocolTrustedCIDRs lists the proxies whose PROXY header is believed.
+	// Connections from any other address are closed, so a client that reaches
+	// tls_port directly cannot claim an arbitrary source address. Defaults to
+	// loopback only, for a proxy on the same host.
+	ProxyProtocolTrustedCIDRs []string `yaml:"proxy_protocol_trusted_cidrs,omitempty"`
 	// PerUserRelayAllocationLimit caps the number of concurrent relay allocations
 	// a single participant credential may hold, keyed by the participant ID. This
 	// stops one authenticated participant from consuming the shared relay-port
@@ -594,6 +598,7 @@ var DefaultConfig = Config{
 	TURN: TURNConfig{
 		Enabled:                     false,
 		BindAddresses:               []string{"0.0.0.0"},
+		ProxyProtocolTrustedCIDRs:   []string{"127.0.0.0/8", "::1/128"},
 		TTLSeconds:                  DefaultTURNTTLSeconds,
 		PerUserRelayAllocationLimit: DefaultTURNPerUserRelayAllocationLimit,
 	},

--- a/pkg/service/turn.go
+++ b/pkg/service/turn.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jxskiss/base62"
 	"github.com/pion/stun/v3"
 	"github.com/pion/turn/v5"
+	"github.com/pires/go-proxyproto"
 	"github.com/pkg/errors"
 
 	"github.com/livekit/protocol/auth"
@@ -162,26 +163,9 @@ func NewTurnServer(conf *config.Config, authHandler turn.AuthHandler, standalone
 		}
 
 		if turnConf.TLSPort > 0 {
-			var listener net.Listener
-			var listenerErr error
-
-			if turnConf.ExternalTLS {
-				listener, listenerErr = net.Listen("tcp", net.JoinHostPort(addr, strconv.Itoa(turnConf.TLSPort)))
-			} else {
-				cert, err := tls.LoadX509KeyPair(turnConf.CertFile, turnConf.KeyFile)
-				if err != nil {
-					return nil, errors.Wrap(err, "TURN tls cert required")
-				}
-
-				listener, listenerErr = tls.Listen("tcp", net.JoinHostPort(addr, strconv.Itoa(turnConf.TLSPort)),
-					&tls.Config{
-						MinVersion:   tls.VersionTLS12,
-						Certificates: []tls.Certificate{cert},
-					})
-			}
-
-			if listenerErr != nil {
-				return nil, errors.Wrap(listenerErr, "could not listen on TURN TCP port")
+			listener, err := newTURNTCPListener(turnConf, net.JoinHostPort(addr, strconv.Itoa(turnConf.TLSPort)))
+			if err != nil {
+				return nil, err
 			}
 			if standalone {
 				listener = telemetry.NewListener(listener)
@@ -194,7 +178,7 @@ func NewTurnServer(conf *config.Config, authHandler turn.AuthHandler, standalone
 			}
 			serverConfig.ListenerConfigs = append(serverConfig.ListenerConfigs, listenerConfig)
 
-			logValues = append(logValues, "turn.portTLS", turnConf.TLSPort, "turn.externalTLS", turnConf.ExternalTLS)
+			logValues = append(logValues, "turn.portTLS", turnConf.TLSPort, "turn.externalTLS", turnConf.ExternalTLS, "turn.proxyProtocol", turnConf.ProxyProtocol)
 		}
 
 		if turnConf.UDPPort > 0 {
@@ -219,6 +203,36 @@ func NewTurnServer(conf *config.Config, authHandler turn.AuthHandler, standalone
 
 	logger.Infow("Starting TURN server", logValues...)
 	return turn.NewServer(serverConfig)
+}
+
+// newTURNTCPListener returns the TCP listener for TURN/TLS. The PROXY protocol
+// header, when enabled, is read before TLS so the client address is known to
+// the TLS layer and to TURN regardless of who terminates TLS.
+func newTURNTCPListener(turnConf config.TURNConfig, address string) (net.Listener, error) {
+	var tlsConfig *tls.Config
+	if !turnConf.ExternalTLS {
+		cert, err := tls.LoadX509KeyPair(turnConf.CertFile, turnConf.KeyFile)
+		if err != nil {
+			return nil, errors.Wrap(err, "TURN tls cert required")
+		}
+		tlsConfig = &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			Certificates: []tls.Certificate{cert},
+		}
+	}
+
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not listen on TURN TCP port")
+	}
+	if turnConf.ProxyProtocol {
+		// the default policy requires the header and rejects connections without it
+		listener = &proxyproto.Listener{Listener: listener}
+	}
+	if tlsConfig != nil {
+		listener = tls.NewListener(listener, tlsConfig)
+	}
+	return listener, nil
 }
 
 func getTURNAuthHandlerFunc(handler *TURNAuthHandler) turn.AuthHandler {

--- a/pkg/service/turn.go
+++ b/pkg/service/turn.go
@@ -221,18 +221,47 @@ func newTURNTCPListener(turnConf config.TURNConfig, address string) (net.Listene
 		}
 	}
 
+	var proxyPolicy proxyproto.ConnPolicyFunc
+	if turnConf.ProxyProtocol {
+		trusted, err := parsePeerCIDRs("turn.proxy_protocol_trusted_cidrs", turnConf.ProxyProtocolTrustedCIDRs)
+		if err != nil {
+			return nil, err
+		}
+		if len(trusted) == 0 {
+			return nil, errors.New("turn.proxy_protocol requires at least one entry in turn.proxy_protocol_trusted_cidrs")
+		}
+		proxyPolicy = proxyProtocolPolicy(trusted)
+	}
+
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not listen on TURN TCP port")
 	}
-	if turnConf.ProxyProtocol {
-		// the default policy requires the header and rejects connections without it
-		listener = &proxyproto.Listener{Listener: listener}
+	if proxyPolicy != nil {
+		listener = &proxyproto.Listener{Listener: listener, ConnPolicy: proxyPolicy}
 	}
 	if tlsConfig != nil {
 		listener = tls.NewListener(listener, tlsConfig)
 	}
 	return listener, nil
+}
+
+// proxyProtocolPolicy requires the PROXY header from trusted proxies and closes
+// every other connection, so the header cannot be forged by a direct client.
+func proxyProtocolPolicy(trusted []*net.IPNet) proxyproto.ConnPolicyFunc {
+	return func(opts proxyproto.ConnPolicyOptions) (proxyproto.Policy, error) {
+		tcpAddr, ok := opts.Upstream.(*net.TCPAddr)
+		if !ok {
+			return proxyproto.REJECT, fmt.Errorf("%w: unexpected address %v", proxyproto.ErrInvalidUpstream, opts.Upstream)
+		}
+		for _, ipnet := range trusted {
+			if ipnet.Contains(tcpAddr.IP) {
+				return proxyproto.REQUIRE, nil
+			}
+		}
+		// wrapping ErrInvalidUpstream closes this connection and keeps the listener accepting
+		return proxyproto.REJECT, fmt.Errorf("%w: %s is not a trusted proxy", proxyproto.ErrInvalidUpstream, tcpAddr.IP)
+	}
 }
 
 func getTURNAuthHandlerFunc(handler *TURNAuthHandler) turn.AuthHandler {

--- a/pkg/service/turn_test.go
+++ b/pkg/service/turn_test.go
@@ -279,8 +279,12 @@ func TestTURNAuthHandler_CreateUsername_TTLClamped(t *testing.T) {
 	require.InDelta(t, time.Now().Unix()+int64(config.DefaultTURNTTLSeconds), negativeExpiry, 2)
 }
 
+func proxyProtocolTURNConfig(trustedCIDRs ...string) config.TURNConfig {
+	return config.TURNConfig{ExternalTLS: true, ProxyProtocol: true, ProxyProtocolTrustedCIDRs: trustedCIDRs}
+}
+
 func TestNewTURNTCPListener_ProxyProtocol(t *testing.T) {
-	listener, err := newTURNTCPListener(config.TURNConfig{ExternalTLS: true, ProxyProtocol: true}, "127.0.0.1:0")
+	listener, err := newTURNTCPListener(proxyProtocolTURNConfig("127.0.0.0/8"), "127.0.0.1:0")
 	require.NoError(t, err)
 	defer listener.Close()
 
@@ -314,7 +318,7 @@ func TestNewTURNTCPListener_ProxyProtocol(t *testing.T) {
 }
 
 func TestNewTURNTCPListener_ProxyProtocolRejectsBareConnection(t *testing.T) {
-	listener, err := newTURNTCPListener(config.TURNConfig{ExternalTLS: true, ProxyProtocol: true}, "127.0.0.1:0")
+	listener, err := newTURNTCPListener(proxyProtocolTURNConfig("127.0.0.0/8"), "127.0.0.1:0")
 	require.NoError(t, err)
 	defer listener.Close()
 
@@ -372,4 +376,41 @@ func TestNewTURNTCPListener_WithoutProxyProtocol(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for the accepted connection")
 	}
+}
+
+func TestNewTURNTCPListener_ProxyProtocolClosesUntrustedProxy(t *testing.T) {
+	listener, err := newTURNTCPListener(proxyProtocolTURNConfig("203.0.113.0/24"), "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	accepted := make(chan struct{}, 1)
+	go func() {
+		if conn, err := listener.Accept(); err == nil {
+			conn.Close()
+			accepted <- struct{}{}
+		}
+	}()
+
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+	_, _ = conn.Write([]byte("PROXY TCP4 203.0.113.9 127.0.0.1 40123 443\r\nx"))
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	_, err = conn.Read(make([]byte, 1))
+	require.Error(t, err, "the listener should have closed the connection")
+
+	select {
+	case <-accepted:
+		t.Fatal("connection from an untrusted proxy must not be accepted")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestNewTURNTCPListener_ProxyProtocolRequiresTrustedCIDRs(t *testing.T) {
+	_, err := newTURNTCPListener(proxyProtocolTURNConfig(), "127.0.0.1:0")
+	require.Error(t, err)
+
+	_, err = newTURNTCPListener(proxyProtocolTURNConfig("not-a-cidr"), "127.0.0.1:0")
+	require.Error(t, err)
 }

--- a/pkg/service/turn_test.go
+++ b/pkg/service/turn_test.go
@@ -278,3 +278,98 @@ func TestTURNAuthHandler_CreateUsername_TTLClamped(t *testing.T) {
 	_, negativeExpiry := h.CreateUsername(turnTestAPIKey, pID, -1<<40)
 	require.InDelta(t, time.Now().Unix()+int64(config.DefaultTURNTTLSeconds), negativeExpiry, 2)
 }
+
+func TestNewTURNTCPListener_ProxyProtocol(t *testing.T) {
+	listener, err := newTURNTCPListener(config.TURNConfig{ExternalTLS: true, ProxyProtocol: true}, "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	accepted := make(chan net.Addr, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			accepted <- nil
+			return
+		}
+		defer conn.Close()
+		// the PROXY header is consumed lazily, on the first read
+		buf := make([]byte, 1)
+		_, _ = conn.Read(buf)
+		accepted <- conn.RemoteAddr()
+	}()
+
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.Write([]byte("PROXY TCP4 203.0.113.9 127.0.0.1 40123 443\r\nx"))
+	require.NoError(t, err)
+
+	select {
+	case addr := <-accepted:
+		require.NotNil(t, addr)
+		require.Equal(t, "203.0.113.9:40123", addr.String())
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the accepted connection")
+	}
+}
+
+func TestNewTURNTCPListener_ProxyProtocolRejectsBareConnection(t *testing.T) {
+	listener, err := newTURNTCPListener(config.TURNConfig{ExternalTLS: true, ProxyProtocol: true}, "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	result := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			result <- err
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, 1)
+		_, err = conn.Read(buf)
+		result <- err
+	}()
+
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.Write([]byte("not a proxy header\r\n"))
+	require.NoError(t, err)
+
+	select {
+	case err := <-result:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the rejected connection")
+	}
+}
+
+func TestNewTURNTCPListener_WithoutProxyProtocol(t *testing.T) {
+	listener, err := newTURNTCPListener(config.TURNConfig{ExternalTLS: true}, "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	accepted := make(chan net.Addr, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			accepted <- nil
+			return
+		}
+		defer conn.Close()
+		accepted <- conn.RemoteAddr()
+	}()
+
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	select {
+	case addr := <-accepted:
+		require.NotNil(t, addr)
+		require.Equal(t, conn.LocalAddr().String(), addr.String())
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the accepted connection")
+	}
+}


### PR DESCRIPTION
Closes #4851.

## What

Adds `turn.proxy_protocol`. When set, the embedded TURN server's TCP listener requires a PROXY protocol v1/v2 header on every connection and uses the client address it carries. The header is only accepted from proxies listed in `turn.proxy_protocol_trusted_cidrs` (default: loopback); connections from any other address are closed before the header is read, so a direct client cannot forge a source address, and connections from a trusted proxy without the header are rejected.

The header is read before TLS, so it works both with the built-in TLS listener and with `external_tls: true`.

## Why

Behind a TLS-terminating or reverse proxy that dials from its own address, TURN reports that address to the client as `XOR-MAPPED-ADDRESS`. Firefox rejects a loopback or wildcard mapped address (`XOR-MAPPED-ADDRESS is bogus` in nICEr) and abandons the allocation, so relay-only Firefox clients never get a relay candidate. #4542 establishes that TURN behind a load balancer is the intended deployment; this makes the non-transparent flavour of it work. Details and `about:webrtc` excerpt in #4851.

## Notes

- New dependency: `github.com/pires/go-proxyproto` v0.15.0.
- The listener setup moved into `newTURNTCPListener` so it can be unit tested. Behaviour without the option is unchanged; the cert is still loaded before the port is bound.
- Tests cover the header being applied, a bare connection being rejected when the option is on, an untrusted peer being closed, the trusted-CIDR validation, and the unchanged path when it is off.
- The v1 text header must arrive in one read (go-proxyproto aborts on a partial v1 header by design, following the spec's sender requirement); the sample config recommends v2 on the proxy side.
- Not yet exercised on a real deployment: our production setup (Caddy layer4 terminating TLS on 443, `external_tls: true`) currently runs the dial-via-public-IP workaround from #4851. I can switch it to `proxy_protocol v2` against a build of this branch and report back if that helps.


