### PR TITLE
Do not add down tracks after receiver close

### DIFF
--- a/pkg/sfu/receiver_base.go
+++ b/pkg/sfu/receiver_base.go
@@ -197,7 +197,7 @@ func (r *ReceiverBase) Close(reason string, clearBuffers bool) {
 	}
 	r.streamTrackerManager.Close()
 
-	closeTrackSenders(r.downTrackSpreader.ResetAndGetDownTracks())
+	closeTrackSenders(r.downTrackSpreader.CloseAndGetDownTracks())
 
 	if rt := r.loadREDTransformer(); rt != nil {
 		rt.Close()
@@ -491,7 +491,9 @@ func (r *ReceiverBase) AddDownTrack(track TrackSender) error {
 	track.UpTrackMaxPublishedLayerChange(r.streamTrackerManager.GetMaxPublishedLayer())
 	track.UpTrackMaxTemporalLayerSeenChange(r.streamTrackerManager.GetMaxTemporalLayerSeen())
 
-	r.downTrackSpreader.Store(track)
+	if !r.downTrackSpreader.TryStore(track) {
+		return ErrReceiverClosed
+	}
 	r.params.Logger.Debugw("downtrack added", "subscriberID", track.SubscriberID())
 	return nil
 }

--- a/pkg/sfu/receiver_close_race_test.go
+++ b/pkg/sfu/receiver_close_race_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sfu_test
+
+import (
+	"testing"
+
+	"github.com/pion/webrtc/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/livekit-server/pkg/sfu"
+	"github.com/livekit/livekit-server/pkg/sfu/sfufakes"
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/logger"
+)
+
+func TestReceiverBaseAddDownTrackReturnsClosedWhenCloseWinsRace(t *testing.T) {
+	receiver := sfu.NewReceiverBase(
+		sfu.ReceiverBaseParams{
+			TrackID:  "track",
+			StreamID: "stream",
+			Kind:     webrtc.RTPCodecTypeAudio,
+			Codec: webrtc.RTPCodecParameters{
+				RTPCodecCapability: webrtc.RTPCodecCapability{
+					MimeType:  webrtc.MimeTypeOpus,
+					ClockRate: 48000,
+					Channels:  2,
+				},
+				PayloadType: 111,
+			},
+			Logger: logger.GetLogger(),
+		},
+		&livekit.TrackInfo{
+			Sid:    "track",
+			Type:   livekit.TrackType_AUDIO,
+			Source: livekit.TrackSource_MICROPHONE,
+		},
+		sfu.ReceiverCodecStateNormal,
+	)
+
+	track := &sfufakes.FakeTrackSender{}
+	track.SubscriberIDReturns("subscriber")
+
+	enteredAdd := make(chan struct{})
+	resumeAdd := make(chan struct{})
+	track.UpTrackMaxPublishedLayerChangeCalls(func(int32) {
+		close(enteredAdd)
+		<-resumeAdd
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- receiver.AddDownTrack(track)
+	}()
+
+	// AddDownTrack has already passed its initial IsClosed check and is now
+	// paused immediately before the eventual Store.
+	<-enteredAdd
+
+	// Close terminally drains/closes the spreader before AddDownTrack resumes.
+	receiver.Close("test", false)
+	close(resumeAdd)
+
+	err := <-errCh
+	require.ErrorIs(t, err, sfu.ErrReceiverClosed)
+	require.True(t, receiver.IsClosed())
+	require.Empty(t, receiver.GetDownTracks())
+}

--- a/pkg/sfu/redprimaryreceiver.go
+++ b/pkg/sfu/redprimaryreceiver.go
@@ -155,7 +155,9 @@ func (r *RedPrimaryReceiver) AddDownTrack(track TrackSender) error {
 		r.logger.Infow("subscriberID already exists, replacing downtrack", "subscriberID", track.SubscriberID())
 	}
 
-	r.downTrackSpreader.Store(track)
+	if !r.downTrackSpreader.TryStore(track) {
+		return ErrReceiverClosed
+	}
 	r.logger.Debugw("red primary receiver downtrack added", "subscriberID", track.SubscriberID())
 	return nil
 }
@@ -195,7 +197,7 @@ func (r *RedPrimaryReceiver) CanClose() bool {
 
 func (r *RedPrimaryReceiver) Close() {
 	r.closed.Store(true)
-	closeTrackSenders(r.downTrackSpreader.ResetAndGetDownTracks())
+	closeTrackSenders(r.downTrackSpreader.CloseAndGetDownTracks())
 }
 
 func (r *RedPrimaryReceiver) ReadRTP(buf []byte, layer uint8, esn uint64) (int, error) {

--- a/pkg/sfu/redreceiver.go
+++ b/pkg/sfu/redreceiver.go
@@ -120,7 +120,9 @@ func (r *RedReceiver) AddDownTrack(track TrackSender) error {
 		r.logger.Infow("subscriberID already exists, replacing downtrack", "subscriberID", track.SubscriberID())
 	}
 
-	r.downTrackSpreader.Store(track)
+	if !r.downTrackSpreader.TryStore(track) {
+		return ErrReceiverClosed
+	}
 	r.logger.Debugw("red receiver downtrack added", "subscriberID", track.SubscriberID())
 	return nil
 }
@@ -160,7 +162,7 @@ func (r *RedReceiver) IsClosed() bool {
 
 func (r *RedReceiver) Close() {
 	r.closed.Store(true)
-	closeTrackSenders(r.downTrackSpreader.ResetAndGetDownTracks())
+	closeTrackSenders(r.downTrackSpreader.CloseAndGetDownTracks())
 }
 
 func (r *RedReceiver) ReadRTP(buf []byte, layer uint8, esn uint64) (int, error) {

--- a/pkg/sfu/utils/downtrackspreader.go
+++ b/pkg/sfu/utils/downtrackspreader.go
@@ -37,6 +37,7 @@ type DownTrackSpreader[T sender] struct {
 	downTrackMu      sync.RWMutex
 	downTracks       map[livekit.ParticipantID]T
 	downTracksShadow []T
+	closed           bool
 }
 
 func NewDownTrackSpreader[T sender](params DownTrackSpreaderParams) *DownTrackSpreader[T] {
@@ -58,20 +59,35 @@ func (d *DownTrackSpreader[T]) ResetAndGetDownTracks() []T {
 	d.downTrackMu.Lock()
 	defer d.downTrackMu.Unlock()
 
-	downTracks := d.downTracksShadow
-
-	d.downTracks = make(map[livekit.ParticipantID]T)
-	d.downTracksShadow = nil
-
-	return downTracks
+	return d.resetAndGetDownTracksLocked()
 }
 
-func (d *DownTrackSpreader[T]) Store(sender T) {
+// CloseAndGetDownTracks terminally closes the spreader and drains all senders.
+// Once it returns, TryStore will reject every subsequent sender.
+func (d *DownTrackSpreader[T]) CloseAndGetDownTracks() []T {
 	d.downTrackMu.Lock()
 	defer d.downTrackMu.Unlock()
 
+	d.closed = true
+	return d.resetAndGetDownTracksLocked()
+}
+
+func (d *DownTrackSpreader[T]) Store(sender T) {
+	_ = d.TryStore(sender)
+}
+
+// TryStore stores sender unless the spreader has been terminally closed.
+func (d *DownTrackSpreader[T]) TryStore(sender T) bool {
+	d.downTrackMu.Lock()
+	defer d.downTrackMu.Unlock()
+
+	if d.closed {
+		return false
+	}
+
 	d.downTracks[sender.SubscriberID()] = sender
 	d.shadowDownTracks()
+	return true
 }
 
 func (d *DownTrackSpreader[T]) Free(subscriberID livekit.ParticipantID) {
@@ -113,6 +129,13 @@ func (d *DownTrackSpreader[T]) DownTrackCount() int {
 	d.downTrackMu.RLock()
 	defer d.downTrackMu.RUnlock()
 	return len(d.downTracksShadow)
+}
+
+func (d *DownTrackSpreader[T]) resetAndGetDownTracksLocked() []T {
+	downTracks := d.downTracksShadow
+	d.downTracks = make(map[livekit.ParticipantID]T)
+	d.downTracksShadow = nil
+	return downTracks
 }
 
 func (d *DownTrackSpreader[T]) shadowDownTracks() {

--- a/pkg/sfu/utils/downtrackspreader_test.go
+++ b/pkg/sfu/utils/downtrackspreader_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/livekit/protocol/livekit"
+	"github.com/stretchr/testify/require"
+)
+
+type testSender struct {
+	subscriberID livekit.ParticipantID
+}
+
+func (s testSender) SubscriberID() livekit.ParticipantID {
+	return s.subscriberID
+}
+
+func TestDownTrackSpreaderResetRemainsReusable(t *testing.T) {
+	spreader := NewDownTrackSpreader[testSender](DownTrackSpreaderParams{})
+	first := testSender{subscriberID: "first"}
+	second := testSender{subscriberID: "second"}
+
+	spreader.Store(first)
+	require.Equal(t, []testSender{first}, spreader.ResetAndGetDownTracks())
+	require.Zero(t, spreader.DownTrackCount())
+
+	spreader.Store(second)
+	require.Equal(t, []testSender{second}, spreader.GetDownTracks())
+}
+
+func TestDownTrackSpreaderRejectsStoreAfterClose(t *testing.T) {
+	spreader := NewDownTrackSpreader[testSender](DownTrackSpreaderParams{})
+	first := testSender{subscriberID: "first"}
+	late := testSender{subscriberID: "late"}
+
+	spreader.Store(first)
+	require.Equal(t, []testSender{first}, spreader.CloseAndGetDownTracks())
+	require.Zero(t, spreader.DownTrackCount())
+
+	require.False(t, spreader.TryStore(late))
+	require.Zero(t, spreader.DownTrackCount())
+}


### PR DESCRIPTION
There is a small window where `AddDownTrack` can pass the receiver closed check, race with `Close`, and store a down track after `Close` has already drained the spreader. In that case the closed receiver owns a down track that was not included in close cleanup, while `AddDownTrack` still returns success.

Make terminal spreader close and the final store check use the spreader's existing lock. `CloseAndGetDownTracks` marks the spreader closed and drains it under that lock, while `TryStore` checks the terminal state and stores under the same lock. If the add wins, `Close` drains the track; if close wins, the add is rejected with `ErrReceiverClosed`.

The existing `Store` and reusable `ResetAndGetDownTracks` behavior is kept for other callers. Apply the close-aware path to `ReceiverBase`, `RedReceiver`, and `RedPrimaryReceiver`.

Add a deterministic regression test for the close-wins race and focused spreader tests for reset reuse and rejecting stores after terminal close.

This does not change the RTP forwarding hot path.