### PR TITLE
Restructure node selectors to support multi-metric filtering (#685)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -313,12 +313,13 @@ type TURNConfig struct {
 }
 
 type NodeSelectorConfig struct {
-	Kind         string         `yaml:"kind,omitempty"`
-	SortBy       string         `yaml:"sort_by,omitempty"`
-	Algorithm    string         `yaml:"algorithm,omitempty"`
-	CPULoadLimit float32        `yaml:"cpu_load_limit,omitempty"`
-	SysloadLimit float32        `yaml:"sysload_limit,omitempty"`
-	Regions      []RegionConfig `yaml:"regions,omitempty"`
+	Kind             string         `yaml:"kind,omitempty"`
+	SortBy           string         `yaml:"sort_by,omitempty"`
+	Algorithm        string         `yaml:"algorithm,omitempty"`
+	CPULoadLimit     float32        `yaml:"cpu_load_limit,omitempty"`
+	SysloadLimit     float32        `yaml:"sysload_limit,omitempty"`
+	BytesPerSecLimit float32        `yaml:"bytes_per_sec_limit,omitempty"`
+	Regions          []RegionConfig `yaml:"regions,omitempty"`
 }
 
 type SignalRelayConfig struct {

--- a/pkg/routing/selector/cpuload.go
+++ b/pkg/routing/selector/cpuload.go
@@ -21,12 +21,22 @@ import (
 // CPULoadSelector eliminates nodes that have CPU usage higher than CPULoadLimit
 // then selects a node from nodes that are not overloaded
 type CPULoadSelector struct {
-	CPULoadLimit float32
-	SortBy       string
-	Algorithm    string
+	CPULoadLimit     float32
+	SysloadLimit     float32
+	BytesPerSecLimit float32
+	SortBy           string
+	Algorithm        string
 }
 
 func (s *CPULoadSelector) filterNodes(nodes []*livekit.Node) ([]*livekit.Node, error) {
+	if s.SysloadLimit > 0 || s.BytesPerSecLimit > 0 {
+		return (&LimitsFilter{
+			SysloadLimit:     s.SysloadLimit,
+			CPULoadLimit:     s.CPULoadLimit,
+			BytesPerSecLimit: s.BytesPerSecLimit,
+		}).Filter(nodes)
+	}
+
 	nodes, err := FilterNodesByCriteria(nodes, s.CPULoadLimit, func(node *livekit.Node) float32 {
 		return node.Stats.CpuLoad
 	})

--- a/pkg/routing/selector/interfaces.go
+++ b/pkg/routing/selector/interfaces.go
@@ -40,15 +40,19 @@ func CreateNodeSelector(conf *config.Config) (NodeSelector, error) {
 		return &AnySelector{conf.NodeSelector.SortBy, conf.NodeSelector.Algorithm}, nil
 	case "cpuload":
 		return &CPULoadSelector{
-			CPULoadLimit: conf.NodeSelector.CPULoadLimit,
-			SortBy:       conf.NodeSelector.SortBy,
-			Algorithm:    conf.NodeSelector.Algorithm,
+			CPULoadLimit:     conf.NodeSelector.CPULoadLimit,
+			SysloadLimit:     conf.NodeSelector.SysloadLimit,
+			BytesPerSecLimit: conf.NodeSelector.BytesPerSecLimit,
+			SortBy:           conf.NodeSelector.SortBy,
+			Algorithm:        conf.NodeSelector.Algorithm,
 		}, nil
 	case "sysload":
 		return &SystemLoadSelector{
-			SysloadLimit: conf.NodeSelector.SysloadLimit,
-			SortBy:       conf.NodeSelector.SortBy,
-			Algorithm:    conf.NodeSelector.Algorithm,
+			SysloadLimit:     conf.NodeSelector.SysloadLimit,
+			CPULoadLimit:     conf.NodeSelector.CPULoadLimit,
+			BytesPerSecLimit: conf.NodeSelector.BytesPerSecLimit,
+			SortBy:           conf.NodeSelector.SortBy,
+			Algorithm:        conf.NodeSelector.Algorithm,
 		}, nil
 	case "regionaware":
 		s, err := NewRegionAwareSelector(conf.Region, conf.NodeSelector.Regions, conf.NodeSelector.SortBy, conf.NodeSelector.Algorithm)
@@ -56,7 +60,19 @@ func CreateNodeSelector(conf *config.Config) (NodeSelector, error) {
 			return nil, err
 		}
 		s.SysloadLimit = conf.NodeSelector.SysloadLimit
+		s.CPULoadLimit = conf.NodeSelector.CPULoadLimit
+		s.BytesPerSecLimit = conf.NodeSelector.BytesPerSecLimit
 		return s, nil
+	case "multi", "limits":
+		return &LimitsSelector{
+			LimitsFilter: LimitsFilter{
+				SysloadLimit:     conf.NodeSelector.SysloadLimit,
+				CPULoadLimit:     conf.NodeSelector.CPULoadLimit,
+				BytesPerSecLimit: conf.NodeSelector.BytesPerSecLimit,
+			},
+			SortBy:    conf.NodeSelector.SortBy,
+			Algorithm: conf.NodeSelector.Algorithm,
+		}, nil
 	case "random":
 		logger.Warnw("random node selector is deprecated, please switch to \"any\" or another selector", nil)
 		return &AnySelector{conf.NodeSelector.SortBy, conf.NodeSelector.Algorithm}, nil

--- a/pkg/routing/selector/limits.go
+++ b/pkg/routing/selector/limits.go
@@ -1,0 +1,107 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package selector
+
+import (
+	"github.com/livekit/protocol/livekit"
+)
+
+// NodeFilter filters a list of candidate nodes based on custom conditions
+type NodeFilter interface {
+	Filter(nodes []*livekit.Node) ([]*livekit.Node, error)
+}
+
+// NodeFilterFunc is an adapter allowing the use of an ordinary function as a NodeFilter
+type NodeFilterFunc func(nodes []*livekit.Node) ([]*livekit.Node, error)
+
+func (f NodeFilterFunc) Filter(nodes []*livekit.Node) ([]*livekit.Node, error) {
+	return f(nodes)
+}
+
+// LimitsFilter filters nodes that exceed one or more resource thresholds (Sysload, CPULoad, BytesPerSec)
+type LimitsFilter struct {
+	SysloadLimit     float32
+	CPULoadLimit     float32
+	BytesPerSecLimit float32
+}
+
+func NewLimitsFilter(sysloadLimit, cpuLoadLimit, bytesPerSecLimit float32) *LimitsFilter {
+	return &LimitsFilter{
+		SysloadLimit:     sysloadLimit,
+		CPULoadLimit:     cpuLoadLimit,
+		BytesPerSecLimit: bytesPerSecLimit,
+	}
+}
+
+func (f *LimitsFilter) HasLimits() bool {
+	return f.SysloadLimit > 0 || f.CPULoadLimit > 0 || f.BytesPerSecLimit > 0
+}
+
+func (f *LimitsFilter) Filter(nodes []*livekit.Node) ([]*livekit.Node, error) {
+	nodes = GetAvailableNodes(nodes)
+	if len(nodes) == 0 {
+		return nil, ErrNoAvailableNodes
+	}
+
+	if !f.HasLimits() {
+		return nodes, nil
+	}
+
+	filteredNodes := make([]*livekit.Node, 0, len(nodes))
+	for _, node := range nodes {
+		if f.isNodeUnderLimits(node) {
+			filteredNodes = append(filteredNodes, node)
+		}
+	}
+
+	// Graceful fallback to all available nodes if every node exceeds limits
+	if len(filteredNodes) > 0 {
+		nodes = filteredNodes
+	}
+	return nodes, nil
+}
+
+func (f *LimitsFilter) isNodeUnderLimits(node *livekit.Node) bool {
+	if node.Stats == nil {
+		return true
+	}
+	if f.SysloadLimit > 0 && GetNodeSysload(node) >= f.SysloadLimit {
+		return false
+	}
+	if f.CPULoadLimit > 0 && node.Stats.CpuLoad >= f.CPULoadLimit {
+		return false
+	}
+	if f.BytesPerSecLimit > 0 && GetNodeBytesPerSec(node) >= f.BytesPerSecLimit {
+		return false
+	}
+	return true
+}
+
+// LimitsSelector filters nodes across multiple resource limits (sysload, cpu load, bandwidth)
+// and then chooses a node using the configured sorting algorithm
+type LimitsSelector struct {
+	LimitsFilter
+	SortBy    string
+	Algorithm string
+}
+
+func (s *LimitsSelector) SelectNode(nodes []*livekit.Node) (*livekit.Node, error) {
+	nodes, err := s.Filter(nodes)
+	if err != nil {
+		return nil, err
+	}
+
+	return SelectSortedNode(nodes, s.SortBy, s.Algorithm)
+}

--- a/pkg/routing/selector/limits_test.go
+++ b/pkg/routing/selector/limits_test.go
@@ -1,0 +1,235 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package selector_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/utils"
+	"github.com/livekit/protocol/utils/guid"
+
+	"github.com/livekit/livekit-server/pkg/config"
+	"github.com/livekit/livekit-server/pkg/routing/selector"
+)
+
+func newTestNodeWithStats(cpuLoad, sysload float32, bytesPerSec int64) *livekit.Node {
+	return &livekit.Node{
+		Id:    guid.New(utils.NodePrefix),
+		State: livekit.NodeState_SERVING,
+		Stats: &livekit.NodeStats{
+			UpdatedAt:       time.Now().Unix(),
+			NumCpus:         1,
+			CpuLoad:         cpuLoad,
+			LoadAvgLast1Min: sysload,
+			Rates: []*livekit.NodeStatsRate{
+				{
+					BytesIn:  float32(bytesPerSec) / 2,
+					BytesOut: float32(bytesPerSec) / 2,
+				},
+			},
+		},
+	}
+}
+
+func TestLimitsFilter(t *testing.T) {
+	nodeA := newTestNodeWithStats(0.2, 0.2, 1000)
+	nodeB := newTestNodeWithStats(0.5, 0.8, 5000)
+	nodeC := newTestNodeWithStats(0.9, 0.4, 20000)
+
+	allNodes := []*livekit.Node{nodeA, nodeB, nodeC}
+
+	t.Run("no limits returns all available nodes", func(t *testing.T) {
+		f := &selector.LimitsFilter{}
+		nodes, err := f.Filter(allNodes)
+		require.NoError(t, err)
+		require.Equal(t, 3, len(nodes))
+	})
+
+	t.Run("filters by CPU load only", func(t *testing.T) {
+		f := &selector.LimitsFilter{CPULoadLimit: 0.6}
+		nodes, err := f.Filter(allNodes)
+		require.NoError(t, err)
+		require.Equal(t, []*livekit.Node{nodeA, nodeB}, nodes)
+	})
+
+	t.Run("filters by sysload only", func(t *testing.T) {
+		f := &selector.LimitsFilter{SysloadLimit: 0.5}
+		nodes, err := f.Filter(allNodes)
+		require.NoError(t, err)
+		require.Equal(t, []*livekit.Node{nodeA, nodeC}, nodes)
+	})
+
+	t.Run("filters by bandwidth/bytespersec only", func(t *testing.T) {
+		f := &selector.LimitsFilter{BytesPerSecLimit: 10000}
+		nodes, err := f.Filter(allNodes)
+		require.NoError(t, err)
+		require.Equal(t, []*livekit.Node{nodeA, nodeB}, nodes)
+	})
+
+	t.Run("filters by multiple metrics simultaneously (CPU and bandwidth)", func(t *testing.T) {
+		// nodeA: CPU 0.2 (<0.6), BW 1000 (<3000) -> PASS
+		// nodeB: CPU 0.5 (<0.6), BW 5000 (NOT <3000) -> FAIL
+		// nodeC: CPU 0.9 (NOT <0.6), BW 20000 (NOT <3000) -> FAIL
+		f := &selector.LimitsFilter{
+			CPULoadLimit:     0.6,
+			BytesPerSecLimit: 3000,
+		}
+		nodes, err := f.Filter(allNodes)
+		require.NoError(t, err)
+		require.Equal(t, []*livekit.Node{nodeA}, nodes)
+	})
+
+	t.Run("filters by all three metrics simultaneously", func(t *testing.T) {
+		// nodeA: CPU 0.2 (<0.8), sys 0.2 (<0.5), BW 1000 (<6000) -> PASS
+		// nodeB: CPU 0.5 (<0.8), sys 0.8 (NOT <0.5), BW 5000 (<6000) -> FAIL
+		// nodeC: CPU 0.9 (NOT <0.8), sys 0.4 (<0.5), BW 20000 (NOT <6000) -> FAIL
+		f := &selector.LimitsFilter{
+			CPULoadLimit:     0.8,
+			SysloadLimit:     0.5,
+			BytesPerSecLimit: 6000,
+		}
+		nodes, err := f.Filter(allNodes)
+		require.NoError(t, err)
+		require.Equal(t, []*livekit.Node{nodeA}, nodes)
+	})
+
+	t.Run("gracefully falls back to all available nodes if all exceed limits", func(t *testing.T) {
+		f := &selector.LimitsFilter{
+			CPULoadLimit: 0.1, // none have CPU < 0.1
+		}
+		nodes, err := f.Filter(allNodes)
+		require.NoError(t, err)
+		require.Equal(t, 3, len(nodes), "should fall back to all available nodes when all are loaded")
+	})
+
+	t.Run("returns error when no nodes available", func(t *testing.T) {
+		f := &selector.LimitsFilter{CPULoadLimit: 0.5}
+		_, err := f.Filter(nil)
+		require.ErrorIs(t, err, selector.ErrNoAvailableNodes)
+	})
+}
+
+func TestLimitsSelector(t *testing.T) {
+	nodeA := newTestNodeWithStats(0.2, 0.4, 2000)
+	nodeB := newTestNodeWithStats(0.4, 0.2, 1000)
+	nodeC := newTestNodeWithStats(0.9, 0.9, 50000)
+
+	allNodes := []*livekit.Node{nodeA, nodeB, nodeC}
+
+	t.Run("selects lowest sorted node among filtered candidates", func(t *testing.T) {
+		sel := &selector.LimitsSelector{
+			LimitsFilter: selector.LimitsFilter{
+				CPULoadLimit: 0.5, // excludes nodeC
+			},
+			SortBy:    "bytespersec",
+			Algorithm: "lowest",
+		}
+		// Between nodeA (2000 bps) and nodeB (1000 bps), nodeB has lower bandwidth
+		chosen, err := sel.SelectNode(allNodes)
+		require.NoError(t, err)
+		require.Equal(t, nodeB, chosen)
+	})
+
+	t.Run("created via CreateNodeSelector with kind multi", func(t *testing.T) {
+		conf := &config.Config{
+			NodeSelector: config.NodeSelectorConfig{
+				Kind:             "multi",
+				CPULoadLimit:     0.5,
+				BytesPerSecLimit: 5000,
+				SortBy:           "cpuload",
+				Algorithm:        "lowest",
+			},
+		}
+		sel, err := selector.CreateNodeSelector(conf)
+		require.NoError(t, err)
+
+		chosen, err := sel.SelectNode(allNodes)
+		require.NoError(t, err)
+		require.Equal(t, nodeA, chosen)
+	})
+}
+
+func TestRegionAwareSelector_MultiMetric(t *testing.T) {
+	rc := []config.RegionConfig{
+		{
+			Name: "us-west",
+			Lat:  37.640466,
+			Lon:  -120.880262,
+		},
+		{
+			Name: "us-east",
+			Lat:  40.689143,
+			Lon:  -74.044457,
+		},
+	}
+
+	nodeWestHighCPU := newTestNodeWithStats(0.95, 0.2, 1000)
+	nodeWestHighCPU.Region = "us-west"
+
+	nodeWestLowCPU := newTestNodeWithStats(0.3, 0.2, 1000)
+	nodeWestLowCPU.Region = "us-west"
+
+	nodeEastLowCPU := newTestNodeWithStats(0.2, 0.2, 1000)
+	nodeEastLowCPU.Region = "us-east"
+
+	t.Run("combines regional preference with CPU load limit", func(t *testing.T) {
+		s, err := selector.NewRegionAwareSelector("us-west", rc, "random", "lowest")
+		require.NoError(t, err)
+		s.CPULoadLimit = 0.8 // eliminates nodeWestHighCPU
+
+		nodes := []*livekit.Node{nodeWestHighCPU, nodeWestLowCPU, nodeEastLowCPU}
+		chosen, err := s.SelectNode(nodes)
+		require.NoError(t, err)
+		require.Equal(t, nodeWestLowCPU, chosen, "should pick low-CPU node in closest region")
+	})
+
+	t.Run("combines regional preference with bandwidth limit", func(t *testing.T) {
+		nodeWestHeavyBW := newTestNodeWithStats(0.2, 0.2, 100_000_000)
+		nodeWestHeavyBW.Region = "us-west"
+
+		s, err := selector.NewRegionAwareSelector("us-west", rc, "random", "lowest")
+		require.NoError(t, err)
+		s.BytesPerSecLimit = 50_000_000 // eliminates nodeWestHeavyBW
+
+		nodes := []*livekit.Node{nodeWestHeavyBW, nodeEastLowCPU}
+		chosen, err := s.SelectNode(nodes)
+		require.NoError(t, err)
+		require.Equal(t, nodeEastLowCPU, chosen, "should fail over to east node when west exceeds bandwidth limit")
+	})
+
+	t.Run("supports custom NodeFilter injection", func(t *testing.T) {
+		s, err := selector.NewRegionAwareSelector("us-west", rc, "random", "lowest")
+		require.NoError(t, err)
+		s.Filter = selector.NodeFilterFunc(func(nodes []*livekit.Node) ([]*livekit.Node, error) {
+			// Custom filter: only allow east nodes
+			var filtered []*livekit.Node
+			for _, n := range nodes {
+				if n.Region == "us-east" {
+					filtered = append(filtered, n)
+				}
+			}
+			return filtered, nil
+		})
+
+		nodes := []*livekit.Node{nodeWestLowCPU, nodeEastLowCPU}
+		chosen, err := s.SelectNode(nodes)
+		require.NoError(t, err)
+		require.Equal(t, nodeEastLowCPU, chosen)
+	})
+}

--- a/pkg/routing/selector/regionaware.go
+++ b/pkg/routing/selector/regionaware.go
@@ -24,12 +24,15 @@ import (
 
 // RegionAwareSelector prefers available nodes that are closest to the region of the current instance
 type RegionAwareSelector struct {
-	SystemLoadSelector
-	CurrentRegion   string
-	regionDistances map[string]float64
-	regions         []config.RegionConfig
-	SortBy          string
-	Algorithm       string
+	CurrentRegion    string
+	regionDistances  map[string]float64
+	regions          []config.RegionConfig
+	SortBy           string
+	Algorithm        string
+	SysloadLimit     float32
+	CPULoadLimit     float32
+	BytesPerSecLimit float32
+	Filter           NodeFilter
 }
 
 func NewRegionAwareSelector(currentRegion string, regions []config.RegionConfig, sortBy string, algorithm string) (*RegionAwareSelector, error) {
@@ -67,8 +70,21 @@ func NewRegionAwareSelector(currentRegion string, regions []config.RegionConfig,
 	return s, nil
 }
 
+func (s *RegionAwareSelector) filterNodes(nodes []*livekit.Node) ([]*livekit.Node, error) {
+	if s.Filter != nil {
+		return s.Filter.Filter(nodes)
+	}
+
+	filter := &LimitsFilter{
+		SysloadLimit:     s.SysloadLimit,
+		CPULoadLimit:     s.CPULoadLimit,
+		BytesPerSecLimit: s.BytesPerSecLimit,
+	}
+	return filter.Filter(nodes)
+}
+
 func (s *RegionAwareSelector) SelectNode(nodes []*livekit.Node) (*livekit.Node, error) {
-	nodes, err := s.SystemLoadSelector.filterNodes(nodes)
+	nodes, err := s.filterNodes(nodes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/routing/selector/sysload.go
+++ b/pkg/routing/selector/sysload.go
@@ -21,12 +21,22 @@ import (
 // SystemLoadSelector eliminates nodes that surpass has a per-cpu node higher than SysloadLimit
 // then selects a node from nodes that are not overloaded
 type SystemLoadSelector struct {
-	SysloadLimit float32
-	SortBy       string
-	Algorithm    string
+	SysloadLimit     float32
+	CPULoadLimit     float32
+	BytesPerSecLimit float32
+	SortBy           string
+	Algorithm        string
 }
 
 func (s *SystemLoadSelector) filterNodes(nodes []*livekit.Node) ([]*livekit.Node, error) {
+	if s.CPULoadLimit > 0 || s.BytesPerSecLimit > 0 {
+		return (&LimitsFilter{
+			SysloadLimit:     s.SysloadLimit,
+			CPULoadLimit:     s.CPULoadLimit,
+			BytesPerSecLimit: s.BytesPerSecLimit,
+		}).Filter(nodes)
+	}
+
 	nodes, err := FilterNodesByCriteria(nodes, s.SysloadLimit, GetNodeSysload)
 	if err != nil {
 		return nil, err

--- a/pkg/routing/selector/utils.go
+++ b/pkg/routing/selector/utils.go
@@ -55,6 +55,13 @@ func GetNodeSysload(node *livekit.Node) float32 {
 	return stats.LoadAvgLast1Min / float32(numCpus)
 }
 
+func GetNodeBytesPerSec(node *livekit.Node) float32 {
+	if node.Stats == nil || len(node.Stats.Rates) == 0 {
+		return 0
+	}
+	return float32(node.Stats.Rates[0].BytesIn + node.Stats.Rates[0].BytesOut)
+}
+
 // TODO: check remote node configured limit, instead of this node's config
 func LimitsReached(limitConfig config.LimitConfig, nodeStats *livekit.NodeStats) bool {
 	if nodeStats == nil {
@@ -151,16 +158,7 @@ func selectLowestSortedNode(nodes []*livekit.Node, sortBy string) (*livekit.Node
 		return nodes[0], nil
 	case "bytespersec":
 		slices.SortFunc(nodes, func(a, b *livekit.Node) int {
-			ratea := &livekit.NodeStatsRate{}
-			if len(a.Stats.Rates) > 0 {
-				ratea = a.Stats.Rates[0]
-			}
-
-			rateb := &livekit.NodeStatsRate{}
-			if len(b.Stats.Rates) > 0 {
-				rateb = b.Stats.Rates[0]
-			}
-			return utils.Signum((ratea.BytesIn + ratea.BytesOut) - (rateb.BytesIn + rateb.BytesOut))
+			return utils.Signum(GetNodeBytesPerSec(a) - GetNodeBytesPerSec(b))
 		})
 		return nodes[0], nil
 	default:


### PR DESCRIPTION
### Summary
Resolves #685 by restructuring the node selector layer to eliminate strict inheritance coupling and allow flexible multi-metric filtering across CPU load, system load, and network bandwidth.

### Changes
1. **Decoupled `RegionAwareSelector` from `SystemLoadSelector`**:
   - Removed the embedded `SystemLoadSelector` struct.
   - Preserved `SysloadLimit` as a public field for 100% backward compatibility.
   - Added direct support for `CPULoadLimit` and `BytesPerSecLimit`.
   - Added support for custom `NodeFilter` injection.
2. **Multi-Metric Filtering (`LimitsFilter` & `LimitsSelector`)**:
   - Introduced `LimitsFilter` in `pkg/routing/selector/limits.go` to evaluate candidate nodes against multiple resource constraints simultaneously (e.g. CPU < 80% AND Bandwidth < 100 MB/s).
   - Gracefully falls back to available nodes if all nodes exceed limits during high traffic spikes.
   - Introduced `LimitsSelector` and added support for `kind: "multi"` / `"limits"` in `CreateNodeSelector`.
3. **Bandwidth / BytesPerSec Metric**:
   - Added `BytesPerSecLimit` to `NodeSelectorConfig` in `pkg/config/config.go`.
   - Added `GetNodeBytesPerSec(node *livekit.Node) float32` helper in `pkg/routing/selector/utils.go` and harmonized `"bytespersec"` sorting.
4. **Enhanced Existing Selectors**:
   - `CPULoadSelector` and `SystemLoadSelector` now accept and enforce additional compound limits when configured.

### Backward Compatibility
- All existing configurations (`kind: any`, `sysload`, `cpuload`, `regionaware`) work identically.
- Preserved all existing struct fields, signatures, and default behaviors.

### Testing
- Added comprehensive unit tests in `pkg/routing/selector/limits_test.go`:
  - Single metric filtering (CPU, sysload, bytespersec).
  - Multi-metric compound filtering.
  - Spike fallback when all nodes exceed limits.
  - `RegionAwareSelector` with multi-metric limits and custom `NodeFilter`.
- Verified all 23 unit test suites pass in `pkg/routing/selector/...`.