### PR TITLE
telemetry: do not recreate a stats worker for a released guard

### DIFF
--- a/pkg/telemetry/statsworker.go
+++ b/pkg/telemetry/statsworker.go
@@ -205,6 +205,10 @@ func (s *StatsWorker) sealStatsLocked() statsBatch {
 }
 
 func (s *StatsWorker) SetConnected() {
+	if s == nil {
+		return
+	}
+
 	s.lock.Lock()
 	s.isConnected = true
 	s.lock.Unlock()

--- a/pkg/telemetry/statsworker_test.go
+++ b/pkg/telemetry/statsworker_test.go
@@ -1,10 +1,13 @@
 package telemetry
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/livekit/protocol/livekit"
 )
 
 func TestStatsWorker(t *testing.T) {
@@ -66,4 +69,22 @@ func TestStatsWorker(t *testing.T) {
 		var w *StatsWorker
 		require.NoError(t, w.MarshalLogObject(zapcore.NewMapObjectEncoder()))
 	})
+}
+
+func TestGetOrCreateWorkerReleasedGuard(t *testing.T) {
+	// ParticipantActive overtaken by the participant's close arrives with a guard that
+	// ParticipantLeft already released. It must not replace the closed worker with one
+	// nothing can release.
+	ts := &telemetryService{workers: make(map[livekit.RoomID]map[livekit.ParticipantID]*StatsWorker)}
+	roomID, pID := livekit.RoomID("room"), livekit.ParticipantID("participant")
+
+	var g ReferenceGuard
+	w, found := ts.getOrCreateWorker(context.Background(), roomID, "", pID, "", &g)
+	require.False(t, found)
+	require.True(t, w.Close(&g))
+
+	late, found := ts.getOrCreateWorker(context.Background(), roomID, "", pID, "", &g)
+	require.True(t, found)
+	require.Same(t, w, late)
+	require.Same(t, w, ts.workers[roomID][pID])
 }

--- a/pkg/telemetry/statsworker_test.go
+++ b/pkg/telemetry/statsworker_test.go
@@ -83,8 +83,20 @@ func TestGetOrCreateWorkerReleasedGuard(t *testing.T) {
 	require.False(t, found)
 	require.True(t, w.Close(&g))
 
-	late, found := ts.getOrCreateWorker(context.Background(), roomID, "", pID, "", &g)
-	require.True(t, found)
-	require.Same(t, w, late)
-	require.Same(t, w, ts.workers[roomID][pID])
+	t.Run("closed worker still in the map", func(t *testing.T) {
+		late, found := ts.getOrCreateWorker(context.Background(), roomID, "", pID, "", &g)
+		require.True(t, found)
+		require.Same(t, w, late)
+		require.Same(t, w, ts.workers[roomID][pID])
+	})
+
+	t.Run("closed worker already reaped", func(t *testing.T) {
+		delete(ts.workers[roomID], pID)
+
+		late, found := ts.getOrCreateWorker(context.Background(), roomID, "", pID, "", &g)
+		require.True(t, found)
+		require.Nil(t, late)
+		require.Empty(t, ts.workers[roomID])
+		late.SetConnected()
+	})
 }

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -303,9 +303,10 @@ func (t *telemetryService) getOrCreateWorker(
 	}
 
 	// only ParticipantLeft releases a guard, so a released guard is a call landing after
-	// the participant left, e.g. ParticipantActive overtaken by the close. Do not replace
-	// the closed worker with one nothing can ever release
-	if ok && guard != nil && guard.released {
+	// the participant left, e.g. ParticipantActive overtaken by the close. Do not create
+	// a worker nothing can ever release. The closed worker, if not yet reaped, is returned
+	// as found, otherwise nil is
+	if guard != nil && guard.released {
 		return worker, true
 	}
 

--- a/pkg/telemetry/telemetryservice.go
+++ b/pkg/telemetry/telemetryservice.go
@@ -302,6 +302,13 @@ func (t *telemetryService) getOrCreateWorker(
 		return worker, true
 	}
 
+	// only ParticipantLeft releases a guard, so a released guard is a call landing after
+	// the participant left, e.g. ParticipantActive overtaken by the close. Do not replace
+	// the closed worker with one nothing can ever release
+	if ok && guard != nil && guard.released {
+		return worker, true
+	}
+
 	existingIsConnected := false
 	if ok {
 		existingIsConnected = worker.IsConnected()


### PR DESCRIPTION
A participant that connects and disconnects within the same instant can have its
`ParticipantActive` overtaken by its close: `updateState` dispatches the state change
on a goroutine while `Close` runs its callbacks inline, so `ParticipantLeft` can be
enqueued first. `ParticipantActive` then finds the worker closed and replaces it
with one created from an already released guard. Nothing can ever release that
worker, so it stays open at `refCount: 0` and its `AddParticipant()` is never undone.

Only `ParticipantLeft` releases a guard, so a released guard means the participant
already left. Return the existing closed worker instead of creating a new one.

Seen with node self-checks, which connect, wait 100ms and disconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)