### PR TITLE
rtc: add GetSubscribedDataTracks to LocalParticipant

### DIFF
--- a/pkg/rtc/subscriptionmanager.go
+++ b/pkg/rtc/subscriptionmanager.go
@@ -307,6 +307,19 @@ func (m *SubscriptionManager) GetSubscribedTracks() []types.SubscribedTrack {
 	return tracks
 }
 
+func (m *SubscriptionManager) GetSubscribedDataTracks() []types.DataDownTrack {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	tracks := make([]types.DataDownTrack, 0, len(m.dataTrackSubscriptions))
+	for _, s := range m.dataTrackSubscriptions {
+		if dt := s.getDataDownTrack(); dt != nil {
+			tracks = append(tracks, dt)
+		}
+	}
+	return tracks
+}
+
 func (m *SubscriptionManager) IsTrackNameSubscribed(publisherIdentity livekit.ParticipantIdentity, trackName string) bool {
 	m.lock.RLock()
 	defer m.lock.RUnlock()

--- a/pkg/rtc/types/interfaces.go
+++ b/pkg/rtc/types/interfaces.go
@@ -548,6 +548,7 @@ type LocalParticipant interface {
 	UnsubscribeFromTrack(trackID livekit.TrackID)
 	UpdateSubscribedTrackSettings(trackID livekit.TrackID, settings *livekit.UpdateTrackSettings)
 	GetSubscribedTracks() []SubscribedTrack
+	GetSubscribedDataTracks() []DataDownTrack
 	IsTrackNameSubscribed(publisherIdentity livekit.ParticipantIdentity, trackName string) bool
 	SubscribeToDataTrack(trackID livekit.TrackID)
 	UnsubscribeFromDataTrack(trackID livekit.TrackID)

--- a/pkg/rtc/types/typesfakes/fake_local_participant.go
+++ b/pkg/rtc/types/typesfakes/fake_local_participant.go
@@ -557,6 +557,16 @@ type FakeLocalParticipant struct {
 	getResponseSinkReturnsOnCall map[int]struct {
 		result1 routing.MessageSink
 	}
+	GetSubscribedDataTracksStub        func() []types.DataDownTrack
+	getSubscribedDataTracksMutex       sync.RWMutex
+	getSubscribedDataTracksArgsForCall []struct {
+	}
+	getSubscribedDataTracksReturns struct {
+		result1 []types.DataDownTrack
+	}
+	getSubscribedDataTracksReturnsOnCall map[int]struct {
+		result1 []types.DataDownTrack
+	}
 	GetSubscribedParticipantsStub        func() []livekit.ParticipantID
 	getSubscribedParticipantsMutex       sync.RWMutex
 	getSubscribedParticipantsArgsForCall []struct {
@@ -4410,6 +4420,59 @@ func (fake *FakeLocalParticipant) GetResponseSinkReturnsOnCall(i int, result1 ro
 	}
 	fake.getResponseSinkReturnsOnCall[i] = struct {
 		result1 routing.MessageSink
+	}{result1}
+}
+
+func (fake *FakeLocalParticipant) GetSubscribedDataTracks() []types.DataDownTrack {
+	fake.getSubscribedDataTracksMutex.Lock()
+	ret, specificReturn := fake.getSubscribedDataTracksReturnsOnCall[len(fake.getSubscribedDataTracksArgsForCall)]
+	fake.getSubscribedDataTracksArgsForCall = append(fake.getSubscribedDataTracksArgsForCall, struct {
+	}{})
+	stub := fake.GetSubscribedDataTracksStub
+	fakeReturns := fake.getSubscribedDataTracksReturns
+	fake.recordInvocation("GetSubscribedDataTracks", []interface{}{})
+	fake.getSubscribedDataTracksMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLocalParticipant) GetSubscribedDataTracksCallCount() int {
+	fake.getSubscribedDataTracksMutex.RLock()
+	defer fake.getSubscribedDataTracksMutex.RUnlock()
+	return len(fake.getSubscribedDataTracksArgsForCall)
+}
+
+func (fake *FakeLocalParticipant) GetSubscribedDataTracksCalls(stub func() []types.DataDownTrack) {
+	fake.getSubscribedDataTracksMutex.Lock()
+	defer fake.getSubscribedDataTracksMutex.Unlock()
+	fake.GetSubscribedDataTracksStub = stub
+}
+
+func (fake *FakeLocalParticipant) GetSubscribedDataTracksReturns(result1 []types.DataDownTrack) {
+	fake.getSubscribedDataTracksMutex.Lock()
+	defer fake.getSubscribedDataTracksMutex.Unlock()
+	fake.GetSubscribedDataTracksStub = nil
+	fake.getSubscribedDataTracksReturns = struct {
+		result1 []types.DataDownTrack
+	}{result1}
+}
+
+func (fake *FakeLocalParticipant) GetSubscribedDataTracksReturnsOnCall(i int, result1 []types.DataDownTrack) {
+	fake.getSubscribedDataTracksMutex.Lock()
+	defer fake.getSubscribedDataTracksMutex.Unlock()
+	fake.GetSubscribedDataTracksStub = nil
+	if fake.getSubscribedDataTracksReturnsOnCall == nil {
+		fake.getSubscribedDataTracksReturnsOnCall = make(map[int]struct {
+			result1 []types.DataDownTrack
+		})
+	}
+	fake.getSubscribedDataTracksReturnsOnCall[i] = struct {
+		result1 []types.DataDownTrack
 	}{result1}
 }
 


### PR DESCRIPTION
Add `GetSubscribedDataTracks()` to the `LocalParticipant` interface, returning the bound data down-tracks, mirroring `GetSubscribedTracks()` for media.

`SubscriptionManager` already tracks data-track subscriptions but exposed no accessor for the active ones, so callers could count subscribed and published media tracks and published data tracks, but not subscribed data tracks. This closes that gap so a participant`\s full down and up track set can be accounted for.

The generated `LocalParticipant` fake is regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
