### PR TITLE
telemetry: add visibility into stats worker reference underflow

### DIFF
--- a/pkg/telemetry/statsworker.go
+++ b/pkg/telemetry/statsworker.go
@@ -328,6 +328,10 @@ func (s *StatsWorker) collectStats(
 }
 
 func (s *StatsWorker) MarshalLogObject(e zapcore.ObjectEncoder) error {
+	if s == nil {
+		return nil
+	}
+
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 

--- a/pkg/telemetry/statsworker_test.go
+++ b/pkg/telemetry/statsworker_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestStatsWorker(t *testing.T) {
@@ -59,5 +60,10 @@ func TestStatsWorker(t *testing.T) {
 			require.False(t, superseded.ForceClose(survivor))
 			require.Equal(t, 0, survivor.refCount.count)
 		})
+	})
+
+	t.Run("logging a nil worker does not panic", func(t *testing.T) {
+		var w *StatsWorker
+		require.NoError(t, w.MarshalLogObject(zapcore.NewMapObjectEncoder()))
 	})
 }

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -286,6 +286,16 @@ func (t *telemetryService) getOrCreateWorker(
 	t.workersMu.Lock()
 	defer t.workersMu.Unlock()
 
+	if roomID == "" {
+		logger.Warnw(
+			"telemetry stats worker keyed under an empty room id", nil,
+			"room", roomName,
+			"participant", participantIdentity,
+			"participantID", participantID,
+			"guard", guard,
+		)
+	}
+
 	roomWorkers := t.workers[roomID]
 	worker, ok := roomWorkers[participantID]
 	if ok && !worker.Closed(guard) {
@@ -295,6 +305,21 @@ func (t *telemetryService) getOrCreateWorker(
 	existingIsConnected := false
 	if ok {
 		existingIsConnected = worker.IsConnected()
+	}
+
+	// a guard references at most once, so a nil or already activated guard leaves the
+	// new worker with no references and its owner's release drives it negative
+	if guard == nil || guard.activated {
+		logger.Infow(
+			"telemetry stats worker created without a reference",
+			"room", roomName,
+			"roomID", roomID,
+			"participant", participantIdentity,
+			"participantID", participantID,
+			"guard", guard,
+			"replacedClosed", ok,
+			"existing", worker,
+		)
 	}
 
 	worker = newStatsWorker(
@@ -366,7 +391,17 @@ func (t *telemetryService) reKeyRoom(prevRoomID livekit.RoomID, roomID livekit.R
 				// only one worker can be keyed at (room, participant) and the one already
 				// filed there wins, close the superseded one so that it drains and is
 				// reaped instead of lingering in the flush list unreachable
-				if worker.ForceClose(survivor) {
+				forceClosed := worker.ForceClose(survivor)
+				logger.Infow(
+					"telemetry force closing superseded stats worker",
+					"prevRoomID", prevRoomID,
+					"roomID", roomID,
+					"participantID", participantID,
+					"forceClosed", forceClosed,
+					"superseded", worker,
+					"survivor", survivor,
+				)
+				if forceClosed {
 					prometheus.SubParticipant()
 				}
 				continue


### PR DESCRIPTION
Adds logging to help pin down the `stats worker active` cases seen in production
where the worker's reference count is `-1` and it never closes.

- warn when a stats worker is keyed under an empty room id
- log when a worker is created without a reference, i.e. with a nil or already
  activated guard, along with the worker it replaced
- log both the superseded and surviving worker when a room re-key force closes one

Logging only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)