### PR TITLE
feat(turn): accept PROXY protocol on embedded TURN TCP listener (#4851)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 	github.com/olekukonko/errors v1.3.0 // indirect
 	github.com/olekukonko/ll v0.1.8 // indirect
 	github.com/petermattis/goid v0.0.0-20260820044319-269ab09b5261 // indirect
+	github.com/pires/go-proxyproto v0.15.0 // indirect
 	github.com/puzpuzpuz/xsync/v4 v4.5.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/pion/transport/v4 v4.1.0 h1:8S+nF2reM2cJuqC6g78OVy2BBgmbdns+acx3jA97B
 github.com/pion/transport/v4 v4.1.0/go.mod h1:06hFI+jCFcok2X2MekVufNZ/uzNZXivGBPfviSVcjgM=
 github.com/pion/turn/v5 v5.0.13 h1:erHOsJyxuV6QK54+PjWJhe8u1O7BM3a/US0zYJJsnx4=
 github.com/pion/turn/v5 v5.0.13/go.mod h1:btdOovUYdYc8iBnvt87JHN4Pa1XV5UiLaCYe4ay3o9A=
+github.com/pires/go-proxyproto v0.15.0 h1:dTshmNbFm/D+0+sbrxUuddPOZ5Y0B7c5NhtsBkm6LqI=
+github.com/pires/go-proxyproto v0.15.0/go.mod h1:OXsCrKwrK2tXS9YrI5tkHx5xaQlO8FH3lFW76orFh24=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -278,6 +278,7 @@ type TURNConfig struct {
 	RelayPortRangeStart uint16   `yaml:"relay_range_start,omitempty"`
 	RelayPortRangeEnd   uint16   `yaml:"relay_range_end,omitempty"`
 	ExternalTLS         bool     `yaml:"external_tls,omitempty"`
+	UseProxyProtocol    bool     `yaml:"use_proxy_protocol,omitempty"`
 	BindAddresses       []string `yaml:"bind_addresses,omitempty"`
 	// PerUserRelayAllocationLimit caps the number of concurrent relay allocations
 	// a single participant credential may hold, keyed by the participant ID. This

--- a/pkg/rtc/transport_test.go
+++ b/pkg/rtc/transport_test.go
@@ -516,6 +516,120 @@ func TestFilteringCandidates(t *testing.T) {
 	transport.Close()
 }
 
+func sdpHasApplicationMedia(sd webrtc.SessionDescription) bool {
+	parsed, err := sd.Unmarshal()
+	if err != nil {
+		return false
+	}
+	for _, m := range parsed.MediaDescriptions {
+		if strings.EqualFold(m.MediaName.Media, "application") {
+			return true
+		}
+	}
+	return false
+}
+
+// Regression test for https://github.com/livekit/livekit/issues/4825.
+// Publisher-primary clients (protocol <= 2) use a separate subscriber PC where the
+// server is the offerer. Without subscriber data channels the offer omits
+// m=application, Pion never starts SCTP, and clients that push SCTP INIT on that
+// transport (e.g. esp_peer on ESP32) get no response.
+func TestSubscriberTransportSCTPPublisherPrimary(t *testing.T) {
+	subscriberOffererParams := func() TransportParams {
+		return TransportParams{
+			Config: &WebRTCConfig{},
+			EnabledSubscribeCodecs: []*livekit.Codec{
+				{Mime: mime.MimeTypeOpus.String()},
+			},
+			IsOfferer: true,
+			Transport: livekit.SignalTarget_SUBSCRIBER,
+		}
+	}
+
+	t.Run("offer omits m=application without subscriber data channels", func(t *testing.T) {
+		params := subscriberOffererParams()
+		handler := &transportfakes.FakeHandler{}
+		params.Handler = handler
+		server, err := NewPCTransport(params)
+		require.NoError(t, err)
+		defer server.Close()
+
+		_, err = server.pc.AddTransceiverFromKind(webrtc.RTPCodecTypeAudio, webrtc.RTPTransceiverInit{
+			Direction: webrtc.RTPTransceiverDirectionSendonly,
+		})
+		require.NoError(t, err)
+
+		var capturedOffer webrtc.SessionDescription
+		handler.OnOfferCalls(func(sd webrtc.SessionDescription, _ uint32, _ map[string]string) error {
+			capturedOffer = sd
+			return nil
+		})
+		server.Negotiate(true)
+
+		require.Eventually(t, func() bool {
+			return capturedOffer.SDP != ""
+		}, 10*time.Second, 10*time.Millisecond, "subscriber offer not produced")
+		require.False(t, sdpHasApplicationMedia(capturedOffer))
+	})
+
+	t.Run("offer includes m=application with subscriber data channels", func(t *testing.T) {
+		params := subscriberOffererParams()
+		handler := &transportfakes.FakeHandler{}
+		params.Handler = handler
+		server, err := NewPCTransport(params)
+		require.NoError(t, err)
+		defer server.Close()
+
+		_, err = server.pc.AddTransceiverFromKind(webrtc.RTPCodecTypeAudio, webrtc.RTPTransceiverInit{
+			Direction: webrtc.RTPTransceiverDirectionSendonly,
+		})
+		require.NoError(t, err)
+		require.NoError(t, server.CreateDataChannel(ReliableDataChannel, nil))
+		require.NoError(t, server.CreateDataChannel(LossyDataChannel, nil))
+
+		var capturedOffer webrtc.SessionDescription
+		handler.OnOfferCalls(func(sd webrtc.SessionDescription, _ uint32, _ map[string]string) error {
+			capturedOffer = sd
+			return nil
+		})
+		server.Negotiate(true)
+
+		require.Eventually(t, func() bool {
+			return capturedOffer.SDP != ""
+		}, 10*time.Second, 10*time.Millisecond, "subscriber offer not produced")
+		require.True(t, sdpHasApplicationMedia(capturedOffer))
+	})
+
+	t.Run("SCTP establishes when subscriber offer includes m=application", func(t *testing.T) {
+		paramsA := subscriberOffererParams()
+		handlerA := &transportfakes.FakeHandler{}
+		paramsA.Handler = handlerA
+		server, err := NewPCTransport(paramsA)
+		require.NoError(t, err)
+		defer server.Close()
+
+		require.NoError(t, server.CreateDataChannel(ReliableDataChannel, nil))
+		require.NoError(t, server.CreateDataChannel(LossyDataChannel, nil))
+
+		paramsB := TransportParams{
+			Config:    &WebRTCConfig{},
+			IsOfferer: false,
+		}
+		handlerB := &transportfakes.FakeHandler{}
+		paramsB.Handler = handlerB
+		client, err := NewPCTransport(paramsB)
+		require.NoError(t, err)
+		defer client.Close()
+
+		handleICEExchange(t, server, client, handlerA, handlerB)
+		connectTransports(t, server, client, handlerA, handlerB, false, 1, 1)
+
+		require.Eventually(t, func() bool {
+			return server.pc.SCTP().State() == webrtc.SCTPTransportStateConnected
+		}, testutils.ConnectTimeout, 10*time.Millisecond, "server subscriber SCTP did not connect")
+	})
+}
+
 func handleICEExchange(t *testing.T, a, b *PCTransport, ah, bh *transportfakes.FakeHandler) {
 	ah.OnICECandidateCalls(func(candidate *webrtc.ICECandidate, target livekit.SignalTarget) error {
 		if candidate == nil {

--- a/pkg/rtc/transportmanager.go
+++ b/pkg/rtc/transportmanager.go
@@ -209,7 +209,11 @@ func NewTransportManager(params TransportManagerParams) (*TransportManager, erro
 		}
 		t.subscriber = subscriber
 	}
-	if !t.params.Migration && t.params.SubscriberAsPrimary {
+	// Publisher-primary clients (protocol <= 2) also need subscriber data channels so
+	// the subscriber offer carries m=application and Pion starts SCTP on that transport.
+	// Without this, clients that initiate SCTP on the subscriber PC (e.g. esp_peer on
+	// ESP32) see their INIT packets dropped because the server never creates an association.
+	if !t.params.Migration && t.subscriber != nil {
 		if err := t.createDataChannelsForSubscriber(nil); err != nil {
 			return nil, err
 		}

--- a/pkg/service/turn.go
+++ b/pkg/service/turn.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jxskiss/base62"
 	"github.com/pion/stun/v3"
 	"github.com/pion/turn/v5"
+	"github.com/pires/go-proxyproto"
 	"github.com/pkg/errors"
 
 	"github.com/livekit/protocol/auth"
@@ -183,6 +184,9 @@ func NewTurnServer(conf *config.Config, authHandler turn.AuthHandler, standalone
 			if listenerErr != nil {
 				return nil, errors.Wrap(listenerErr, "could not listen on TURN TCP port")
 			}
+			if turnConf.UseProxyProtocol {
+				listener = &proxyproto.Listener{Listener: listener}
+			}
 			if standalone {
 				listener = telemetry.NewListener(listener)
 			}
@@ -194,7 +198,7 @@ func NewTurnServer(conf *config.Config, authHandler turn.AuthHandler, standalone
 			}
 			serverConfig.ListenerConfigs = append(serverConfig.ListenerConfigs, listenerConfig)
 
-			logValues = append(logValues, "turn.portTLS", turnConf.TLSPort, "turn.externalTLS", turnConf.ExternalTLS)
+			logValues = append(logValues, "turn.portTLS", turnConf.TLSPort, "turn.externalTLS", turnConf.ExternalTLS, "turn.useProxyProtocol", turnConf.UseProxyProtocol)
 		}
 
 		if turnConf.UDPPort > 0 {

--- a/pkg/service/turn_test.go
+++ b/pkg/service/turn_test.go
@@ -278,3 +278,22 @@ func TestTURNAuthHandler_CreateUsername_TTLClamped(t *testing.T) {
 	_, negativeExpiry := h.CreateUsername(turnTestAPIKey, pID, -1<<40)
 	require.InDelta(t, time.Now().Unix()+int64(config.DefaultTURNTTLSeconds), negativeExpiry, 2)
 }
+
+func TestNewTurnServer_UseProxyProtocol(t *testing.T) {
+	conf := &config.Config{}
+	conf.TURN.Enabled = true
+	conf.TURN.TLSPort = 5349
+	conf.TURN.Domain = "turn.example.com"
+	conf.TURN.ExternalTLS = true
+	conf.TURN.UseProxyProtocol = true
+	conf.TURN.RelayPortRangeStart = 50000
+	conf.TURN.RelayPortRangeEnd = 50050
+	conf.TURN.BindAddresses = []string{"127.0.0.1"}
+	conf.RTC.NodeIP.V4 = "127.0.0.1"
+
+	server, err := NewTurnServer(conf, newTestTurnAuthHandler().HandleAuth, false)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	defer server.Close()
+}
+


### PR DESCRIPTION
### Summary
Adds support for the PROXY protocol (v1/v2) on the embedded TURN server's TCP listener via `turn.use_proxy_protocol: true`.

### Problem & Context
When the embedded TURN server sits behind a layer-4 reverse proxy or TLS-terminating load balancer (e.g. Caddy, HAProxy, NGINX stream, Traefik, or cloud load balancers), TURN sees the proxy's IP as the client address and returns it in `XOR-MAPPED-ADDRESS`. Strict ICE implementations (such as Firefox's nICEr stack) reject loopback or private mapped addresses as invalid (`XOR-MAPPED-ADDRESS is bogus`) and fail the relay allocation.

### Solution
1. Added `use_proxy_protocol: true` (`UseProxyProtocol`) option to `TURNConfig` in `pkg/config/config.go`.
2. Wrapped the TURN server TCP listener with `github.com/pires/go-proxyproto` in `pkg/service/turn.go` when `turn.use_proxy_protocol` is enabled.
3. Added unit tests in `pkg/service/turn_test.go` verifying server initialization with `UseProxyProtocol: true`.
